### PR TITLE
Refactor location snapping

### DIFF
--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -33,7 +33,6 @@ class CustomViewController: UIViewController, MGLMapViewDelegate, AVSpeechSynthe
         let locationManager = simulateLocation ? SimulatedLocationManager(route: userRoute!) : NavigationLocationManager()
         
         routeController = RouteController(along: userRoute!, directions: directions, locationManager: locationManager)
-        routeController.snapsUserLocationAnnotationToRoute = true
         
         mapView.userLocationVerticalAlignment = .center
         mapView.userTrackingMode = .followWithCourse

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -230,15 +230,15 @@ open class RouteController: NSObject {
      
      This is a raw location received from `locationManager`. To obtain an idealized location, use the `snappedLocation` property.
      */
-    public var location: CLLocation?
+    var rawLocation: CLLocation?
     
     /**
      The most recently received user location, snapped to the route line.
      
-     This property contains a `CLLocation` object located along the route line near the `CLLocation` object in the `location` property. This property is set to `nil` if the route controller is unable to snap `location` to the route line for some reason.
+     This property contains a `CLLocation` object located along the route line near the most recently received user location. This property is set to `nil` if the route controller is unable to snap the user’s location to the route line for some reason.
      */
-    public var snappedLocation: CLLocation? {
-        guard let location = location, userIsOnRoute(location) else { return nil }
+    public var location: CLLocation? {
+        guard let location = rawLocation, userIsOnRoute(location) else { return nil }
         guard let stepCoordinates = routeProgress.currentLegProgress.currentStep.coordinates else { return nil }
         guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
         
@@ -380,7 +380,7 @@ extension RouteController: CLLocationManagerDelegate {
         guard let location = locations.last else {
             return
         }
-        self.location = location
+        self.rawLocation = location
         
         delegate?.routeController?(self, didUpdateLocations: [location])
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -132,12 +132,6 @@ open class RouteController: NSObject {
         }
     }
     
-    /**
-     If true, the user puck is snapped to closest location on the route. 
-     Defaults to false.
-     */
-    public var snapsUserLocationAnnotationToRoute = true
-    
     var isRerouting = false
     var lastRerouteLocation: CLLocation?
     
@@ -234,24 +228,19 @@ open class RouteController: NSObject {
     /**
      The most recently received user location.
      
-     This is a raw location received from `locationManager`. If `snapsUserLocationAnnotationToRoute` is set to `true`, you can obtain an idealized location from the `snappedLocation` property.
+     This is a raw location received from `locationManager`. To obtain an idealized location, use the `snappedLocation` property.
      */
     public var location: CLLocation?
     
     /**
      The most recently received user location, snapped to the route line.
      
-     If `snapsUserLocationAnnotationToRoute` is set to `true`, this property contains a `CLLocation` object located along the route line near the `CLLocation` object in the `location` property. This property is set to `nil` if the route controller is unable to snap `location` to the route line for some reason.
+     This property contains a `CLLocation` object located along the route line near the `CLLocation` object in the `location` property. This property is set to `nil` if the route controller is unable to snap `location` to the route line for some reason.
      */
     public var snappedLocation: CLLocation? {
         guard let location = location, userIsOnRoute(location) else { return nil }
         guard let stepCoordinates = routeProgress.currentLegProgress.currentStep.coordinates else { return nil }
         guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
-        
-        // Snap user and course to route
-        guard snapsUserLocationAnnotationToRoute else {
-            return location
-        }
         
         guard location.course != -1, location.speed >= 0 else {
             return location

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -216,9 +216,16 @@ open class NavigationMapView: MGLMapView {
 
 @objc
 public protocol NavigationMapViewDelegate: class  {
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
+    @objc(navigationMapView:shouldUpdateToLocation:)
+    optional func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation?
+    
     @objc optional func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    
     @objc optional func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
+    
+    @objc(navigationMapView:shapeDescribingRoute:)
+    optional func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    
+    @objc(navigationMapView:simplifiedShapeDescribingRoute:)
+    optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -191,6 +191,17 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     }
     
     /**
+     Determines whether the user location annotation is moved from the raw user location reported by the device to the nearest location along the route.
+     
+     By default, this property is set to `true`, causing the user location annotation to be snapped to the route.
+     */
+    public var snapsUserLocationAnnotationToRoute = true {
+        didSet {
+            mapViewController?.snapsUserLocationAnnotationToRoute = snapsUserLocationAnnotationToRoute
+        }
+    }
+    
+    /**
      Toggles sending of UILocalNotification upon upcoming steps when application is in the background. Defaults to `true`.
      */
     public var sendNotifications: Bool = true

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -289,14 +289,9 @@ extension RouteMapViewController: NavigationMapViewDelegate {
     }
 
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation? {
-        guard let snappedLocation = routeController.snappedLocation else {
-            return nil
-        }
-        labelCurrentRoad(at: snappedLocation)
-        guard snapsUserLocationAnnotationToRoute else {
-            return nil
-        }
-        return snappedLocation
+        let snappedLocation = routeController.location
+        labelCurrentRoad(at: snappedLocation ?? location)
+        return snapsUserLocationAnnotationToRoute ? snappedLocation : nil
     }
     
     /**

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -18,6 +18,13 @@ class RouteMapViewController: UIViewController {
     @IBOutlet weak var wayNameLabel: WayNameLabel!
     @IBOutlet weak var wayNameView: UIView!
     
+    /**
+     Determines whether the user location annotation is moved from the raw user location reported by the device to the nearest location along the route.
+     
+     By default, this property is set to `true`, causing the user location annotation to be snapped to the route.
+     */
+    var snapsUserLocationAnnotationToRoute = true
+    
     var routePageViewController: RoutePageViewController!
     var routeTableViewController: RouteTableViewController?
     let routeStepFormatter = RouteStepFormatter()
@@ -286,6 +293,9 @@ extension RouteMapViewController: NavigationMapViewDelegate {
             return nil
         }
         labelCurrentRoad(at: snappedLocation)
+        guard snapsUserLocationAnnotationToRoute else {
+            return nil
+        }
         return snappedLocation
     }
     

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -283,10 +283,17 @@ extension RouteMapViewController: NavigationMapViewDelegate {
 
     @objc(navigationMapView:shouldUpdateTo:)
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation? {
-
-        guard routeController.userIsOnRoute(location) else { return nil }
-        guard let stepCoordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates else  { return nil }
-        guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
+        guard let snappedLocation = locationSnappedToRoute(from: location) else {
+            return nil
+        }
+        updateWayNameLabel(for: snappedLocation)
+        return snappedLocation
+    }
+    
+    func updateWayNameLabel(for location: CLLocation) {
+        guard routeController.userIsOnRoute(location) else { return }
+        guard let stepCoordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates else { return }
+        guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return }
 
         // Add current way name to UI
         if let style = mapView.style, recenterButton.isHidden && hasFinishedLoadingMap {
@@ -362,7 +369,12 @@ extension RouteMapViewController: NavigationMapViewDelegate {
                 wayNameView.isHidden = true
             }
         }
-        
+    }
+    
+    func locationSnappedToRoute(from location: CLLocation) -> CLLocation? {
+        guard routeController.userIsOnRoute(location) else { return nil }
+        guard let stepCoordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates else { return nil }
+        guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
         
         // Snap user and course to route
         guard routeController.snapsUserLocationAnnotationToRoute else {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -281,7 +281,6 @@ extension RouteMapViewController: NavigationMapViewDelegate {
         hasFinishedLoadingMap = true
     }
 
-    @objc(navigationMapView:shouldUpdateTo:)
     func navigationMapView(_ mapView: NavigationMapView, shouldUpdateTo location: CLLocation) -> CLLocation? {
         guard let snappedLocation = routeController.snappedLocation else {
             return nil


### PR DESCRIPTION
This PR moves the user location snapping code from RouteMapViewController in MapboxNavigation to RouteController in CoreNavigation. Conversely, it moves the `snapsUserLocationAnnotationToRoute` property from RouteController in CoreNavigation to RouteMapViewController in MapboxNavigation, where it’s actually used.

RouteController now has public `location` and `snappedLocation` properties, while NavigationViewController has a `snapsUserLocationAnnotationToRoute` property.

Along the way, the current road name label now respects course snapping, and various NavigationMapViewDelegate methods have proper Objective-C names. (Previously, selector pieces ended in dangling prepositions instead of nouns.)

#402 partly refactors the location snapping code as well. I think this PR should land before that one to keep things simple.

To summarize:

* [x] Move user location snapping to Core Navigation (to fix #373)
* [x] Move `snapsUserLocationAnnotationToRoute` property to NavigationViewController (to fix #406)
* [x] Fix current road name label with respect to course snapping (to fix #407)
* [x] Keep labeling the current road even after the user goes off-course
* [x] Fix Objective-C names of NavigationMapViewDelegate methods

/ref #321
/cc @ericrwolfe @frederoni @bsudekum