### PR TITLE
Use calculated speed versus user speed [WIP]

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -94,7 +94,7 @@ public var RouteControllerMediumAlertInterval: TimeInterval = 70
 /**
  Number of seconds left on step when a `high` alert is emitted.
  */
-public var RouteControllerHighAlertInterval: TimeInterval = 15
+public var RouteControllerHighAlertInterval: TimeInterval = 20
 
 
 /**
@@ -110,81 +110,15 @@ public var MaxSecondsSpentTravelingAwayFromStartOfRoute: TimeInterval = 3
 
 
 /**
- Distance in meters for the minimum length of a step for giving a `medium` alert while using `MBDirectionsProfileIdentifierAutomobile` or `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`.
+ Remaing distance on a motorway at which the `.high` `AlertLevel` will be given. This overrides `RouteControllerHighAlertInterval` only when the current step is a motorway.
  */
-public var RouteControllerMinimumDistanceForMediumAlertDriving: CLLocationDistance = 400
+public var RouteControllerMotorwayHighAlertDistance: CLLocationDistance = 804.672
 
 
 /**
- Distance in meters for the minimum length of a step for giving a `medium` alert while using `MBDirectionsProfileIdentifierCycling`.
+ Remaing distance on a motorway at which the `.medium` `AlertLevel` will be given. This overrides `RouteControllerMediumAlertInterval` only when the current step is a motorway.
  */
-public var RouteControllerMinimumDistanceForMediumAlertCycling: CLLocationDistance = 200
-
-
-/**
- Distance in meters for the minimum length of a step for giving a `medium` alert while using `MBDirectionsProfileIdentifierWalking`.
- */
-public var RouteControllerMinimumDistanceForMediumAlertWalking: CLLocationDistance = 100
-
-
-/**
- Returns the appropriate `mediium` `AlertLevel` distance for a given `MBDirectionsProfileIdentifier`.
- */
-public func RouteControllerMinimumDistanceForMediumAlert(identifier: MBDirectionsProfileIdentifier) -> CLLocationDistance {
-    switch identifier {
-    case MBDirectionsProfileIdentifier.automobileAvoidingTraffic:
-        return RouteControllerMinimumDistanceForMediumAlertDriving
-    case MBDirectionsProfileIdentifier.automobile:
-        return RouteControllerMinimumDistanceForMediumAlertDriving
-    case MBDirectionsProfileIdentifier.cycling:
-        return RouteControllerMinimumDistanceForMediumAlertCycling
-    case MBDirectionsProfileIdentifier.walking:
-        return RouteControllerMinimumDistanceForMediumAlertWalking
-    default:
-        break
-    }
-    
-    return RouteControllerMinimumDistanceForMediumAlertDriving
-}
-
-
-/**
- Distance in meters for the minimum length of a step for giving a `high` alert while using `MBDirectionsProfileIdentifierAutomobile` or `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`.
- */
-public var RouteControllerMinimumDistanceForHighAlertDriving: CLLocationDistance = 100
-
-
-/**
- Distance in meters for the minimum length of a step for giving a `high` alert while using `MBDirectionsProfileIdentifierCycling`.
- */
-public var RouteControllerMinimumDistanceForHighAlertCycling: CLLocationDistance = 60
-
-
-/**
- Distance in meters for the minimum length of a step for giving a `high` alert while using `MBDirectionsProfileIdentifierWalking`.
- */
-public var RouteControllerMinimumDistanceForHighAlertWalking: CLLocationDistance = 20
-
-
-/**
- Returns a the appropriate `high` `AlertLevel` distance for a given `MBDirectionsProfileIdentifier`.
- */
-public func RouteControllerMinimumDistanceForHighAlert(identifier: MBDirectionsProfileIdentifier) -> CLLocationDistance {
-    switch identifier {
-    case MBDirectionsProfileIdentifier.automobileAvoidingTraffic:
-        return RouteControllerMinimumDistanceForHighAlertDriving
-    case MBDirectionsProfileIdentifier.automobile:
-        return RouteControllerMinimumDistanceForHighAlertDriving
-    case MBDirectionsProfileIdentifier.cycling:
-        return RouteControllerMinimumDistanceForHighAlertCycling
-    case MBDirectionsProfileIdentifier.walking:
-        return RouteControllerMinimumDistanceForHighAlertWalking
-    default:
-        break
-    }
-    
-    return RouteControllerMinimumDistanceForHighAlertDriving
-}
+public var RouteControllerMotorwayMediumAlertDistance: CLLocationDistance = 3218.69
 
 
 /**

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -94,7 +94,7 @@ public var RouteControllerMediumAlertInterval: TimeInterval = 70
 /**
  Number of seconds left on step when a `high` alert is emitted.
  */
