### PR TITLE
Expose route line configuration to delegates

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -144,17 +144,6 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         present(navigationViewController, animated: true, completion: nil)
     }
     
-    func removeRoutesFromMap() {
-        guard let style = mapView.style else {
-            return
-        }
-        if let line = style.layer(withIdentifier: layerIdentifier) {
-            style.removeLayer(line)
-        }
-        if let source = style.source(withIdentifier: sourceIdentifier) {
-            style.removeSource(source)
-        }
-    }
     
     func roundToTens(_ x: CLLocationDistance) -> Int {
         return 10 * Int(round(x / 10.0))

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -8,11 +8,10 @@ import CoreLocation
 let sourceIdentifier = "sourceIdentifier"
 let layerIdentifier = "layerIdentifier"
 
-class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewControllerDelegate {
+class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewControllerDelegate, NavigationMapViewDelegate {
     
     var destination: MGLPointAnnotation?
     var navigation: RouteController?
-    var navigationViewController: NavigationViewController?
     var userRoute: Route?
     
     @IBOutlet weak var mapView: NavigationMapView!
@@ -24,6 +23,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         super.viewDidLoad()
         
         mapView.delegate = self
+        mapView.navigationMapDelegate = self
         
         mapView.userTrackingMode = .follow
         resumeNotifications()
@@ -113,34 +113,14 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
             guard let route = routes?.first else {
                 return
             }
-            guard let style = self?.mapView.style else {
-                return
-            }
             
             self?.userRoute = route
             self?.toggleNavigationButton.isHidden = false
             self?.howToBeginLabel.isHidden = true
             
-            self?.removeRoutesFromMap()
             
-            let polyline = MGLPolylineFeature(coordinates: route.coordinates!, count: route.coordinateCount)
-            let geoJSONSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
-            let line = MGLLineStyleLayer(identifier: layerIdentifier, source: geoJSONSource)
-            
-            // Style the line
-            line.lineColor = MGLStyleValue(rawValue: UIColor(red:0.00, green:0.45, blue:0.74, alpha:0.9))
-            line.lineWidth = MGLStyleValue(rawValue: 5)
-            line.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
-            line.lineJoin = MGLStyleValue(rawValue: NSValue(mglLineJoin: .round))
-            
-            // Add source and layer
-            style.addSource(geoJSONSource)
-            for layer in style.layers.reversed() {
-                if !(layer is MGLSymbolStyleLayer) {
-                    style.insertLayer(line, above: layer)
-                    break
-                }
-            }
+            // Open method for adding and updating the route line
+            self?.mapView.showRoute(route)
             
             didFinish?()
         }
@@ -150,18 +130,18 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         // Pass through a
         // 1. the route the user will take
         // 2. A `Directions` class, used for rerouting.
-        let viewController = NavigationViewController(for: route)
+        let navigationViewController = NavigationViewController(for: route)
         
         // If you'd like to use AWS Polly, provide your IdentityPoolId below
         // `identityPoolId` is a required value for using AWS Polly voice instead of iOS's built in AVSpeechSynthesizer
         // You can get a token here: http://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth-aws-identity-for-ios.html
         // viewController.voiceController?.identityPoolId = "<#Your AWS IdentityPoolId. Remove Argument if you do not want to use AWS Polly#>"
         
-        viewController.routeController.snapsUserLocationAnnotationToRoute = true
-        viewController.voiceController?.volume = 0.5
-        viewController.navigationDelegate = self
+        navigationViewController.routeController.snapsUserLocationAnnotationToRoute = true
+        navigationViewController.voiceController?.volume = 0.5
+        navigationViewController.navigationDelegate = self
         
-        present(viewController, animated: true, completion: nil)
+        present(navigationViewController, animated: true, completion: nil)
     }
     
     func removeRoutesFromMap() {
@@ -180,21 +160,24 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         return 10 * Int(round(x / 10.0))
     }
     
+    
+    /// Delegate method for chaning the route line style
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         let lineCasing = MGLLineStyleLayer(identifier: identifier, source: source)
         
-        lineCasing.lineColor = MGLStyleValue(rawValue: .blue)
-        lineCasing.lineWidth = MGLStyleValue(rawValue: 4)
+        lineCasing.lineColor = MGLStyleValue(rawValue: UIColor(red:0.00, green:0.70, blue:0.99, alpha:1.0))
+        lineCasing.lineWidth = MGLStyleValue(rawValue: 6)
         
         lineCasing.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
         lineCasing.lineJoin = MGLStyleValue(rawValue: NSValue(mglLineJoin: .round))
         return lineCasing
     }
     
