### PR TITLE
Revert https://github.com/mapbox/mapbox-navigation-ios/pull/296/

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -156,7 +156,13 @@ class ViewController: UIViewController, MGLMapViewDelegate, NavigationViewContro
         
         let camera = mapView.camera
         camera.pitch = 45
-        camera.altitude = 1_000
+        camera.altitude = 600
+        if let userLocation = mapView.userLocation {
+            camera.centerCoordinate = userLocation.coordinate
+            if let location = userLocation.location {
+                camera.heading = location.course
+            }
+        }
         navigationViewController.pendingCamera = camera
         
         present(navigationViewController, animated: true, completion: nil)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -82,15 +82,15 @@ class RouteMapViewController: UIViewController {
         } else {
             setDefaultCamera(animated: false)
         }
-        
-        mapView.setUserLocationVerticalAlignment(.bottom, animated: false)
-        mapView.setUserTrackingMode(.followWithCourse, animated: false)
 
         UIDevice.current.addObserver(self, forKeyPath: "batteryState", options: .initial, context: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        
+        mapView.setUserTrackingMode(.followWithCourse, animated: false)
+        mapView.setUserLocationVerticalAlignment(.bottom, animated: false)
 
         if simulatesLocationUpdates {
             mapView.locationManager.stopUpdatingLocation()


### PR DESCRIPTION
Reverts https://github.com/mapbox/mapbox-navigation-ios/pull/296

We need to take a look at this in depth later on. With #296, the user never enters `.followWithCourse` mode.

Also added some camera changes so you're facing the right direction when the view loads.

/cc @frederoni 