### PR TITLE
Replace temporary profile identifier

### DIFF
--- a/Example/Objective-C/ViewController.m
+++ b/Example/Objective-C/ViewController.m
@@ -18,7 +18,6 @@
 
 @implementation ViewController
 
-static NSString *MBXTempProfileIdentifierAutomobileAvoidingTraffic = @"mapbox/driving-traffic";
 static NSString *MapboxAccessToken = @"<#Your Mapbox access token#>";
 
 - (void)viewDidLoad {
@@ -112,7 +111,7 @@ static NSString *MapboxAccessToken = @"<#Your Mapbox access token#>";
     NSArray<MBWaypoint *> *waypoints = @[[[MBWaypoint alloc] initWithCoordinate:self.mapView.userLocation.coordinate coordinateAccuracy:-1 name:nil],
                                          [[MBWaypoint alloc] initWithCoordinate:self.destination coordinateAccuracy:-1 name:nil]];
     
-    MBRouteOptions *options = [[MBRouteOptions alloc] initWithWaypoints:waypoints profileIdentifier:MBXTempProfileIdentifierAutomobileAvoidingTraffic];
+    MBRouteOptions *options = [[MBRouteOptions alloc] initWithWaypoints:waypoints profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
     options.includesSteps = YES;
     options.routeShapeResolution = MBRouteShapeResolutionFull;
     

--- a/MapboxNavigationTests/MapboxNavigationTests.swift
+++ b/MapboxNavigationTests/MapboxNavigationTests.swift
@@ -14,7 +14,7 @@ let response = Fixture.JSONFromFileNamed(name: "route")
 let jsonRoute = (response["routes"] as! [AnyObject]).first as! [String : Any]
 let waypoint1 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.795042, longitude: -122.413165))
 let waypoint2 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.7727, longitude: -122.433378))
-let route = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], profileIdentifier: MBDirectionsProfileIdentifierAutomobile)
+let route = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], profileIdentifier: MBDirectionsProfileIdentifier.automobile.rawValue)
 
 let waitForInterval: TimeInterval = 5
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 def shared_pods
     pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-beta.3/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
-    pod 'MapboxDirections.swift', :git => 'https://github.com/mapbox/MapboxDirections.swift.git', :commit => 'ceaf58b780fc17ea44a9150041b602d017c1e567'
+    pod 'MapboxDirections.swift', :git => 'https://github.com/mapbox/MapboxDirections.swift.git', :branch => 'fred-objc-compatibility'
 end
 
 target 'MapboxNavigation' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,18 +6,18 @@ PODS:
 
 DEPENDENCIES:
   - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-beta.3/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
-  - MapboxDirections.swift (from `https://github.com/mapbox/MapboxDirections.swift.git`, commit `ceaf58b780fc17ea44a9150041b602d017c1e567`)
+  - MapboxDirections.swift (from `https://github.com/mapbox/MapboxDirections.swift.git`, branch `fred-objc-compatibility`)
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK:
     :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-beta.3/platform/ios/Mapbox-iOS-SDK-symbols.podspec
   MapboxDirections.swift:
-    :commit: ceaf58b780fc17ea44a9150041b602d017c1e567
+    :branch: fred-objc-compatibility
     :git: https://github.com/mapbox/MapboxDirections.swift.git
 
 CHECKOUT OPTIONS:
   MapboxDirections.swift:
-    :commit: ceaf58b780fc17ea44a9150041b602d017c1e567
+    :commit: 77670cb2e7a30b87d27023b62af0bd354deecb9a
     :git: https://github.com/mapbox/MapboxDirections.swift.git
 
 SPEC CHECKSUMS:
@@ -25,6 +25,6 @@ SPEC CHECKSUMS:
   MapboxDirections.swift: 4acd753d0079bae4f2fae2b2cbda98922909de09
   Polyline: c6de7430bf6ff0bfff1f087343597b83b38fdb69
 
-PODFILE CHECKSUM: 3633a7a320ccd501bace96a72a9b735c578b0e03
+PODFILE CHECKSUM: 7d034813c3542f388ff2c31cbcd1557601cb4252
 
 COCOAPODS: 1.2.0.rc.1


### PR DESCRIPTION
Replaced the temporary profile identifier now when it bridges from Swift (https://github.com/mapbox/MapboxDirections.swift/pull/106)

The PR mentioned above have to land before this one. Then we can point the MapboxDirections dependency back to the latest swift3 commit.