### PR TITLE
Defer presenting UIAlertController

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -101,7 +101,9 @@ class ViewController: UIViewController, MGLMapViewDelegate {
             self.startMultipleWaypoints()
         }))
         alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        present(alertController, animated: true, completion: nil)
+        DispatchQueue.main.async {
+            self.present(alertController, animated: true, completion: nil)
+        }
     }
     
     // Helper for requesting a route


### PR DESCRIPTION
We've seen slow speeds when entering navigation mode. Turns out, a lot of time is spent adding actions to the UIAlertController which is not thread safe. This PR defers presenting the controller to the next tick. Feels 💯  and much snappier.

/cc @frederoni 