### PR TITLE
Fix table view crash after rerouting with simulated locations

### DIFF
--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -61,7 +61,9 @@ public class SimulatedLocationManager: NavigationLocationManager {
             
             currentDistance = 0
             currentSpeed = 30
-            startUpdatingLocation()
+            DispatchQueue.main.async {
+                self.startUpdatingLocation()
+            }
         }
     }
     


### PR DESCRIPTION
Waits until next run loop to restart simulated location updates after a reroute occurs.

Otherwise, a DidReroute notification causes simulated location updates to start which triggers a AlertLevelChange notification before all of the reroute cleanup has finished.

cc @bsudekum @frederoni