+    /// Delegate method for chaning the route line casing style
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         let line = MGLLineStyleLayer(identifier: identifier, source: source)
         
-        line.lineColor = MGLStyleValue(rawValue: .red)
+        line.lineColor = MGLStyleValue(rawValue: UIColor(red:0.18, green:0.49, blue:0.78, alpha:1.0))
         line.lineWidth = MGLStyleValue(rawValue: 8)
         
         line.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -8,7 +8,7 @@ import CoreLocation
 let sourceIdentifier = "sourceIdentifier"
 let layerIdentifier = "layerIdentifier"
 
-class ViewController: UIViewController, MGLMapViewDelegate {
+class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewControllerDelegate {
     
     var destination: MGLPointAnnotation?
     var navigation: RouteController?
@@ -159,6 +159,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         
         viewController.routeController.snapsUserLocationAnnotationToRoute = true
         viewController.voiceController?.volume = 0.5
+        viewController.navigationDelegate = self
         
         present(viewController, animated: true, completion: nil)
     }
@@ -177,5 +178,27 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     
     func roundToTens(_ x: CLLocationDistance) -> Int {
         return 10 * Int(round(x / 10.0))
+    }
+    
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        let lineCasing = MGLLineStyleLayer(identifier: identifier, source: source)
+        
+        lineCasing.lineColor = MGLStyleValue(rawValue: .blue)
+        lineCasing.lineWidth = MGLStyleValue(rawValue: 4)
+        
+        lineCasing.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
+        lineCasing.lineJoin = MGLStyleValue(rawValue: NSValue(mglLineJoin: .round))
+        return lineCasing
+    }
+    
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        let line = MGLLineStyleLayer(identifier: identifier, source: source)
+        
+        line.lineColor = MGLStyleValue(rawValue: .red)
+        line.lineWidth = MGLStyleValue(rawValue: 8)
+        
+        line.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
+        line.lineJoin = MGLStyleValue(rawValue: NSValue(mglLineJoin: .round))
+        return line
     }
 }

--- a/MapboxNavigation/MGLMapView.swift
+++ b/MapboxNavigation/MGLMapView.swift
@@ -3,9 +3,6 @@ import Mapbox
 import MapboxDirections
 import MapboxCoreNavigation
 
-let sourceIdentifier = "routeSource"
-let routeLayerIdentifier = "routeLayer"
-let routeLayerCasingIdentifier = "routeLayerCasing"
 let arrowSourceIdentifier = "arrowSource"
 let arrowSourceStrokeIdentifier = "arrowSourceStroke"
 let arrowLayerIdentifier = "arrowLayer"
@@ -127,4 +124,5 @@ protocol NavigationMapViewDelegate: class  {
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
 }

--- a/MapboxNavigation/MGLMapView.swift
+++ b/MapboxNavigation/MGLMapView.swift
@@ -124,7 +124,7 @@ extension MGLMapView {
 @objc
 protocol NavigationMapViewDelegate: class  {
     @objc optional func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
 }

--- a/MapboxNavigation/MGLMapView.swift
+++ b/MapboxNavigation/MGLMapView.swift
@@ -117,12 +117,3 @@ extension MGLMapView {
         }
     }
 }
-
-@objc
-protocol NavigationMapViewDelegate: class  {
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
-    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
-}

