### PR TITLE
Fix tracking mode

### DIFF
--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -106,7 +106,6 @@
                                     <constraint firstItem="drb-do-FoT" firstAttribute="centerX" secondItem="nNr-30-cGD" secondAttribute="centerX" id="TCg-jZ-7G3"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showsUserLocation" value="YES"/>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-guidance-day-v2"/>
                                 </userDefinedRuntimeAttributes>
                             </view>


### PR DESCRIPTION
This fixes:

- Initial camera view when entering navigation mode
- Shows the route earlier
- Puck float while rotating the screen

![untitled](https://user-images.githubusercontent.com/1058624/28690068-b59259ae-72cc-11e7-96f8-21a3097ffa60.gif)

However, toggling `automaticallyAdjustsScrollViewInsets = false` causes the camera to zoom from 0,0 to the current location. This is even though I'm not animating any camera/tracking mode changes. Also turning it off prevents the drawer change in position from changing the inset location for items on the map.

I need to play with this more, but it's getting close.

/cc @frederoni @1ec5 