-public var RouteControllerHighAlertInterval: TimeInterval = 20
+public var RouteControllerHighAlertInterval: TimeInterval = 15
 
 
 /**
@@ -110,13 +110,13 @@ public var MaxSecondsSpentTravelingAwayFromStartOfRoute: TimeInterval = 3
 
 
 /**
- Remaing distance on a motorway at which the `.high` `AlertLevel` will be given. This overrides `RouteControllerHighAlertInterval` only when the current step is a motorway.
+ Remaing distance on a motorway at which the `.high` `AlertLevel` will be given. This overrides `RouteControllerHighAlertInterval` only when the current step is a motorway. Default value is a half mile.
  */
 public var RouteControllerMotorwayHighAlertDistance: CLLocationDistance = 804.672
 
 
 /**
- Remaing distance on a motorway at which the `.medium` `AlertLevel` will be given. This overrides `RouteControllerMediumAlertInterval` only when the current step is a motorway.
+ Remaing distance on a motorway at which the `.medium` `AlertLevel` will be given. This overrides `RouteControllerMediumAlertInterval` only when the current step is a motorway. Defauly value is 2 miles.
  */
 public var RouteControllerMotorwayMediumAlertDistance: CLLocationDistance = 3218.69
 

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -84,48 +84,40 @@ public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 10
  */
 public var RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion: Double = 30
 
-
 /**
- Number of seconds left on step when a `medium` alert is emitted.
+ Number of seconds left on step when a `AlertLevel.medium` alert is emitted.
  */
 public var RouteControllerMediumAlertInterval: TimeInterval = 70
 
-
 /**
- Number of seconds left on step when a `high` alert is emitted.
+ Number of seconds left on step when a `AlertLevel.high` alert is emitted.
  */
 public var RouteControllerHighAlertInterval: TimeInterval = 15
-
 
 /**
  Radius in meters the user must enter to count as completing a step. One of two heuristics used to know when a user completes a step, see `RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion`.
  */
 public var RouteControllerManeuverZoneRadius: CLLocationDistance = 40
 
-
 /**
  Maximum number of seconds the user can travel away from the start of the route before rerouting occurs
  */
 public var MaxSecondsSpentTravelingAwayFromStartOfRoute: TimeInterval = 3
 
+/**
+ Remaing distance on a motorway at which the `AlertLevel.high` `AlertLevel` will be given. This overrides `RouteControllerHighAlertInterval` only when the current step is a motorway. Default value is a half mile.
+ */
+public var RouteControllerMotorwayHighAlertDistance: CLLocationDistance = 0.5 * milesToMeters
 
 /**
- Remaing distance on a motorway at which the `.high` `AlertLevel` will be given. This overrides `RouteControllerHighAlertInterval` only when the current step is a motorway. Default value is a half mile.
+ Remaing distance on a motorway at which the `AlertLevel.medium` `AlertLevel` will be given. This overrides `RouteControllerMediumAlertInterval` only when the current step is a motorway. Defauly value is 2 miles.
  */
-public var RouteControllerMotorwayHighAlertDistance: CLLocationDistance = 804.672
-
-
-/**
- Remaing distance on a motorway at which the `.medium` `AlertLevel` will be given. This overrides `RouteControllerMediumAlertInterval` only when the current step is a motorway. Defauly value is 2 miles.
- */
-public var RouteControllerMotorwayMediumAlertDistance: CLLocationDistance = 3218.69
-
+public var RouteControllerMotorwayMediumAlertDistance: CLLocationDistance = 2 * milesToMeters
 
 /**
  When calculating whether or not the user is on the route, we look where the user will be given their speed and this variable.
  */
 public var RouteControllerDeadReckoningTimeInterval:TimeInterval = 1.0
