### PR TITLE
Route simulation

### DIFF
--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -1,11 +1,3 @@
-//
-//  AppDelegate.swift
-//  Example-Swift
-//
-//  Created by Fredrik Karlsson on 2/22/17.
-//  Copyright © 2017 Mapbox. All rights reserved.
-//
-
 import UIKit
 import Mapbox
 

--- a/Examples/Swift/Base.lproj/Main.storyboard
+++ b/Examples/Swift/Base.lproj/Main.storyboard
@@ -5,6 +5,7 @@
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,16 +25,33 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Sl-bV-xyU">
-                                        <rect key="frame" x="132" y="615" width="111" height="30"/>
+                                        <rect key="frame" x="0.0" y="623" width="187.5" height="44"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.75" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="MYC-X6-san"/>
+                                        </constraints>
                                         <state key="normal" title="Start Navigation"/>
                                         <connections>
-                                            <action selector="didToggleNavigation:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gd6-mu-4Zl"/>
+                                            <action selector="didTapStartNavigation:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1ZD-3x-Irh"/>
                                         </connections>
                                     </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Long press map to select a route" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hk0-SM-2Wl">
-                                        <rect key="frame" x="62" y="619" width="251" height="21"/>
+                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KIU-cH-IXd">
+                                        <rect key="frame" x="187.5" y="623" width="187.5" height="44"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.75" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="R3B-3E-Ka9"/>
+                                        </constraints>
+                                        <state key="normal" title="Simulate Navigation"/>
+                                        <connections>
+                                            <action selector="didTapSimulateNavigation:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2pl-dE-TSM"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Long press to select a destination" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hk0-SM-2Wl">
+                                        <rect key="frame" x="0.0" y="623" width="375" height="44"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.75" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="D7X-rJ-g4m"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -42,10 +60,15 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <gestureRecognizers/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="Hk0-SM-2Wl" secondAttribute="bottom" constant="27" id="7Oc-HJ-zKe"/>
-                                    <constraint firstItem="8Sl-bV-xyU" firstAttribute="centerX" secondItem="A3N-JT-loC" secondAttribute="centerX" id="FIj-BC-6LP"/>
-                                    <constraint firstAttribute="bottom" secondItem="8Sl-bV-xyU" secondAttribute="bottom" constant="22" id="LOb-l9-Iql"/>
-                                    <constraint firstItem="Hk0-SM-2Wl" firstAttribute="centerX" secondItem="A3N-JT-loC" secondAttribute="centerX" id="O4U-Pg-RJR"/>
+                                    <constraint firstAttribute="bottom" secondItem="Hk0-SM-2Wl" secondAttribute="bottom" id="7Oc-HJ-zKe"/>
+                                    <constraint firstAttribute="bottom" secondItem="8Sl-bV-xyU" secondAttribute="bottom" id="LOb-l9-Iql"/>
+                                    <constraint firstItem="8Sl-bV-xyU" firstAttribute="width" secondItem="A3N-JT-loC" secondAttribute="width" multiplier="1:2" id="Pds-uP-zSB"/>
+                                    <constraint firstAttribute="trailing" secondItem="KIU-cH-IXd" secondAttribute="trailing" id="Q7E-HM-WIz"/>
+                                    <constraint firstAttribute="bottom" secondItem="KIU-cH-IXd" secondAttribute="bottom" id="TjN-pb-n3K"/>
+                                    <constraint firstItem="8Sl-bV-xyU" firstAttribute="leading" secondItem="A3N-JT-loC" secondAttribute="leading" id="dsN-v1-DQf"/>
+                                    <constraint firstItem="KIU-cH-IXd" firstAttribute="leading" secondItem="8Sl-bV-xyU" secondAttribute="trailing" id="q92-IP-Nlc"/>
+                                    <constraint firstAttribute="trailing" secondItem="Hk0-SM-2Wl" secondAttribute="trailing" id="qaa-r0-NSw"/>
+                                    <constraint firstItem="Hk0-SM-2Wl" firstAttribute="leading" secondItem="A3N-JT-loC" secondAttribute="leading" id="vRW-UT-mQD"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/streets-v10"/>
@@ -77,7 +100,8 @@
                     <connections>
                         <outlet property="howToBeginLabel" destination="Hk0-SM-2Wl" id="iU7-G1-DBc"/>
                         <outlet property="mapView" destination="A3N-JT-loC" id="iZS-hq-X5f"/>
