### PR TITLE
Default directions

### DIFF
--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -136,8 +136,8 @@
 -(void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
     if ([segue.identifier isEqualToString:@"StartNavigation"]) {
         MBNavigationViewController *controller = (MBNavigationViewController *)[segue destinationViewController];
-        controller.route = self.route;
         controller.directions = [MBDirections sharedDirections];
+        controller.route = self.route;
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -134,7 +134,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
      See [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift)
      for further information.
      */
-    public var directions: Directions!
+    public var directions: Directions = Directions.shared
     
     /**
      `pendingCamera` is an optional `MGLMapCamera` you can use to improve


### PR DESCRIPTION
Fixes #273 

Using storyboards forces you to set `directions` before `route` to avoid trying to unwrap an implicitly unwrapped optional triggered by the `route`'s didSet which resulted in a crash.

@friedbunny 👀 