### PR TITLE
Set maximum progress upon arrival

### DIFF
--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -49,7 +49,7 @@ class RouteTableViewController: UIViewController {
     }
     
     func notifyDidChange(routeProgress: RouteProgress) {
-        headerView.progress = CGFloat(routeProgress.fractionTraveled)
+        headerView.progress = routeProgress.currentLegProgress.alertUserLevel == .arrive ? 1 : CGFloat(routeProgress.fractionTraveled)
         showETA(routeProgress: routeProgress)
     }
     


### PR DESCRIPTION
Fixes #97 

The `.arrive` notification is fired within a certain radius of the destination when `fractionsTraveled` is below 1.0. This PR avoids an incomplete progress bar by setting the progress to 1.0 if `AlertLevel` is `.arrive`.

@bsudekum 👀 

![arrive100](https://cloud.githubusercontent.com/assets/764476/25149074/6e2e8e90-247d-11e7-965d-6cbf7c8be0f8.gif)
