### PR TITLE
Check availability

### DIFF
--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -17,8 +17,10 @@ open class NavigationLocationManager: CLLocationManager {
             requestWhenInUseAuthorization()
         }
         
-        if Bundle.main.backgroundModeLocationSupported {
-            allowsBackgroundLocationUpdates = true
+        if #available(iOS 9.0, *) {
+            if Bundle.main.backgroundModeLocationSupported {
+                allowsBackgroundLocationUpdates = true
+            }
         }
     }
 }


### PR DESCRIPTION
An application with deployment target set to iOS 8 gives an error at compile time w/o this availability check.

@ericrwolfe 