### PR TITLE
Add start/end button, add route below labels

### DIFF
--- a/Example/Swift/ViewController.swift
+++ b/Example/Swift/ViewController.swift
@@ -39,6 +39,8 @@ class ViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthesizerD
         
         MGLAccountManager.setAccessToken(MapboxAccessToken)
         
+        mapView.delegate = self
+        
         lengthFormatter.unitStyle = .short
         mapView.userTrackingMode = .follow
         resumeNotifications()
@@ -63,7 +65,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthesizerD
         }
         
         destination = mapView.convert(sender.location(in: mapView), toCoordinateFrom: mapView)
-        getRoute(isReroute: false)
+        getRoute(forRerouting: false)
     }
     
     func resumeNotifications() {
@@ -81,7 +83,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthesizerD
     func mapView(_ mapView: MGLMapView, didChange mode: MGLUserTrackingMode, animated: Bool) {
         if mode == .followWithCourse {
             startNavigationButton.titleLabel?.text = "End Navigation"
-        } else {
+        } else if mode == .none {
             startNavigationButton.titleLabel?.text = "Start Navigation"
         }
     }
@@ -123,10 +125,10 @@ class ViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthesizerD
     // Fired when the user is no longer on the route.
     // A new route should be fetched at this time.
     func rerouted(_ notification: NSNotification) {
-        getRoute(isReroute: true)
+        getRoute(forRerouting: true)
     }
     
-    func getRoute(isReroute: Bool) {
+    func getRoute(forRerouting: Bool) {
         let options = RouteOptions(coordinates: [mapView.userLocation!.coordinate, destination!])
         options.includesSteps = true
         options.routeShapeResolution = .full
@@ -155,7 +157,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthesizerD
             
             
             // Don't fit bounds and show button if rerouting
-            if !isReroute {
+            if !forRerouting {
                 self?.mapView.setVisibleCoordinateBounds(MGLPolyline(coordinates: &coordinates, count: UInt(coordinates.count)).overlayBounds, edgePadding: edgePadding, animated: true)
                 self?.startNavigationButton.isHidden = false
             }

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '8.0'
 use_frameworks!
 
 def shared_pods
-    pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-beta.7/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
+    pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-rc.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
     pod 'MapboxDirections.swift', :git => 'https://github.com/mapbox/MapboxDirections.swift.git', :commit => 'ceaf58b780fc17ea44a9150041b602d017c1e567'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Mapbox-iOS-SDK (3.4.0-beta.7-symbols)
+  - Mapbox-iOS-SDK-symbols (3.4.0-rc.1-symbols)
   - MapboxDirections.swift (0.6.0):
     - Polyline (~> 4.0.0)
   - Polyline (4.0.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-beta.7/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
+  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-rc.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
   - MapboxDirections.swift (from `https://github.com/mapbox/MapboxDirections.swift.git`, commit `ceaf58b780fc17ea44a9150041b602d017c1e567`)
 
 EXTERNAL SOURCES:
-  Mapbox-iOS-SDK:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-beta.7/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+  Mapbox-iOS-SDK-symbols:
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-rc.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec
   MapboxDirections.swift:
     :commit: ceaf58b780fc17ea44a9150041b602d017c1e567
     :git: https://github.com/mapbox/MapboxDirections.swift.git
@@ -21,10 +21,10 @@ CHECKOUT OPTIONS:
     :git: https://github.com/mapbox/MapboxDirections.swift.git
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: de477a618e364552cc1ca867c4602ef3b5c46ffa
+  Mapbox-iOS-SDK-symbols: bc87efa7ae4c14c65b42bdbaa75973b4934fc7cc
   MapboxDirections.swift: 4acd753d0079bae4f2fae2b2cbda98922909de09
   Polyline: c6de7430bf6ff0bfff1f087343597b83b38fdb69
 
-PODFILE CHECKSUM: 53a90412a8dd1453b8cfe332930391d02e80434e
+PODFILE CHECKSUM: 7e3dfb94d4f4342b4c58f46080de411549df8440
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
Updates the example a bit:

* adds start/stop button
* puts the route line under the labels; something all devs will do 

todo: 

- [x] get `mapView(_ mapView: MGLMapView, didChange mode:)` to actually fire
- [ ] Do the same for obj c