### PR TITLE
Unregister battery state observation

### DIFF
--- a/MapboxNavigation/DefaultLocationManager.swift
+++ b/MapboxNavigation/DefaultLocationManager.swift
@@ -20,6 +20,6 @@ class DefaultLocationManager: NavigationLocationManager {
     }
     
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        UIDevice.current.removeObserver(self, forKeyPath: "batteryState")
     }
 }


### PR DESCRIPTION
Fixed a memory leak in DefaultLocationManager. DefaultLocationManager observes battery state changes via KVO, not NotificationCenter.

/cc @frederoni