### PR TITLE
Fix global tint

### DIFF
--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -141,7 +141,7 @@ public class Style: NSObject {
         let style = Style(traitCollection: UITraitCollection())
         
         // General styling
-        if let tintColor = UIApplication.shared.delegate?.window??.rootViewController?.view.tintColor {
+        if let tintColor = UIApplication.shared.delegate?.window??.tintColor {
             style.tintColor = tintColor
         } else {
             style.tintColor = .defaultTint


### PR DESCRIPTION
The window's tint color corresponds to the storyboard's global tint, not the rootViewController's view.

@1ec5 👀 