### PR TITLE
Make geometry.swift methods public [Not ready]

### DIFF
--- a/MapboxNavigation/Geometry.swift
+++ b/MapboxNavigation/Geometry.swift
@@ -21,12 +21,12 @@ public struct RadianCoordinate2D {
     var latitude: LocationRadians
     var longitude: LocationRadians
     
-    init(latitude: LocationRadians, longitude: LocationRadians) {
+    public init(latitude: LocationRadians, longitude: LocationRadians) {
         self.latitude = latitude
         self.longitude = longitude
     }
     
-    init(_ degreeCoordinate: CLLocationCoordinate2D) {
+    public init(_ degreeCoordinate: CLLocationCoordinate2D) {
         latitude = degreeCoordinate.latitude.toRadians()
         longitude = degreeCoordinate.longitude.toRadians()
     }
@@ -128,9 +128,9 @@ public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocati
 
 
 public struct CoordinateAlongPolyline {
-    let coordinate: Array<CLLocationCoordinate2D>.Element
-    let index: Array<CLLocationCoordinate2D>.Index
-    let distance: CLLocationDistance
+    public let coordinate: Array<CLLocationCoordinate2D>.Element
+    public let index: Array<CLLocationCoordinate2D>.Index
+    public let distance: CLLocationDistance
 }
 
 
@@ -252,7 +252,7 @@ public func coordinate(at distance: CLLocationDistance, fromStartOf polyline: [C
 /*
  Returns a coordinate along a polyline with x units away from a coordinate
  */
-func polyline(along polyline: [CLLocationCoordinate2D], within distance: CLLocationDistance, of coordinate: CLLocationCoordinate2D) -> [CLLocationCoordinate2D] {
+public func polyline(along polyline: [CLLocationCoordinate2D], within distance: CLLocationDistance, of coordinate: CLLocationCoordinate2D) -> [CLLocationCoordinate2D] {
     let startVertex = closestCoordinate(on: polyline, to: coordinate)
     guard startVertex != nil && distance != 0 else {
         return []

--- a/MapboxNavigation/Geometry.swift
+++ b/MapboxNavigation/Geometry.swift
@@ -4,18 +4,17 @@ import MapboxDirections
 public typealias LocationRadians = Double
 public typealias RadianDistance = Double
 public typealias RadianDirection = Double
+let metersPerRadian = 6_373_000.0
 
 public extension CLLocationDegrees {
-    public func toRadians() -> LocationRadians {
+    public func mb_toRadians() -> LocationRadians {
         return self * M_PI / 180.0
     }
     
-    public func toDegrees() -> CLLocationDirection {
+    public func mb_toDegrees() -> CLLocationDirection {
         return self * 180.0 / M_PI
     }
 }
-
-let metersPerRadian = 6_373_000.0
 
 public struct RadianCoordinate2D {
     var latitude: LocationRadians
@@ -27,15 +26,15 @@ public struct RadianCoordinate2D {
     }
     
     public init(_ degreeCoordinate: CLLocationCoordinate2D) {
-        latitude = degreeCoordinate.latitude.toRadians()
-        longitude = degreeCoordinate.longitude.toRadians()
+        latitude = degreeCoordinate.latitude.mb_toRadians()
+        longitude = degreeCoordinate.longitude.mb_toRadians()
     }
     
     
     /*
      Returns direction given two coordinates.
     */
-    public func direction(to coordinate: RadianCoordinate2D) -> RadianDirection {
+    public func MBDirection(to coordinate: RadianCoordinate2D) -> RadianDirection {
         let a = sin(coordinate.longitude - longitude) * cos(coordinate.latitude)
         let b = cos(latitude) * sin(coordinate.latitude)
             - sin(latitude) * cos(coordinate.latitude) * cos(coordinate.longitude - longitude)
@@ -46,7 +45,7 @@ public struct RadianCoordinate2D {
     /*
      Returns coordinate at a given distance and direction away from coordinate.
     */
-    public func coordinate(at distance: RadianDistance, facing direction: RadianDirection) -> RadianCoordinate2D {
+    public func MBCoordinate(at distance: RadianDistance, facing direction: RadianDirection) -> RadianCoordinate2D {
         let distance = distance, direction = direction
         let otherLatitude = asin(sin(latitude) * cos(distance)
             + cos(latitude) * sin(distance) * cos(direction))
@@ -77,18 +76,18 @@ public func -(left: CLLocationCoordinate2D, right: CLLocationCoordinate2D) -> CL
 
 public extension CLLocationCoordinate2D {
     init(_ radianCoordinate: RadianCoordinate2D) {
-        latitude = radianCoordinate.latitude.toDegrees()
-        longitude = radianCoordinate.longitude.toDegrees()
+        latitude = radianCoordinate.latitude.mb_toDegrees()
+        longitude = radianCoordinate.longitude.mb_toDegrees()
     }
     
     /// Returns the direction from the receiver to the given coordinate.
-    public func direction(to coordinate: CLLocationCoordinate2D) -> CLLocationDirection {
-        return RadianCoordinate2D(self).direction(to: RadianCoordinate2D(coordinate)).toDegrees()
+    public func mb_direction(to coordinate: CLLocationCoordinate2D) -> CLLocationDirection {
+        return RadianCoordinate2D(self).MBDirection(to: RadianCoordinate2D(coordinate)).mb_toDegrees()
     }
     
     /// Returns a coordinate a certain Haversine distance away in the given direction.
-    public func coordinate(at distance: CLLocationDistance, facing direction: CLLocationDirection) -> CLLocationCoordinate2D {
-        let radianCoordinate = RadianCoordinate2D(self).coordinate(at: distance / metersPerRadian, facing: direction.toRadians())
+    public func mb_coordinate(at distance: CLLocationDistance, facing direction: CLLocationDirection) -> CLLocationCoordinate2D {
+        let radianCoordinate = RadianCoordinate2D(self).MBCoordinate(at: distance / metersPerRadian, facing: direction.mb_toRadians())
         return CLLocationCoordinate2D(radianCoordinate)
     }
 }
@@ -100,7 +99,7 @@ public typealias LineSegment = (CLLocationCoordinate2D, CLLocationCoordinate2D)
 /* 
  Returns the intersection of two line segments.
  */
-public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoordinate2D? {
+public func MBIntersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoordinate2D? {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js, in turn adapted from http://jsfiddle.net/justin_c_rounds/Gd2S2/light/
     let denominator = ((line2.1.latitude - line2.0.latitude) * (line1.1.longitude - line1.0.longitude))
         - ((line2.1.longitude - line2.0.longitude) * (line1.1.latitude - line1.0.latitude))
@@ -139,7 +138,7 @@ public struct CoordinateAlongPolyline {
  
  The returned coordinate may not correspond to one of the polyline’s vertices, but it always lies along the polyline.
 */
-public func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordinate: CLLocationCoordinate2D) -> CoordinateAlongPolyline? {
+public func MBClosestCoordinate(on polyline: [CLLocationCoordinate2D], to coordinate: CLLocationCoordinate2D) -> CoordinateAlongPolyline? {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js
     let polyline = polyline, coordinate = coordinate
     guard !polyline.isEmpty else {
@@ -156,10 +155,10 @@ public func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordina
         let distances = (coordinate - segment.0, coordinate - segment.1)
         
         let maxDistance = max(distances.0, distances.1)
-        let direction = segment.0.direction(to: segment.1)
-        let perpendicularPoint1 = coordinate.coordinate(at: maxDistance, facing: direction + 90)
-        let perpendicularPoint2 = coordinate.coordinate(at: maxDistance, facing: direction - 90)
-        let intersectionPoint = intersection((perpendicularPoint1, perpendicularPoint2), segment)
+        let direction = segment.0.mb_direction(to: segment.1)
+        let perpendicularPoint1 = coordinate.mb_coordinate(at: maxDistance, facing: direction + 90)
+        let perpendicularPoint2 = coordinate.mb_coordinate(at: maxDistance, facing: direction - 90)
+        let intersectionPoint = MBIntersection((perpendicularPoint1, perpendicularPoint2), segment)
         let intersectionDistance: CLLocationDistance? = intersectionPoint != nil ? coordinate - intersectionPoint! : nil
         
         if distances.0 < closestCoordinate?.distance ?? CLLocationDistanceMax {
@@ -180,14 +179,14 @@ public func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordina
 /*
  Returns a subset of the polyline between given coordinates.
  */
-public func polyline(along polyline: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> [CLLocationCoordinate2D] {
+public func MBPolyline(along polyline: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> [CLLocationCoordinate2D] {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-line-slice/index.js
     guard !polyline.isEmpty else {
         return []
     }
     
-    let startVertex = (start != nil ? closestCoordinate(on: polyline, to: start!) : nil) ?? CoordinateAlongPolyline(coordinate: polyline.first!, index: 0, distance: 0)
-    let endVertex = (end != nil ? closestCoordinate(on: polyline, to: end!) : nil) ?? CoordinateAlongPolyline(coordinate: polyline.last!, index: polyline.indices.last!, distance: 0)
+    let startVertex = (start != nil ? MBClosestCoordinate(on: polyline, to: start!) : nil) ?? CoordinateAlongPolyline(coordinate: polyline.first!, index: 0, distance: 0)
+    let endVertex = (end != nil ? MBClosestCoordinate(on: polyline, to: end!) : nil) ?? CoordinateAlongPolyline(coordinate: polyline.last!, index: polyline.indices.last!, distance: 0)
     let ends: (CoordinateAlongPolyline, CoordinateAlongPolyline)
     if startVertex.index <= endVertex.index {
         ends = (startVertex, endVertex)
@@ -206,13 +205,13 @@ public func polyline(along polyline: [CLLocationCoordinate2D], from start: CLLoc
 /*
  Returns the distance along a slice of a polyline with the given endpoints.
  */
-public func distance(along line: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> CLLocationDistance {
+public func MBDistance(along line: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> CLLocationDistance {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-line-slice/index.js
     guard !line.isEmpty else {
         return 0
     }
     
-    let sliced = polyline(along: line, from: start, to: end)
+    let sliced = MBPolyline(along: line, from: start, to: end)
     
     // Zip together the starts and ends of each segment, then map those pairs of coordinates to the distances between them, then take the sum.
     let distance = zip(sliced.prefix(upTo: sliced.count - 1), sliced.suffix(from: 1)).map(-).reduce(0, +)
@@ -224,7 +223,7 @@ public func distance(along line: [CLLocationCoordinate2D], from start: CLLocatio
 /*
  Returns a coordinate along a polyline at a certain distance from the start of the polyline.
  */
-public func coordinate(at distance: CLLocationDistance, fromStartOf polyline: [CLLocationCoordinate2D]) -> CLLocationCoordinate2D? {
+public func MBCoordinate(at distance: CLLocationDistance, fromStartOf polyline: [CLLocationCoordinate2D]) -> CLLocationCoordinate2D? {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-along/index.js
     var traveled: CLLocationDistance = 0
     for i in 0..<polyline.count {
@@ -238,8 +237,8 @@ public func coordinate(at distance: CLLocationDistance, fromStartOf polyline: [C
                 return polyline[i]
             }
             
-            let direction = polyline[i].direction(to: polyline[i - 1]) - 180
-            return polyline[i].coordinate(at: overshoot, facing: direction)
+            let direction = polyline[i].mb_direction(to: polyline[i - 1]) - 180
+            return polyline[i].mb_coordinate(at: overshoot, facing: direction)
         }
         
         traveled += polyline[i] - polyline[i + 1]
@@ -252,8 +251,8 @@ public func coordinate(at distance: CLLocationDistance, fromStartOf polyline: [C
 /*
  Returns a coordinate along a polyline with x units away from a coordinate
  */
-public func polyline(along polyline: [CLLocationCoordinate2D], within distance: CLLocationDistance, of coordinate: CLLocationCoordinate2D) -> [CLLocationCoordinate2D] {
-    let startVertex = closestCoordinate(on: polyline, to: coordinate)
+public func MBPolyline(along polyline: [CLLocationCoordinate2D], within distance: CLLocationDistance, of coordinate: CLLocationCoordinate2D) -> [CLLocationCoordinate2D] {
+    let startVertex = MBClosestCoordinate(on: polyline, to: coordinate)
     guard startVertex != nil && distance != 0 else {
         return []
     }
@@ -269,8 +268,8 @@ public func polyline(along polyline: [CLLocationCoordinate2D], within distance: 
             return true
         } else {
             let remainingDistance = abs(distance) - cumulativeDistance
-            let direction = lastVertex.direction(to: vertex)
-            let endpoint = lastVertex.coordinate(at: remainingDistance, facing: direction)
+            let direction = lastVertex.mb_direction(to: vertex)
+            let endpoint = lastVertex.mb_coordinate(at: remainingDistance, facing: direction)
             vertices.append(endpoint)
             cumulativeDistance += remainingDistance
             return false
@@ -298,7 +297,7 @@ public func polyline(along polyline: [CLLocationCoordinate2D], within distance: 
 /*
  Returns a normalized number given min and max bounds.
  */
-public func wrap(_ value: Double, min minValue: Double, max maxValue: Double) -> Double {
+public func MBWrap(_ value: Double, min minValue: Double, max maxValue: Double) -> Double {
     let d = maxValue - minValue
     return fmod((fmod((value - minValue), d) + d), d) + minValue
 }
@@ -308,8 +307,8 @@ public extension CLLocation {
     /*
      Returns a Boolean value indicating whether the receiver is within a given distance of a route step, inclusive.
     */
-    func isWithin(_ maximumDistance: CLLocationDistance, of routeStep: RouteStep) -> Bool {
-        guard let closestCoordinate = closestCoordinate(on: routeStep.coordinates!, to: coordinate) else {
+    func mb_isWithin(_ maximumDistance: CLLocationDistance, of routeStep: RouteStep) -> Bool {
+        guard let closestCoordinate = MBClosestCoordinate(on: routeStep.coordinates!, to: coordinate) else {
             return true
         }
         return closestCoordinate.distance < maximumDistance

--- a/MapboxNavigation/Geometry.swift
+++ b/MapboxNavigation/Geometry.swift
@@ -6,11 +6,11 @@ public typealias RadianDistance = Double
 public typealias RadianDirection = Double
 
 public extension CLLocationDegrees {
-    func toRadians() -> LocationRadians {
+    public func toRadians() -> LocationRadians {
         return self * M_PI / 180.0
     }
     
-    func toDegrees() -> CLLocationDirection {
+    public func toDegrees() -> CLLocationDirection {
         return self * 180.0 / M_PI
     }
 }
@@ -35,7 +35,7 @@ public struct RadianCoordinate2D {
     /*
      Returns direction given two coordinates.
     */
-    func direction(to coordinate: RadianCoordinate2D) -> RadianDirection {
+    public func direction(to coordinate: RadianCoordinate2D) -> RadianDirection {
         let a = sin(coordinate.longitude - longitude) * cos(coordinate.latitude)
         let b = cos(latitude) * sin(coordinate.latitude)
             - sin(latitude) * cos(coordinate.latitude) * cos(coordinate.longitude - longitude)
@@ -46,7 +46,7 @@ public struct RadianCoordinate2D {
     /*
      Returns coordinate at a given distance and direction away from coordinate.
     */
-    func coordinate(at distance: RadianDistance, facing direction: RadianDirection) -> RadianCoordinate2D {
+    public func coordinate(at distance: RadianDistance, facing direction: RadianDirection) -> RadianCoordinate2D {
         let distance = distance, direction = direction
         let otherLatitude = asin(sin(latitude) * cos(distance)
             + cos(latitude) * sin(distance) * cos(direction))
@@ -82,12 +82,12 @@ public extension CLLocationCoordinate2D {
     }
     
     /// Returns the direction from the receiver to the given coordinate.
-    func direction(to coordinate: CLLocationCoordinate2D) -> CLLocationDirection {
+    public func direction(to coordinate: CLLocationCoordinate2D) -> CLLocationDirection {
         return RadianCoordinate2D(self).direction(to: RadianCoordinate2D(coordinate)).toDegrees()
     }
     
     /// Returns a coordinate a certain Haversine distance away in the given direction.
-    func coordinate(at distance: CLLocationDistance, facing direction: CLLocationDirection) -> CLLocationCoordinate2D {
+    public func coordinate(at distance: CLLocationDistance, facing direction: CLLocationDirection) -> CLLocationCoordinate2D {
         let radianCoordinate = RadianCoordinate2D(self).coordinate(at: distance / metersPerRadian, facing: direction.toRadians())
         return CLLocationCoordinate2D(radianCoordinate)
     }

--- a/MapboxNavigation/Geometry.swift
+++ b/MapboxNavigation/Geometry.swift
@@ -1,11 +1,11 @@
 import CoreLocation
 import MapboxDirections
 
-typealias LocationRadians = Double
-typealias RadianDistance = Double
-typealias RadianDirection = Double
+public typealias LocationRadians = Double
+public typealias RadianDistance = Double
+public typealias RadianDirection = Double
 
-extension CLLocationDegrees {
+public extension CLLocationDegrees {
     func toRadians() -> LocationRadians {
         return self * M_PI / 180.0
     }
@@ -17,7 +17,7 @@ extension CLLocationDegrees {
 
 let metersPerRadian = 6_373_000.0
 
-struct RadianCoordinate2D {
+public struct RadianCoordinate2D {
     var latitude: LocationRadians
     var longitude: LocationRadians
     
@@ -60,7 +60,7 @@ struct RadianCoordinate2D {
 /*
  Returns the Haversine distance between two coordinates measured in radians.
  */
-func -(left: RadianCoordinate2D, right: RadianCoordinate2D) -> RadianDistance {
+public func -(left: RadianCoordinate2D, right: RadianCoordinate2D) -> RadianDistance {
     let a = pow(sin((right.latitude - left.latitude) / 2), 2)
         + pow(sin((right.longitude - left.longitude) / 2), 2) * cos(left.latitude) * cos(right.latitude)
     return 2 * atan2(sqrt(a), sqrt(1 - a))
@@ -70,12 +70,12 @@ func -(left: RadianCoordinate2D, right: RadianCoordinate2D) -> RadianDistance {
 /*
  Returns the Haversine distance between two coordinates measured in degrees.
  */
-func -(left: CLLocationCoordinate2D, right: CLLocationCoordinate2D) -> CLLocationDistance {
+public func -(left: CLLocationCoordinate2D, right: CLLocationCoordinate2D) -> CLLocationDistance {
     return (RadianCoordinate2D(left) - RadianCoordinate2D(right)) * metersPerRadian
 }
 
 
-extension CLLocationCoordinate2D {
+public extension CLLocationCoordinate2D {
     init(_ radianCoordinate: RadianCoordinate2D) {
         latitude = radianCoordinate.latitude.toDegrees()
         longitude = radianCoordinate.longitude.toDegrees()
@@ -94,13 +94,13 @@ extension CLLocationCoordinate2D {
 }
 
 
-typealias LineSegment = (CLLocationCoordinate2D, CLLocationCoordinate2D)
+public typealias LineSegment = (CLLocationCoordinate2D, CLLocationCoordinate2D)
 
 
 /* 
  Returns the intersection of two line segments.
  */
-func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoordinate2D? {
+public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoordinate2D? {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js, in turn adapted from http://jsfiddle.net/justin_c_rounds/Gd2S2/light/
     let denominator = ((line2.1.latitude - line2.0.latitude) * (line1.1.longitude - line1.0.longitude))
         - ((line2.1.longitude - line2.0.longitude) * (line1.1.latitude - line1.0.latitude))
@@ -127,7 +127,7 @@ func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoord
 }
 
 
-struct CoordinateAlongPolyline {
+public struct CoordinateAlongPolyline {
     let coordinate: Array<CLLocationCoordinate2D>.Element
     let index: Array<CLLocationCoordinate2D>.Index
     let distance: CLLocationDistance
@@ -139,7 +139,7 @@ struct CoordinateAlongPolyline {
  
  The returned coordinate may not correspond to one of the polyline’s vertices, but it always lies along the polyline.
 */
-func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordinate: CLLocationCoordinate2D) -> CoordinateAlongPolyline? {
+public func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordinate: CLLocationCoordinate2D) -> CoordinateAlongPolyline? {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js
     let polyline = polyline, coordinate = coordinate
     guard !polyline.isEmpty else {
@@ -180,7 +180,7 @@ func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordinate: CLL
 /*
  Returns a subset of the polyline between given coordinates.
  */
-func polyline(along polyline: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> [CLLocationCoordinate2D] {
+public func polyline(along polyline: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> [CLLocationCoordinate2D] {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-line-slice/index.js
     guard !polyline.isEmpty else {
         return []
@@ -206,7 +206,7 @@ func polyline(along polyline: [CLLocationCoordinate2D], from start: CLLocationCo
 /*
  Returns the distance along a slice of a polyline with the given endpoints.
  */
-func distance(along line: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> CLLocationDistance {
+public func distance(along line: [CLLocationCoordinate2D], from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> CLLocationDistance {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-line-slice/index.js
     guard !line.isEmpty else {
         return 0
@@ -224,7 +224,7 @@ func distance(along line: [CLLocationCoordinate2D], from start: CLLocationCoordi
 /*
  Returns a coordinate along a polyline at a certain distance from the start of the polyline.
  */
-func coordinate(at distance: CLLocationDistance, fromStartOf polyline: [CLLocationCoordinate2D]) -> CLLocationCoordinate2D? {
+public func coordinate(at distance: CLLocationDistance, fromStartOf polyline: [CLLocationCoordinate2D]) -> CLLocationCoordinate2D? {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-along/index.js
     var traveled: CLLocationDistance = 0
     for i in 0..<polyline.count {
@@ -304,7 +304,7 @@ public func wrap(_ value: Double, min minValue: Double, max maxValue: Double) ->
 }
 
 
-extension CLLocation {
+public extension CLLocation {
     /*
      Returns a Boolean value indicating whether the receiver is within a given distance of a route step, inclusive.
     */


### PR DESCRIPTION
A lot of these functions are useful while using this library. This PR makes functions in `Geometry.swift` public so they can be consumed. 

todo: 

- [ ] bridge `struct`s for obj c