### PR TITLE
Version Core Navigation and Navigation in lockstep

### DIFF
--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
 
-  s.dependency "MapboxCoreNavigation"
+  s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
   s.dependency "MapboxDirections.swift", "~> 0.9.0"
   s.dependency "Mapbox-iOS-SDK", "~> 3.5"
   s.dependency "OSRMTextInstructions", "~> 0.1.1"


### PR DESCRIPTION
A particular version of MapboxNavigation always needs exactly the same version of MapboxCoreNavigation.

/cc @bsudekum @frederoni