### PR TITLE
Turn off exceissive debug logging

### DIFF
--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-Objective-C.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-Objective-C.xcscheme
@@ -71,6 +71,13 @@
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-Swift.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-Swift.xcscheme
@@ -71,6 +71,13 @@
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
There is too much logging happening in the demo apps. Let's turn it off. 