### PR TITLE
Use Locale for deciding current language code

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		C52D09CE1DEF5E5100BE3C5C /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
 		C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09D21DEF636C00BE3C5C /* Fixture.swift */; };
 		C53208AB1E81FFB900910266 /* NavigationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53208AA1E81FFB900910266 /* NavigationMapView.swift */; };
+		C55CEB281EB7E4240065D7D9 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55CEB271EB7E4240065D7D9 /* Locale.swift */; };
 		C58159011EA6D02700FC6C3D /* MGLVectorSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58159001EA6D02700FC6C3D /* MGLVectorSource.swift */; };
 		C58D6BAD1DDCF2AE00387F53 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58D6BAC1DDCF2AE00387F53 /* Constants.swift */; };
 		C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADFBD71DDCC7840011824B /* MapboxCoreNavigationTests.swift */; };
@@ -304,6 +305,7 @@
 		C52D09CD1DEF5E5100BE3C5C /* route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = route.json; sourceTree = "<group>"; };
 		C52D09D21DEF636C00BE3C5C /* Fixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
 		C53208AA1E81FFB900910266 /* NavigationMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationMapView.swift; sourceTree = "<group>"; };
+		C55CEB271EB7E4240065D7D9 /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		C58159001EA6D02700FC6C3D /* MGLVectorSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLVectorSource.swift; sourceTree = "<group>"; };
 		C58D6BAC1DDCF2AE00387F53 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C5ADFBC91DDCC7840011824B /* MapboxCoreNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxCoreNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -550,13 +552,14 @@
 			children = (
 				351BEC081E5BCC72006FE110 /* Bundle.swift */,
 				351BEC0A1E5BCC72006FE110 /* Directions.swift */,
+				C55CEB271EB7E4240065D7D9 /* Locale.swift */,
 				351BEC041E5BCC6C006FE110 /* ManeuverDirection.swift */,
 				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
 				35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */,
 				35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */,
+				C58159001EA6D02700FC6C3D /* MGLVectorSource.swift */,
 				351BEBEB1E5BCC63006FE110 /* String.swift */,
 				351BEBF01E5BCC63006FE110 /* UIView.swift */,
-				C58159001EA6D02700FC6C3D /* MGLVectorSource.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1066,6 +1069,7 @@
 				351BEC011E5BCC63006FE110 /* TurnArrowView.swift in Sources */,
 				351BEBFA1E5BCC63006FE110 /* RouteTableViewController.swift in Sources */,
 				351BEC101E5BCC72006FE110 /* DistanceFormatter.swift in Sources */,
+				C55CEB281EB7E4240065D7D9 /* Locale.swift in Sources */,
 				351BEC0E1E5BCC72006FE110 /* DashedLineView.swift in Sources */,
 				351BEBF71E5BCC63006FE110 /* RoutePageViewController.swift in Sources */,
 				351BEC051E5BCC6C006FE110 /* LaneArrowView.swift in Sources */,

--- a/MapboxNavigation/Locale.swift
+++ b/MapboxNavigation/Locale.swift
@@ -9,8 +9,7 @@ extension Locale {
             return firstBundleLocale
         }
         
-        let countryCode = NSLocale.Key.countryCode
-        let countryString = (NSLocale.current as NSLocale).object(forKey: countryCode) as! String
+        let countryString = (NSLocale.current as NSLocale).object(forKey: .countryCode) as! String
         return "\(bundleLocale.first!)-\(countryString)"
     }
     

--- a/MapboxNavigation/Locale.swift
+++ b/MapboxNavigation/Locale.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Locale {
+    static var preferredLocalLanguageCountryCode: String {
+        let bundleLanguage = Bundle.main.preferredLocalizations.first!
+        let bundleLanguages = bundleLanguage.components(separatedBy: "-")
+        
+        if bundleLanguages.count == 2 {
+            return bundleLanguage
+        }
+        
+        let countryCode = NSLocale.Key.countryCode
+        let locale = NSLocale.current as NSLocale
+        let countryString = locale.object(forKey: countryCode) as! String
+        return "\(bundleLanguages.first!)-\(countryString)"
+    }
+}

