### PR TITLE
Unduck rerouteSoundPlayer

### DIFF
--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -126,15 +126,3 @@ public class PollyVoiceController: RouteVoiceController {
         }
     }
 }
-
-extension PollyVoiceController: AVAudioPlayerDelegate {
-    
-    public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        guard audioPlayer?.isPlaying == false else { return }
-        do {
-            try unDuckAudio()
-        } catch {
-            print(error.localizedDescription)
-        }
-    }
-}

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -7,7 +7,7 @@ import MapboxCoreNavigation
  The `RouteVoiceController` class provides voice guidance.
  */
 @objc(MBRouteVoiceController)
-open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
+open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioPlayerDelegate {
     
     lazy var speechSynth = AVSpeechSynthesizer()
     var audioPlayer: AVAudioPlayer?
@@ -70,6 +70,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         }
         
         speechSynth.delegate = self
+        rerouteSoundPlayer.delegate = self
         maneuverVoiceDistanceFormatter.unitStyle = .long
         maneuverVoiceDistanceFormatter.numberFormatter.locale = .nationalizedCurrent
         resumeNotifications()
@@ -96,12 +97,12 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
         guard playRerouteSound else {
             return
         }
-        
+
         rerouteSoundPlayer.volume = volume
         rerouteSoundPlayer.play()
     }
     
-    func audioPlayerDidFinishPlaying(notification: NSNotification) {
+    public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         do {
             try unDuckAudio()
         } catch {


### PR DESCRIPTION
The reroute ding is never unducked after player. If the reroute sound plays without a subsequent announcement, the user's music will never resume.

/cc @1ec5 @frederoni 