### PR TITLE
Limit destinations to number of lines

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -37,13 +37,17 @@ class RouteManeuverViewController: UIViewController {
             if let distance = distance {
                 distanceLabel.isHidden = false
                 distanceLabel.text = distanceFormatter.string(from: distance)
-                streetLabel.numberOfLines = 1
+                streetLabel.numberOfLines = streetLabelLines
             } else {
                 distanceLabel.isHidden = true
                 distanceLabel.text = nil
-                streetLabel.numberOfLines = 2
+                streetLabel.numberOfLines = streetLabelLines
             }
         }
+    }
+    
+    var streetLabelLines: Int {
+        return distance != nil ? 1 : 2
     }
     
     var shieldImage: UIImage? {
@@ -67,7 +71,7 @@ class RouteManeuverViewController: UIViewController {
     var maximumAvailableStreetLabelSize: CGSize {
         get {
             let height = ("|" as NSString).size(attributes: [NSFontAttributeName: streetLabel.font]).height
-            let lines: CGFloat = distance == nil ? 2 : 1
+            let lines = CGFloat(streetLabelLines)
             let padding: CGFloat = 8*4
             return CGSize(width: view.bounds.width-padding-shieldImageView.bounds.size.width-turnArrowView.bounds.width, height: height*lines)
         }
@@ -101,8 +105,8 @@ class RouteManeuverViewController: UIViewController {
     public func updateStreetNameForStep() {
         if let name = step?.names?.first {
             streetLabel.unabridgedText = name
-        } else if let destinations = step?.destinations?.joined(separator: "\n") {
-            streetLabel.unabridgedText = destinations
+        } else if let destinations = step?.destinations {
+            streetLabel.unabridgedText = destinations.prefix(min(streetLabelLines, destinations.count)).joined(separator: "\n")
         } else if let step = step {
             streetLabel.unabridgedText = routeStepFormatter.string(for: step)
         }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -498,10 +498,10 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
     internal func routePageViewController(_ controller: RoutePageViewController, willTransitionTo maneuverViewController: RouteManeuverViewController) {
         let step = maneuverViewController.step
 
-        maneuverViewController.shieldImage = nil
-        maneuverViewController.updateStreetNameForStep()
-        maneuverViewController.distance = step!.distance > 0 ? step!.distance : nil
         maneuverViewController.turnArrowView.step = step
+        maneuverViewController.shieldImage = nil
+        maneuverViewController.distance = step!.distance > 0 ? step!.distance : nil
+        maneuverViewController.updateStreetNameForStep()
         
         updateShield(for: maneuverViewController)
         


### PR DESCRIPTION
Fixes #256 

Limit lines of destinations to show to the number of lines available in the streetLabel.

<img src="https://cloud.githubusercontent.com/assets/764476/26756345/9e223092-48a0-11e7-8ea1-e3c31b9e4f8f.png" width=300><img src="https://cloud.githubusercontent.com/assets/764476/26756346/9f077102-48a0-11e7-963d-86aa886d0e18.png" width=300>


@bsudekum @1ec5 👀 