### PR TITLE
Specify full route shape resolution in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ let origin = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.9131752, l
 let destination = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365), name: "White House")
 
 let options = RouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
+options.routeShapeResolution = .full
 options.includesSteps = true
 
 Directions.shared.calculate(options) { (waypoints, routes, error) in


### PR DESCRIPTION
For consistency with the Directions API, the default is low resolution (simplified), which can produce wildly inaccurate timing and rerouting.

/cc @bsudekum @frederoni @ericrwolfe