### PR TITLE
Hide logo when resume is enabled

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -112,6 +112,7 @@ class RouteMapViewController: UIViewController {
     @IBAction func recenter(_ sender: AnyObject) {
         mapView.setCamera(tiltedCamera, animated: false)
         mapView.userTrackingMode = .followWithCourse
+        mapView.logoView.isHidden = false
 
         // Recenter also resets the current page. Same behavior as rerouting.
         routePageViewController.notifyDidReRoute()
@@ -120,11 +121,13 @@ class RouteMapViewController: UIViewController {
     @IBAction func toggleOverview(_ sender: Any) {
         if isInOverviewMode {
             overviewButton.isHidden = false
+            mapView.logoView.isHidden = false
             mapView.setCamera(tiltedCamera, animated: false)
             mapView.setUserTrackingMode(.followWithCourse, animated: true)
         } else {
             wayNameView.isHidden = true
             overviewButton.isHidden = true
+            mapView.logoView.isHidden = true
             updateVisibleBounds(coordinates: routeController.routeProgress.route.coordinates!)
         }
         resetTrackingModeTimer?.invalidate()
@@ -386,6 +389,7 @@ extension RouteMapViewController: MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, didChange mode: MGLUserTrackingMode, animated: Bool) {
         if isInOverviewMode && mode != .followWithCourse {
             recenterButton.isHidden = false
+            mapView.logoView.isHidden = true
             wayNameView.isHidden = true
             startResetTrackingModeTimer()
         } else {
@@ -393,15 +397,18 @@ extension RouteMapViewController: MGLMapViewDelegate {
             
             if mode != .followWithCourse {
                 recenterButton.isHidden = false
+                mapView.logoView.isHidden = true
                 startResetTrackingModeTimer()
             } else {
                 recenterButton.isHidden = true
+                mapView.logoView.isHidden = false
             }
         }
         
         if isInOverviewMode {
             overviewButton.isHidden = false
             recenterButton.isHidden = true
+            mapView.logoView.isHidden = false
             isInOverviewMode = false
         }
     }


### PR DESCRIPTION
Redoing https://github.com/mapbox/mapbox-navigation-ios/pull/421

When I toggled the image, it deemphasized the button. Since it's very important, I'm going to keep the location but as @1ec5 recommended, just hide the logo.

/cc @frederoni 