### PR TITLE
Stop updating location on map view

### DIFF
--- a/MapboxNavigation/MGLMapView+MGLNavigationAdditions.h
+++ b/MapboxNavigation/MGLMapView+MGLNavigationAdditions.h
@@ -5,6 +5,9 @@
 // FIXME: This will be removed once https://github.com/mapbox/mapbox-gl-native/issues/6867 is implemented
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations;
 
+// FIXME: This will be removed once https://github.com/mapbox/mapbox-navigation-ios/issues/352 is implemented.
+- (void)validateLocationServices;
+
 @property (nonatomic, readonly) CLLocationManager *locationManager;
 
 @end

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -21,15 +21,33 @@ open class NavigationMapView: MGLMapView {
         22: MGLStyleValue(rawValue: 18)
     ]
     
+    var manuallyUpdatesLocation: Bool = false {
+        didSet {
+            if manuallyUpdatesLocation {
+                locationManager.stopUpdatingLocation()
+                locationManager.stopUpdatingHeading()
+                locationManager.delegate = nil
+            } else {
+                validateLocationServices()
+            }
+        }
+    }
+    
     public weak var navigationMapDelegate: NavigationMapViewDelegate?
     
-    open override func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [CLLocation]!) {
+    override open func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [CLLocation]!) {
         guard let location = locations.first else { return }
         
         if let modifiedLocation = navigationMapDelegate?.navigationMapView?(self, shouldUpdateTo: location) {
             super.locationManager(manager, didUpdateLocations: [modifiedLocation])
         } else {
             super.locationManager(manager, didUpdateLocations: locations)
+        }
+    }
+    
+    override open func validateLocationServices() {
+        if !manuallyUpdatesLocation {
+            super.validateLocationServices()
         }
     }
     

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -61,6 +61,7 @@ class RouteMapViewController: UIViewController {
         
         mapView.delegate = self
         mapView.navigationMapDelegate = self
+        mapView.manuallyUpdatesLocation = true
         
         overviewButton.applyDefaultCornerRadiusShadow(cornerRadius: 20)
         recenterButton.applyDefaultCornerRadiusShadow()
@@ -73,9 +74,6 @@ class RouteMapViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        mapView.locationManager.stopUpdatingLocation()
-        mapView.locationManager.stopUpdatingHeading()
         
         mapView.compassView.isHidden = true
         mapView.addAnnotation(destination)


### PR DESCRIPTION
Fixes #341 

When an application is sent to the background and brought back to the foreground, `MGLMapView` calls `-validateLocationServices` and starts updating locations again.

This is easy to spot when using `SimulatedLocationManager` or `ReplayLocationManager` but _not_ if you're using the `DefaultLocationManager` since the location will be exactly the same.

<img src="https://user-images.githubusercontent.com/764476/27966695-798820a6-6340-11e7-9ca5-c8a79fb9f334.gif" width=200>

The fix in this PR works, however, I think a more appropriate solution would be to expose a `manuallyUpdatesLocation` (or similar) on `MGLMapView` that would leave location updating to the user. At the same time, we would also expose that `MGLMapView` conforms to `CLLocationManagerDelegate` so that you can feed `MGLMapView` with locations without using the workaround in https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxNavigation/MGLMapView%2BMGLNavigationAdditions.h#L5


@1ec5 @bsudekum @ericrwolfe 👀 


