### PR TITLE
Fix jazzy doc image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods](https://img.shields.io/cocoapods/v/MapboxNavigation.svg)](http://cocoadocs.org/docsets/MapboxNavigation/)
 
-![Mapbox Navigation SDK](https://github.com/mapbox/mapbox-navigation-ios/blob/master/docs/img/navigation.png)
+![Mapbox Navigation SDK](https://github.com/mapbox/mapbox-navigation-ios/raw/master/docs/img/navigation.png)
 
 Mapbox Navigation gives you all the tools you need to add turn-by-turn navigation to your apps.
 


### PR DESCRIPTION
Fixes the lead image on the jazzy documentation site (https://mapbox.github.io/mapbox-navigation-ios/navigation/0.4.0/index.html). Doesn't affect the main image in the readme in master right now.