### PR TITLE
Reduce to Continue for low alert only

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -231,7 +231,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
             } else {
                 text = String.localizedStringWithFormat(NSLocalizedString("CONTINUE", value: "Continue on %@ for %@", comment: "Format for speech string; 1 = way name; 2 = distance"), localizeRoadDescription(step, markUpWithSSML: markUpWithSSML), escapeIfNecessary(maneuverVoiceDistanceFormatter.string(from: userDistance)))
             }
-        } else if routeProgress.currentLegProgress.currentStep.distance > 2_000 {
+        } else if routeProgress.currentLegProgress.currentStep.distance > 2_000 && routeProgress.currentLegProgress.alertUserLevel == .low {
             text = String.localizedStringWithFormat(NSLocalizedString("CONTINUE", value: "Continue on %@ for %@", comment: "Format for speech string; 1 = way name; 2 = distance"), localizeRoadDescription(step, markUpWithSSML: markUpWithSSML), escapeIfNecessary(maneuverVoiceDistanceFormatter.string(from: userDistance)))
         } else if alertLevel == .high && stepDistance < minimumDistanceForHighAlert {
             text = String.localizedStringWithFormat(NSLocalizedString("LINKED_UTTERANCE_FORMAT", value: "%@, then %@", comment: "Format for speech string; 1 = current instruction; 2 = the following linked instruction"), upComingInstruction, followOnInstruction)


### PR DESCRIPTION
For longer steps, when we announce the low alert, we try not to confuse the user about unnecessary information by just saying "Continue for a bit on the road your on". However, on steps where we announce this continue, we only want to say continue once. Once the user approaches the maneuver point, we need to give them the regular instruction.

![untitled](https://cloud.githubusercontent.com/assets/1058624/26325119/843713c4-3eea-11e7-929f-49ee72253a64.png)

For the [example](http://map.project-osrm.org/?z=16&center=37.333126%2C-122.047076&loc=37.336026%2C-122.032464&loc=37.336282%2C-122.068040&hl=en&alt=0) above, previously we would announce continue 3 times; once at each alert location. This is because the current step is greater than 2,000 meters.

Now, we will announce the continue once only at the low alert location.

/cc @frederoni @1ec5 @willwhite @ericfischer 