### PR TITLE
Correctly draw uturns

### DIFF
--- a/MapboxNavigation/TurnArrowView.swift
+++ b/MapboxNavigation/TurnArrowView.swift
@@ -93,7 +93,7 @@ public class TurnArrowView: UIView {
                 flip = true
             case .uTurn:
                 StyleKitArrows.drawArrow180(scale: scale)
-                flip = [.left, .slightLeft, .sharpLeft].contains(ManeuverDirection(angle: angle))
+                flip = angle < 0
             default:
                 StyleKitArrows.drawArrow0(scale: scale)
             }

--- a/MapboxNavigation/TurnArrowView.swift
+++ b/MapboxNavigation/TurnArrowView.swift
@@ -93,6 +93,7 @@ public class TurnArrowView: UIView {
                 flip = true
             case .uTurn:
                 StyleKitArrows.drawArrow180(scale: scale)
+                flip = [.left, .slightLeft, .sharpLeft].contains(ManeuverDirection(angle: angle))
             default:
                 StyleKitArrows.drawArrow0(scale: scale)
             }


### PR DESCRIPTION
We're drawing uturns always turning to the right now. This changes to draw either to the left or right  depending on enter/exit bearings.

