### PR TITLE
Show shield for swiped to step

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -516,11 +516,7 @@ extension RouteMapViewController: MGLMapViewDelegate {
     }
 
     func updateShield(for controller: RouteManeuverViewController) {
-        let currentLegProgress = routeController.routeProgress.currentLegProgress
-
-        guard let upComingStep = currentLegProgress?.upComingStep else { return }
-        guard let ref = upComingStep.codes?.first else { return }
-        guard controller.shieldImage == nil else { return }
+        guard let ref = controller.step.codes?.first else { return }
 
         let components = ref.components(separatedBy: " ")
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -516,6 +516,7 @@ extension RouteMapViewController: MGLMapViewDelegate {
     }
 
     func updateShield(for controller: RouteManeuverViewController) {
+        guard let upComingStep = routeController.routeProgress.currentLegProgress?.upComingStep, upComingStep != controller.step else { return }
         guard let ref = controller.step.codes?.first else { return }
 
         let components = ref.components(separatedBy: " ")

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -259,10 +259,6 @@ class RouteMapViewController: UIViewController {
         let imageName = imageNamePattern.replacingOccurrences(of: " ", with: "_").replacingOccurrences(of: "{ref}", with: number)
         let apiURL = URL(string: "https://commons.wikimedia.org/w/api.php?action=query&format=json&maxage=86400&prop=imageinfo&titles=File%3A\(imageName)&iiprop=url%7Csize&iiurlheight=\(Int(round(height)))")!
 
-        guard shieldAPIDataTask?.originalRequest?.url != apiURL else {
-            return nil
-        }
-
         shieldAPIDataTask?.cancel()
         return URLSession.shared.dataTask(with: apiURL) { [weak self] (data, response, error) in
             var json: [String: Any] = [:]
@@ -516,8 +512,7 @@ extension RouteMapViewController: MGLMapViewDelegate {
     }
 
     func updateShield(for controller: RouteManeuverViewController) {
-        guard let upComingStep = routeController.routeProgress.currentLegProgress?.upComingStep, upComingStep != controller.step else { return }
-        guard let ref = controller.step.codes?.first else { return }
+        guard let ref = controller.step.codes?.first, controller.shieldImage == nil else { return }
 
         let components = ref.components(separatedBy: " ")
 


### PR DESCRIPTION
We're attempting to show the shield for the current step instead of the provide step. In cases where we're swiping ahead, we should show the highway shield provided in the function call.

/cc @frederoni 