### PR TITLE
Fix fluttering distance label

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -85,7 +85,7 @@ class RouteManeuverViewController: UIViewController {
         let stepProgress = routeProgress.currentLegProgress.currentStepProgress
         let distanceRemaining = stepProgress.distanceRemaining
         
-        distance = secondsRemaining > 5 ? distanceRemaining : nil
+        distance = distanceRemaining > 10 ? distanceRemaining : nil
         
         if routeProgress.currentLegProgress.alertUserLevel == .arrive {
             distance = nil


### PR DESCRIPTION
In cases where a user is approaching a maneuver and their speed decreases, `secondsRemaining` could dip below this threshold then go above it. This effect makes the distance remaining on step disappear then show again.

Now when the user is basically at the maneuver will it disappear. The real goal here is to never show `0ft`.