-                        <outlet property="toggleNavigationButton" destination="8Sl-bV-xyU" id="LwJ-MX-oWU"/>
+                        <outlet property="simulateNavigationButton" destination="KIU-cH-IXd" id="Bdk-oG-55B"/>
+                        <outlet property="startNavigationButton" destination="8Sl-bV-xyU" id="t1d-SH-adQ"/>
                         <segue destination="dYn-UD-FHX" kind="presentation" identifier="StartNavigation" id="CX3-Eh-kHD"/>
                     </connections>
                 </viewController>

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -136,10 +136,14 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         // You can get a token here: http://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth-aws-identity-for-ios.html
         // viewController.voiceController?.identityPoolId = "<#Your AWS IdentityPoolId. Remove Argument if you do not want to use AWS Polly#>"
         
-        navigationViewController.routeController.snapsUserLocationAnnotationToRoute = true
-        navigationViewController.voiceController?.volume = 0.5
-        navigationViewController.navigationDelegate = self
-        navigationViewController.pendingCamera = mapView.camera
+        let camera = mapView.camera
+        camera.pitch = 45
+        camera.altitude = 1_000
+        
+        viewController.pendingCamera = camera
+        viewController.simulatesLocationUpdates = true
+        viewController.routeController.snapsUserLocationAnnotationToRoute = true
+        viewController.voiceController?.volume = 0.5
         
         present(navigationViewController, animated: true, completion: nil)
     }

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -53,11 +53,11 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
     }
     
     @IBAction func didTapStartNavigation(_ sender: Any) {
-        startNavigation(userRoute!)
+        startNavigation(along: userRoute!)
     }
     
     @IBAction func didTapSimulateNavigation(_ sender: Any) {
-        startNavigation(userRoute!, true)
+        startNavigation(along: userRoute!, simulatesLocationUpdates: true)
     }
     
     func resumeNotifications() {
@@ -132,7 +132,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         }
     }
     
-    func startNavigation(_ route: Route,_ simulatesLocationUpdates: Bool = false) {
+    func startNavigation(along route: Route, simulatesLocationUpdates: Bool = false) {
         // Pass through a
         // 1. the route the user will take
         // 2. A `Directions` class, used for rerouting.

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -14,13 +14,16 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
     var userRoute: Route?
     
     @IBOutlet weak var mapView: NavigationMapView!
-    @IBOutlet weak var toggleNavigationButton: UIButton!
+    @IBOutlet weak var startNavigationButton: UIButton!
+    @IBOutlet weak var simulateNavigationButton: UIButton!
     @IBOutlet weak var howToBeginLabel: UILabel!
     
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        automaticallyAdjustsScrollViewInsets = false
+        mapView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 44, right: 0)
         mapView.delegate = self
         mapView.navigationMapDelegate = self
         
@@ -49,8 +52,12 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         getRoute()
     }
     
-    @IBAction func didToggleNavigation(_ sender: Any) {
+    @IBAction func didTapStartNavigation(_ sender: Any) {
         startNavigation(userRoute!)
+    }
+    
+    @IBAction func didTapSimulateNavigation(_ sender: Any) {
+        startNavigation(userRoute!, true)
     }
     
     func resumeNotifications() {
@@ -114,9 +121,9 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
             }
             
             self?.userRoute = route
-            self?.toggleNavigationButton.isHidden = false
+            self?.startNavigationButton.isHidden = false
+            self?.simulateNavigationButton.isHidden = false
             self?.howToBeginLabel.isHidden = true
-            
             
             // Open method for adding and updating the route line
             self?.mapView.showRoute(route)
@@ -125,7 +132,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         }
     }
     
