### PR TITLE
Make route line more configurable

### DIFF
--- a/MapboxNavigationUI/MGLMapView.swift
+++ b/MapboxNavigationUI/MGLMapView.swift
@@ -12,61 +12,6 @@ let arrowLayerIdentifier = "arrowLayer"
 
 extension MGLMapView {
     
-    public func annotate(_ route: Route) {
-        guard var coordinates = route.coordinates else {
-            return
-        }
-        
-        guard let style = style else {
-            return
-        }
-        
-        if let line = style.layer(withIdentifier: routeLayerIdentifier) {
-            style.removeLayer(line)
-        }
-        
-        if let lineCasing = style.layer(withIdentifier: routeLayerCasingIdentifier) {
-            style.removeLayer(lineCasing)
-        }
-        
-        if let source = style.source(withIdentifier: sourceIdentifier) {
-            style.removeSource(source)
-        }
-        
-        let polyline = MGLPolylineFeature(coordinates: &coordinates, count: route.coordinateCount)
-        
-        if let source = style.source(withIdentifier: sourceIdentifier) as? MGLShapeSource {
-            source.shape = polyline
-        } else {
-            let geoJSONSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
-            let line = MGLLineStyleLayer(identifier: routeLayerIdentifier, source: geoJSONSource)
-            let lineCasing = MGLLineStyleLayer(identifier: routeLayerCasingIdentifier, source: geoJSONSource)
-            
-            line.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor.withAlphaComponent(0.6))
-            line.lineWidth = MGLStyleValue(rawValue: 5)
-            lineCasing.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor)
-            lineCasing.lineWidth = MGLStyleValue(rawValue: 9)
-            
-            let cap = NSValue(mglLineCap: .round)
-            let join = NSValue(mglLineJoin: .round)
-            
-            line.lineCap = MGLStyleValue(rawValue: cap)
-            line.lineJoin = MGLStyleValue(rawValue: join)
-            lineCasing.lineCap = MGLStyleValue(rawValue: cap)
-            lineCasing.lineJoin = MGLStyleValue(rawValue: join)
-            
-            style.addSource(geoJSONSource)
-            for layer in style.layers.reversed() {
-                if let layer = layer as? MGLStyleLayer, !(layer is MGLSymbolStyleLayer) &&
-                    layer.identifier != arrowLayerIdentifier && layer.identifier != arrowSourceIdentifier {
-                    style.insertLayer(line, above: layer)
-                    style.insertLayer(lineCasing, below: line)
-                    return
-                }
-            }
-        }
-    }
-    
     public var showsTraffic: Bool {
         get {
             if let style = style {

--- a/MapboxNavigationUI/NavigationMapView.swift
+++ b/MapboxNavigationUI/NavigationMapView.swift
@@ -1,10 +1,14 @@
 import Foundation
+import MapboxDirections
 
-public class NavigationMapView: MGLMapView {
+open class NavigationMapView: MGLMapView {
     
     var navigationMapDelegate: NavigationMapViewDelegate?
     
-    public override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [Any]!) {
+    let cap = NSValue(mglLineCap: .round)
+    let join = NSValue(mglLineJoin: .round)
+    
+    open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [Any]!) {
         guard let location = locations.first as? CLLocation else { return }
         
         if let modifiedLocation = navigationMapDelegate?.navigationMapView(self, shouldUpdateTo: location) {
@@ -12,5 +16,78 @@ public class NavigationMapView: MGLMapView {
         } else {
             super.locationManager(manager, didUpdateLocations: locations)
         }
+    }
+    
+    public func annotate(_ route: Route) {
+        guard let style = style else {
+            return
+        }
+        
+        if let line = style.layer(withIdentifier: routeLayerIdentifier) {
+            style.removeLayer(line)
+        }
+        
+        if let lineCasing = style.layer(withIdentifier: routeLayerCasingIdentifier) {
+            style.removeLayer(lineCasing)
+        }
+        
+        if let source = style.source(withIdentifier: sourceIdentifier) {
+            style.removeSource(source)
+        }
+        
+        let polyline = shape(for: route)
+        
+        if let source = style.source(withIdentifier: sourceIdentifier) as? MGLShapeSource {
+            source.shape = polyline
+        } else {
+            let geoJSONSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
+            style.addSource(geoJSONSource)
+            
+            let line = lineStyle(MGLLineStyleLayer(identifier: routeLayerIdentifier, source: geoJSONSource))
+            let lineCasing = lineCasingStyle(MGLLineStyleLayer(identifier: routeLayerCasingIdentifier, source: geoJSONSource))
+            
+            for layer in style.layers.reversed() {
+                if !(layer is MGLSymbolStyleLayer) &&
+                    layer.identifier != arrowLayerIdentifier && layer.identifier != arrowSourceIdentifier {
+                    style.insertLayer(line, above: layer)
+                    style.insertLayer(lineCasing, below: line)
+                    return
+                }
+            }
+        }
+    }
+    
+    public func shape(for route: Route) -> MGLShape? {
+        guard var coordinates = route.coordinates else {
+            return nil
+        }
+        
+        return MGLPolylineFeature(coordinates: &coordinates, count: route.coordinateCount)
+    }
+    
+    public func lineStyle(_ line: MGLLineStyleLayer) -> MGLLineStyleLayer {
+        let cap = NSValue(mglLineCap: .round)
+        let join = NSValue(mglLineJoin: .round)
+        
+        line.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor.withAlphaComponent(0.6))
+        line.lineWidth = MGLStyleValue(rawValue: 5)
+        
+        line.lineCap = MGLStyleValue(rawValue: cap)
+        line.lineJoin = MGLStyleValue(rawValue: join)
+        
+        return line
+    }
+    
+    public func lineCasingStyle(_ lineCasing: MGLLineStyleLayer) -> MGLLineStyleLayer {
+        let cap = NSValue(mglLineCap: .round)
+        let join = NSValue(mglLineJoin: .round)
+        
+        lineCasing.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor)
+        lineCasing.lineWidth = MGLStyleValue(rawValue: 9)
+        
+        lineCasing.lineCap = MGLStyleValue(rawValue: cap)
+        lineCasing.lineJoin = MGLStyleValue(rawValue: join)
+        
+        return lineCasing
     }
 }

--- a/MapboxNavigationUI/NavigationMapView.swift
+++ b/MapboxNavigationUI/NavigationMapView.swift
@@ -15,7 +15,10 @@ open class NavigationMapView: MGLMapView {
         }
     }
     
-    public func annotate(_ route: Route) {
+    /**
+     Annotates the map with a route line.
+     */
+    open func annotate(_ route: Route) {
         guard let style = style else {
             return
         }
@@ -54,7 +57,7 @@ open class NavigationMapView: MGLMapView {
         }
     }
     
-    public func shape(describing route: Route) -> MGLShape? {
+    open func shape(describing route: Route) -> MGLShape? {
         guard var coordinates = route.coordinates else {
             return nil
         }
@@ -62,7 +65,10 @@ open class NavigationMapView: MGLMapView {
         return MGLPolylineFeature(coordinates: &coordinates, count: route.coordinateCount)
     }
     
-    public func routeStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
+    /**
+     Function for overriding the default route line style.
+     */
+    open func routeStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
         
         let line = MGLLineStyleLayer(identifier: identifier, source: source)
         
@@ -75,7 +81,10 @@ open class NavigationMapView: MGLMapView {
         return line
     }
     
-    public func routeCasingStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
+    /**
+     Function for overriding the default route line casing style.
+     */
+    open func routeCasingStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
         
         let lineCasing = MGLLineStyleLayer(identifier: identifier, source: source)
         

--- a/MapboxNavigationUI/NavigationMapView.swift
+++ b/MapboxNavigationUI/NavigationMapView.swift
@@ -5,9 +5,6 @@ open class NavigationMapView: MGLMapView {
     
     var navigationMapDelegate: NavigationMapViewDelegate?
     
-    let cap = NSValue(mglLineCap: .round)
-    let join = NSValue(mglLineJoin: .round)
-    
     open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [Any]!) {
         guard let location = locations.first as? CLLocation else { return }
         
@@ -35,16 +32,16 @@ open class NavigationMapView: MGLMapView {
             style.removeSource(source)
         }
         
-        let polyline = shape(for: route)
+        let polyline = shape(describing: route)
         
         if let source = style.source(withIdentifier: sourceIdentifier) as? MGLShapeSource {
             source.shape = polyline
         } else {
-            let geoJSONSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
-            style.addSource(geoJSONSource)
+            let lineSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
+            style.addSource(lineSource)
             
-            let line = lineStyle(MGLLineStyleLayer(identifier: routeLayerIdentifier, source: geoJSONSource))
-            let lineCasing = lineCasingStyle(MGLLineStyleLayer(identifier: routeLayerCasingIdentifier, source: geoJSONSource))
+            let line = routeStyleLayer(identifier: routeLayerIdentifier, source: lineSource)
+            let lineCasing = routeCasingStyleLayer(identifier: routeLayerCasingIdentifier, source: lineSource)
             
             for layer in style.layers.reversed() {
                 if !(layer is MGLSymbolStyleLayer) &&
@@ -57,7 +54,7 @@ open class NavigationMapView: MGLMapView {
         }
     }
     
-    public func shape(for route: Route) -> MGLShape? {
+    public func shape(describing route: Route) -> MGLShape? {
         guard var coordinates = route.coordinates else {
             return nil
         }
@@ -65,28 +62,28 @@ open class NavigationMapView: MGLMapView {
         return MGLPolylineFeature(coordinates: &coordinates, count: route.coordinateCount)
     }
     
-    public func lineStyle(_ line: MGLLineStyleLayer) -> MGLLineStyleLayer {
-        let cap = NSValue(mglLineCap: .round)
-        let join = NSValue(mglLineJoin: .round)
+    public func routeStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
+        
+        let line = MGLLineStyleLayer(identifier: identifier, source: source)
         
         line.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor.withAlphaComponent(0.6))
         line.lineWidth = MGLStyleValue(rawValue: 5)
         
-        line.lineCap = MGLStyleValue(rawValue: cap)
-        line.lineJoin = MGLStyleValue(rawValue: join)
+        line.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
+        line.lineJoin = MGLStyleValue(rawValue: NSValue(mglLineJoin: .round))
         
         return line
     }
     
-    public func lineCasingStyle(_ lineCasing: MGLLineStyleLayer) -> MGLLineStyleLayer {
-        let cap = NSValue(mglLineCap: .round)
-        let join = NSValue(mglLineJoin: .round)
+    public func routeCasingStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
+        
+        let lineCasing = MGLLineStyleLayer(identifier: identifier, source: source)
         
         lineCasing.lineColor = MGLStyleValue(rawValue: NavigationUI.shared.tintStrokeColor)
         lineCasing.lineWidth = MGLStyleValue(rawValue: 9)
         
-        lineCasing.lineCap = MGLStyleValue(rawValue: cap)
-        lineCasing.lineJoin = MGLStyleValue(rawValue: join)
+        lineCasing.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
+        lineCasing.lineJoin = MGLStyleValue(rawValue: NSValue(mglLineJoin: .round))
         
         return lineCasing
     }

--- a/MapboxNavigationUI/RouteMapViewController.swift
+++ b/MapboxNavigationUI/RouteMapViewController.swift
@@ -321,7 +321,8 @@ extension RouteMapViewController: MGLMapViewDelegate {
     }
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
-        mapView.annotate(route)
+        let map = mapView as! NavigationMapView
+        map.annotate(route)
     }
     
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {


### PR DESCRIPTION
This makes the annotate not only public, but also overrideable. This way, developers can specify a custom source for route line and also styling for it too.

/cc @1ec5 @frederoni 