### PR TITLE
Fixed bugs in closestCoordinate and addArrow functions.

### DIFF
--- a/MapboxCoreNavigation/Geometry.swift
+++ b/MapboxCoreNavigation/Geometry.swift
@@ -151,7 +151,7 @@ func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordinate: CLL
     
     var closestCoordinate: CoordinateAlongPolyline?
     
-    for var index in 0..<polyline.count - 1 {
+    for index in 0..<polyline.count - 1 {
         let segment = (polyline[index], polyline[index + 1])
         let distances = (coordinate - segment.0, coordinate - segment.1)
         
@@ -166,11 +166,10 @@ func closestCoordinate(on polyline: [CLLocationCoordinate2D], to coordinate: CLL
             closestCoordinate = CoordinateAlongPolyline(coordinate: segment.0, index: index, distance: distances.0)
         }
         if distances.1 < closestCoordinate?.distance ?? CLLocationDistanceMax {
-            index = index + 1
-            closestCoordinate = CoordinateAlongPolyline(coordinate: segment.1, index: index, distance: distances.1)
+            closestCoordinate = CoordinateAlongPolyline(coordinate: segment.1, index: index+1, distance: distances.1)
         }
         if intersectionDistance != nil && intersectionDistance! < closestCoordinate?.distance ?? CLLocationDistanceMax {
-            closestCoordinate = CoordinateAlongPolyline(coordinate: intersectionPoint!, index: index, distance: intersectionDistance!)
+            closestCoordinate = CoordinateAlongPolyline(coordinate: intersectionPoint!, index: (distances.0 < distances.1 ? index : index+1), distance: intersectionDistance!)
         }
     }
     

--- a/MapboxNavigation/MGLMapView.swift
+++ b/MapboxNavigation/MGLMapView.swift
@@ -44,13 +44,13 @@ extension MGLMapView {
         }
         
         let shaftLength = max(min(50 * metersPerPoint(atLatitude: maneuverCoordinate!.latitude), 50), 10)
-        let shaftCoordinates = polyline(along: polylineCoordinates!, within: -shaftLength / 2, of: maneuverCoordinate!)
-            + polyline(along: polylineCoordinates!, within: shaftLength, of: maneuverCoordinate!)
+        let shaftCoordinates = Array(polyline(along: polylineCoordinates!, within: -shaftLength / 2, of: maneuverCoordinate!).reversed()
+            + polyline(along: polylineCoordinates!, within: shaftLength, of: maneuverCoordinate!).suffix(from: 1))
         
         if shaftCoordinates.count > 1 {
             let shaftStrokeLength = shaftLength * 1.1
-            var shaftStrokeCoordinates = polyline(along: polylineCoordinates!, within: -shaftStrokeLength / 2, of: maneuverCoordinate!)
-                + polyline(along: polylineCoordinates!, within: shaftLength, of: maneuverCoordinate!)
+            var shaftStrokeCoordinates = Array(polyline(along: polylineCoordinates!, within: -shaftStrokeLength / 2, of: maneuverCoordinate!).reversed()
+                + polyline(along: polylineCoordinates!, within: shaftLength, of: maneuverCoordinate!).suffix(from: 1))
             let shaftStrokePolyline = ArrowStrokePolyline(coordinates: &shaftStrokeCoordinates, count: UInt(shaftStrokeCoordinates.count))
             
             var maneuverArrowStrokePolylines = [shaftStrokePolyline]


### PR DESCRIPTION
Referring to #283 

In _closestCoordinate_ function:
when the closest point to the polyline segment is the projection, now the index is set to the index of the coordinate closest to the intersection.

In _addArrow_ function:
shafts are now generated by concatenating the points before the maneuver **in the right order** with the points after the maneuver, making sure the **closest point to the maneuver is taken once**.

EDIT:
I now realize that the changes in _closestCoordinate_ might not be strictly necessary, but it's probably clearer and safer now anyways.