### PR TITLE
Fix build warning in RouteController.startEvents(_:)

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -180,7 +180,7 @@ open class RouteController: NSObject {
     }
     
     func startEvents(route: Route) {
-        var eventLoggingEnabled = UserDefaults.standard.bool(forKey: NavigationMetricsDebugLoggingEnabled)
+        let eventLoggingEnabled = UserDefaults.standard.bool(forKey: NavigationMetricsDebugLoggingEnabled)
         
         var mapboxAccessToken: String? = nil
         if let accessToken = route.accessToken {


### PR DESCRIPTION
Fixed a build warning about an unmutated variable:

```
/path/to/mapbox-navigation-ios/MapboxCoreNavigation/RouteController.swift:183:13: Variable 'eventLoggingEnabled' was never mutated; consider changing to 'let' constant
```

/cc @ericrwolfe