### PR TITLE
Refactor voice controllers

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		35002D711E5F6C7F0090E733 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 35002D6D1E5F6C7F0090E733 /* main.m */; };
 		35002D761E5F6CD30090E733 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 35002D741E5F6CD30090E733 /* Main.storyboard */; };
 		351174F41EF1C0530065E248 /* ReplayLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351174F31EF1C0530065E248 /* ReplayLocationManager.swift */; };
+		351A40161F0291D100E6D378 /* PollyVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351A40151F0291D100E6D378 /* PollyVoiceController.swift */; };
 		351BEBF11E5BCC63006FE110 /* MGLMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */; };
 		351BEBF21E5BCC63006FE110 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBE01E5BCC63006FE110 /* Style.swift */; };
 		351BEBF51E5BCC63006FE110 /* RouteManeuverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEBE31E5BCC63006FE110 /* RouteManeuverViewController.swift */; };
@@ -263,6 +264,7 @@
 		35002D6D1E5F6C7F0090E733 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		35002D751E5F6CD30090E733 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		351174F31EF1C0530065E248 /* ReplayLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplayLocationManager.swift; sourceTree = "<group>"; };
+		351A40151F0291D100E6D378 /* PollyVoiceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollyVoiceController.swift; sourceTree = "<group>"; };
 		351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		351BEBDA1E5BCC28006FE110 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLMapView.swift; sourceTree = "<group>"; };
@@ -509,6 +511,7 @@
 				35C997401E732C5400544D1C /* RouteStepFormatter.swift */,
 				35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */,
 				353E69001EF0C2B6007B2AE5 /* DefaultLocationManager.swift */,
+				351A40151F0291D100E6D378 /* PollyVoiceController.swift */,
 			);
 			path = MapboxNavigation;
 			sourceTree = "<group>";
@@ -1159,6 +1162,7 @@
 				35D825FC1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m in Sources */,
 				351BEBFF1E5BCC63006FE110 /* StyleKitArrows.swift in Sources */,
 				351BEBF91E5BCC63006FE110 /* RouteTableViewCell.swift in Sources */,
+				351A40161F0291D100E6D378 /* PollyVoiceController.swift in Sources */,
 				C5000A931EC25C6E00563EA9 /* Abbreviations.swift in Sources */,
 				35C9973F1E732C1B00544D1C /* RouteVoiceController.swift in Sources */,
 				351BEBFC1E5BCC63006FE110 /* NavigationViewController.swift in Sources */,

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -2,6 +2,11 @@ import Foundation
 import AWSPolly
 import AVFoundation
 
