### PR TITLE
Don't announce when merging onto highway

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -182,7 +182,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         fallbackText = speechString(notification: notification, markUpWithSSML: false)
         
         // If the user is merging onto a highway, an announcement to merge is a bit excessive
-        if let upComingStep = routeProgress.currentLegProgress.upComingStep, (routeProgress.currentLegProgress.currentStep.maneuverType == .takeOnRamp && upComingStep.maneuverType == .merge && routeProgress.currentLegProgress.alertUserLevel == .high) {
+        if let upComingStep = routeProgress.currentLegProgress.upComingStep, routeProgress.currentLegProgress.currentStep.maneuverType == .takeOnRamp && upComingStep.maneuverType == .merge && routeProgress.currentLegProgress.alertUserLevel == .high {
             return
         }
         

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -181,6 +181,11 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         
         fallbackText = speechString(notification: notification, markUpWithSSML: false)
         
+        // If the user is merging onto a highway, an announcement to merge is a bit excessive
+        guard let upComingStep = routeProgress.currentLegProgress.upComingStep, !(routeProgress.currentLegProgress.currentStep.maneuverType == .takeOnRamp && upComingStep.maneuverType == .merge && routeProgress.currentLegProgress.alertUserLevel == .high) else {
+            return
+        }
+        
         if useDefaultVoice {
             speakFallBack(fallbackText)
         } else {

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -182,7 +182,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         fallbackText = speechString(notification: notification, markUpWithSSML: false)
         
         // If the user is merging onto a highway, an announcement to merge is a bit excessive
-        guard let upComingStep = routeProgress.currentLegProgress.upComingStep, !(routeProgress.currentLegProgress.currentStep.maneuverType == .takeOnRamp && upComingStep.maneuverType == .merge && routeProgress.currentLegProgress.alertUserLevel == .high) else {
+        if let upComingStep = routeProgress.currentLegProgress.upComingStep, (routeProgress.currentLegProgress.currentStep.maneuverType == .takeOnRamp && upComingStep.maneuverType == .merge && routeProgress.currentLegProgress.alertUserLevel == .high) {
             return
         }
         


### PR DESCRIPTION
When there is only a single option and it is to merge onto a highway, a `high` alert becomes redundant and is noise. The removes the high alert when the upcoming maneuver is merge and the current maneuver is `takeOnRamp`.

/cc @ericrwolfe 