-
 
 /**
  Maximum angle the user puck will be rotated when snapping the user's course to the route line.
@@ -136,3 +128,15 @@ public var RouteControllerMaxManipulatedCourseAngle:CLLocationDirection = 25
  :nodoc This is used internally for debugging metrics
  */
 public var NavigationMetricsDebugLoggingEnabled = "MBNavigationMetricsDebugLoggingEnabled"
+
+/**
+ For shorter upcoming steps, we link the `AlertLevel.high` instruction. If the upcoming step duration is near the duration of `RouteControllerHighAlertInterval`, we need to apply a bit of a buffer to prevent back to back notifications.
+ 
+ A multiplier of `1.2` gives us a buffer of 3 seconds, enough time insert a new instruction.
+ */
+let RouteControllerLinkedInstructionBufferMultiplier: Double = 1.2
+
+/**
+ Approximately the number of meters in a mile.
+ */
+let milesToMeters = 1609.34

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -651,14 +651,11 @@ extension RouteController: CLLocationManagerDelegate {
         // Force an announcement when the user begins a route
         var alertLevel: AlertLevel = routeProgress.currentLegProgress.alertUserLevel == .none ? .depart : routeProgress.currentLegProgress.alertUserLevel
         var updateStepIndex = false
-        let profileIdentifier = routeProgress.route.routeOptions.profileIdentifier
         
         let userSnapToStepDistanceFromManeuver = distance(along: routeProgress.currentLegProgress.currentStep.coordinates!, from: location.coordinate)
         let secondsToEndOfStep = routeProgress.currentLegProgress.currentStepProgress.durationRemaining
         var courseMatchesManeuverFinalHeading = false
-        
-        let minimumDistanceForHighAlert = RouteControllerMinimumDistanceForHighAlert(identifier: profileIdentifier)
-        let minimumDistanceForMediumAlert = RouteControllerMinimumDistanceForMediumAlert(identifier: profileIdentifier)
+
         let outletRoadClasses = routeProgress.currentLegProgress.currentStepProgress.step.intersections?.first?.outletRoadClasses
         
         // Bearings need to normalized so when the `finalHeading` is 359 and the user heading is 1,
@@ -692,10 +689,10 @@ extension RouteController: CLLocationManagerDelegate {
                 alertLevel = .high
             }
         } else if let _ = outletRoadClasses?.contains(.motorway),
