### PR TITLE
Measure British distances in imperial units

### DIFF
--- a/MapboxNavigation/DistanceFormatter.swift
+++ b/MapboxNavigation/DistanceFormatter.swift
@@ -36,7 +36,8 @@ public class DistanceFormatter: LengthFormatter {
         let miles = distance / metersPerMile
         let feet = miles * feetPerMile
         
-        let isBritish = Locale.current.regionCode == "GB"
+        // British roads are measured in miles, yards, and feet. Simulate this idiosyncrasy using the U.S. locale.
+        let isBritish = Locale.current.identifier == "en-GB"
         numberFormatter.locale = isBritish ? Locale(identifier: "en-US") : Locale.current
         
         var unit: LengthFormatter.Unit = .millimeter

--- a/MapboxNavigation/DistanceFormatter.swift
+++ b/MapboxNavigation/DistanceFormatter.swift
@@ -36,6 +36,9 @@ public class DistanceFormatter: LengthFormatter {
         let miles = distance / metersPerMile
         let feet = miles * feetPerMile
         
+        let isBritish = Locale.current.regionCode == "GB"
+        numberFormatter.locale = isBritish ? Locale(identifier: "en-US") : Locale.current
+        
         var unit: LengthFormatter.Unit = .millimeter
         unitString(fromMeters: distance, usedUnit: &unit)
         let replacesYardsWithMiles = unit == .yard && miles > 0.2
@@ -69,10 +72,13 @@ public class DistanceFormatter: LengthFormatter {
             if miles > 0.2 {
                 unit = .mile
                 formattedDistance = string(fromValue: miles, unit: unit)
-            } else {
+            } else if !isBritish {
                 unit = .foot
                 numberFormatter.roundingIncrement = 50
                 formattedDistance = string(fromValue: feet, unit: unit)
+            } else {
+                numberFormatter.roundingIncrement = 50
+                formattedDistance = string(fromMeters: distance)
             }
         } else {
             formattedDistance = string(fromMeters: distance)


### PR DESCRIPTION
Force the number formatter underlying the distance formatter to use a U.S. locale (for its customary units) and avoid replacing yards with feet.

Fixes #242.

/cc @bsudekum @andrey-str