### PR TITLE
Wait until style has loaded before doing things to it

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -26,6 +26,8 @@ class RouteMapViewController: UIViewController {
 
     var route: Route { return routeController.routeProgress.route }
     var previousStep: RouteStep?
+    
+    var hasFinishedLoadingStyle = false
 
     var destination: MGLAnnotation!
     var pendingCamera: MGLMapCamera? {
@@ -315,9 +317,15 @@ extension RouteMapViewController: NavigationMapViewDelegate {
     func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
         return delegate?.navigationMapView(mapView, imageFor:annotation)
     }
+    
+    func mapViewDidFinishLoadingMap(_ mapView: MGLMapView) {
+        hasFinishedLoadingStyle = true
+    }
 
     @objc(navigationMapView:shouldUpdateTo:)
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation? {
+        
+        guard hasFinishedLoadingStyle else { return nil }
 
         guard routeController.userIsOnRoute(location) else { return nil }
         guard let stepCoordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates else  { return nil }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -324,15 +324,13 @@ extension RouteMapViewController: NavigationMapViewDelegate {
 
     @objc(navigationMapView:shouldUpdateTo:)
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation? {
-        
-        guard hasFinishedLoadingStyle else { return nil }
 
         guard routeController.userIsOnRoute(location) else { return nil }
         guard let stepCoordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates else  { return nil }
         guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
 
         // Add current way name to UI
-        if let style = mapView.style, recenterButton.isHidden{
+        if let style = mapView.style, recenterButton.isHidden && hasFinishedLoadingStyle {
             let closestCoordinate = snappedCoordinate.coordinate
             let roadLabelLayerIdentifier = "roadLabelLayer"
             var streetsSources = style.sources.flatMap {


### PR DESCRIPTION
Attempts to fix the black lines in https://github.com/mapbox/mapbox-navigation-ios/issues/338.

I think in some cases, https://github.com/mapbox/mapbox-navigation-ios/blob/eab11c929885b270e8c655495ed4e0b25123a78b/MapboxNavigation/RouteMapViewController.swift#L345-L358 could be causing a race condition if the style is not fully loaded.

/cc @frederoni @1ec5 @zijiazhai