### PR TITLE
Change reroute radius threshold calculation

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -159,7 +159,7 @@ extension RouteController: CLLocationManagerDelegate {
         let metersInFrontOfUser = location.speed * RouteControllerDeadReckoningTimeInterval
         let locationInfrontOfUser = location.coordinate.coordinate(at: metersInFrontOfUser, facing: location.course)
         let newLocation = CLLocation(latitude: locationInfrontOfUser.latitude, longitude: locationInfrontOfUser.longitude)
-        let radius = min(RouteControllerMaximumDistanceBeforeRecalculating,
+        let radius = max(RouteControllerMaximumDistanceBeforeRecalculating,
                          location.horizontalAccuracy + RouteControllerUserLocationSnappingDistance)
 
         let isCloseToCurrentStep = newLocation.isWithin(radius, of: routeProgress.currentLegProgress.currentStep)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -329,16 +329,12 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         guard routeController.userIsOnRoute(location) else { return nil }
         guard let stepCoordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates else  { return nil }
         
-        var possibleClosestCoordinateToRoute = location.coordinate
-        if routeController.snapsUserLocationAnnotationToRoute {
-            let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate)
-            if let coordinate = snappedCoordinate?.coordinate {
-                possibleClosestCoordinateToRoute = coordinate
-            }
-        }
+        let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate)
 
         // Add current way name to UI
-        if let style = mapView.style, recenterButton.isHidden {
+        if let style = mapView.style, recenterButton.isHidden,
+            let snappedCoordinate = snappedCoordinate {
+            let closestCoordinate = snappedCoordinate.coordinate
             let roadLabelLayerIdentifier = "roadLabelLayer"
             var streetsSources = style.sources.flatMap {
                 $0 as? MGLVectorSource
@@ -362,7 +358,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                 style.insertLayer(streetLabelLayer, at: 0)
             }
             
-            let userPuck = mapView.convert(possibleClosestCoordinateToRoute, toPointTo: mapView)
+            let userPuck = mapView.convert(closestCoordinate, toPointTo: mapView)
             let features = mapView.visibleFeatures(at: userPuck, styleLayerIdentifiers: Set([roadLabelLayerIdentifier]))
             var smallestLabelDistance = Double.infinity
             var currentName: String?
@@ -378,12 +374,12 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                 
                 for line in allLines {
                     let featureCoordinates =  Array(UnsafeBufferPointer(start: line.coordinates, count: Int(line.pointCount)))
-                    let slicedLine = polyline(along: stepCoordinates, from: possibleClosestCoordinateToRoute)
+                    let slicedLine = polyline(along: stepCoordinates, from: closestCoordinate)
                     
                     let lookAheadDistance:CLLocationDistance = 10
-                    guard let pointAheadFeature = coordinate(at: lookAheadDistance, fromStartOf: polyline(along: featureCoordinates, from: possibleClosestCoordinateToRoute)) else { continue }
+                    guard let pointAheadFeature = coordinate(at: lookAheadDistance, fromStartOf: polyline(along: featureCoordinates, from: closestCoordinate)) else { continue }
                     guard let pointAheadUser = coordinate(at: lookAheadDistance, fromStartOf: slicedLine) else { continue }
-                    guard let reversedPoint = coordinate(at: lookAheadDistance, fromStartOf: polyline(along: featureCoordinates.reversed(), from: possibleClosestCoordinateToRoute)) else { continue }
+                    guard let reversedPoint = coordinate(at: lookAheadDistance, fromStartOf: polyline(along: featureCoordinates.reversed(), from: closestCoordinate)) else { continue }
                     
                     let distanceBetweenPointsAhead = pointAheadFeature - pointAheadUser
                     let distanceBetweenReversedPoint = reversedPoint - pointAheadUser
@@ -413,10 +409,16 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         
         
         // Snap user and course to route
-        let defaultReturn = CLLocation(coordinate: possibleClosestCoordinateToRoute, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: location.course, speed: location.speed, timestamp: location.timestamp)
+        guard routeController.snapsUserLocationAnnotationToRoute else {
+            return location
+        }
         
         guard location.course != -1 else {
-            return defaultReturn
+            return location
+        }
+        
+        guard let snappedClosestCoordinate = snappedCoordinate else {
+            return location
         }
         
         let nearByCoordinates = routeController.routeProgress.currentLegProgress.nearbyCoordinates
@@ -442,12 +444,16 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         let absoluteDirection = wrap(wrappedCourse + averageRelativeAngle, min: 0 , max: 360)
 
         guard differenceBetweenAngles(absoluteDirection, location.course) < RouteControllerMaxManipulatedCourseAngle else {
-            return defaultReturn
+            return location
         }
 
         let course = averageRelativeAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion ? absoluteDirection : location.course
         
-        return CLLocation(coordinate: possibleClosestCoordinateToRoute, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
+        guard snappedClosestCoordinate.distance < RouteControllerUserLocationSnappingDistance else {
+            return location
+        }
+        
+        return CLLocation(coordinate: snappedClosestCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
     }
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -328,12 +328,10 @@ extension RouteMapViewController: NavigationMapViewDelegate {
 
         guard routeController.userIsOnRoute(location) else { return nil }
         guard let stepCoordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates else  { return nil }
-        
-        let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate)
+        guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
 
         // Add current way name to UI
-        if let style = mapView.style, recenterButton.isHidden,
-            let snappedCoordinate = snappedCoordinate {
+        if let style = mapView.style, recenterButton.isHidden{
             let closestCoordinate = snappedCoordinate.coordinate
             let roadLabelLayerIdentifier = "roadLabelLayer"
             var streetsSources = style.sources.flatMap {
@@ -417,10 +415,6 @@ extension RouteMapViewController: NavigationMapViewDelegate {
             return location
         }
         
-        guard let snappedClosestCoordinate = snappedCoordinate else {
-            return location
-        }
-        
         let nearByCoordinates = routeController.routeProgress.currentLegProgress.nearbyCoordinates
         let closest = closestCoordinate(on: nearByCoordinates, to: location.coordinate)!
         let slicedLine = polyline(along: nearByCoordinates, from: closest.coordinate, to: nearByCoordinates.last)
@@ -449,11 +443,11 @@ extension RouteMapViewController: NavigationMapViewDelegate {
 
         let course = averageRelativeAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion ? absoluteDirection : location.course
         
-        guard snappedClosestCoordinate.distance < RouteControllerUserLocationSnappingDistance else {
+        guard snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance else {
             return location
         }
         
-        return CLLocation(coordinate: snappedClosestCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
+        return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
     }
 }
 


### PR DESCRIPTION
We've had reports of constant rerouting on highways. Our current thinking that this is a combination of a few factors:

* user has very high gps accuracy
* user is traveling on large highway with many lanes
* user has high horizontal distance from the route geometry (I.E. in first lane)

These combinations could produce a rerouting event since their `horizontalAccuracy ` is < 10m and the `RouteControllerUserLocationSnappingDistance` is `10m. This produces a radius threshold of only 20m. 

This change now looks at the maximum value between `RouteControllerMaximumDistanceBeforeRecalculating` (50m) and the `horizontalAccuracy` + `RouteControllerUserLocationSnappingDistance` (10m).

Here are the situations that will change:
* :+1: fewer rerouting on a highway with good accuracy 
* :-1: possibly longer time to reroute while in urban areas (with worse horizontal accuracy)

/cc @mapbox/navigation @danpat @willwhite
