### PR TITLE
Suppress freeway names in post-maneuver instructions

### DIFF
--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -1,5 +1,8 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Continue on %1$@ for %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = distance */
+"CONTINUE" = "Continue for %@";
+
+/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Continue on %1$@ for %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/Resources/ca.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ca.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Continua per %1$@ cap a %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Continua per %1$@ cap a %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/Resources/es.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/es.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Continúe en %1$@ por %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Continúe en %1$@ por %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/Resources/fr.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/fr.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Continuez sur %1$@ pendant %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Continuez sur %1$@ pendant %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/Resources/hu.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/hu.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Continue on %1$@ for %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Continue on %1$@ for %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/Resources/lt.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/lt.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Tęskite %1$@ %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Tęskite %1$@ %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "iki %@";

--- a/MapboxNavigation/Resources/sv.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/sv.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Fortsätt på %1$@ i %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Fortsätt på %1$@ i %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/Resources/vi.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/vi.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "Chạy tiếp trên %1$@ cho %2$@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "Chạy tiếp trên %1$@ cho %2$@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-﻿/* Format for speech string; 1 = way name; 2 = distance */
-"CONTINUE" = "继续沿%@行驶%@";
+﻿/* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
+"CONTINUE_ON_ROAD" = "继续沿%@行驶%@";
 
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "＜%@";

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -170,8 +170,7 @@ class RouteManeuverViewController: UIViewController {
     }
     
     func updateStreetNameForStep() {
-        let isMotorway = step?.intersections?.first?.outletRoadClasses?.contains(.motorway) ?? false
-        if isMotorway, let codes = step?.codes, let digitRange = codes.first?.rangeOfCharacter(from: .decimalDigits), !digitRange.isEmpty {
+        if let step = step, step.isNumberedMotorway, let codes = step.codes {
             destinationLabel.unabridgedText = codes.joined(separator: NSLocalizedString("REF_DELIMITER", bundle: .mapboxNavigation, value: " / ", comment: "Delimiter between route numbers in a road concurrency"))
         } else if let name = step?.names?.first {
             destinationLabel.unabridgedText = name

--- a/MapboxNavigation/RouteStepFormatter.swift
+++ b/MapboxNavigation/RouteStepFormatter.swift
@@ -38,3 +38,47 @@ public class RouteStepFormatter: Formatter {
         return false
     }
 }
+
+extension RouteStep {
+    /**
+     Returns true if the route travels on a motorway primarily identified by a route number rather than a road name.
+     */
+    var isNumberedMotorway: Bool {
+        guard intersections?.first?.outletRoadClasses?.contains(.motorway) == true else {
+            return false
+        }
+        guard let codes = codes, let digitRange = codes.first?.rangeOfCharacter(from: .decimalDigits) else {
+            return false
+        }
+        return !digitRange.isEmpty
+    }
+    
+    /**
+     Returns a string describing the step’s road by its name, route number, or both, depending on the kind of road.
+     
+     - parameter markedUpWithSSML: True to wrap the name and route number in SSML tags that cause them to be read as addresses.
+     - returns: A string describing the step’s road, or `nil` if the step lacks the information needed to describe the step.
+     */
+    func roadDescription(markedUpWithSSML: Bool) -> String? {
+        let addressSSML = { (text: String?) -> String? in
+            guard let text = text else {
+                return nil
+            }
+            return markedUpWithSSML ? "<say-as interpret-as=\"address\">\(text.addingXMLEscapes)</say-as>" : text
+        }
+        
+        let nameSSML = addressSSML(names?.first)
+        let codeSSML = addressSSML(codes?.first)
+        
+        if let codeSSML = codeSSML, nameSSML == nil || isNumberedMotorway {
+            return codeSSML
+        } else if let nameSSML = nameSSML {
+            if let codeSSML = codeSSML {
+                return String.localizedStringWithFormat(NSLocalizedString("NAME_AND_REF", bundle: .mapboxNavigation, value: "%@ (%@)", comment: "Format for speech string; 1 = way name; 2 = way route number"), nameSSML, codeSSML)
+            } else {
+                return nameSSML
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Refactored the post-maneuver instruction generation code to account for the road class (as in #410) and moved the code to an extension on RouteStep. Consistently mark up road names and route numbers as addresses when either (but not both) is available on the step in question. In the rare event that a motorway has no name or number, deliver a post-maneuver instruction without the “on [road name]” prepositional phrase.

Project-OSRM/osrm-text-instructions#88 tracks upstreaming this post-maneuver instruction to OSRM Text Instructions.

/cc @bsudekum @ericrwolfe @frederoni