### PR TITLE
Fix Bitrise shield url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mapbox Navigation SDK for iOS
 
-[![Build Status](https://www.bitrise.io/app/2f82077d3f083479.svg?token=mC783nGMKA3XrvcMCJAOLg&branch=master)](https://www.bitrise.io/app/2f82077d3f083479)
+[![Build Status](https://www.bitrise.io/app/6fc45a7e2817b859.svg?token=XTgNMVxObhd8w8EmsAgJ1Q&branch=master)](https://www.bitrise.io/app/6fc45a7e2817b859)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods](https://img.shields.io/cocoapods/v/MapboxNavigation.svg)](http://cocoadocs.org/docsets/MapboxNavigation/)
 


### PR DESCRIPTION
The Bitrise shield now links to navigation and shows correct status for this repo instead of Mapbox Directions.

@1ec5 👀 