+/**
+ `PollyVoiceController` extends the default `RouteVoiceController` by providing
+ support for AWSPolly. `RouteVoiceController` will be used as a fallback during
+ poor network conditions.
+ */
 @objc(MBPollyVoiceController)
 public class PollyVoiceController: RouteVoiceController {
     

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -1,0 +1,122 @@
+import Foundation
+import AWSPolly
+import AVFoundation
+
+@objc(MBPollyVoiceController)
+public class PollyVoiceController: RouteVoiceController {
+    
+    /**
+     Forces Polly voice to always be of specified type. If not set, a localized voice will be used.
+     */
+    public var globalVoiceId: AWSPollyVoiceId?
+    
+    /**
+     `regionType` specifies what AWS region to use for Polly.
+     */
+    public var regionType: AWSRegionType = .USEast1
+    
+    /**
+     `identityPoolId` is a required value for using AWS Polly voice instead of iOS's built in AVSpeechSynthesizer.
+     You can get a token here: http://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth-aws-identity-for-ios.html
+     */
+    public var identityPoolId: String
+    
+    public init(identityPoolId: String) {
+        self.identityPoolId = identityPoolId
+        
+        let credentialsProvider = AWSCognitoCredentialsProvider(regionType: regionType, identityPoolId: identityPoolId)
+        let configuration = AWSServiceConfiguration(region: regionType, credentialsProvider: credentialsProvider)
+        AWSServiceManager.default().defaultServiceConfiguration = configuration
+        
+        super.init()
+    }
+    
+    public override func alertLevelDidChange(notification: NSNotification) {
+        guard shouldSpeak(for: notification) == true else { return }
+        speak(speechString(notification: notification, markUpWithSSML: true), error: nil)
+        startAnnouncementTimer()
+    }
+    
+    override func speak(_ text: String, error: String?) {
+        assert(!text.isEmpty)
+        
+        let input = AWSPollySynthesizeSpeechURLBuilderRequest()
+        input.textType = .ssml
+        input.outputFormat = .mp3
+        
+        let langs = Locale.preferredLocalLanguageCountryCode.components(separatedBy: "-")
+        let langCode = langs[0]
+        var countryCode = ""
+        if langs.count > 1 {
+            countryCode = langs[1]
+        }
+        
+        switch (langCode, countryCode) {
+        case ("de", _):
+            input.voiceId = .marlene
+        case ("en", "CA"):
+            input.voiceId = .joanna
+        case ("en", "GB"):
+            input.voiceId = .brian
+        case ("en", "AU"):
+            input.voiceId = .nicole
+        case ("en", "IN"):
+            input.voiceId = .raveena
+        case ("en", _):
+            input.voiceId = .joanna
+        case ("es", _):
+            input.voiceId = .miguel
+        case ("fr", _):
+            input.voiceId = .celine
+        case ("nl", _):
+            input.voiceId = .lotte
+        case ("ru", _):
+            input.voiceId = .maxim
+        case ("sv", _):
+            input.voiceId = .astrid
+        default:
+            super.speak(fallbackText, error: "Voice \(langCode)-\(countryCode) not found")
+            return
+        }
+        
+        if let voiceId = globalVoiceId {
+            input.voiceId = voiceId
+        }
+        
+        input.text = "<speak><prosody volume='\(instructionVoiceVolume)' rate='\(instructionVoiceSpeedRate)'>\(text)</prosody></speak>"
+        
+        let builder = AWSPollySynthesizeSpeechURLBuilder.default().getPreSignedURL(input)
+        builder.continueWith { [weak self] (awsTask: AWSTask<NSURL>) -> Any? in
+            guard let strongSelf = self else {
+                return nil
+            }
+            
+            strongSelf.handle(awsTask)
+            
+            return nil
+        }
+    }
+    
+    func handle(_ awsTask: AWSTask<NSURL>) {
+        guard awsTask.error == nil else {
+            super.speak(fallbackText, error: awsTask.error!.localizedDescription)
+            return
+        }
+        
+        guard let url = awsTask.result else {
+            super.speak(fallbackText, error: "No polly response")
+            return
+        }
+        
+        do {
+            let soundData = try Data(contentsOf: url as URL)
+            audioPlayer = try AVAudioPlayer(data: soundData)
+            if let audioPlayer = audioPlayer {
+                audioPlayer.volume = volume
+                audioPlayer.play()
+            }
+        } catch {
+            super.speak(fallbackText, error: error.localizedDescription)
+        }
+    }
+}

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -3,6 +3,9 @@ import AVFoundation
 import MapboxDirections
 import MapboxCoreNavigation
 
+/**
+ The `RouteVoiceController` class provides voice guidance.
+ */
 @objc(MBRouteVoiceController)
 open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -2,10 +2,9 @@ import Foundation
 import AVFoundation
 import MapboxDirections
 import MapboxCoreNavigation
-import AWSPolly
 
 @objc(MBRouteVoiceController)
-public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
+open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     
     lazy var speechSynth = AVSpeechSynthesizer()
     var audioPlayer: AVAudioPlayer?
@@ -13,8 +12,6 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     let routeStepFormatter = RouteStepFormatter()
     var recentlyAnnouncedRouteStep: RouteStep?
     var fallbackText: String!
-    // Use default speech synthesizer if identityPool is unset
-    var useDefaultVoice: Bool { return identityPoolId == nil }
     var announcementTimer: Timer!
     
     /**
@@ -30,12 +27,6 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     
     
     /**
-     Forces Polly voice to always be of specified type. If not set, a localized voice will be used.
-     */
-    public var globalVoiceId: AWSPollyVoiceId?
-    
-    
-    /**
      SSML option which controls at which speed Polly instructions are read.
      */
     public var instructionVoiceSpeedRate = 1.08
@@ -45,12 +36,6 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
      SSML option that specifies the voice loudness.
      */
     public var instructionVoiceVolume = "x-loud"
-    
-    
-    /**
-     `regionType` specifies what AWS region to use for Polly.
-     */
-    public var regionType: AWSRegionType = .USEast1
     
     
     /**
@@ -69,24 +54,10 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
      Buffer time between announcements. After an announcement is given any announcement given within this `TimeInterval` will be suppressed.
     */
     public var bufferBetweenAnnouncements: TimeInterval = 3
-
-    
-    /**
-     `identityPoolId` is a required value for using AWS Polly voice instead of iOS's built in AVSpeechSynthesizer.
-     You can get a token here: http://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth-aws-identity-for-ios.html
-     */
-    public var identityPoolId: String? {
-        didSet {
-            if let poolId = identityPoolId {
-                let credentialsProvider = AWSCognitoCredentialsProvider(regionType:regionType, identityPoolId: poolId)
-                let configuration = AWSServiceConfiguration(region:regionType, credentialsProvider:credentialsProvider)
-                AWSServiceManager.default().defaultServiceConfiguration = configuration
-            }
-        }
-    }
     
     override public init() {
         super.init()
+        speechSynth.delegate = self
         maneuverVoiceDistanceFormatter.unitStyle = .long
         maneuverVoiceDistanceFormatter.numberFormatter.locale = .nationalizedCurrent
         resumeNotifications()
@@ -161,12 +132,19 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         announcementTimer.invalidate()
     }
     
-    func alertLevelDidChange(notification: NSNotification) {
-        guard isEnabled, volume > 0 else { return }
+    open func alertLevelDidChange(notification: NSNotification) {
+        guard shouldSpeak(for: notification) == true else { return }
+        
+        speak(fallbackText, error: nil)
+        startAnnouncementTimer()
+    }
+    
+    func shouldSpeak(for notification: NSNotification) -> Bool {
+        guard isEnabled, volume > 0 else { return false }
         
         guard let routeProgress = notification.userInfo![RouteControllerAlertLevelDidChangeNotificationRouteProgressKey] as? RouteProgress else {
             assert(false)
-            return
+            return false
         }
         
         // We're guarding against two things here:
@@ -174,7 +152,7 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         //   2. `recentlyAnnouncedRouteStep` being equal to currentStep
         // If it has a value and they're equal, this means we gave an announcement with x seconds ago for this step
         guard recentlyAnnouncedRouteStep != routeProgress.currentLegProgress.currentStep else {
-            return
+            return false
         }
         
         // Set recentlyAnnouncedRouteStep to the current step
@@ -184,16 +162,10 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         
         // If the user is merging onto a highway, an announcement to merge is a bit excessive
         if let upComingStep = routeProgress.currentLegProgress.upComingStep, routeProgress.currentLegProgress.currentStep.maneuverType == .takeOnRamp && upComingStep.maneuverType == .merge && routeProgress.currentLegProgress.alertUserLevel == .high {
-            return
+            return false
         }
         
-        if useDefaultVoice {
-            speakFallBack(fallbackText)
-        } else {
-            speakWithPolly(speechString(notification: notification, markUpWithSSML: true))
-        }
-        
-        startAnnouncementTimer()
+        return true
     }
     
     func speechString(notification: NSNotification, markUpWithSSML: Bool) -> String {
@@ -269,96 +241,14 @@ public class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         return road
     }
     
-    func speakWithPolly(_ text: String) {
-        assert(!text.isEmpty)
-        
-        speechSynth.delegate = self
-        let input = AWSPollySynthesizeSpeechURLBuilderRequest()
-        input.textType = .ssml
-        input.outputFormat = .mp3
-
-        let langs = Locale.preferredLocalLanguageCountryCode.components(separatedBy: "-")
-        let langCode = langs[0]
-        var countryCode = ""
-        if langs.count > 1 {
-            countryCode = langs[1]
-        }
-        
-        switch (langCode, countryCode) {
-        case ("de", _):
-            input.voiceId = .marlene
-        case ("en", "CA"):
-            input.voiceId = .joanna
-        case ("en", "GB"):
-             input.voiceId = .brian
-        case ("en", "AU"):
-            input.voiceId = .nicole
-        case ("en", "IN"):
-            input.voiceId = .raveena
-        case ("en", _):
-            input.voiceId = .joanna
-        case ("es", _):
-            input.voiceId = .miguel
-        case ("fr", _):
-            input.voiceId = .celine
-        case ("nl", _):
-            input.voiceId = .lotte
-        case ("ru", _):
-            input.voiceId = .maxim
-        case ("sv", _):
-            input.voiceId = .astrid
-        default:
-            speakFallBack(fallbackText, error: "Voice \(langCode)-\(countryCode) not found")
-            return
-        }
-        
-        if let voiceId = globalVoiceId {
-            input.voiceId = voiceId
-        }
-        
-        input.text = "<speak><prosody volume='\(instructionVoiceVolume)' rate='\(instructionVoiceSpeedRate)'>\(text)</prosody></speak>"
-        
-        let builder = AWSPollySynthesizeSpeechURLBuilder.default().getPreSignedURL(input)
-        builder.continueWith { [weak self] (awsTask: AWSTask<NSURL>) -> Any? in
-            guard let strongSelf = self else {
-                return nil
-            }
-            
-            guard awsTask.error == nil else {
-                strongSelf.speakFallBack(strongSelf.fallbackText, error: awsTask.error!.localizedDescription)
-                return nil
-            }
-            
-            guard let url = awsTask.result else {
-                strongSelf.speakFallBack(strongSelf.fallbackText, error: "No polly response")
-                return nil
-            }
-            
-            
-            do {
-                let soundData = try Data(contentsOf: url as URL)
-                strongSelf.audioPlayer = try AVAudioPlayer(data: soundData)
-                if let audioPlayer = strongSelf.audioPlayer {
-                    audioPlayer.volume = strongSelf.volume
-                    audioPlayer.play()
-                }
-            } catch {
-                strongSelf.speakFallBack(strongSelf.fallbackText, error: error.localizedDescription)
-            }
-            
-            return nil
-        }
-    }
-
-    
-    func speakFallBack(_ text: String, error: String? = nil) {
+    func speak(_ text: String, error: String? = nil) {
         // Note why it failed
         if let error = error {
             print(error)
         }
         
         let utterance = AVSpeechUtterance(string: text)
-
+        
         // Only localized languages will have a proper fallback voice
         utterance.voice = AVSpeechSynthesisVoice(language: Locale.preferredLocalLanguageCountryCode)
         utterance.volume = volume


### PR DESCRIPTION
Fixes #280 

Split up voice controllers into RouteVoiceController and PollyVoiceController.

Replace AVSpeech with Polly:
```swift
navigationViewController.voiceController = PollyVoiceController(identityPoolId: "…")
```

@1ec5 @bsudekum 👀 