### PR TITLE
Upgrade to map SDK v3.6.0

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.5.4"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.6.0"
 github "52inc/Pulley" "1.4"
 github "Project-OSRM/osrm-text-instructions.swift" "v0.1.2"
 github "facebook/ios-snapshot-test-case" "2.1.4"


### PR DESCRIPTION
Upgraded example applications to v3.6.0 of the map SDK. Note that this PR doesn’t increase the minimum required version specified in either Cartfile or Podfile.

/cc @frederoni @friedbunny