### PR TITLE
Don't use ceremonial name when way is interstate

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		C55CEB281EB7E4240065D7D9 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55CEB271EB7E4240065D7D9 /* Locale.swift */; };
 		C58159011EA6D02700FC6C3D /* MGLVectorSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58159001EA6D02700FC6C3D /* MGLVectorSource.swift */; };
 		C58D6BAD1DDCF2AE00387F53 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58D6BAC1DDCF2AE00387F53 /* Constants.swift */; };
+		C594260D1F1EBA2B00C8E59C /* Highways.plist in Resources */ = {isa = PBXBuildFile; fileRef = C594260C1F1EBA2B00C8E59C /* Highways.plist */; };
 		C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADFBD71DDCC7840011824B /* MapboxCoreNavigationTests.swift */; };
 		C5C94C1B1DDCD22B0097296A /* MapboxCoreNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = C5ADFBCC1DDCC7840011824B /* MapboxCoreNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C5C94C1C1DDCD2340097296A /* RouteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADFBF91DDCC9580011824B /* RouteController.swift */; };
@@ -366,6 +367,7 @@
 		C55CEB271EB7E4240065D7D9 /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		C58159001EA6D02700FC6C3D /* MGLVectorSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLVectorSource.swift; sourceTree = "<group>"; };
 		C58D6BAC1DDCF2AE00387F53 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		C594260C1F1EBA2B00C8E59C /* Highways.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Highways.plist; sourceTree = "<group>"; };
 		C5ADFBC91DDCC7840011824B /* MapboxCoreNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxCoreNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5ADFBCC1DDCC7840011824B /* MapboxCoreNavigation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapboxCoreNavigation.h; sourceTree = "<group>"; };
 		C5ADFBCD1DDCC7840011824B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -561,6 +563,7 @@
 			children = (
 				351BEC281E5BD530006FE110 /* Assets.xcassets */,
 				351BEC2A1E5BD538006FE110 /* Shields.plist */,
+				C594260C1F1EBA2B00C8E59C /* Highways.plist */,
 				C520EE921EBB84F9008805BC /* Navigation.storyboard */,
 				DAAE5F321EAE4C4700832871 /* Localizable.strings */,
 				C5212B571EC4BE97009538EB /* Abbreviations.plist */,
@@ -1050,6 +1053,7 @@
 			files = (
 				351BEC2B1E5BD538006FE110 /* Shields.plist in Resources */,
 				DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */,
+				C594260D1F1EBA2B00C8E59C /* Highways.plist in Resources */,
 				351BEC291E5BD530006FE110 /* Assets.xcassets in Resources */,
 				C520EE901EBB84F9008805BC /* Navigation.storyboard in Resources */,
 				C5212B551EC4BE97009538EB /* Abbreviations.plist in Resources */,

--- a/MapboxNavigation/Bundle.swift
+++ b/MapboxNavigation/Bundle.swift
@@ -13,3 +13,10 @@ var ShieldImageNamesByPrefix: [String: String] = {
     }
     return NSDictionary(contentsOfFile: plistPath) as! [String: String]
 }()
+
+var HighwayNamesByPrefix: [String: String] = {
+    guard let plistPath = Bundle.mapboxNavigation.path(forResource: "Highways", ofType: "plist") else {
+        return [:]
+    }
+    return NSDictionary(contentsOfFile: plistPath) as! [String: String]
+}()

