### PR TITLE
Allow custom (destination) annotations

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -94,6 +94,8 @@ public protocol NavigationViewControllerDelegate {
      If this method is unimplemented, the navigation map view represents the route line’s casing using an `MGLPolylineFeature` identical to the one returned by `navigationMapView(_:shapeDescribing:)`.
      */
     @objc optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
+    
+    @objc optional func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
 }
 
 /**
@@ -382,6 +384,10 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     
     func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape? {
         return navigationDelegate?.navigationMapView?(mapView, shapeDescribing: route)
+    }
+    
+    func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+        return navigationDelegate?.navigationMapView?(mapView, imageFor: annotation)
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -95,6 +95,11 @@ public protocol NavigationViewControllerDelegate {
      */
     @objc optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
     
+    /**
+     Return an `MGLAnnotationImage` that represents the destination marker.
+     
+     If this method is unimplemented, the navigation map view will represent the destination annotation with the default marker.
+     */
     @objc optional func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -195,6 +195,10 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
             mapView.addArrow(routeProgress)
         }
     }
+    
+    func mapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+        return navigationMapView(mapView, imageFor: annotation)
+    }
 
     func setDefaultCamera(animated: Bool) {
         let camera = mapView.camera
@@ -292,6 +296,10 @@ extension RouteMapViewController: NavigationMapViewDelegate {
 
     func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape? {
         return delegate?.navigationMapView(mapView, simplifiedShapeDescribing: route)
+    }
+    
+    func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+        return delegate?.navigationMapView(mapView, imageFor:annotation)
     }
 
     @objc(navigationMapView:shouldUpdateTo:)
@@ -556,4 +564,5 @@ protocol RouteMapViewControllerDelegate: class {
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
     func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
+    func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
 }


### PR DESCRIPTION
This addition allows the developer to provide a custom annotation image for all annotations on the map. Note, the only annotations on the map currently is the destination marker.

/cc @frederoni 