--- a/MapboxNavigation/MGLMapView.swift
+++ b/MapboxNavigation/MGLMapView.swift
@@ -121,6 +121,10 @@ extension MGLMapView {
     }
 }
 
+@objc
 protocol NavigationMapViewDelegate: class  {
-    func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
 }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -9,7 +9,7 @@ open class NavigationMapView: MGLMapView {
     open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [Any]!) {
         guard let location = locations.first as? CLLocation else { return }
         
-        if let modifiedLocation = navigationMapDelegate?.navigationMapView(self, shouldUpdateTo: location) {
+        if let modifiedLocation = navigationMapDelegate?.navigationMapView?(self, shouldUpdateTo: location) {
             super.locationManager(manager, didUpdateLocations: [modifiedLocation])
         } else {
             super.locationManager(manager, didUpdateLocations: locations)
@@ -24,19 +24,7 @@ open class NavigationMapView: MGLMapView {
             return
         }
         
-        if let line = style.layer(withIdentifier: routeLayerIdentifier) {
-            style.removeLayer(line)
-        }
-        
-        if let lineCasing = style.layer(withIdentifier: routeLayerCasingIdentifier) {
-            style.removeLayer(lineCasing)
-        }
-        
-        if let source = style.source(withIdentifier: sourceIdentifier) {
-            style.removeSource(source)
-        }
-        
-        let polyline = shape(describing: route)
+        let polyline = navigationMapDelegate?.navigationMapView(self, shapeDescribing: route) ?? shape(describing: route)
         
         if let source = style.source(withIdentifier: sourceIdentifier) as? MGLShapeSource {
             source.shape = polyline
@@ -44,8 +32,8 @@ open class NavigationMapView: MGLMapView {
             let lineSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
             style.addSource(lineSource)
             
-            let line = routeStyleLayer(identifier: routeLayerIdentifier, source: lineSource)
-            let lineCasing = routeCasingStyleLayer(identifier: routeLayerCasingIdentifier, source: lineSource)
+            let line = navigationMapDelegate?.navigationMapView(self, routeStyleLayerWithIdenitier: routeLayerIdentifier, source: lineSource) ?? routeStyleLayer(identifier: routeLayerIdentifier, source: lineSource)
+            let lineCasing = navigationMapDelegate?.navigationMapView(self, routeCasingStyleLayerWithIdenitier: routeLayerCasingIdentifier, source: lineSource) ?? routeCasingStyleLayer(identifier: routeLayerCasingIdentifier, source: lineSource)
             
             for layer in style.layers.reversed() {
                 if !(layer is MGLSymbolStyleLayer) &&

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -56,6 +56,31 @@ open class NavigationMapView: MGLMapView {
         }
     }
     
+    /**
+     Removes route line and route line casing from map
+     */
+    public func removeRoute() {
+        guard let style = style else {
+            return
+        }
+        
+        if let line = style.layer(withIdentifier: routeLayerIdentifier) {
+            style.removeLayer(line)
+        }
+        
+        if let lineCasing = style.layer(withIdentifier: routeLayerCasingIdentifier) {
+            style.removeLayer(lineCasing)
+        }
+        
+        if let lineSource = style.source(withIdentifier: sourceIdentifier) {
+            style.removeSource(lineSource)
+        }
+        
+        if let lineCasingSource = style.source(withIdentifier: sourceCasingIdentifier) {
+            style.removeSource(lineCasingSource)
+        }
+    }
+    
     func shape(describing route: Route) -> MGLShape? {
         guard var coordinates = route.coordinates else {
             return nil

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -9,7 +9,7 @@ open class NavigationMapView: MGLMapView {
     let routeLayerIdentifier = "routeLayer"
     let routeLayerCasingIdentifier = "routeLayerCasing"
     
-    weak var navigationMapDelegate: NavigationMapViewDelegate?
+    public weak var navigationMapDelegate: NavigationMapViewDelegate?
     
     open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [Any]!) {
         guard let location = locations.first as? CLLocation else { return }
@@ -21,13 +21,16 @@ open class NavigationMapView: MGLMapView {
         }
     }
     
-    func annotate(_ route: Route) {
+    /**
+     Adds or updates both the route line and the route line casing
+     */
+    public func showRoute(_ route: Route) {
         guard let style = style else {
             return
         }
         
-        let polyline = navigationMapDelegate?.navigationMapView(self, shapeDescribing: route) ?? shape(describing: route)
-        let polylineSimplified = navigationMapDelegate?.navigationMapView(self, simplifiedShapeDescribing: route) ?? simplifiedShape(describing: route)
+        let polyline = navigationMapDelegate?.navigationMapView?(self, shapeDescribing: route) ?? shape(describing: route)
+        let polylineSimplified = navigationMapDelegate?.navigationMapView?(self, simplifiedShapeDescribing: route) ?? simplifiedShape(describing: route)
         
         if let source = style.source(withIdentifier: sourceIdentifier) as? MGLShapeSource {
             source.shape = polyline
@@ -39,8 +42,8 @@ open class NavigationMapView: MGLMapView {
             style.addSource(lineSource)
             style.addSource(lineCasingSource)
             
-            let line = navigationMapDelegate?.navigationMapView(self, routeStyleLayerWithIdentifier: routeLayerIdentifier, source: lineSource) ?? routeStyleLayer(identifier: routeLayerIdentifier, source: lineSource)
-            let lineCasing = navigationMapDelegate?.navigationMapView(self, routeCasingStyleLayerWithIdentifier: routeLayerCasingIdentifier, source: lineSource) ?? routeCasingStyleLayer(identifier: routeLayerCasingIdentifier, source: lineSource)
+            let line = navigationMapDelegate?.navigationMapView?(self, routeStyleLayerWithIdentifier: routeLayerIdentifier, source: lineSource) ?? routeStyleLayer(identifier: routeLayerIdentifier, source: lineSource)
+            let lineCasing = navigationMapDelegate?.navigationMapView?(self, routeCasingStyleLayerWithIdentifier: routeLayerCasingIdentifier, source: lineSource) ?? routeCasingStyleLayer(identifier: routeLayerCasingIdentifier, source: lineSource)
             
             for layer in style.layers.reversed() {
                 if !(layer is MGLSymbolStyleLayer) &&
@@ -94,4 +97,13 @@ open class NavigationMapView: MGLMapView {
         
         return lineCasing
     }
+}
+
+@objc
+public protocol NavigationMapViewDelegate: class  {
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
 }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -19,7 +19,7 @@ open class NavigationMapView: MGLMapView {
     /**
      Annotates the map with a route line.
      */
-    open func annotate(_ route: Route) {
+    func annotate(_ route: Route) {
         guard let style = style else {
             return
         }
@@ -32,8 +32,8 @@ open class NavigationMapView: MGLMapView {
             let lineSource = MGLShapeSource(identifier: sourceIdentifier, shape: polyline, options: nil)
             style.addSource(lineSource)
             
-            let line = navigationMapDelegate?.navigationMapView(self, routeStyleLayerWithIdenitier: routeLayerIdentifier, source: lineSource) ?? routeStyleLayer(identifier: routeLayerIdentifier, source: lineSource)
-            let lineCasing = navigationMapDelegate?.navigationMapView(self, routeCasingStyleLayerWithIdenitier: routeLayerCasingIdentifier, source: lineSource) ?? routeCasingStyleLayer(identifier: routeLayerCasingIdentifier, source: lineSource)
+            let line = navigationMapDelegate?.navigationMapView(self, routeStyleLayerWithIdentifier: routeLayerIdentifier, source: lineSource) ?? routeStyleLayer(identifier: routeLayerIdentifier, source: lineSource)
+            let lineCasing = navigationMapDelegate?.navigationMapView(self, routeCasingStyleLayerWithIdentifier: routeLayerCasingIdentifier, source: lineSource) ?? routeCasingStyleLayer(identifier: routeLayerCasingIdentifier, source: lineSource)
             
             for layer in style.layers.reversed() {
                 if !(layer is MGLSymbolStyleLayer) &&
@@ -46,7 +46,7 @@ open class NavigationMapView: MGLMapView {
         }
     }
     
-    open func shape(describing route: Route) -> MGLShape? {
+    func shape(describing route: Route) -> MGLShape? {
         guard var coordinates = route.coordinates else {
             return nil
         }
@@ -57,7 +57,7 @@ open class NavigationMapView: MGLMapView {
     /**
      Function for overriding the default route line style.
      */
-    open func routeStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
+    func routeStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
         
         let line = MGLLineStyleLayer(identifier: identifier, source: source)
         
@@ -73,7 +73,7 @@ open class NavigationMapView: MGLMapView {
     /**
      Function for overriding the default route line casing style.
      */
-    open func routeCasingStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
+    func routeCasingStyleLayer(identifier: String, source: MGLSource) -> MGLStyleLayer {
         
         let lineCasing = MGLLineStyleLayer(identifier: identifier, source: source)
         

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -13,6 +13,7 @@ public protocol NavigationViewControllerDelegate {
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
 }
 
 /**
@@ -312,6 +313,10 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     }
     
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {
+        return navigationDelegate?.navigationMapView(mapView, shapeDescribing: route)
+    }
+    
+    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape? {
         return navigationDelegate?.navigationMapView(mapView, shapeDescribing: route)
     }
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -7,12 +7,11 @@ import Pulley
 @objc(MBNavigationPulleyViewController)
 public class NavigationPulleyViewController: PulleyViewController {}
 
-
 @objc(MBNavigationViewControllerDelegate)
 public protocol NavigationViewControllerDelegate {
-    @objc optional func navigationViewControllerDidCancelNavigation(_: NavigationViewController)
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewControllerDidCancelNavigation(_:NavigationViewController)
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
 }
 
@@ -304,12 +303,12 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         }
     }
     
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return navigationDelegate?.navigationMapView(mapView, routeCasingStyleLayerWithIdenitier: identifier, source: source)
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return navigationDelegate?.navigationMapView(mapView, routeCasingStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return navigationDelegate?.navigationMapView(mapView, routeStyleLayerWithIdenitier: identifier, source: source)
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return navigationDelegate?.navigationMapView(mapView, routeStyleLayerWithIdentifier: identifier, source: source)
     }
     
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -10,10 +10,10 @@ public class NavigationPulleyViewController: PulleyViewController {}
 @objc(MBNavigationViewControllerDelegate)
 public protocol NavigationViewControllerDelegate {
     @objc optional func navigationViewControllerDidCancelNavigation(_:NavigationViewController)
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
-    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
 }
 
 /**
@@ -305,19 +305,19 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     }
     
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return navigationDelegate?.navigationMapView(mapView, routeCasingStyleLayerWithIdentifier: identifier, source: source)
+        return navigationDelegate?.navigationMapView?(mapView, routeCasingStyleLayerWithIdentifier: identifier, source: source)
     }
     
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return navigationDelegate?.navigationMapView(mapView, routeStyleLayerWithIdentifier: identifier, source: source)
+        return navigationDelegate?.navigationMapView?(mapView, routeStyleLayerWithIdentifier: identifier, source: source)
     }
     
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {
-        return navigationDelegate?.navigationMapView(mapView, shapeDescribing: route)
+        return navigationDelegate?.navigationMapView?(mapView, shapeDescribing: route)
     }
     
     func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape? {
-        return navigationDelegate?.navigationMapView(mapView, shapeDescribing: route)
+        return navigationDelegate?.navigationMapView?(mapView, shapeDescribing: route)
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -7,12 +7,34 @@ import Pulley
 @objc(MBNavigationPulleyViewController)
 public class NavigationPulleyViewController: PulleyViewController {}
 
+/**
+ The `NavigationViewControllerDelegate` provides methods for listening and mamipulating items in the Navigation UI.
+ */
 @objc(MBNavigationViewControllerDelegate)
 public protocol NavigationViewControllerDelegate {
+    /**
+     Called when the user exits the navigation UI by tapping the `Cancel` button.
+     */
     @objc optional func navigationViewControllerDidCancelNavigation(_:NavigationViewController)
+    
+    /**
+     Returns the line layer for the route line. Used for styling the route line.
+     */
     @objc optional func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    
+    /**
+     Returns the line layer for the route line casing. Used for styling the route line casing.
+     */
     @objc optional func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    
+    /**
+     Returns shape for route line.
+     */
     @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    
+    /**
+     Returns shape for route line casing.
+     */
     @objc optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -135,6 +135,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         self.mapViewController = mapViewController
         self.tableViewController = tableViewController
         
+        mapViewController.delegate = self
         mapViewController.routeController = routeController
         mapViewController.destination = destination
         mapViewController.pendingCamera = pendingCamera

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -214,12 +214,12 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
 
 extension RouteMapViewController: NavigationMapViewDelegate {
     
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationMapView(mapView, routeCasingStyleLayerWithIdenitier: identifier, source: source)
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return delegate?.navigationMapView(mapView, routeCasingStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationMapView(mapView, routeStyleLayerWithIdenitier: identifier, source: source)
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return delegate?.navigationMapView(mapView, routeStyleLayerWithIdentifier: identifier, source: source)
     }
     
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {
@@ -423,7 +423,7 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
 }
 
 protocol RouteMapViewControllerDelegate: class {
-    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -124,7 +124,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     func notifyDidReroute(route: Route) {
         routePageViewController.notifyDidReRoute()
         mapView.addArrow(routeController.routeProgress)
-        mapView.annotate(route)
+        mapView.showRoute(route)
         mapView.userTrackingMode = .followWithCourse
     }
     
@@ -338,7 +338,7 @@ extension RouteMapViewController: MGLMapViewDelegate {
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         let map = mapView as! NavigationMapView
-        map.annotate(route)
+        map.showRoute(route)
     }
     
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -226,6 +226,10 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         return delegate?.navigationMapView(mapView, shapeDescribing: route)
     }
     
+    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape? {
+        return delegate?.navigationMapView(mapView, simplifiedShapeDescribing: route)
+    }
+    
     @objc(navigationMapView:shouldUpdateTo:)
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation? {
 
@@ -426,4 +430,5 @@ protocol RouteMapViewControllerDelegate: class {
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -22,6 +22,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     
     var destination: MGLAnnotation!
     var pendingCamera: MGLMapCamera?
+    weak var delegate: RouteMapViewControllerDelegate?
     
     weak var routeController: RouteController!
     
@@ -213,7 +214,19 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
 
 extension RouteMapViewController: NavigationMapViewDelegate {
     
-    @objc(navigationMapView:shouldUpdateToLocation:)
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return delegate?.navigationMapView(mapView, routeCasingStyleLayerWithIdenitier: identifier, source: source)
+    }
+    
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return delegate?.navigationMapView(mapView, routeStyleLayerWithIdenitier: identifier, source: source)
+    }
+    
+    func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {
+        return delegate?.navigationMapView(mapView, shapeDescribing: route)
+    }
+    
+    @objc(navigationMapView:shouldUpdateTo:)
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation? {
 
         guard routeController.userIsOnRoute(location) else { return nil }
@@ -407,4 +420,10 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
     func stepAfter(_ step: RouteStep) -> RouteStep? {
         return routeController.routeProgress.currentLegProgress.stepAfter(step)
     }
+}
+
+protocol RouteMapViewControllerDelegate: class {
+    func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/134

Exposes 3 delegate methods:

```swift
func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdenitier identifier: String, source: MGLSource) -> MGLStyleLayer?
func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
```

/cc @frederoni @1ec5 