--- a/MapboxNavigation/Highways.plist
+++ b/MapboxNavigation/Highways.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>us-interstate</key>
+	<string>I</string>
+	<key>us-interstate-business</key>
+	<string>I</string>
+	<key>us-interstate-duplex</key>
+	<string>I</string>
+	<key>us-interstate-truck</key>
+	<string>I</string>
+	<key>us-highway</key>
+	<string>US</string>
+	<key>us-highway-duplex</key>
+	<string>US</string>
+	<key>us-highway-alternate</key>
+	<string>US</string>
+	<key>us-highway-business</key>
+	<string>US</string>
+	<key>us-highway-bypass</key>
+	<string>US</string>
+	<key>us-highway-truck</key>
+	<string>US</string>
+</dict>
+</plist>

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -171,7 +171,11 @@ class RouteManeuverViewController: UIViewController {
     
     func updateStreetNameForStep() {
         if let name = step?.names?.first {
-            destinationLabel.unabridgedText = name
+            if let step = step, let ref = step.codes?.first, ["i", "us", "ca"].contains(ref.lowercased().components(separatedBy: " ").first!) {
+                destinationLabel.unabridgedText = ref.components(separatedBy: " ").joined(separator: "-")
+            } else {
+                destinationLabel.unabridgedText = name
+            }
         } else if let destinations = step?.destinations {
             destinationLabel.unabridgedText = destinations.prefix(min(numberOfDestinationLines, destinations.count)).joined(separator: "\n")
         } else if let step = step {

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -173,7 +173,7 @@ class RouteManeuverViewController: UIViewController {
         if let destinations = step?.destinations {
             destinationLabel.unabridgedText = destinations.prefix(min(numberOfDestinationLines, destinations.count)).joined(separator: "\n")
         } else if let name = step?.names?.first {
-            if let ref = step.codes?.first, !["freeway", "expressway", "highway"].contains(name.lowercased()) {
+            if let ref = step.codes?.first, name.isFreeway {
                 destinationLabel.unabridgedText = ref
             } else {
                 destinationLabel.unabridgedText = name

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -170,14 +170,21 @@ class RouteManeuverViewController: UIViewController {
     }
     
     func updateStreetNameForStep() {
-        if let name = step?.names?.first {
-            if let step = step, let ref = step.codes?.first, ["i", "us", "ca"].contains(ref.lowercased().components(separatedBy: " ").first!) {
-                destinationLabel.unabridgedText = ref.components(separatedBy: " ").joined(separator: "-")
+        var stepRef: String?
+        if let step = step, let ref = step.codes?.first, ["i", "us"].contains(ref.lowercased().components(separatedBy: " ").first!) {
+            stepRef = ref
+        }
+        
+        if let destinations = step?.destinations {
+            let dest = destinations.prefix(min(numberOfDestinationLines, destinations.count)).joined(separator: "\n")
+            
+            if let stepRef = stepRef {
+                destinationLabel.unabridgedText = "\(stepRef) / \(dest)"
             } else {
-                destinationLabel.unabridgedText = name
+                destinationLabel.unabridgedText = dest
             }
-        } else if let destinations = step?.destinations {
-            destinationLabel.unabridgedText = destinations.prefix(min(numberOfDestinationLines, destinations.count)).joined(separator: "\n")
+        } else if let name = step?.names?.first {
+            destinationLabel.unabridgedText = stepRef ?? name
         } else if let step = step {
             destinationLabel.unabridgedText = routeStepFormatter.string(for: step)
         }

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -170,21 +170,14 @@ class RouteManeuverViewController: UIViewController {
     }
     
     func updateStreetNameForStep() {
-        var stepRef: String?
-        if let step = step, let ref = step.codes?.first, ["i", "us"].contains(ref.lowercased().components(separatedBy: " ").first!) {
-            stepRef = ref
-        }
-        
         if let destinations = step?.destinations {
-            let dest = destinations.prefix(min(numberOfDestinationLines, destinations.count)).joined(separator: "\n")
-            
-            if let stepRef = stepRef {
-                destinationLabel.unabridgedText = "\(stepRef) / \(dest)"
-            } else {
-                destinationLabel.unabridgedText = dest
-            }
+            destinationLabel.unabridgedText = destinations.prefix(min(numberOfDestinationLines, destinations.count)).joined(separator: "\n")
         } else if let name = step?.names?.first {
-            destinationLabel.unabridgedText = stepRef ?? name
+            if let ref = step.codes?.first, !["freeway", "expressway", "highway"].contains(name.lowercased()) {
+                destinationLabel.unabridgedText = ref
+            } else {
+                destinationLabel.unabridgedText = name
+            }
         } else if let step = step {
             destinationLabel.unabridgedText = routeStepFormatter.string(for: step)
         }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -407,14 +407,6 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         
         return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
     }
-    
-    func choose(name: String, ref: String) -> String? {
-        if !["freeway", "expressway", "highway"].contains(name.lowercased()) {
-            return ref
-        } else {
-            return name
-        }
-    }
 }
 
 // MARK: MGLMapViewDelegate

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -336,10 +336,18 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                     if minDistanceBetweenPoints < smallestLabelDistance {
                         smallestLabelDistance = minDistanceBetweenPoints
                         
-                        if let line = feature as? MGLPolylineFeature, let name = line.attribute(forKey: "name") as? String {
-                            currentName = name
-                        } else if let line = feature as? MGLMultiPolylineFeature, let name = line.attribute(forKey: "name") as? String {
-                            currentName = name
+                        if let line = feature as? MGLPolylineFeature {
+                            if let name = line.attribute(forKey: "name") as? String, !name.isFreeway {
+                                currentName = name
+                            } else if let ref = line.attribute(forKey: "ref") as? String, let shield = line.attribute(forKey: "shield") as? String {
+                                currentName = "\(shield) \(ref)"
+                            }
+                        } else if let line = feature as? MGLMultiPolylineFeature {
+                            if let name = line.attribute(forKey: "name") as? String, !name.isFreeway {
+                                currentName = name
+                            } else if let ref = line.attribute(forKey: "ref") as? String, let shield = line.attribute(forKey: "shield") as? String {
+                                currentName = "\(shield) \(ref)"
+                            }
                         } else {
                             currentName = nil
                         }
@@ -398,6 +406,14 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         }
         
         return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
+    }
+    
+    func choose(name: String, ref: String) -> String? {
+        if !["freeway", "expressway", "highway"].contains(name.lowercased()) {
+            return ref
+        } else {
+            return name
+        }
     }
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -340,13 +340,21 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                             if let name = line.attribute(forKey: "name") as? String, !name.isFreeway {
                                 currentName = name
                             } else if let ref = line.attribute(forKey: "ref") as? String, let shield = line.attribute(forKey: "shield") as? String {
-                                currentName = "\(shield) \(ref)"
+                                if let highwayName = HighwayNamesByPrefix[shield] {
+                                    currentName = "\(highwayName) \(ref)"
+                                } else {
+                                    currentName = ref
+                                }
                             }
                         } else if let line = feature as? MGLMultiPolylineFeature {
                             if let name = line.attribute(forKey: "name") as? String, !name.isFreeway {
                                 currentName = name
                             } else if let ref = line.attribute(forKey: "ref") as? String, let shield = line.attribute(forKey: "shield") as? String {
-                                currentName = "\(shield) \(ref)"
+                                if let highwayName = HighwayNamesByPrefix[shield] {
+                                    currentName = "\(highwayName) \(ref)"
+                                } else {
+                                    currentName = ref
+                                }
                             }
                         } else {
                             currentName = nil
@@ -355,7 +363,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                 }
             }
             
-            if smallestLabelDistance < 5 && currentName != nil {
+            if smallestLabelDistance < 10 && currentName != nil {
                 wayNameLabel.text = currentName
                 wayNameView.isHidden = false
             } else {

--- a/MapboxNavigation/String.swift
+++ b/MapboxNavigation/String.swift
@@ -10,10 +10,7 @@ extension String {
             return NSRange(location: 0, length: characters.count)
         }
     }
-}
 
-
-extension String {
     typealias Replacement = (of: String, with: String)
 
     func byReplacing(_ replacements: [Replacement]) -> String {
@@ -27,5 +24,11 @@ extension String {
             ("\"", "&quot;"),
             ("'", "&apos;")
             ])
+    }
+
+    var isFreeway: Bool {
+        return self.components(separatedBy: " ").filter {
+            ["freeway", "expressway", "highway", "fwy", "hwy"].contains($0)
+        }.isEmpty
     }
 }


### PR DESCRIPTION
In cases where the user is coming up to a highway, we should not show the ceremonial highway name.

What should the text say? Right now it says `US-280` and also shows the shield image.

/cc @1ec5 @frederoni @ericrwolfe 