### PR TITLE
Don't suspend notifications on viewWillDisappear

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -277,11 +277,6 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         self.delegate = self
     }
     
-    public override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        suspendNotifications()
-    }
-    
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -87,8 +87,7 @@ class RouteManeuverViewController: UIViewController {
         resumeNotifications()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    deinit {
         suspendNotifications()
     }
     


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-navigation-ios/issues/303, but these lifecycle events should be looked at more closely.

cc @frederoni