### PR TITLE
Allow snaping when speed is zero

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -251,16 +251,16 @@ open class RouteController: NSObject {
         guard let stepCoordinates = routeProgress.currentLegProgress.currentStep.coordinates else { return nil }
         guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
         
-        guard location.speed >= 0 else {
-            return location
-        }
-        
         let nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
         guard let closest = closestCoordinate(on: nearByCoordinates, to: location.coordinate) else { return nil }
         
         let slicedLineBehind = polyline(along: nearByCoordinates.reversed(), from: closest.coordinate, to: nearByCoordinates.reversed().last)
         let slicedLineInfront = polyline(along: nearByCoordinates, from: closest.coordinate, to: nearByCoordinates.last)
         let userDistanceBuffer: CLLocationDistance = location.speed * RouteControllerDeadReckoningTimeInterval / 2
+        
+        // At the beginning of the route, the `slicedLineBehind` will have no coordinates.
+        // This gives the user some time before we start snapping their course and location.
+        guard slicedLineBehind.count > 2 else { return location }
         
         guard let pointBehind = coordinate(at: userDistanceBuffer, fromStartOf: slicedLineBehind) else { return nil }
         guard let pointBehindClosest = closestCoordinate(on: nearByCoordinates, to: pointBehind) else { return nil }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -280,7 +280,9 @@ open class RouteController: NSObject {
         
         // If the course is inaccurate and the user is on the route,
         // calculate a rough estimate as to what the course should be at that point on the route.
-        if location.course <= 0 && snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance {
+        // Or if the user is going slow, snap the course to the calculated course given the route.
+        // This is because when a device is moving slowly, the course becomes more inaccurate.
+        if location.course <= 0 && snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance || location.speed <= 1 {
             let calculatedCourse = wrap((wrappedPointBehind + wrappedPointAhead) / 2, min: 0 , max: 360)
             return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: calculatedCourse, speed: location.speed, timestamp: location.timestamp)
         }


### PR DESCRIPTION
This does two things:
* Allows snapping to occur (if deemed possible) when the user speed is zero. This will help at stop lights
* At the beginning of the route, it's difficult to snap the user course and location if we cannot look behind the user. Instead, use the location and let the user begin navigating on the route. This will only happen momentarily and is probably a good thing to allow the user some buffer time when beginning a route.

/cc @frederoni @ericrwolfe @1ec5 