### PR TITLE
Add status view

### DIFF
--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -4,6 +4,27 @@
 /* Format for speech string after completing a maneuver and starting a new step; 1 = way name; 2 = distance */
 "CONTINUE_ON_ROAD" = "Continue on %1$@ for %2$@";
 
+/* Delimiter between multiple destinations */
+"DESTINATION_DELIMITER" = " / ";
+
+/* Feedback type for Accident */
+"FEEDBACK_ACCIDENT" = "Accident";
+
+/* Feedback type for Closure */
+"FEEDBACK_CLOSURE" = "Closure";
+
+/* Feedback type for Confusing */
+"FEEDBACK_CONFUSING" = "Confusing";
+
+/* Feedback type for Hazard */
+"FEEDBACK_HAZARD" = "Hazard";
+
+/* Feedback type for Other Issue */
+"FEEDBACK_OTHER" = "Other Issue";
+
+/* Feedback type for Unallowed Turn */
+"FEEDBACK_UNALLOWED_TURN" = "Not Allowed";
+
 /* Format string for less than; 1 = duration remaining */
 "LESS_THAN" = "%@";
 
@@ -19,8 +40,8 @@
 /* Delimiter between route numbers in a road concurrency */
 "REF_DELIMITER" = " / ";
 
-/* Delimiter between multiple destinations */
-"DESTINATION_DELIMITER" = " / ";
+/* Indicates that rerouting is in progress */
+"REROUTING" = "Rerouting…";
 
 /* Format for speech string; 1 = formatted distance; 2 = instruction */
 "WITH_DISTANCE_UTTERANCE_FORMAT" = "In %1$@, %2$@";

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -272,6 +272,33 @@
                                 </constraints>
                                 <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jym-DH-tdD" customClass="MBStatusView">
+                                <rect key="frame" x="0.0" y="155" width="375" height="30"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rerouting…" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UpZ-gr-OKM">
+                                        <rect key="frame" x="141.5" y="5" width="92.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                        <color key="textColor" red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="jgC-8q-YUu">
+                                        <rect key="frame" x="345" y="5" width="20" height="20"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.67473591549295775" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstItem="jgC-8q-YUu" firstAttribute="centerY" secondItem="Jym-DH-tdD" secondAttribute="centerY" id="Ghp-Pc-H3U"/>
+                                    <constraint firstAttribute="trailing" secondItem="jgC-8q-YUu" secondAttribute="trailing" constant="10" id="JTW-3W-9TJ"/>
+                                    <constraint firstItem="UpZ-gr-OKM" firstAttribute="centerX" secondItem="Jym-DH-tdD" secondAttribute="centerX" id="gSp-Qg-FgY"/>
+                                    <constraint firstAttribute="height" constant="30" id="lnn-re-skW"/>
+                                    <constraint firstItem="UpZ-gr-OKM" firstAttribute="centerY" secondItem="Jym-DH-tdD" secondAttribute="centerY" id="uEG-1L-ErF"/>
+                                </constraints>
+                                <connections>
+                                    <outlet property="activityIndicatorView" destination="jgC-8q-YUu" id="mGB-sM-IEl"/>
+                                    <outlet property="textLabel" destination="UpZ-gr-OKM" id="aOh-bx-0nv"/>
+                                    <outlet property="topConstraint" destination="rsm-7B-ry2" id="5X1-Ym-fhx"/>
+                                </connections>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="76S-HP-bfy" userLabel="Background View" customClass="MBManeuverView">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="114.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -359,11 +386,12 @@
                             <constraint firstItem="nNr-30-cGD" firstAttribute="top" secondItem="Gvo-VD-DXF" secondAttribute="top" id="0tN-KV-QpL"/>
                             <constraint firstItem="nNr-30-cGD" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="4Si-h7-lL5"/>
                             <constraint firstAttribute="trailing" secondItem="NE9-ru-uJw" secondAttribute="trailing" id="52l-ND-Jdc"/>
