### PR TITLE
Fix location permissions and adopt iOS 11 description

### DIFF
--- a/Examples/Swift/Info.plist
+++ b/Examples/Swift/Info.plist
@@ -28,6 +28,8 @@
 	<string>Get user location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Get user location</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Get user location</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>

--- a/MapboxCoreNavigation/Bundle.swift
+++ b/MapboxCoreNavigation/Bundle.swift
@@ -1,12 +1,31 @@
 import Foundation
 
 extension Bundle {
+    
     var backgroundModeLocationSupported: Bool {
         get {
-            if let modes = Bundle.main.object(forInfoDictionaryKey: "UIBackgroundModes") as? [String] {
+            if let modes = object(forInfoDictionaryKey: "UIBackgroundModes") as? [String] {
                 return modes.contains("location")
             }
             return false
+        }
+    }
+    
+    var locationAlwaysAndWhenInUseUsageDescription: String? {
+        get {
+            return object(forInfoDictionaryKey: "NSLocationAlwaysAndWhenInUseUsageDescription") as? String
+        }
+    }
+    
+    var locationWhenInUseUsageDescription: String? {
+        get {
+            return object(forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription") as? String
+        }
+    }
+    
+    var locationAlwaysUsageDescription: String? {
+        get {
+            return object(forInfoDictionaryKey: "NSLocationAlwaysUsageDescription") as? String
         }
     }
 }

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -13,7 +13,12 @@ open class NavigationLocationManager: CLLocationManager {
     override public init() {
         super.init()
         
-        if CLLocationManager.authorizationStatus() == .notDetermined {
+        let always = Bundle.main.locationAlwaysUsageDescription
+        let both = Bundle.main.locationAlwaysAndWhenInUseUsageDescription
+        
+        if always != nil || both != nil {
+            requestAlwaysAuthorization()
+        } else {
             requestWhenInUseAuthorization()
         }
         


### PR DESCRIPTION
Added the new `NSLocationAlwaysAndWhenInUseUsageDescription` to the example app to support iOS 11.

Request always authorization if `Always` or `AlwaysAndWhenInUse` keys are provided otherwise request when in use authorization.

@bsudekum @friedbunny 👀 