-    func startNavigation(_ route: Route) {
+    func startNavigation(_ route: Route,_ simulatesLocationUpdates: Bool = false) {
         // Pass through a
         // 1. the route the user will take
         // 2. A `Directions` class, used for rerouting.
@@ -136,14 +143,15 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         // You can get a token here: http://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth-aws-identity-for-ios.html
         // viewController.voiceController?.identityPoolId = "<#Your AWS IdentityPoolId. Remove Argument if you do not want to use AWS Polly#>"
         
+        navigationViewController.simulatesLocationUpdates = simulatesLocationUpdates
+        navigationViewController.routeController.snapsUserLocationAnnotationToRoute = true
+        navigationViewController.voiceController?.volume = 0.5
+        navigationViewController.navigationDelegate = self
+        
         let camera = mapView.camera
         camera.pitch = 45
         camera.altitude = 1_000
-        
-        viewController.pendingCamera = camera
-        viewController.simulatesLocationUpdates = true
-        viewController.routeController.snapsUserLocationAnnotationToRoute = true
-        viewController.voiceController?.volume = 0.5
+        navigationViewController.pendingCamera = camera
         
         present(navigationViewController, animated: true, completion: nil)
     }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -32,19 +32,23 @@ open class RouteController: NSObject {
     */
     public var snapsUserLocationAnnotationToRoute = false
     
+    var simulatesLocationUpdates: Bool = false
     
     /*
      Intializes a new `RouteController`.
      
      - parameter Route: A `Route` object representing the users route it will follow.
      */
-    public init(route: Route) {
+    public init(route: Route, simulatesLocationUpdates: Bool = false) {
         self.routeProgress = RouteProgress(route: route)
+        self.simulatesLocationUpdates = simulatesLocationUpdates
         super.init()
         
-        locationManager.delegate = self
-        if CLLocationManager.authorizationStatus() == .notDetermined {
-            locationManager.requestWhenInUseAuthorization()
+        if !simulatesLocationUpdates {
+            locationManager.delegate = self
+            if CLLocationManager.authorizationStatus() == .notDetermined {
+                locationManager.requestWhenInUseAuthorization()
+            }
         }
     }
     

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -32,23 +32,24 @@ open class RouteController: NSObject {
     */
     public var snapsUserLocationAnnotationToRoute = false
     
-    var simulatesLocationUpdates: Bool = false
+    public var simulatesLocationUpdates: Bool = false {
+        didSet {
+            locationManager.delegate = simulatesLocationUpdates ? nil : self
+        }
+    }
     
     /*
      Intializes a new `RouteController`.
      
      - parameter Route: A `Route` object representing the users route it will follow.
      */
-    public init(route: Route, simulatesLocationUpdates: Bool = false) {
+    public init(route: Route) {
         self.routeProgress = RouteProgress(route: route)
-        self.simulatesLocationUpdates = simulatesLocationUpdates
         super.init()
         
-        if !simulatesLocationUpdates {
-            locationManager.delegate = self
-            if CLLocationManager.authorizationStatus() == .notDetermined {
-                locationManager.requestWhenInUseAuthorization()
-            }
+        locationManager.delegate = self
+        if CLLocationManager.authorizationStatus() == .notDetermined {
+            locationManager.requestWhenInUseAuthorization()
         }
     }
     

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -89,7 +89,6 @@
 		359D00CF1E732D7100C2E770 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 354A01BC1E66259600D765C2 /* Polyline.framework */; };
 		35B711D21E5E7AD2001EDA8D /* MapboxNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B711D11E5E7AD2001EDA8D /* MapboxNavigationTests.swift */; };
 		35B711D41E5E7AD2001EDA8D /* MapboxNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */; };
-		35B7911C1E9CF99400565600 /* Simulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B7911A1E9CDDA500565600 /* Simulation.swift */; };
 		35B839491E2E3D5D0045A868 /* MBRouteController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B839481E2E3D5D0045A868 /* MBRouteController.m */; };
 		35C6A35B1E5E418D0004CA57 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C6A34D1E5E418D0004CA57 /* ViewController.m */; };
 		35C9973F1E732C1B00544D1C /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */; };
@@ -98,6 +97,7 @@
 		35D825FB1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35D825FC1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */; };
 		35D825FE1E6A2EC60088F83B /* MapboxNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35EC316D1EA64057004280F5 /* SimulatedRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35EC316C1EA64057004280F5 /* SimulatedRoute.swift */; };
 		C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52AC1251DF0E48600396B9F /* RouteProgressTests.swift */; };
 		C52D09CC1DEF444D00BE3C5C /* GeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09CB1DEF444D00BE3C5C /* GeometryTests.swift */; };
 		C52D09CE1DEF5E5100BE3C5C /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