--- a/MapboxNavigation/Locale.swift
+++ b/MapboxNavigation/Locale.swift
@@ -2,16 +2,17 @@ import Foundation
 
 extension Locale {
     static var preferredLocalLanguageCountryCode: String {
-        let bundleLanguage = Bundle.main.preferredLocalizations.first!
-        let bundleLanguages = bundleLanguage.components(separatedBy: "-")
+        let firstBundleLocale = Bundle.main.preferredLocalizations.first!
+        let bundleLocale = firstBundleLocale.components(separatedBy: "-")
         
-        if bundleLanguages.count == 2 {
-            return bundleLanguage
+        if bundleLocale.count > 1 {
+            return firstBundleLocale
         }
         
         let countryCode = NSLocale.Key.countryCode
-        let locale = NSLocale.current as NSLocale
-        let countryString = locale.object(forKey: countryCode) as! String
-        return "\(bundleLanguages.first!)-\(countryString)"
+        let countryString = (NSLocale.current as NSLocale).object(forKey: countryCode) as! String
+        return "\(bundleLocale.first!)-\(countryString)"
     }
+    
+    static var nationalizedCurrent = Locale(identifier: preferredLocalLanguageCountryCode)
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -52,7 +52,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
         super.viewDidLoad()
         automaticallyAdjustsScrollViewInsets = false
         
-        distanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
+        distanceFormatter.numberFormatter.locale = .nationalizedCurrent
         
         mapView.delegate = self
         mapView.navigationMapDelegate = self

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -52,7 +52,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
         super.viewDidLoad()
         automaticallyAdjustsScrollViewInsets = false
         
-        distanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
+        distanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
         
         mapView.delegate = self
         mapView.navigationMapDelegate = self

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -52,6 +52,8 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
         super.viewDidLoad()
         automaticallyAdjustsScrollViewInsets = false
         
+        distanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
+        
         mapView.delegate = self
         mapView.navigationMapDelegate = self
         recenterButton.applyDefaultCornerRadiusShadow(cornerRadius: 22)

--- a/MapboxNavigation/RouteTableViewCell.swift
+++ b/MapboxNavigation/RouteTableViewCell.swift
@@ -20,7 +20,7 @@ class RouteTableViewCell: UITableViewCell {
             
             turnArrowView.step = step
             titleLabel.text = routeStepFormatter.string(for: step)
-            distanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
+            distanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
             subtitleLabel.text = distanceFormatter.string(from: step.distance)
         }
     }

--- a/MapboxNavigation/RouteTableViewCell.swift
+++ b/MapboxNavigation/RouteTableViewCell.swift
@@ -20,6 +20,7 @@ class RouteTableViewCell: UITableViewCell {
             
             turnArrowView.step = step
             titleLabel.text = routeStepFormatter.string(for: step)
+            distanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
             subtitleLabel.text = distanceFormatter.string(from: step.distance)
         }
     }

--- a/MapboxNavigation/RouteTableViewCell.swift
+++ b/MapboxNavigation/RouteTableViewCell.swift
@@ -20,7 +20,7 @@ class RouteTableViewCell: UITableViewCell {
             
             turnArrowView.step = step
             titleLabel.text = routeStepFormatter.string(for: step)
-            distanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
+            distanceFormatter.numberFormatter.locale = .nationalizedCurrent
             subtitleLabel.text = distanceFormatter.string(from: step.distance)
         }
     }

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -22,7 +22,7 @@ class RouteTableViewController: UIViewController {
         dateComponentsFormatter.maximumUnitCount = 2
         dateComponentsFormatter.allowedUnits = [.day, .hour, .minute]
         dateComponentsFormatter.unitsStyle = .short
-        distanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
+        distanceFormatter.numberFormatter.locale = .nationalizedCurrent
         headerView.progress = CGFloat(routeController.routeProgress.fractionTraveled)
     }
     

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -22,7 +22,7 @@ class RouteTableViewController: UIViewController {
         dateComponentsFormatter.maximumUnitCount = 2
         dateComponentsFormatter.allowedUnits = [.day, .hour, .minute]
         dateComponentsFormatter.unitsStyle = .short
-        distanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
+        distanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
         headerView.progress = CGFloat(routeController.routeProgress.fractionTraveled)
     }
     

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -22,6 +22,7 @@ class RouteTableViewController: UIViewController {
         dateComponentsFormatter.maximumUnitCount = 2
         dateComponentsFormatter.allowedUnits = [.day, .hour, .minute]
         dateComponentsFormatter.unitsStyle = .short
+        distanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
         headerView.progress = CGFloat(routeController.routeProgress.fractionTraveled)
     }
     

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -83,7 +83,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     override public init() {
         super.init()
         maneuverVoiceDistanceFormatter.unitStyle = .long
-        maneuverVoiceDistanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
+        maneuverVoiceDistanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
         resumeNotifications()
     }
     

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -83,6 +83,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     override public init() {
         super.init()
         maneuverVoiceDistanceFormatter.unitStyle = .long
+        maneuverVoiceDistanceFormatter.numberFormatter.locale = Locale.init(identifier: Locale.preferredLocalLanguageCountryCode)
         resumeNotifications()
     }
     
@@ -269,8 +270,8 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         let input = AWSPollySynthesizeSpeechURLBuilderRequest()
         input.textType = .ssml
         input.outputFormat = .mp3
-        
-        let langs = Locale.preferredLanguages.first!.components(separatedBy: "-")
+
+        let langs = Locale.preferredLocalLanguageCountryCode.components(separatedBy: "-")
         let langCode = langs[0]
         var countryCode = ""
         if langs.count > 1 {
@@ -369,7 +370,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         }
         
         // Only localized languages will have a proper fallback voice
-        utterance.voice = AVSpeechSynthesisVoice(language: Locale.preferredLanguages.first!)
+        utterance.voice = AVSpeechSynthesisVoice(language: Locale.preferredLocalLanguageCountryCode)
         utterance.volume = volume
         
         speechSynth.speak(utterance)

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -369,7 +369,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         }
         
         // Only localized languages will have a proper fallback voice
-        utterance.voice = AVSpeechSynthesisVoice(language: Bundle.main.preferredLocalizations.first)
+        utterance.voice = AVSpeechSynthesisVoice(language: Locale.preferredLanguages.first!)
         utterance.volume = volume
         
         speechSynth.speak(utterance)

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -83,7 +83,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     override public init() {
         super.init()
         maneuverVoiceDistanceFormatter.unitStyle = .long
-        maneuverVoiceDistanceFormatter.numberFormatter.locale = Locale.nationalizedCurrent
+        maneuverVoiceDistanceFormatter.numberFormatter.locale = .nationalizedCurrent
         resumeNotifications()
     }
     


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/183

`Bundle.main.preferredLocalizations.first`  only would specify `en` vs with `Locale.preferredLanguages` which produces `en-us`.  We use the same lookup for Polly voices.

/cc @incanus 