-                            <constraint firstItem="8P3-NB-IRq" firstAttribute="top" secondItem="NE9-ru-uJw" secondAttribute="bottom" constant="10" id="6B7-Si-R4L"/>
                             <constraint firstItem="5HY-QD-dBq" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leadingMargin" constant="-6" id="DLa-g1-fxC"/>
                             <constraint firstItem="p9E-v0-Rt6" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="DvR-Su-3GN"/>
                             <constraint firstItem="C23-DT-v2t" firstAttribute="trailing" secondItem="p9E-v0-Rt6" secondAttribute="trailing" id="HsP-If-DXW"/>
+                            <constraint firstItem="8P3-NB-IRq" firstAttribute="top" secondItem="Jym-DH-tdD" secondAttribute="bottom" constant="10" id="IRw-J2-Ori"/>
                             <constraint firstItem="p9E-v0-Rt6" firstAttribute="top" secondItem="Gvo-VD-DXF" secondAttribute="top" id="K6m-Le-IeP"/>
+                            <constraint firstAttribute="trailing" secondItem="Jym-DH-tdD" secondAttribute="trailing" id="Oy8-JD-Az4"/>
                             <constraint firstAttribute="trailing" secondItem="p9E-v0-Rt6" secondAttribute="trailing" id="UtJ-Ea-CLv"/>
                             <constraint firstItem="NE9-ru-uJw" firstAttribute="top" secondItem="p9E-v0-Rt6" secondAttribute="bottom" identifier="Lane Views Top Constraint" id="VHU-Yr-eQL" userLabel="Lane Views Top Constraint"/>
                             <constraint firstAttribute="bottom" secondItem="nNr-30-cGD" secondAttribute="bottom" id="Wir-eN-QUd"/>
@@ -374,7 +402,9 @@
                             <constraint firstItem="C23-DT-v2t" firstAttribute="leading" secondItem="p9E-v0-Rt6" secondAttribute="leading" id="ijr-CB-GLx"/>
                             <constraint firstItem="8P3-NB-IRq" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" constant="10" id="kcQ-AN-lKG"/>
                             <constraint firstItem="fVn-1d-beh" firstAttribute="top" secondItem="5HY-QD-dBq" secondAttribute="bottom" constant="92" id="leu-SU-9Qj"/>
+                            <constraint firstItem="Jym-DH-tdD" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="nv3-G5-3zY"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="leading" secondItem="p9E-v0-Rt6" secondAttribute="leading" id="pfx-SS-Xux"/>
+                            <constraint firstItem="Jym-DH-tdD" firstAttribute="top" secondItem="NE9-ru-uJw" secondAttribute="bottom" id="rsm-7B-ry2" userLabel="Status View Top Constraint"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="top" secondItem="p9E-v0-Rt6" secondAttribute="top" id="uLe-Ov-1yA"/>
                             <constraint firstItem="C23-DT-v2t" firstAttribute="top" secondItem="p9E-v0-Rt6" secondAttribute="bottom" constant="0.5" id="xsN-Bb-wmd"/>
                         </constraints>
@@ -388,6 +418,7 @@
                         <outlet property="overviewButton" destination="Dry-gO-T7u" id="8s7-hO-rHP"/>
                         <outlet property="recenterButton" destination="5HY-QD-dBq" id="6ev-zD-MJ9"/>
                         <outlet property="reportButton" destination="EeE-dV-610" id="C8S-JP-WAr"/>
+                        <outlet property="statusView" destination="Jym-DH-tdD" id="9Hw-jY-J4n"/>
                         <outlet property="wayNameLabel" destination="bcm-ca-nGv" id="8Sy-Pk-fQZ"/>
                         <outlet property="wayNameView" destination="drb-do-FoT" id="oby-w9-mC3"/>
                         <outletCollection property="laneViews" destination="xMK-ix-h83" collectionClass="NSMutableArray" id="3Oz-eZ-e73"/>

