### PR TITLE
Fix phantom laneview

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -132,9 +132,7 @@ class RouteManeuverViewController: UIViewController {
             destinationLabel.unabridgedText = routeProgress.currentLeg.destination.name ?? routeStepFormatter.string(for: routeStepFormatter.string(for: routeProgress.currentLegProgress.upComingStep, legIndex: routeProgress.legIndex, numberOfLegs: routeProgress.route.legs.count, markUpWithSSML: false))
         } else if let upComingStep = routeProgress.currentLegProgress?.upComingStep {
             updateStreetNameForStep()
-            if routeProgress.currentLegProgress.alertUserLevel == .medium || routeProgress.currentLegProgress.alertUserLevel == .high {
-                showLaneView(step: upComingStep)
-            }
+            showLaneView(step: upComingStep, alertLevel: routeProgress.currentLegProgress.alertUserLevel)
         }
         
         turnArrowView.step = routeProgress.currentLegProgress.upComingStep
@@ -198,8 +196,11 @@ class RouteManeuverViewController: UIViewController {
         stackViewContainer.isHidden = true
     }
     
-    func showLaneView(step: RouteStep) {
-        if let allLanes = step.intersections?.first?.approachLanes, let usableLanes = step.intersections?.first?.usableApproachLanes {
+    func showLaneView(step: RouteStep, alertLevel: AlertLevel) {
+        if let allLanes = step.intersections?.first?.approachLanes,
+            let usableLanes = step.intersections?.first?.usableApproachLanes,
+            alertLevel == .high,
+            alertLevel == .medium {
             for (i, lane) in allLanes.enumerated() {
                 guard i < laneViews.count else {
                     return

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -475,7 +475,7 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
         maneuverViewController.roadCode = step.codes?.first ?? step.destinationCodes?.first ?? step.destinations?.first
         maneuverViewController.updateStreetNameForStep()
         
-        maneuverViewController.showLaneView(step: step)
+        maneuverViewController.showLaneView(step: step, alertLevel: .high)
         
         let initialPaddingForOverviewButton:CGFloat = maneuverViewController.stackViewContainer.isHidden ? -30 : -20 + maneuverViewController.laneViews.first!.frame.maxY
         UIView.animate(withDuration: 0.5) {


### PR DESCRIPTION
Followup to https://github.com/mapbox/mapbox-navigation-ios/pull/444

@frederoni was right, the check needs to happen inside of the showLanes function. Sometimes, the laneview grey bar shows up without any lanes, this fixes this issue.

/cc @frederoni @ericrwolfe 