### PR TITLE
Avoid matching bannered routes to shields

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -49,7 +49,7 @@ class RouteManeuverViewController: UIViewController {
                 return
             }
             
-            if components.count == 2 || (components.count == 3 && ["North", "South", "East", "West"].contains(components[2])) {
+            if components.count == 2 || (components.count == 3 && ["North", "South", "East", "West", "Nord", "Sud", "Est", "Ouest"].contains(components[2])) {
                 shieldAPIDataTask = dataTaskForShieldImage(network: components[0], number: components[1], height: 32 * UIScreen.main.scale) { [weak self] (image) in
                     self?.shieldImage = image
                 }

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -49,7 +49,7 @@ class RouteManeuverViewController: UIViewController {
                 return
             }
             
-            if components.count > 1 {
+            if components.count == 2 || (components.count == 3 && ["North", "South", "East", "West"].contains(components[2])) {
                 shieldAPIDataTask = dataTaskForShieldImage(network: components[0], number: components[1], height: 32 * UIScreen.main.scale) { [weak self] (image) in
                     self?.shieldImage = image
                 }
@@ -121,7 +121,7 @@ class RouteManeuverViewController: UIViewController {
         
         if routeProgress.currentLegProgress.alertUserLevel == .arrive {
             distance = nil
-            destinationLabel.unabridgedText = routeStepFormatter.string(for: routeStepFormatter.string(for: routeProgress.currentLegProgress.upComingStep))
+            destinationLabel.unabridgedText = routeStepFormatter.string(for: routeStepFormatter.string(for: routeProgress.currentLegProgress.upComingStep, legIndex: routeProgress.legIndex, numberOfLegs: routeProgress.route.legs.count, markUpWithSSML: false))
         } else if let upComingStep = routeProgress.currentLegProgress?.upComingStep {
             updateStreetNameForStep()
             showLaneView(step: upComingStep)


### PR DESCRIPTION
A destination code such as `I 75 South` should match the Interstate shield, but a code such as `I 75 Alt` or `I 75 Truck` should not. Bannered routes are usually less important, and it’s misleading to show a bannered route shield without the banner.

<img src="https://user-images.githubusercontent.com/1231218/28634357-cfa85172-71eb-11e7-8f36-65f1132a641f.png" width="300" alt="before"> <img src="https://user-images.githubusercontent.com/1231218/28634358-cfaf1002-71eb-11e7-845b-aedab4a71244.png" width="300" alt="after">

For #365, we’ll have an opportunity to display the banner as text to the right of the shield.

/cc @frederoni