### PR TITLE
Store current road details in map view controller

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -43,6 +43,17 @@ class RouteMapViewController: UIViewController {
         }
     }
     weak var delegate: RouteMapViewControllerDelegate?
+    
+    var currentRoadName: String? {
+        didSet {
+            if let currentRoadName = currentRoadName {
+                wayNameLabel.text = currentRoadName
+                wayNameView.isHidden = false
+            } else {
+                wayNameView.isHidden = true
+            }
+        }
+    }
 
     weak var routeController: RouteController!
 
@@ -347,12 +358,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                 }
             }
             
-            if smallestLabelDistance < 5 && currentName != nil {
-                wayNameLabel.text = currentName
-                wayNameView.isHidden = false
-            } else {
-                wayNameView.isHidden = true
-            }
+            currentRoadName = smallestLabelDistance < 5 ? currentName : nil
         }
         
         


### PR DESCRIPTION
RouteMapViewController now stores the current name and classification of the current road, based on the same process by which the current road name label is populated. Eventually, perhaps RouteVoiceController could somehow gain access to this information so that it could word and time voice announcements differently on freeways versus surface streets.

At first glance, this might also look like a good solution to https://github.com/mapbox/mapbox-navigation-ios/pull/291#discussion_r123060422, Project-OSRM/osrm-text-instructions#51, and https://github.com/mapbox/mapbox-navigation-ios/issues/286#issuecomment-309649781. However, this feature querying mechanism only gives us information about the road the user is currently traveling on, not the one the user needs to turn onto.

/cc @bsudekum @frederoni