### PR TITLE
Add 'location' override for NavigationLocationManager subclasses

### DIFF
--- a/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -24,6 +24,12 @@ public class ReplayLocationManager: NavigationLocationManager {
         }
     }
     
+    override public var location: CLLocation? {
+        get {
+            return lastKnownLocation
+        }
+    }
+    
     public init(locations: [CLLocation]) {
         self.locations = locations
         super.init()

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -35,6 +35,12 @@ public class SimulatedLocationManager: NavigationLocationManager {
     fileprivate var locations: [SimulatedLocation]!
     fileprivate var routeLine = [CLLocationCoordinate2D]()
     
+    override public var location: CLLocation? {
+        get {
+            return currentLocation
+        }
+    }
+    
     var route: Route? {
         didSet {
             reset()
@@ -120,13 +126,15 @@ public class SimulatedLocationManager: NavigationLocationManager {
             currentSpeed = reversedTurnPenalty.scale(minimumIn: minimumTurnPenalty, maximumIn: maximumTurnPenalty, minimumOut: minimumSpeed, maximumOut: maximumSpeed)
         }
         
-        currentLocation = CLLocation(coordinate: newCoordinate,
+        let location = CLLocation(coordinate: newCoordinate,
                                      altitude: 0,
                                      horizontalAccuracy: horizontalAccuracy,
                                      verticalAccuracy: verticalAccuracy,
                                      course: wrap(floor(newCoordinate.direction(to: lookAheadCoordinate)), min: 0, max: 360),
                                      speed: currentSpeed,
                                      timestamp: Date())
+        currentLocation = location
+        lastKnownLocation = location
         
         delegate?.locationManager?(self, didUpdateLocations: [currentLocation])
         currentDistance += currentSpeed


### PR DESCRIPTION
Currently, querying `routeController.locationManager.location` when using a simulated location manager returns the device's current location. 

This PR has overrides the `var location: CLLocation` property to return the custom locations from SimulatedLocationManager or ReplayLocationManager

cc @frederoni @1ec5 