### PR TITLE
Fix attribution and logo layout

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -234,6 +234,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         
         mapViewController.delegate = self
         mapViewController.routeController = routeController
+        mapViewController.routeTableViewController = tableViewController
         mapViewController.destination = destination
         
         tableViewController.routeController = routeController

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -10,7 +10,7 @@ class ArrowFillPolyline: MGLPolylineFeature {}
 class ArrowStrokePolyline: ArrowFillPolyline {}
 
 
-class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDelegate {
+class RouteMapViewController: UIViewController {
     @IBOutlet weak var mapView: NavigationMapView!
 
     @IBOutlet weak var overviewButton: Button!
@@ -20,7 +20,7 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     @IBOutlet weak var wayNameView: UIView!
     
     var routePageViewController: RoutePageViewController!
-    var routeTableViewController: RouteTableViewController!
+    var routeTableViewController: RouteTableViewController?
     let routeStepFormatter = RouteStepFormatter()
     let MBSecondsBeforeResetTrackingMode: TimeInterval = 25.0
 
@@ -46,8 +46,6 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
     var shieldImageDownloadToken: SDWebImageDownloadToken?
     var arrowCurrentStep: RouteStep?
     var isInOverviewMode = false
-
-    let overviewContentInset = UIEdgeInsets(top: 65, left: 15, bottom: 55, right: 15)
 
     var simulatesLocationUpdates: Bool {
         guard let parent = parent as? NavigationViewController else { return false }
@@ -97,8 +95,8 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
             mapView.locationManager.stopUpdatingLocation()
             mapView.locationManager.stopUpdatingHeading()
         }
-
-        mapView.setContentInset(overviewContentInset, animated: false)
+        
+        mapView.setContentInset(contentInsets, animated: false)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -166,7 +164,8 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
         guard polyline.overlayBounds.ne - polyline.overlayBounds.sw > 200 else {
             return
         }
-        mapView.setVisibleCoordinateBounds(polyline.overlayBounds, edgePadding: overviewContentInset, animated: true)
+        
+        mapView.setVisibleCoordinateBounds(polyline.overlayBounds, edgePadding: contentInsets, animated: true)
     }
 
     func startResetTrackingModeTimer() {
@@ -275,6 +274,24 @@ class RouteMapViewController: UIViewController, PulleyPrimaryContentControllerDe
                 completion(image)
             }
         }
+    }
+    
+    var contentInsets: UIEdgeInsets {
+        guard let tableViewController = routeTableViewController else { return .zero }
+        guard let drawer = parent as? NavigationViewController else { return .zero }
+        
+        return UIEdgeInsets(top: routePageViewController.view.bounds.height,
+                            left: 0,
+                            bottom: drawer.drawerPosition == .partiallyRevealed ? tableViewController.partialRevealDrawerHeight() : tableViewController.collapsedDrawerHeight(),
+                            right: 0)
+    }
+}
+
+// MARK: PulleyPrimaryContentControllerDelegate
+
+extension RouteMapViewController: PulleyPrimaryContentControllerDelegate {
+    func drawerPositionDidChange(drawer: PulleyViewController) {
+        mapView.setContentInset(contentInsets, animated: true)
     }
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -165,7 +165,8 @@ class RouteMapViewController: UIViewController {
             return
         }
         
-        mapView.setVisibleCoordinateBounds(polyline.overlayBounds, edgePadding: contentInsets, animated: true)
+        let overviewContentInset = UIEdgeInsets(top: 65, left: 15, bottom: 55, right: 15)
+        mapView.setVisibleCoordinateBounds(polyline.overlayBounds, edgePadding: overviewContentInset, animated: true)
     }
 
     func startResetTrackingModeTimer() {

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -99,13 +99,6 @@ extension RouteTableViewController: PulleyDrawerViewControllerDelegate {
         ]
     }
     
-    func drawerPositionDidChange(drawer: PulleyViewController) {
-        var rect = tableView.frame
-        // Workaround for Pulley’s bounceOverflowMargin
-        rect.origin.y = drawer.drawerPosition == .collapsed ? 0 : -20
-        tableView.frame = rect
-    }
-    
     func collapsedDrawerHeight() -> CGFloat {
         return headerView.intrinsicContentSize.height
     }

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -97,7 +97,13 @@ extension RouteTableViewController: PulleyDrawerViewControllerDelegate {
             .open,
             .closed
         ]
-        
+    }
+    
+    func drawerPositionDidChange(drawer: PulleyViewController) {
+        var rect = tableView.frame
+        // Workaround for Pulley’s bounceOverflowMargin
+        rect.origin.y = drawer.drawerPosition == .collapsed ? 0 : -20
+        tableView.frame = rect
     }
     
     func collapsedDrawerHeight() -> CGFloat {
@@ -105,6 +111,6 @@ extension RouteTableViewController: PulleyDrawerViewControllerDelegate {
     }
     
     func partialRevealDrawerHeight() -> CGFloat {
-        return UIScreen.main.bounds.height * 0.75
+        return UIScreen.main.bounds.height * 0.60
     }
 }


### PR DESCRIPTION
Fixes #236 

Besides moving the ornaments, this PR also changes the partially revealed height from 75% to 60% of the screen height.

<img src="https://user-images.githubusercontent.com/764476/27319268-d41dcc86-5590-11e7-896d-3698a7f13457.png" width=200><img src="https://user-images.githubusercontent.com/764476/27319274-d5c5084c-5590-11e7-851e-74828eae26c8.png" width=200>

@bsudekum 👀 