### PR TITLE
Only suppress announcements on long first steps after reroute

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -366,7 +366,13 @@ extension RouteController: CLLocationManagerDelegate {
             }
             
             if let route = routes?.first {
-                strongSelf.routeProgress = RouteProgress(route: route, legIndex: 0, alertLevel: .depart)
+
+                // If the first step of the new route is greater than 0.5km, let user continue without announcement.
+                var alertLevel: AlertLevel = .none
+                if let firstLeg = route.legs.first, let firstStep = firstLeg.steps.first, firstStep.distance > 500 {
+                    alertLevel = .depart
+                }
+                strongSelf.routeProgress = RouteProgress(route: route, legIndex: 0, alertLevel: alertLevel)
                 strongSelf.routeProgress.currentLegProgress.stepIndex = 0
                 strongSelf.delegate?.routeController?(strongSelf, didRerouteAlong: route)
             } else if let error = error {


### PR DESCRIPTION
Followup to https://github.com/mapbox/mapbox-navigation-ios/pull/382

We got a lot of feedback that the lack of information after rerouting was troubling. Now, if the first step of the new reroute is short, alert the user of it. Otherwise when the step is long (greater than 0.5km) just let them continue.

/cc @willwhite @1ec5 @ericrwolfe @frederoni 