### PR TITLE
Remove reroute status bar after route is fetched

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -117,10 +117,12 @@ class RouteMapViewController: UIViewController {
     
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
     }
     
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
+        NotificationCenter.default.removeObserver(self, name: RouteControllerDidReroute, object: nil)
     }
 
     @IBAction func recenter(_ sender: AnyObject) {
@@ -222,7 +224,11 @@ class RouteMapViewController: UIViewController {
     
     func willReroute(notification: NSNotification) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
-        statusView.show(title, showSpinner: true, duration: 3)
+        statusView.show(title, showSpinner: true)
+    }
+    
+    func didReroute(notification: NSNotification) {
+        statusView.hide()
     }
 
     func notifyAlertLevelDidChange(routeProgress: RouteProgress) {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -118,11 +118,13 @@ class RouteMapViewController: UIViewController {
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidFailToReroute, object: nil)
     }
     
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: RouteControllerDidReroute, object: nil)
+        NotificationCenter.default.removeObserver(self, name: RouteControllerDidFailToReroute, object: nil)
     }
 
     @IBAction func recenter(_ sender: AnyObject) {
@@ -228,7 +230,7 @@ class RouteMapViewController: UIViewController {
     }
     
     func didReroute(notification: NSNotification) {
-        statusView.hide()
+        statusView.hide(delay: 0.5, animated: true)
     }
 
     func notifyAlertLevelDidChange(routeProgress: RouteProgress) {

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -532,8 +532,7 @@ class StatusView: UIView {
         
         UIView.defaultAnimation(0.3, animations: {
             self.superview?.layoutIfNeeded()
-        }) { (completed) in
-        }
+        }, completion: nil)
     }
     
     func hide(delay: TimeInterval = 0, animated: Bool = true) {

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -522,19 +522,17 @@ class StatusView: UIView {
     @IBOutlet weak var textLabel: UILabel!
     @IBOutlet weak var topConstraint: NSLayoutConstraint!
     
-    func show(_ title: String, showSpinner: Bool, duration: TimeInterval) {
+    func show(_ title: String, showSpinner: Bool) {
         textLabel.text = title
         activityIndicatorView.isHidden = !showSpinner
         activityIndicatorView.startAnimating()
         isHidden = false
         
         updateConstraints(show: true)
+        
         UIView.defaultAnimation(0.3, animations: {
             self.superview?.layoutIfNeeded()
         }) { (completed) in
-            if completed && duration > 0 {
-                self.hide(delay: duration, animated: true)
-            }
         }
     }
     


### PR DESCRIPTION
We should hide the status bar once the new route is fetched.

/cc @frederoni 