### PR TITLE
Always fire alertLevelDidChange after incrementing step

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -493,9 +493,11 @@ extension RouteController: CLLocationManagerDelegate {
     }
     
     func incrementRouteProgress(_ newlyCalculatedAlertLevel: AlertLevel, location: CLLocation, updateStepIndex: Bool) {
-        
+        var didIncrementStep = false
+
         if updateStepIndex {
             routeProgress.currentLegProgress.stepIndex += 1
+            didIncrementStep = true
         }
         
         // If the step is not being updated, don't accept a lower alert level.
@@ -504,7 +506,7 @@ extension RouteController: CLLocationManagerDelegate {
             return
         }
         
-        if routeProgress.currentLegProgress.alertUserLevel != newlyCalculatedAlertLevel {
+        if routeProgress.currentLegProgress.alertUserLevel != newlyCalculatedAlertLevel || didIncrementStep {
             routeProgress.currentLegProgress.alertUserLevel = newlyCalculatedAlertLevel
             // Use fresh user location distance to end of step
             // since the step could of changed

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -493,11 +493,8 @@ extension RouteController: CLLocationManagerDelegate {
     }
     
     func incrementRouteProgress(_ newlyCalculatedAlertLevel: AlertLevel, location: CLLocation, updateStepIndex: Bool) {
-        var didIncrementStep = false
-
         if updateStepIndex {
             routeProgress.currentLegProgress.stepIndex += 1
-            didIncrementStep = true
         }
         
         // If the step is not being updated, don't accept a lower alert level.
@@ -506,7 +503,7 @@ extension RouteController: CLLocationManagerDelegate {
             return
         }
         
-        if routeProgress.currentLegProgress.alertUserLevel != newlyCalculatedAlertLevel || didIncrementStep {
+        if routeProgress.currentLegProgress.alertUserLevel != newlyCalculatedAlertLevel || updateStepIndex {
             routeProgress.currentLegProgress.alertUserLevel = newlyCalculatedAlertLevel
             // Use fresh user location distance to end of step
             // since the step could of changed


### PR DESCRIPTION
It is possible to complete a step and go directly from a high alert into another high alert. Because of this, the alertLevelDidChange notification is not firing although the step did increment.

Until we refactor alertLevel, this bandaid should go in as the current implementation is a bug.

/cc @ericrwolfe @1ec5 