### PR TITLE
Did arrive once

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -319,6 +319,19 @@ extension RouteController: CLLocationManagerDelegate {
         
         if routeProgress.currentLegProgress.alertUserLevel != newlyCalculatedAlertLevel {
             routeProgress.currentLegProgress.alertUserLevel = newlyCalculatedAlertLevel
+
+            guard routeProgress.currentLegProgress.alertUserLevel != .arrive else {
+                let userSnapToStepDistanceFromManeuver = distance(along: routeProgress.currentLegProgress.currentStep.coordinates!, from: location.coordinate)
+                let secondsToEndOfStep = userSnapToStepDistanceFromManeuver / location.speed
+                
+                NotificationCenter.default.post(name: RouteControllerProgressDidChange, object: self, userInfo: [
+                    RouteControllerProgressDidChangeNotificationProgressKey: routeProgress,
+                    RouteControllerProgressDidChangeNotificationLocationKey: location,
+                    RouteControllerProgressDidChangeNotificationSecondsRemainingOnStepKey: secondsToEndOfStep
+                    ])
+                return
+            }
+            
             // Use fresh user location distance to end of step
             // since the step could of changed
             let userDistance = distance(along: routeProgress.currentLegProgress.currentStep.coordinates!, from: location.coordinate)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -319,7 +319,6 @@ extension RouteController: CLLocationManagerDelegate {
         
         if routeProgress.currentLegProgress.alertUserLevel != newlyCalculatedAlertLevel {
             routeProgress.currentLegProgress.alertUserLevel = newlyCalculatedAlertLevel
-            
             // Use fresh user location distance to end of step
             // since the step could of changed
             let userDistance = distance(along: routeProgress.currentLegProgress.currentStep.coordinates!, from: location.coordinate)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -319,18 +319,6 @@ extension RouteController: CLLocationManagerDelegate {
         
         if routeProgress.currentLegProgress.alertUserLevel != newlyCalculatedAlertLevel {
             routeProgress.currentLegProgress.alertUserLevel = newlyCalculatedAlertLevel
-
-            guard routeProgress.currentLegProgress.alertUserLevel != .arrive else {
-                let userSnapToStepDistanceFromManeuver = distance(along: routeProgress.currentLegProgress.currentStep.coordinates!, from: location.coordinate)
-                let secondsToEndOfStep = userSnapToStepDistanceFromManeuver / location.speed
-                
-                NotificationCenter.default.post(name: RouteControllerProgressDidChange, object: self, userInfo: [
-                    RouteControllerProgressDidChangeNotificationProgressKey: routeProgress,
-                    RouteControllerProgressDidChangeNotificationLocationKey: location,
-                    RouteControllerProgressDidChangeNotificationSecondsRemainingOnStepKey: secondsToEndOfStep
-                    ])
-                return
-            }
             
             // Use fresh user location distance to end of step
             // since the step could of changed

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -324,10 +324,6 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
 
         mapViewController?.notifyDidChange(routeProgress: routeProgress, location: location, secondsRemaining: secondsRemaining)
         tableViewController?.notifyDidChange(routeProgress: routeProgress)
-        
-        if routeProgress.currentLegProgress.alertUserLevel == .arrive {
-            navigationDelegate?.navigationViewController?(self, didArriveAt: destination)
-        }
     }
     
     func alertLevelDidChange(notification: NSNotification) {
@@ -339,6 +335,10 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         
         if let upComingStep = routeProgress.currentLegProgress.upComingStep, alertLevel == .high {
             giveLocalNotification(upComingStep)
+        }
+        
+        if routeProgress.currentLegProgress.alertUserLevel == .arrive {
+            navigationDelegate?.navigationViewController?(self, didArriveAt: destination)
         }
     }
     


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/345

We should only be alerting `didArriveAt` when the alert level changes and not on every progress update.

/cc @1ec5 @ericrwolfe 