### PR TITLE
Only show lanes for medium/high alerts

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -132,7 +132,9 @@ class RouteManeuverViewController: UIViewController {
             destinationLabel.unabridgedText = routeProgress.currentLeg.destination.name ?? routeStepFormatter.string(for: routeStepFormatter.string(for: routeProgress.currentLegProgress.upComingStep, legIndex: routeProgress.legIndex, numberOfLegs: routeProgress.route.legs.count, markUpWithSSML: false))
         } else if let upComingStep = routeProgress.currentLegProgress?.upComingStep {
             updateStreetNameForStep()
-            showLaneView(step: upComingStep)
+            if routeProgress.currentLegProgress.alertUserLevel == .medium || routeProgress.currentLegProgress.alertUserLevel == .high {
+                showLaneView(step: upComingStep)
+            }
         }
         
         turnArrowView.step = routeProgress.currentLegProgress.upComingStep


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/434

This changes only to show the lane UI when the user is approaching the intersection. This seems like a good/safe first move.

/cc @ericrwolfe @frederoni @1ec5 