### PR TITLE
Remove redundant arrival notification

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -341,10 +341,6 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         if routeProgress.currentLegProgress.alertUserLevel == .arrive {
             navigationDelegate?.navigationViewController?(self, didArriveAt: destination)
         }
-        
-        if routeProgress.currentLegProgress.alertUserLevel == .arrive {
-            navigationDelegate?.navigationViewController?(self, didArriveAt: destination)
-        }
     }
     
     func scheduleLocalNotification(about step: RouteStep, legIndex: Int?, numberOfLegs: Int?) {


### PR DESCRIPTION
`NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:)` is getting called twice in a row. This change removes the redundant call.

/cc @bsudekum