### PR TITLE
Improve slight turn completion heuristic

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -394,7 +394,7 @@ extension RouteController: CLLocationManagerDelegate {
             let initialHeadingNormalized = wrap(initialHeading, min: 0, max: 360)
             let finalHeadingNormalized = wrap(finalHeading, min: 0, max: 360)
             let userHeadingNormalized = wrap(location.course, min: 0, max: 360)
-            let differenceBetweenInitialAndFinalHeading = differenceBetweenAngles(initialHeadingNormalized, finalHeadingNormalized)
+            let expectedTurningAngle = differenceBetweenAngles(initialHeadingNormalized, finalHeadingNormalized)
             
             // If the upcoming maneuver is fairly straight,
             // do not check if the user is within x degrees of the exit heading.
@@ -402,7 +402,7 @@ extension RouteController: CLLocationManagerDelegate {
             // We need to wait until their moving away from the maneuver location instead.
             // We can do this by looking at their snapped distance from the maneuver.
             // Once this distance is zero, they are at more moving away from the maneuver location
-            if differenceBetweenInitialAndFinalHeading <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion {
+            if expectedTurningAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion {
                 courseMatchesManeuverFinalHeading = userSnapToStepDistanceFromManeuver == 0
             } else {
                 courseMatchesManeuverFinalHeading = differenceBetweenAngles(finalHeadingNormalized, userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -390,10 +390,23 @@ extension RouteController: CLLocationManagerDelegate {
         
         // Bearings need to normalized so when the `finalHeading` is 359 and the user heading is 1,
         // we count this as within the `RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion`
-        if let finalHeading = routeProgress.currentLegProgress.upComingStep?.finalHeading {
+        if let upcomingStep = routeProgress.currentLegProgress.upComingStep, let finalHeading = upcomingStep.finalHeading, let initialHeading = upcomingStep.initialHeading {
+            let initialHeadingNormalized = wrap(initialHeading, min: 0, max: 360)
             let finalHeadingNormalized = wrap(finalHeading, min: 0, max: 360)
             let userHeadingNormalized = wrap(location.course, min: 0, max: 360)
-            courseMatchesManeuverFinalHeading = differenceBetweenAngles(finalHeadingNormalized, userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
+            let differenceBetweenInitialAndFinalHeading = differenceBetweenAngles(initialHeadingNormalized, finalHeadingNormalized)
+            
+            // If the upcoming maneuver is fairly straight,
+            // do not check if the user is within x degrees of the exit heading.
+            // For ramps, their current heading will very close to the exit heading.
+            // We need to wait until their moving away from the maneuver location instead.
+            // We can do this by looking at their snapped distance from the maneuver.
+            // Once this distance is zero, they are at more moving away from the maneuver location
+            if differenceBetweenInitialAndFinalHeading <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion {
+                courseMatchesManeuverFinalHeading = userSnapToStepDistanceFromManeuver == 0
+            } else {
+                courseMatchesManeuverFinalHeading = differenceBetweenAngles(finalHeadingNormalized, userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
+            }
         }
 
         // When departing, `userSnapToStepDistanceFromManeuver` is most often less than `RouteControllerManeuverZoneRadius`


### PR DESCRIPTION
Turn completion boils down to two different heuristics:
* is within x meters of maneuver radius
* user course is with x degrees of the exit heading

For slight turns like on/off ramps, this falls apart quickly since the user's course is easily within x degrees of the exit heading. 

This PR looks at the difference between the initial and exit heading. If their difference is less than x degrees, then don't rely on the exit heading check. Instead, rely on their snapped distance from the maneuver location. Once the user is at or moving away from the maneuver location, their snapped distance will always be zero. If it's zero, increment the step.

/cc @1ec5 @frederoni @ericrwolfe 