### PR TITLE
Fix memory leaks

### DIFF
--- a/MapboxNavigationUI/MGLMapView.swift
+++ b/MapboxNavigationUI/MGLMapView.swift
@@ -121,6 +121,6 @@ extension MGLMapView {
     }
 }
 
-protocol NavigationMapViewDelegate {
+protocol NavigationMapViewDelegate: class  {
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
 }

--- a/MapboxNavigationUI/NavigationMapView.swift
+++ b/MapboxNavigationUI/NavigationMapView.swift
@@ -3,7 +3,7 @@ import MapboxDirections
 
 open class NavigationMapView: MGLMapView {
     
-    var navigationMapDelegate: NavigationMapViewDelegate?
+    weak var navigationMapDelegate: NavigationMapViewDelegate?
     
     open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [Any]!) {
         guard let location = locations.first as? CLLocation else { return }

--- a/MapboxNavigationUI/RoutePageViewController.swift
+++ b/MapboxNavigationUI/RoutePageViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import MapboxDirections
 import MapboxNavigation
 
-protocol RoutePageViewControllerDelegate {
+protocol RoutePageViewControllerDelegate: class {
     func currentStep() -> RouteStep
     func stepBefore(_ step: RouteStep) -> RouteStep?
     func stepAfter(_ step: RouteStep) -> RouteStep?
@@ -11,7 +11,7 @@ protocol RoutePageViewControllerDelegate {
 
 class RoutePageViewController: UIPageViewController {
     
-    var maneuverDelegate: RoutePageViewControllerDelegate!
+    weak var maneuverDelegate: RoutePageViewControllerDelegate!
     var currentManeuverPage: RouteManeuverViewController!
 
     override func viewDidLoad() {

--- a/MapboxNavigationUI/RouteTableViewHeaderView.swift
+++ b/MapboxNavigationUI/RouteTableViewHeaderView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol RouteTableViewHeaderViewDelegate {
+protocol RouteTableViewHeaderViewDelegate: class {
     func didTapCancel()
 }
 
@@ -14,7 +14,7 @@ class RouteTableViewHeaderView: UIView {
     @IBOutlet weak var etaLabel: StyleLabel!
     @IBOutlet weak var dividerView: UIView!
     
-    var delegate: RouteTableViewHeaderViewDelegate?
+    weak var delegate: RouteTableViewHeaderViewDelegate?
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/MapboxNavigationUI/RouteViewController.swift
+++ b/MapboxNavigationUI/RouteViewController.swift
@@ -110,6 +110,8 @@ public class RouteViewController: NavigationPulleyViewController {
     
     deinit {
         suspendNotifications()
+        mapViewController?.resetTrackingModeTimer?.invalidate()
+        voiceController?.announcementTimer?.invalidate()
     }
     
     override public func viewDidLoad() {
@@ -262,7 +264,6 @@ public class RouteViewController: NavigationPulleyViewController {
 
 extension RouteViewController: RouteTableViewHeaderViewDelegate {
     func didTapCancel() {
-        voiceController = nil
         if navigationDelegate?.routeViewControllerDidCancelNavigation(self) != nil {
             // The receiver should handle dismissal of the RouteViewController
         } else {


### PR DESCRIPTION
Hey!

This PR fixes various memory leaks, that prevents several MapboxNavigationUI components from being deallocated.

Three of them are usual non-weak delegate suspects. 

Two more are NSTimer instances retaining their target until invalidated. I chose to invalidate them in RouteViewController deinit, since after main controller deinit probably there's no use in them