### PR TITLE
Improve off route calculation

### DIFF
--- a/MapboxNavigation/Constants.swift
+++ b/MapboxNavigation/Constants.swift
@@ -19,6 +19,10 @@ public let RouteControllerShouldReroute = Notification.Name(MBRouteControllerSho
 */
 public var RouteControllerMaximumDistanceBeforeRecalculating: CLLocationDistance = 50
 
+/*
+ Accepted deviation excluding horizontal accuracy before the user is considered to be off route.
+ */
+public var RouteControllerHorizontalAccuracyAnomaly: CLLocationDistance = 5
 
 /*
  Threshold user must be in within to count as completing a step. One of two heuristics used to know when a user completes a step, see `RouteControllerManeuverZoneRadius`.

--- a/MapboxNavigation/RouteController.swift
+++ b/MapboxNavigation/RouteController.swift
@@ -112,7 +112,13 @@ extension RouteController: CLLocationManagerDelegate {
         let metersInFrontOfUser = location.speed * RouteControllerDeadReckoningTimeInterval
         let locationInfrontOfUser = location.coordinate.coordinate(at: metersInFrontOfUser, facing: location.course)
         let newLocation = CLLocation(latitude: locationInfrontOfUser.latitude, longitude: locationInfrontOfUser.longitude)
-        return newLocation.isWithin(RouteControllerMaximumDistanceBeforeRecalculating, of: routeProgress.currentLegProgress.currentStep)
+        var radius = RouteControllerMaximumDistanceBeforeRecalculating
+        
+        if 0...RouteControllerMaximumDistanceBeforeRecalculating ~= location.horizontalAccuracy {
+            radius = location.horizontalAccuracy + RouteControllerHorizontalAccuracyAnomaly
+        }
+        
+        return newLocation.isWithin(radius, of: routeProgress.currentLegProgress.currentStep)
     }
     
     func monitorStepProgress(_ location: CLLocation) {


### PR DESCRIPTION
`userIsOnRoute(_:)` previously used a constant of 50 meters no matter what the horizontal accuracy was. This PR tweaks that by using a lower value if we know that the accuracy is lower than `RouteControllerMaximumDistanceBeforeRecalculating`.

This greatly improves off route detection for cycling and driving. It also improves the snap-to-route behavior.

@1ec5 @bsudekum 👀 
