### PR TITLE
Suppress reroute announcement on long steps

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -356,8 +356,6 @@ extension RouteController: CLLocationManagerDelegate {
             firstWaypoint.heading = location.course
             firstWaypoint.headingAccuracy = 90
         }
-        
-        let currentStepDistanceRemaining = routeProgress.currentLegProgress.currentStepProgress.distanceRemaining
 
         routeTask = directions.calculate(options, completionHandler: { [weak self] (waypoints, routes, error) in
             guard let strongSelf = self else {
@@ -365,15 +363,7 @@ extension RouteController: CLLocationManagerDelegate {
             }
             
             if let route = routes?.first {
-                
-                // If the new route has a first step that has a distance greater than 1km,
-                // surpress the first announcement since they have ample time until the next maneuver
-                var newAlertLevel: AlertLevel = .none
-                if let firstLeg = route.legs.first, let firstStep = firstLeg.steps.first, firstStep.distance > currentStepDistanceRemaining {
-                    newAlertLevel = .depart
-                }
-                
-                strongSelf.routeProgress = RouteProgress(route: route, legIndex: 0, alertLevel: newAlertLevel)
+                strongSelf.routeProgress = RouteProgress(route: route, legIndex: 0, alertLevel: .depart)
                 strongSelf.routeProgress.currentLegProgress.stepIndex = 0
                 strongSelf.delegate?.routeController?(strongSelf, didRerouteAlong: route)
             } else if let error = error {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -356,6 +356,8 @@ extension RouteController: CLLocationManagerDelegate {
             firstWaypoint.heading = location.course
             firstWaypoint.headingAccuracy = 90
         }
+        
+        let currentStepDistanceRemaining = routeProgress.currentLegProgress.currentStepProgress.distanceRemaining
 
         routeTask = directions.calculate(options, completionHandler: { [weak self] (waypoints, routes, error) in
             guard let strongSelf = self else {
@@ -367,7 +369,7 @@ extension RouteController: CLLocationManagerDelegate {
                 // If the new route has a first step that has a distance greater than 1km,
                 // surpress the first announcement since they have ample time until the next maneuver
                 var newAlertLevel: AlertLevel = .none
-                if let firstLeg = route.legs.first, let firstStep = firstLeg.steps.first, firstStep.distance > 1_000 {
+                if let firstLeg = route.legs.first, let firstStep = firstLeg.steps.first, firstStep.distance > currentStepDistanceRemaining {
                     newAlertLevel = .depart
                 }
                 

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -124,11 +124,11 @@ open class RouteProgress: NSObject {
      - parameter route: The route to follow.
      - parameter legIndex: Zero-based index indicating the current leg the user is on.
      */
-    public init(route: Route, legIndex: Int = 0) {
+    public init(route: Route, legIndex: Int = 0, alertLevel: AlertLevel = .none) {
         self.route = route
         self.legIndex = legIndex
         super.init()
-        currentLegProgress = RouteLegProgress(leg: currentLeg)
+        currentLegProgress = RouteLegProgress(leg: currentLeg, stepIndex: 0, alertLevel: alertLevel)
     }
 }
 
@@ -274,9 +274,10 @@ open class RouteLegProgress: NSObject {
      - parameter leg: Leg on a `Route`.
      - parameter stepIndex: Current step the user is on.
      */
-    public init(leg: RouteLeg, stepIndex: Int = 0) {
+    public init(leg: RouteLeg, stepIndex: Int = 0, alertLevel: AlertLevel = .none) {
         self.leg = leg
         self.stepIndex = stepIndex
+        self.alertUserLevel = alertLevel
         currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex])
     }
     

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -123,6 +123,7 @@ open class RouteProgress: NSObject {
      
      - parameter route: The route to follow.
      - parameter legIndex: Zero-based index indicating the current leg the user is on.
+     - parameter alertLevel: Optional `AlertLevel` to start the `RouteProgress` at.
      */
     public init(route: Route, legIndex: Int = 0, alertLevel: AlertLevel = .none) {
         self.route = route
@@ -273,6 +274,7 @@ open class RouteLegProgress: NSObject {
      
      - parameter leg: Leg on a `Route`.
      - parameter stepIndex: Current step the user is on.
+     - parameter alertLevel: Optional `AlertLevel` to start the `RouteProgress` at.
      */
     public init(leg: RouteLeg, stepIndex: Int = 0, alertLevel: AlertLevel = .none) {
         self.leg = leg


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/374

In cases where we reroute the user and the new route has a first step which has very long (1km), there is no need to alert the user about the first step. This is because they have ample time until the upcoming maneuver.

/cc @1ec5 @frederoni @ericrwolfe 