@@ -295,7 +295,6 @@
 		35B711CF1E5E7AD2001EDA8D /* MapboxNavigationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxNavigationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		35B711D11E5E7AD2001EDA8D /* MapboxNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxNavigationTests.swift; sourceTree = "<group>"; };
 		35B711D31E5E7AD2001EDA8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		35B7911A1E9CDDA500565600 /* Simulation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Simulation.swift; sourceTree = "<group>"; };
 		35B839481E2E3D5D0045A868 /* MBRouteController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBRouteController.m; sourceTree = "<group>"; };
 		35C6A3461E5E418D0004CA57 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		35C6A3471E5E418D0004CA57 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -307,6 +306,7 @@
 		35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLMapView+MGLNavigationAdditions.h"; sourceTree = "<group>"; };
 		35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLMapView+MGLNavigationAdditions.m"; sourceTree = "<group>"; };
 		35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MapboxNavigation.h; sourceTree = "<group>"; };
+		35EC316C1EA64057004280F5 /* SimulatedRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimulatedRoute.swift; sourceTree = "<group>"; };
 		C52AC1251DF0E48600396B9F /* RouteProgressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteProgressTests.swift; sourceTree = "<group>"; };
 		C52D09CB1DEF444D00BE3C5C /* GeometryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeometryTests.swift; sourceTree = "<group>"; };
 		C52D09CD1DEF5E5100BE3C5C /* route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = route.json; sourceTree = "<group>"; };
@@ -432,35 +432,21 @@
 		351BEBD81E5BCC28006FE110 /* MapboxNavigation */ = {
 			isa = PBXGroup;
 			children = (
-				35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */,
-				35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */,
-				35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */,
-				351BEC081E5BCC72006FE110 /* Bundle.swift */,
-				351BEC091E5BCC72006FE110 /* DashedLineView.swift */,
-				351BEC0A1E5BCC72006FE110 /* Directions.swift */,
+				C51923B41EA55C5E002AF9E1 /* Extensions */,
+				C51923B71EA58D28002AF9E1 /* RouteTableView */,
+				351BEC201E5BD4DC006FE110 /* Supporting files */,
+				C51923B51EA55CD4002AF9E1 /* Views */,
 				351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */,
-				351BEC031E5BCC6C006FE110 /* LaneArrowView.swift */,
-				351BEC041E5BCC6C006FE110 /* ManeuverDirection.swift */,
-				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
+				35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */,
+				C53208AA1E81FFB900910266 /* NavigationMapView.swift */,
 				351BEBE01E5BCC63006FE110 /* NavigationUI.swift */,
+				351BEBEA1E5BCC63006FE110 /* NavigationViewController.swift */,
 				351BEBE31E5BCC63006FE110 /* RouteManeuverViewController.swift */,
-				35C997401E732C5400544D1C /* RouteStepFormatter.swift */,
 				351BEBE41E5BCC63006FE110 /* RouteMapViewController.swift */,
 				351BEBE51E5BCC63006FE110 /* RoutePageViewController.swift */,
-				351BEBE71E5BCC63006FE110 /* RouteTableViewCell.swift */,
-				351BEBE81E5BCC63006FE110 /* RouteTableViewController.swift */,
-				351BEBE91E5BCC63006FE110 /* RouteTableViewHeaderView.swift */,
-				351BEBEA1E5BCC63006FE110 /* NavigationViewController.swift */,
+				35C997401E732C5400544D1C /* RouteStepFormatter.swift */,
 				35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */,
-				35B7911A1E9CDDA500565600 /* Simulation.swift */,
-				351BEBEB1E5BCC63006FE110 /* String.swift */,
-				351BEBEC1E5BCC63006FE110 /* StyleButton.swift */,
-				351BEBED1E5BCC63006FE110 /* StyleKitArrows.swift */,
-				351BEBEE1E5BCC63006FE110 /* StyleLabel.swift */,
-				351BEC201E5BD4DC006FE110 /* Supporting files */,
-				351BEBEF1E5BCC63006FE110 /* TurnArrowView.swift */,
-				351BEBF01E5BCC63006FE110 /* UIView.swift */,
-				C53208AA1E81FFB900910266 /* NavigationMapView.swift */,
+				35EC316C1EA64057004280F5 /* SimulatedRoute.swift */,
 			);
 			path = MapboxNavigation;
 			sourceTree = "<group>";
@@ -564,6 +550,44 @@
 				35A1D3651E6624EF00A48FE8 /* Mapbox.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C51923B41EA55C5E002AF9E1 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				351BEC081E5BCC72006FE110 /* Bundle.swift */,
+				351BEC0A1E5BCC72006FE110 /* Directions.swift */,
+				351BEC041E5BCC6C006FE110 /* ManeuverDirection.swift */,
+				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
+				35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */,
+				35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */,
+				351BEBEB1E5BCC63006FE110 /* String.swift */,
+				351BEBF01E5BCC63006FE110 /* UIView.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		C51923B51EA55CD4002AF9E1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				351BEC091E5BCC72006FE110 /* DashedLineView.swift */,
+				351BEC031E5BCC6C006FE110 /* LaneArrowView.swift */,
+				351BEBEC1E5BCC63006FE110 /* StyleButton.swift */,
+				351BEBED1E5BCC63006FE110 /* StyleKitArrows.swift */,
+				351BEBEE1E5BCC63006FE110 /* StyleLabel.swift */,
+				351BEBEF1E5BCC63006FE110 /* TurnArrowView.swift */,
+			);
+			name = Views;
+			sourceTree = "<group>";
+		};
+		C51923B71EA58D28002AF9E1 /* RouteTableView */ = {
+			isa = PBXGroup;
+			children = (
+				351BEBE71E5BCC63006FE110 /* RouteTableViewCell.swift */,
+				351BEBE81E5BCC63006FE110 /* RouteTableViewController.swift */,
+				351BEBE91E5BCC63006FE110 /* RouteTableViewHeaderView.swift */,
+			);
+			name = RouteTableView;
 			sourceTree = "<group>";
 		};
 		C52D09CF1DEF5E5F00BE3C5C /* Fixtures */ = {
@@ -1044,10 +1068,10 @@
 				351BEC0F1E5BCC72006FE110 /* Directions.swift in Sources */,
 				35C997411E732C5400544D1C /* RouteStepFormatter.swift in Sources */,
 				351BEBFB1E5BCC63006FE110 /* RouteTableViewHeaderView.swift in Sources */,
+				35EC316D1EA64057004280F5 /* SimulatedRoute.swift in Sources */,
 				C53208AB1E81FFB900910266 /* NavigationMapView.swift in Sources */,
 				351BEBF61E5BCC63006FE110 /* RouteMapViewController.swift in Sources */,
 				351BEBF51E5BCC63006FE110 /* RouteManeuverViewController.swift in Sources */,
-				35B7911C1E9CF99400565600 /* Simulation.swift in Sources */,
 				351BEC011E5BCC63006FE110 /* TurnArrowView.swift in Sources */,
 				351BEBFA1E5BCC63006FE110 /* RouteTableViewController.swift in Sources */,
 				351BEC101E5BCC72006FE110 /* DistanceFormatter.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		359D00CF1E732D7100C2E770 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 354A01BC1E66259600D765C2 /* Polyline.framework */; };
 		35B711D21E5E7AD2001EDA8D /* MapboxNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B711D11E5E7AD2001EDA8D /* MapboxNavigationTests.swift */; };
 		35B711D41E5E7AD2001EDA8D /* MapboxNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */; };