-            routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= 402.336 {
+            routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= RouteControllerMotorwayHighAlertDistance {
             alertLevel = .high
         } else if let _ = outletRoadClasses?.contains(.motorway),
-            routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= 3218.69 {
+            routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= RouteControllerMotorwayMediumAlertDistance {
             alertLevel = .medium
         } else if userSnapToStepDistanceFromManeuver <= RouteControllerManeuverZoneRadius {
             // Use the currentStep if there is not a next step
@@ -729,13 +726,9 @@ extension RouteController: CLLocationManagerDelegate {
                     assert(false, "In this case, there should always be an upcoming step")
                 }
             }
-        } else if secondsToEndOfStep <= RouteControllerHighAlertInterval && routeProgress.currentLegProgress.currentStep.distance > minimumDistanceForHighAlert {
+        } else if secondsToEndOfStep <= RouteControllerHighAlertInterval {
             alertLevel = .high
-        } else if secondsToEndOfStep <= RouteControllerMediumAlertInterval &&
-            // Don't alert if the route segment is shorter than X
-            // However, if it's the beginning of the route
-            // There needs to be an alert
-            routeProgress.currentLegProgress.currentStep.distance > minimumDistanceForMediumAlert {
+        } else if secondsToEndOfStep <= RouteControllerMediumAlertInterval {
             alertLevel = .medium
         }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -659,6 +659,7 @@ extension RouteController: CLLocationManagerDelegate {
         
         let minimumDistanceForHighAlert = RouteControllerMinimumDistanceForHighAlert(identifier: profileIdentifier)
         let minimumDistanceForMediumAlert = RouteControllerMinimumDistanceForMediumAlert(identifier: profileIdentifier)
+        let outletRoadClasses = routeProgress.currentLegProgress.currentStepProgress.step.intersections?.first?.outletRoadClasses
         
         // Bearings need to normalized so when the `finalHeading` is 359 and the user heading is 1,
         // we count this as within the `RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion`
@@ -690,6 +691,12 @@ extension RouteController: CLLocationManagerDelegate {
             if secondsToEndOfStep <= RouteControllerHighAlertInterval {
                 alertLevel = .high
             }
+        } else if let _ = outletRoadClasses?.contains(.motorway),
+            routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= 402.336 {
+            alertLevel = .high
+        } else if let _ = outletRoadClasses?.contains(.motorway),
+            routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= 3218.69 {
+            alertLevel = .medium
         } else if userSnapToStepDistanceFromManeuver <= RouteControllerManeuverZoneRadius {
             // Use the currentStep if there is not a next step
             // This occurs when arriving

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -509,7 +509,7 @@ extension RouteController: CLLocationManagerDelegate {
         if let upComingStep = routeProgress.currentLegProgress.upComingStep {
             let isCloseToUpComingStep = newLocation.isWithin(radius, of: upComingStep)
             if !isCloseToCurrentStep && isCloseToUpComingStep {
-                incrementRouteProgress(calculateNewAlert(from: upComingStep), location: location, updateStepIndex: true)
+                incrementRouteProgress(newAlert(from: upComingStep), location: location, updateStepIndex: true)
                 return true
             }
         }
@@ -721,7 +721,7 @@ extension RouteController: CLLocationManagerDelegate {
                 
                 // Look at the following step to determine what the new alert level should be
                 if let upComingStep = routeProgress.currentLegProgress.upComingStep {
-                    alertLevel = calculateNewAlert(from: upComingStep)
+                    alertLevel = newAlert(from: upComingStep)
                 } else {
                     assert(false, "In this case, there should always be an upcoming step")
                 }
@@ -735,12 +735,11 @@ extension RouteController: CLLocationManagerDelegate {
         incrementRouteProgress(alertLevel, location: location, updateStepIndex: updateStepIndex)
     }
     
-    func calculateNewAlert(from upcomginStep: RouteStep) -> AlertLevel {
-        let expectedTravelTime = upcomginStep.expectedTravelTime
-        switch expectedTravelTime {
-        case let x where x <= RouteControllerHighAlertInterval:
+    func newAlert(from upcomingStep: RouteStep) -> AlertLevel {
+        switch upcomingStep.expectedTravelTime {
+        case 0..<RouteControllerHighAlertInterval:
             return .high
-        case let x where x > RouteControllerHighAlertInterval && x <= RouteControllerMediumAlertInterval:
+        case RouteControllerHighAlertInterval..<RouteControllerMediumAlertInterval:
             return .medium
         default:
             return .low

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -219,7 +219,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
         let step = routeProgress.currentLegProgress.currentStep
         var text: String
         
-        // Prevent back to back instructions
+        // Prevent back to back instructions by adding a little more wiggle room
         let linkedInstructionMultiplier = RouteControllerHighAlertInterval * 1.2
         
         // We only want to announce this special depature announcement once.

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -220,7 +220,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
         var text: String
         
         // Prevent back to back instructions by adding a little more wiggle room
-        let linkedInstructionMultiplier = RouteControllerHighAlertInterval * 1.2
+        let linkedInstructionMultiplier = RouteControllerHighAlertInterval * RouteControllerMaxManipulatedCourseAngle
         
         // We only want to announce this special depature announcement once.
         // Once it has been announced, all subsequnt announcements will not have an alert level of low


### PR DESCRIPTION
Seconds remaining on a step is currently calculated using the users instantaneous speed. Seconds remaining on step is then used to figure out when to give an alert. If below x give y alert.

This PR moves away from using the users speed and instead calculates seconds remaining by looking at their percent complete and then subtracting this from the step duration. The idea here is that the server can influence a little more about when alerts are give. This also prevents the case where a user speeds up suddenly triggering a premature alert. 

This PR also adds a new `calculateNewAlert(from upcomginStep:)` function which helps in figuring out the alert level on the new step. This will also be useful when improving linked instructions when we move voice logic over to core.

/cc @1ec5 @frederoni @willwhite @ericrwolfe @cammace 