### PR TITLE
Weaken navigation delegate

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -150,7 +150,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     /**
      The receiver’s delegate.
      */
-    public var navigationDelegate: NavigationViewControllerDelegate?
+    public weak var navigationDelegate: NavigationViewControllerDelegate?
     
     /**
      `voiceController` provides access to various speech synthesizer options.


### PR DESCRIPTION
`NavigationViewController.navigationDelegate` must be weak; otherwise, it can lead to a retain cycle.

/cc @frederoni