### PR TITLE
Don't move alert level backwards

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -371,7 +371,8 @@ extension RouteController: CLLocationManagerDelegate {
             // Don't alert if the route segment is shorter than X
             // However, if it's the beginning of the route
             // There needs to be an alert
-            routeProgress.currentLegProgress.currentStep.distance > minimumDistanceForMediumAlert {
+            routeProgress.currentLegProgress.currentStep.distance > minimumDistanceForMediumAlert &&
+            alertLevel != .high {
             alertLevel = .medium
         }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -234,7 +234,7 @@ extension RouteController: CLLocationManagerDelegate {
         if let upComingStep = routeProgress.currentLegProgress.upComingStep {
             let isCloseToUpComingStep = newLocation.isWithin(radius, of: upComingStep)
             if !isCloseToCurrentStep && isCloseToUpComingStep {
-                let userSnapToStepDistanceFromManeuver = distance(along: routeProgress.currentLegProgress.currentStep.coordinates!, from: location.coordinate)
+                let userSnapToStepDistanceFromManeuver = distance(along: upComingStep.coordinates!, from: location.coordinate)
                 let secondsToEndOfStep = userSnapToStepDistanceFromManeuver / location.speed
                 incrementRouteProgress(secondsToEndOfStep <= RouteControllerMediumAlertInterval ? .medium : .low, location: location, updateStepIndex: true)
                 return true

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -371,9 +371,7 @@ extension RouteController: CLLocationManagerDelegate {
                 
                 // Look at the following step to determine what the new alert level should be
                 if let upComingStep = routeProgress.currentLegProgress.upComingStep {
-                    let userSnapToUpComingStepDistanceFromManeuver = distance(along: upComingStep.coordinates!, from: location.coordinate)
-                    let secondsToEndOfStep = userSnapToUpComingStepDistanceFromManeuver / location.speed
-                    alertLevel = secondsToEndOfStep <= RouteControllerMediumAlertInterval ? .medium : .low
+                    alertLevel = upComingStep.expectedTravelTime <= RouteControllerMediumAlertInterval ? .medium : .low
                 } else {
                     assert(false, "In this case, there should always be an upcoming step")
                 }


### PR DESCRIPTION
![simulator screen shot may 31 2017 2 52 57 pm](https://cloud.githubusercontent.com/assets/1058624/26655727/de016f80-4610-11e7-8b1b-46b2877fcf57.png)

In simulation mode for the test above, when heading south on north de anza blvd, the alert level could flutter between high and medium. This caused many voice prompts. Really, there is no need to ever degrade an alert level from high to medium. This change makes it's so we do not move back to medium if the alert level is already high.