### PR TITLE
Sync ReplayLocationManager

### DIFF
--- a/MapboxCoreNavigation/Array.swift
+++ b/MapboxCoreNavigation/Array.swift
@@ -33,7 +33,7 @@ extension Array {
                 locations.append(CLLocation(dictionary: dict))
             }
             
-            return locations.sorted(by: { $0.timestamp < $1.timestamp })
+            return locations.sorted { $0.timestamp < $1.timestamp }
             
         } catch {
             return []


### PR DESCRIPTION
After a minute, the replaying could lag behind ~10 seconds on a slow simulator due to the average discrepancy of NSTimer. This PR introduces resynchronization on each location update.

```
Started: 71.14s ago actualInterval: 70.99s ago Diff: 0.144978046417236
Total resync diff: 10.3568930029869
```

@ericrwolfe @bsudekum 👀 