--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -101,20 +101,10 @@ class RouteManeuverViewController: UIViewController {
         super.viewDidLoad()
         turnArrowView.backgroundColor = .clear
         destinationLabel.availableBounds = {[weak self] in CGRect(origin: .zero, size: self != nil ? self!.maximumAvailableStreetLabelSize : .zero) }
-        resumeNotifications()
     }
     
     deinit {
-        suspendNotifications()
         webImageManager.cancelAll()
-    }
-    
-    func resumeNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
-    }
-    
-    func suspendNotifications() {
-        NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
     }
     
     func notifyDidChange(routeProgress: RouteProgress, secondsRemaining: TimeInterval) {
@@ -184,9 +174,5 @@ class RouteManeuverViewController: UIViewController {
         } else if let step = step {
             destinationLabel.unabridgedText = routeStepFormatter.string(for: step)
         }
-    }
-    
-    func willReroute(notification: NSNotification) {
-        
     }
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -18,6 +18,7 @@ class RouteMapViewController: UIViewController {
     @IBOutlet weak var wayNameLabel: WayNameLabel!
     @IBOutlet weak var wayNameView: UIView!
     @IBOutlet weak var maneuverContainerView: ManeuverContainerView!
+    @IBOutlet weak var statusView: StatusView!
     @IBOutlet weak var laneViewsTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var laneViewsContainerView: UIView!
     @IBOutlet var laneViews: [LaneArrowView]!
@@ -77,6 +78,13 @@ class RouteMapViewController: UIViewController {
         
         wayNameView.layer.borderWidth = 1.0 / UIScreen.main.scale
         wayNameView.applyDefaultCornerRadiusShadow()
+        statusView.hide(delay: 0, animated: false)
+        
+        resumeNotifications()
+    }
+    
+    deinit {
+        suspendNotifications()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -106,6 +114,14 @@ class RouteMapViewController: UIViewController {
         mapView.setContentInset(contentInsets, animated: false)
         
         showRouteIfNeeded()
+    }
+    
+    func resumeNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
+    }
+    
+    func suspendNotifications() {
+        NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
     }
 
     @IBAction func recenter(_ sender: AnyObject) {
@@ -203,6 +219,11 @@ class RouteMapViewController: UIViewController {
             mapView.userTrackingMode = .followWithCourse
             wayNameView.isHidden = true
         }
+    }
+    
+    func willReroute(notification: NSNotification) {
+        let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
+        statusView.show(title, showSpinner: true, duration: 3)
     }
 
     func notifyAlertLevelDidChange(routeProgress: RouteProgress) {

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -527,7 +527,7 @@ class StatusView: UIView {
         activityIndicatorView.isHidden = !showSpinner
         activityIndicatorView.startAnimating()
         
-        show()
+        updateConstraints(show: true)
         UIView.defaultAnimation(0.3, animations: {
             self.superview?.layoutIfNeeded()
         }) { (completed) in
@@ -539,26 +539,21 @@ class StatusView: UIView {
     
     func hide(delay: TimeInterval = 0, animated: Bool = true) {
         if animated {
-            hide()
+            updateConstraints(show: false)
             UIView.defaultAnimation(0.3, delay: delay, animations: {
                 self.superview?.layoutIfNeeded()
             }, completion: { (completed) in
                 self.activityIndicatorView.stopAnimating()
             })
         } else {
-            hide()
+            updateConstraints(show: false)
             self.activityIndicatorView.stopAnimating()
             self.superview?.layoutIfNeeded()
         }
     }
     
-    fileprivate func hide() {
-        topConstraint.constant = -bounds.height
-        superview?.setNeedsUpdateConstraints()
-    }
-    
-    fileprivate func show() {
-        topConstraint.constant = 0
+    fileprivate func updateConstraints(show: Bool) {
+        topConstraint.constant = show ? 0 : -bounds.height
         superview?.setNeedsUpdateConstraints()
     }
 }

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -498,9 +498,11 @@ public class StylableButton: UIButton {
     }
 }
 
+/// :nodoc:
 @objc(MBManeuverView)
 class ManeuverView: UIView { }
 
+/// :nodoc:
 @objc(MBManeuverContainerView)
 class ManeuverContainerView: UIView {
     @IBOutlet weak var heightConstraint: NSLayoutConstraint!
@@ -510,5 +512,53 @@ class ManeuverContainerView: UIView {
             heightConstraint.constant = height
             setNeedsUpdateConstraints()
         }
+    }
+}
+
+/// :nodoc:
+@objc(MBStatusView)
+class StatusView: UIView {
+    @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
+    @IBOutlet weak var textLabel: UILabel!
+    @IBOutlet weak var topConstraint: NSLayoutConstraint!
+    
+    func show(_ title: String, showSpinner: Bool, duration: TimeInterval) {
+        textLabel.text = title
+        activityIndicatorView.isHidden = !showSpinner
+        activityIndicatorView.startAnimating()
+        
+        show()
+        UIView.defaultAnimation(0.3, animations: {
+            self.superview?.layoutIfNeeded()
+        }) { (completed) in
+            if completed && duration > 0 {
+                self.hide(delay: duration, animated: true)
+            }
+        }
+    }
+    
+    func hide(delay: TimeInterval = 0, animated: Bool = true) {
+        if animated {
+            hide()
+            UIView.defaultAnimation(0.3, delay: delay, animations: {
+                self.superview?.layoutIfNeeded()
+            }, completion: { (completed) in
+                self.activityIndicatorView.stopAnimating()
+            })
+        } else {
+            hide()
+            self.activityIndicatorView.stopAnimating()
+            self.superview?.layoutIfNeeded()
+        }
+    }
+    
+    fileprivate func hide() {
+        topConstraint.constant = -bounds.height
+        superview?.setNeedsUpdateConstraints()
+    }
+    
+    fileprivate func show() {
+        topConstraint.constant = 0
+        superview?.setNeedsUpdateConstraints()
     }
 }

--- a/MapboxNavigation/UIView.swift
+++ b/MapboxNavigation/UIView.swift
@@ -1,8 +1,8 @@
 import UIKit
 
 extension UIView {
-    class func defaultAnimation(_ duration: TimeInterval, animations: @escaping () -> Void, completion: ((_ completed: Bool) -> Void)?) {
-        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: animations, completion: completion)
+    class func defaultAnimation(_ duration: TimeInterval, delay: TimeInterval = 0, animations: @escaping () -> Void, completion: ((_ completed: Bool) -> Void)?) {
+        UIView.animate(withDuration: duration, delay: delay, options: .curveEaseInOut, animations: animations, completion: completion)
     }
     
     func applyDefaultCornerRadiusShadow(cornerRadius: CGFloat? = 4, shadowOpacity: CGFloat? = 0.1) {

--- a/scripts/extract_localizable.sh
+++ b/scripts/extract_localizable.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+NAVIGATION=../MapboxNavigation
+CORE=../MapboxCoreNavigation
+
+LANGUAGES=( "Base" )
+
+for lang in ${LANGUAGES[@]}
+do
+    echo "Extracting ${lang} strings"
+
+    # Extract localizable strings from .swift files
+    find ${NAVIGATION} -name "*.swift" -print0 | xargs -0 xcrun extractLocStrings -o "${NAVIGATION}/Resources/${lang}.lproj"
+    STRINGS_FILE="${NAVIGATION}/Resources/${lang}.lproj/Localizable.strings"
+
+    # Convert UTF-16LE generated files to UTF-8
+    iconv -f UTF-16LE -t UTF-8 ${STRINGS_FILE} > ${STRINGS_FILE}.new
+    mv -f ${STRINGS_FILE}.new ${STRINGS_FILE}
+done


### PR DESCRIPTION
The rerouting UI was removed in #464 
This PR adds a new reusable status view that also acts as a rerouting UI.

@bsudekum @ericrwolfe 👀 

<img src="https://user-images.githubusercontent.com/764476/29095160-3b8bd75c-7c90-11e7-926b-aca21ec304bf.gif" width=200>

_The rerouting ui is presented manually in this gif_