+		35B7911C1E9CF99400565600 /* Simulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B7911A1E9CDDA500565600 /* Simulation.swift */; };
 		35B839491E2E3D5D0045A868 /* MBRouteController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B839481E2E3D5D0045A868 /* MBRouteController.m */; };
 		35C6A35B1E5E418D0004CA57 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C6A34D1E5E418D0004CA57 /* ViewController.m */; };
 		35C9973F1E732C1B00544D1C /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */; };
@@ -294,6 +295,7 @@
 		35B711CF1E5E7AD2001EDA8D /* MapboxNavigationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxNavigationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		35B711D11E5E7AD2001EDA8D /* MapboxNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxNavigationTests.swift; sourceTree = "<group>"; };
 		35B711D31E5E7AD2001EDA8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		35B7911A1E9CDDA500565600 /* Simulation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Simulation.swift; sourceTree = "<group>"; };
 		35B839481E2E3D5D0045A868 /* MBRouteController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBRouteController.m; sourceTree = "<group>"; };
 		35C6A3461E5E418D0004CA57 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		35C6A3471E5E418D0004CA57 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -430,20 +432,35 @@
 		351BEBD81E5BCC28006FE110 /* MapboxNavigation */ = {
 			isa = PBXGroup;
 			children = (
-				C51923B41EA55C5E002AF9E1 /* Extensions */,
-				C51923B71EA58D28002AF9E1 /* RouteTableView */,
-				351BEC201E5BD4DC006FE110 /* Supporting files */,
-				C51923B51EA55CD4002AF9E1 /* Views */,
-				351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */,
 				35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */,
-				C53208AA1E81FFB900910266 /* NavigationMapView.swift */,
+				35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */,
+				35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */,
+				351BEC081E5BCC72006FE110 /* Bundle.swift */,
+				351BEC091E5BCC72006FE110 /* DashedLineView.swift */,
+				351BEC0A1E5BCC72006FE110 /* Directions.swift */,
+				351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */,
+				351BEC031E5BCC6C006FE110 /* LaneArrowView.swift */,
+				351BEC041E5BCC6C006FE110 /* ManeuverDirection.swift */,
+				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
 				351BEBE01E5BCC63006FE110 /* NavigationUI.swift */,
-				351BEBEA1E5BCC63006FE110 /* NavigationViewController.swift */,
 				351BEBE31E5BCC63006FE110 /* RouteManeuverViewController.swift */,
+				35C997401E732C5400544D1C /* RouteStepFormatter.swift */,
 				351BEBE41E5BCC63006FE110 /* RouteMapViewController.swift */,
 				351BEBE51E5BCC63006FE110 /* RoutePageViewController.swift */,
-				35C997401E732C5400544D1C /* RouteStepFormatter.swift */,
+				351BEBE71E5BCC63006FE110 /* RouteTableViewCell.swift */,
+				351BEBE81E5BCC63006FE110 /* RouteTableViewController.swift */,
+				351BEBE91E5BCC63006FE110 /* RouteTableViewHeaderView.swift */,
+				351BEBEA1E5BCC63006FE110 /* NavigationViewController.swift */,
 				35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */,
+				35B7911A1E9CDDA500565600 /* Simulation.swift */,
+				351BEBEB1E5BCC63006FE110 /* String.swift */,
+				351BEBEC1E5BCC63006FE110 /* StyleButton.swift */,
+				351BEBED1E5BCC63006FE110 /* StyleKitArrows.swift */,
+				351BEBEE1E5BCC63006FE110 /* StyleLabel.swift */,
+				351BEC201E5BD4DC006FE110 /* Supporting files */,
+				351BEBEF1E5BCC63006FE110 /* TurnArrowView.swift */,
+				351BEBF01E5BCC63006FE110 /* UIView.swift */,
+				C53208AA1E81FFB900910266 /* NavigationMapView.swift */,
 			);
 			path = MapboxNavigation;
 			sourceTree = "<group>";
@@ -547,44 +564,6 @@
 				35A1D3651E6624EF00A48FE8 /* Mapbox.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		C51923B41EA55C5E002AF9E1 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				351BEC081E5BCC72006FE110 /* Bundle.swift */,
-				351BEC0A1E5BCC72006FE110 /* Directions.swift */,
-				351BEC041E5BCC6C006FE110 /* ManeuverDirection.swift */,
-				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
-				35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */,
-				35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */,
-				351BEBEB1E5BCC63006FE110 /* String.swift */,
-				351BEBF01E5BCC63006FE110 /* UIView.swift */,
-			);
-			name = Extensions;
-			sourceTree = "<group>";
-		};
-		C51923B51EA55CD4002AF9E1 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				351BEC091E5BCC72006FE110 /* DashedLineView.swift */,
-				351BEC031E5BCC6C006FE110 /* LaneArrowView.swift */,
-				351BEBEC1E5BCC63006FE110 /* StyleButton.swift */,
-				351BEBED1E5BCC63006FE110 /* StyleKitArrows.swift */,
-				351BEBEE1E5BCC63006FE110 /* StyleLabel.swift */,
-				351BEBEF1E5BCC63006FE110 /* TurnArrowView.swift */,
-			);
-			name = Views;
-			sourceTree = "<group>";
-		};
-		C51923B71EA58D28002AF9E1 /* RouteTableView */ = {
-			isa = PBXGroup;
-			children = (
-				351BEBE71E5BCC63006FE110 /* RouteTableViewCell.swift */,
-				351BEBE81E5BCC63006FE110 /* RouteTableViewController.swift */,
-				351BEBE91E5BCC63006FE110 /* RouteTableViewHeaderView.swift */,
-			);
-			name = RouteTableView;
 			sourceTree = "<group>";
 		};
 		C52D09CF1DEF5E5F00BE3C5C /* Fixtures */ = {
@@ -1068,6 +1047,7 @@
 				C53208AB1E81FFB900910266 /* NavigationMapView.swift in Sources */,
 				351BEBF61E5BCC63006FE110 /* RouteMapViewController.swift in Sources */,
 				351BEBF51E5BCC63006FE110 /* RouteManeuverViewController.swift in Sources */,
+				35B7911C1E9CF99400565600 /* Simulation.swift in Sources */,
 				351BEC011E5BCC63006FE110 /* TurnArrowView.swift in Sources */,
 				351BEBFA1E5BCC63006FE110 /* RouteTableViewController.swift in Sources */,
 				351BEC101E5BCC72006FE110 /* DistanceFormatter.swift in Sources */,

--- a/MapboxNavigation/MGLMapView+MGLNavigationAdditions.h
+++ b/MapboxNavigation/MGLMapView+MGLNavigationAdditions.h
@@ -3,6 +3,8 @@
 @interface MGLMapView (MGLNavigationAdditions) <CLLocationManagerDelegate>
 
 // FIXME: This will be removed once https://github.com/mapbox/mapbox-gl-native/issues/6867 is implemented
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations;
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations;
+
+@property (nonatomic, readonly) CLLocationManager *locationManager;
 
 @end

--- a/MapboxNavigation/MGLMapView+MGLNavigationAdditions.m
+++ b/MapboxNavigation/MGLMapView+MGLNavigationAdditions.m
@@ -2,4 +2,6 @@
 
 @implementation MGLMapView (MGLNavigationAdditions)
 
+@dynamic locationManager;
+
 @end

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -11,8 +11,8 @@ open class NavigationMapView: MGLMapView {
     
     public weak var navigationMapDelegate: NavigationMapViewDelegate?
     
-    open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [Any]!) {
-        guard let location = locations.first as? CLLocation else { return }
+    open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [CLLocation]!) {
+        guard let location = locations.first else { return }
         
         if let modifiedLocation = navigationMapDelegate?.navigationMapView?(self, shouldUpdateTo: location) {
             super.locationManager(manager, didUpdateLocations: [modifiedLocation])

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -392,7 +392,7 @@ extension NavigationViewController: PulleyDelegate {
     }
 }
 
-extension RouteViewController: SimulationDelegate {
+extension NavigationViewController: SimulatedRouteDelegate {
     func simulation(_ locationManager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         mapViewController?.mapView.locationManager(locationManager, didUpdateLocations: locations)
         routeController.locationManager(locationManager, didUpdateLocations: locations)

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -110,7 +110,11 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     /**
      `simulate` provides simulated location updates along the given route.
      */
-    public var simulatesLocationUpdates: Bool = false
+    public var simulatesLocationUpdates: Bool = false {
+        didSet {
+            routeController.simulatesLocationUpdates = simulatesLocationUpdates
+        }
+    }
     
     /**
      `mapView` provides access to the navigation's `MGLMapView` with all its styling capabilities.
@@ -332,7 +336,8 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     
     func setupRouteController() {
         if routeController == nil {
-            routeController = RouteController(route: route, simulatesLocationUpdates: simulatesLocationUpdates)
+            routeController = RouteController(route: route)
+            routeController.simulatesLocationUpdates = simulatesLocationUpdates
             
             if Bundle.main.backgroundModeLocationSupported {
                 routeController.locationManager.activityType = .automotiveNavigation

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -40,6 +40,11 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     var shieldImageDownloadToken: SDWebImageDownloadToken?
     var arrowCurrentStep: RouteStep?
     
+    var simulatesLocationUpdates: Bool {
+        guard let parent = parent as? RouteViewController else { return false }
+        return parent.simulatesLocationUpdates
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         automaticallyAdjustsScrollViewInsets = false
@@ -74,6 +79,11 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
         
         mapView.setUserLocationVerticalAlignment(.bottom, animated: false)
         mapView.setUserTrackingMode(.followWithCourse, animated: false)
+        
+        if simulatesLocationUpdates {
+            mapView.locationManager.stopUpdatingLocation()
+            mapView.locationManager.stopUpdatingHeading()
+        }
         
         let topPadding: CGFloat = 30
         let bottomPadding: CGFloat = 50

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -41,7 +41,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     var arrowCurrentStep: RouteStep?
     
     var simulatesLocationUpdates: Bool {
-        guard let parent = parent as? RouteViewController else { return false }
+        guard let parent = parent as? NavigationViewController else { return false }
         return parent.simulatesLocationUpdates
     }
     

--- a/MapboxNavigation/SimulatedRoute.swift
+++ b/MapboxNavigation/SimulatedRoute.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreLocation
 
-protocol SimulationDelegate : class {
+protocol SimulatedRouteDelegate : class {
     func simulation(_ locationManager: CLLocationManager, didUpdateLocations locations: [CLLocation])
 }
 
@@ -19,7 +19,7 @@ class SimulatedRoute : NSObject {
     
     let locationManager = CLLocationManager()
     
-    weak var delegate: SimulationDelegate?
+    weak var delegate: SimulatedRouteDelegate?
     
     convenience init(_ polyline: [CLLocationCoordinate2D]) {
         self.init()

--- a/MapboxNavigation/SimulatedRoute.swift
+++ b/MapboxNavigation/SimulatedRoute.swift
@@ -7,7 +7,7 @@ protocol SimulatedRouteDelegate : class {
 
 class SimulatedRoute : NSObject {
     
-    var speed: CLLocationSpeed = 10
+    var speed: CLLocationSpeed = 30
     
     var distanceFilter: CLLocationDistance = 10
     

--- a/MapboxNavigation/SimulatedRoute.swift
+++ b/MapboxNavigation/SimulatedRoute.swift
@@ -58,7 +58,7 @@ class SimulatedRoute : NSObject {
         guard locations.count > 0 else { return }
         let location = locations[0]
         
-        delegate?.simulation(locationManager, didUpdateLocations: [location.shifted(Date())])
+        delegate?.simulation(locationManager, didUpdateLocations: [location.shifted(to: Date())])
         
         if (locations.count > 1) {
             let nextLocation = locations[1]
@@ -77,13 +77,13 @@ class SimulatedRoute : NSObject {
 }
 
 extension CLLocation {
-    func shifted(_ to: Date) -> CLLocation {
+    func shifted(to shiftedTimestamp: Date) -> CLLocation {
         return CLLocation(coordinate: coordinate,
                           altitude: altitude,
                           horizontalAccuracy: horizontalAccuracy,
                           verticalAccuracy: verticalAccuracy,
                           course: course,
                           speed: speed,
-                          timestamp: to)
+                          timestamp: shiftedTimestamp)
     }
 }

--- a/MapboxNavigation/Simulation.swift
+++ b/MapboxNavigation/Simulation.swift
@@ -1,0 +1,89 @@
+import Foundation
+import CoreLocation
+
+protocol SimulationDelegate : class {
+    func simulation(_ locationManager: CLLocationManager, didUpdateLocations locations: [CLLocation])
+}
+
+class SimulatedRoute : NSObject {
+    
+    var speed: CLLocationSpeed = 10
+    
+    var distanceFilter: CLLocationDistance = 10
+    
+    var verticalAccuracy: CLLocationAccuracy = 40
+    
+    var horizontalAccuracy: CLLocationAccuracy = 40
+    
+    var locations = [CLLocation]()
+    
+    let locationManager = CLLocationManager()
+    
+    weak var delegate: SimulationDelegate?
+    
+    convenience init(_ polyline: [CLLocationCoordinate2D]) {
+        self.init()
+        
+        let totalDistance = distance(along: polyline)
+        let stops = UInt(totalDistance / distanceFilter)
+        let distancePerStop = totalDistance / Double(stops)
+        
+        for index in 0...stops {
+            let distance = CLLocationDistance(UInt(distanceFilter) * (index + 1))
+            var course: CLLocationDegrees = 0
+            let newCoordinate = coordinate(at: distance, fromStartOf: polyline)
+            guard let currentCoordinate = newCoordinate else { continue }
+            
+            if let nextCoordinate = coordinate(at: distance + distanceFilter, fromStartOf: polyline) {
+                course = currentCoordinate.direction(to: nextCoordinate)
+            }
+            
+            let timestamp = Date(timeIntervalSince1970: (distancePerStop / speed) * Double(index))
+            let location = CLLocation(coordinate: currentCoordinate,
+                                      altitude: 0,
+                                      horizontalAccuracy: horizontalAccuracy,
+                                      verticalAccuracy: verticalAccuracy,
+                                      course: course,
+                                      speed: speed,
+                                      timestamp: timestamp)
+            locations.append(location)
+        }
+    }
+    
+    func start() {
+        tick()
+    }
+    
+    @objc fileprivate func tick() {
+        guard locations.count > 0 else { return }
+        let location = locations[0]
+        
+        delegate?.simulation(locationManager, didUpdateLocations: [location.shifted(Date())])
+        
+        if (locations.count > 1) {
+            let nextLocation = locations[1]
+            let delay = nextLocation.timestamp.timeIntervalSince(location.timestamp)
+            perform(#selector(tick), with: nil, afterDelay: delay)
+        } else {
+            // Simulation finished
+        }
+        
+        locations.remove(at: 0)
+    }
+    
+    func stop() {
+        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(tick), object: nil)
+    }
+}
+
+extension CLLocation {
+    func shifted(_ to: Date) -> CLLocation {
+        return CLLocation(coordinate: coordinate,
+                          altitude: altitude,
+                          horizontalAccuracy: horizontalAccuracy,
+                          verticalAccuracy: verticalAccuracy,
+                          course: course,
+                          speed: speed,
+                          timestamp: to)
+    }
+}


### PR DESCRIPTION
This PR adds support for simulating location updates.
Just set `RouteViewController.simulate` to true and the given route's coordinates will be used for simulation.

The route can be archived for offline use cases.

@bsudekum @1ec5 👀 