### PR TITLE
Fix maneuver swiping

### DIFF
--- a/MapboxNavigation/RoutePageViewController.swift
+++ b/MapboxNavigation/RoutePageViewController.swift
@@ -34,8 +34,8 @@ class RoutePageViewController: UIPageViewController {
     }
     
     func setupRoutePageViewController() {
-        let currentStep = maneuverDelegate.upComingStep ?? maneuverDelegate.currentStep
-        let controller = routeManeuverViewController(with: currentStep)!
+        let step = maneuverDelegate.upComingStep ?? maneuverDelegate.currentStep
+        let controller = routeManeuverViewController(with: step)!
         setViewControllers([controller], direction: .forward, animated: false, completion: nil)
         currentManeuverPage = controller
         maneuverDelegate.routePageViewController(self, willTransitionTo: controller)


### PR DESCRIPTION
Swiping the maneuver list suffers from two issues:

* The current step shows up twice
* Swiping backwards can jump from x index all the way to the current step

@frederoni I'm not really certain why this code was here or why it fixed both the issues above, but it does ¯\_(ツ)_/¯.