### PR TITLE
Suppress freeway names in turn banner

### DIFF
--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -13,6 +13,9 @@
 /* Format for speech string; 1 = way name; 2 = way route number */
 "NAME_AND_REF" = "%1$@ (%2$@)";
 
+/* Delimiter between route numbers in a road concurrency */
+"REF_DELIMITER" = " / ";
+
 /* Format for speech string; 1 = formatted distance; 2 = instruction */
 "WITH_DISTANCE_UTTERANCE_FORMAT" = "In %1$@, %2$@";
 

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -16,10 +16,10 @@ class RouteManeuverViewController: UIViewController {
     let distanceFormatter = DistanceFormatter(approximate: true)
     let routeStepFormatter = RouteStepFormatter()
     
-    weak var step: RouteStep! {
+    weak var step: RouteStep? {
         didSet {
             if isViewLoaded {
-                roadCode = step.codes?.first ?? step.destinationCodes?.first ?? step.destinations?.first
+                roadCode = step?.codes?.first ?? step?.destinationCodes?.first ?? step?.destinations?.first
                 updateStreetNameForStep()
             }
         }
@@ -170,7 +170,10 @@ class RouteManeuverViewController: UIViewController {
     }
     
     func updateStreetNameForStep() {
-        if let name = step?.names?.first {
+        let isMotorway = step?.intersections?.first?.outletRoadClasses?.contains(.motorway) ?? false
+        if isMotorway, let codes = step?.codes, let digitRange = codes.first?.rangeOfCharacter(from: .decimalDigits), !digitRange.isEmpty {
+            destinationLabel.unabridgedText = codes.joined(separator: NSLocalizedString("REF_DELIMITER", bundle: .mapboxNavigation, value: " / ", comment: "Delimiter between route numbers in a road concurrency"))
+        } else if let name = step?.names?.first {
             destinationLabel.unabridgedText = name
         } else if let destinations = step?.destinations {
             destinationLabel.unabridgedText = destinations.prefix(min(numberOfDestinationLines, destinations.count)).joined(separator: "\n")

--- a/MapboxNavigation/RoutePageViewController.swift
+++ b/MapboxNavigation/RoutePageViewController.swift
@@ -56,13 +56,13 @@ class RoutePageViewController: UIPageViewController {
 extension RoutePageViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         let controller = viewController as! RouteManeuverViewController
-        let stepAfter = maneuverDelegate.stepAfter(controller.step)
+        let stepAfter = maneuverDelegate.stepAfter(controller.step!)
         return routeManeuverViewController(with: stepAfter)
     }
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         let controller = viewController as! RouteManeuverViewController
-        let stepBefore = maneuverDelegate.stepBefore(controller.step)
+        let stepBefore = maneuverDelegate.stepBefore(controller.step!)
         return routeManeuverViewController(with: stepBefore)
     }
     

--- a/MapboxNavigation/RouteStepFormatter.swift
+++ b/MapboxNavigation/RouteStepFormatter.swift
@@ -21,18 +21,16 @@ public class RouteStepFormatter: Formatter {
             return nil
         }
         
-        guard markUpWithSSML else {
-            return instructions.string(for: step)
-        }
-        
-        return instructions.string(for: step, legIndex: legIndex, numberOfLegs: numberOfLegs, roadClasses: step.intersections?.first?.outletRoadClasses, modifyValueByKey: { (key, value) -> String in
+        let modifyValueByKey = { (key: OSRMTextInstructions.TokenType, value: String) -> String in
             switch key {
             case .wayName, .destination, .rotaryName:
                 return "<say-as interpret-as=\"address\">\(value.addingXMLEscapes)</say-as>"
             default:
                 return value
             }
-        })
+        }
+        
+        return instructions.string(for: step, legIndex: legIndex, numberOfLegs: numberOfLegs, roadClasses: step.intersections?.first?.outletRoadClasses, modifyValueByKey: markUpWithSSML ? modifyValueByKey : nil)
         
     }
     


### PR DESCRIPTION
If the upcoming road is a freeway, suppress its name in the turn banner in favor of a textual representation of the route number.

<img src="https://user-images.githubusercontent.com/1231218/28484811-776459f4-6e29-11e7-9d2e-a6044d998b0b.png" width="300" alt="I-75"> <img src="https://user-images.githubusercontent.com/1231218/28484882-f2b66868-6e29-11e7-8b7d-eab1140255f4.png" width="300" alt="SR 126">

This is a more tightly scoped alternative to #291 based on Project-OSRM/osrm-text-instructions.swift#28. It focuses on the turn banner and leaves the current road name label alone for the time being.

/cc @ericrwolfe @frederoni