### PR TITLE
Various UI tweaks

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -184,6 +184,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         style.fontFamily = "Georgia"
         style.turnArrowPrimaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         style.turnArrowSecondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)
+        style.floatingButtonBackgroundColor = #colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1)
         
         // Maneuver view (Page view)
         style.maneuverViewBackgroundColor = #colorLiteral(red: 0.2974345386, green: 0.4338284135, blue: 0.9865127206, alpha: 1)

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -185,6 +185,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         style.turnArrowPrimaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         style.turnArrowSecondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)
         style.floatingButtonBackgroundColor = #colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1)
+        style.lanesViewBackgroundColor = #colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1)
         
         // Maneuver view (Page view)
         style.maneuverViewBackgroundColor = #colorLiteral(red: 0.2974345386, green: 0.4338284135, blue: 0.9865127206, alpha: 1)

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.dependency "MapboxDirections.swift", "~> 0.10.1"
   s.dependency "Mapbox-iOS-SDK", "~> 3.5"
   s.dependency "OSRMTextInstructions", "~> 0.3.0"
-  s.dependency "Pulley", "~> 1.3"
+  s.dependency "Pulley", "1.4"
   s.dependency "SDWebImage", "~> 4.0"
   s.dependency "AWSPolly", "~> 2.5"
 

--- a/MapboxNavigation/DefaultStyle.swift
+++ b/MapboxNavigation/DefaultStyle.swift
@@ -58,6 +58,8 @@ open class DefaultStyle: Style {
         turnArrowPrimaryColor = .defaultTurnArrowPrimary
         turnArrowSecondaryColor = .defaultTurnArrowSecondary
         
+        floatingButtonBackgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        
         // Maneuver view (Page view)
         maneuverViewBackgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         

--- a/MapboxNavigation/DefaultStyle.swift
+++ b/MapboxNavigation/DefaultStyle.swift
@@ -59,6 +59,7 @@ open class DefaultStyle: Style {
         turnArrowSecondaryColor = .defaultTurnArrowSecondary
         
         floatingButtonBackgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        lanesViewBackgroundColor = #colorLiteral(red: 0.968627451, green: 0.968627451, blue: 0.968627451, alpha: 1)
         
         // Maneuver view (Page view)
         maneuverViewBackgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -31,7 +31,7 @@ class FeedbackViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .clear
-        containerView.applyDefaultCornerRadiusShadow(cornerRadius: 8)
+        containerView.applyDefaultCornerRadiusShadow(cornerRadius: 16)
         
         let accidentImage       = Bundle.mapboxNavigation.image(named: "feedback_car_crash")!.withRenderingMode(.alwaysTemplate)
         let hazardImage         = Bundle.mapboxNavigation.image(named: "feedback_hazard")!.withRenderingMode(.alwaysTemplate)

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -15,11 +15,11 @@ open class NavigationMapView: MGLMapView {
     let routeLayerCasingIdentifier = "routeLayerCasing"
     
     let routeLineWidthAtZoomLevels: [Int: MGLStyleValue<NSNumber>] = [
-        10: MGLStyleValue(rawValue: 6),
-        13: MGLStyleValue(rawValue: 7),
-        16: MGLStyleValue(rawValue: 10),
-        19: MGLStyleValue(rawValue: 22),
-        22: MGLStyleValue(rawValue: 28)
+        10: MGLStyleValue(rawValue: 8),
+        13: MGLStyleValue(rawValue: 9),
+        16: MGLStyleValue(rawValue: 12),
+        19: MGLStyleValue(rawValue: 24),
+        22: MGLStyleValue(rawValue: 30)
     ]
     
     var manuallyUpdatesLocation: Bool = false {

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -70,45 +70,37 @@
                         <subviews>
                             <view contentMode="scaleToFill" restorationIdentifier="mapView" translatesAutoresizingMaskIntoConstraints="NO" id="nNr-30-cGD" customClass="MBNavigationMapView">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="324"/>
-                                <subviews>
-                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="drb-do-FoT" userLabel="Way Name View" customClass="MBWayNameView">
-                                        <rect key="frame" x="134.5" y="205" width="106.5" height="29"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcm-ca-nGv" customClass="MBWayNameLabel">
-                                                <rect key="frame" x="14" y="6" width="78.5" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                                <attributedString key="userComments">
-                                                    <fragment content="DO NOT TRANSLATE">
-                                                        <attributes>
-                                                            <font key="NSFont" metaFont="smallSystem"/>
-                                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                        </attributes>
-                                                    </fragment>
-                                                </attributedString>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="bcm-ca-nGv" secondAttribute="trailing" constant="14" id="16w-UW-7Y7"/>
-                                            <constraint firstAttribute="bottom" secondItem="bcm-ca-nGv" secondAttribute="bottom" constant="6" id="Hs4-ZE-bmP"/>
-                                            <constraint firstItem="bcm-ca-nGv" firstAttribute="top" secondItem="drb-do-FoT" secondAttribute="top" constant="6" id="N8i-oQ-85J"/>
-                                            <constraint firstItem="bcm-ca-nGv" firstAttribute="leading" secondItem="drb-do-FoT" secondAttribute="leading" constant="14" id="gei-Oh-7XJ"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
                                 <color key="backgroundColor" red="0.90196078430000004" green="0.89019607840000003" blue="0.87450980389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="drb-do-FoT" secondAttribute="bottom" constant="90" id="0ay-99-AQJ"/>
-                                    <constraint firstItem="drb-do-FoT" firstAttribute="centerX" secondItem="nNr-30-cGD" secondAttribute="centerX" id="TCg-jZ-7G3"/>
-                                    <constraint firstItem="drb-do-FoT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="nNr-30-cGD" secondAttribute="leading" constant="20" id="fHo-P2-05s"/>
-                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="drb-do-FoT" secondAttribute="trailing" constant="20" id="mlv-9X-djl"/>
-                                </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="showsUserLocation" value="YES"/>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-guidance-day-v2"/>
                                 </userDefinedRuntimeAttributes>
+                            </view>
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="drb-do-FoT" userLabel="Way Name View" customClass="MBWayNameView">
+                                <rect key="frame" x="134" y="204.5" width="106.5" height="29"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcm-ca-nGv" customClass="MBWayNameLabel">
+                                        <rect key="frame" x="14" y="6" width="78.5" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                        <attributedString key="userComments">
+                                            <fragment content="DO NOT TRANSLATE">
+                                                <attributes>
+                                                    <font key="NSFont" metaFont="smallSystem"/>
+                                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                </attributes>
+                                            </fragment>
+                                        </attributedString>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="bcm-ca-nGv" secondAttribute="trailing" constant="14" id="16w-UW-7Y7"/>
+                                    <constraint firstAttribute="bottom" secondItem="bcm-ca-nGv" secondAttribute="bottom" constant="6" id="Hs4-ZE-bmP"/>
+                                    <constraint firstItem="bcm-ca-nGv" firstAttribute="top" secondItem="drb-do-FoT" secondAttribute="top" constant="6" id="N8i-oQ-85J"/>
+                                    <constraint firstItem="bcm-ca-nGv" firstAttribute="leading" secondItem="drb-do-FoT" secondAttribute="leading" constant="14" id="gei-Oh-7XJ"/>
+                                </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Stack View" customClass="MBLanesView">
                                 <rect key="frame" x="0.0" y="114.5" width="375" height="40"/>
@@ -387,16 +379,20 @@
                         <constraints>
                             <constraint firstItem="nNr-30-cGD" firstAttribute="top" secondItem="Gvo-VD-DXF" secondAttribute="top" id="0tN-KV-QpL"/>
                             <constraint firstItem="nNr-30-cGD" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="4Si-h7-lL5"/>
+                            <constraint firstItem="drb-do-FoT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Gvo-VD-DXF" secondAttribute="leading" constant="20" id="4oP-yz-9W5"/>
                             <constraint firstAttribute="trailing" secondItem="NE9-ru-uJw" secondAttribute="trailing" id="52l-ND-Jdc"/>
                             <constraint firstItem="5HY-QD-dBq" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leadingMargin" constant="-6" id="DLa-g1-fxC"/>
                             <constraint firstItem="p9E-v0-Rt6" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="DvR-Su-3GN"/>
                             <constraint firstItem="C23-DT-v2t" firstAttribute="trailing" secondItem="p9E-v0-Rt6" secondAttribute="trailing" id="HsP-If-DXW"/>
                             <constraint firstItem="8P3-NB-IRq" firstAttribute="top" secondItem="Jym-DH-tdD" secondAttribute="bottom" constant="10" id="IRw-J2-Ori"/>
                             <constraint firstItem="p9E-v0-Rt6" firstAttribute="top" secondItem="Gvo-VD-DXF" secondAttribute="top" id="K6m-Le-IeP"/>
+                            <constraint firstItem="drb-do-FoT" firstAttribute="centerX" secondItem="Gvo-VD-DXF" secondAttribute="centerX" id="O0m-0k-ilC"/>
+                            <constraint firstItem="fVn-1d-beh" firstAttribute="top" secondItem="drb-do-FoT" secondAttribute="bottom" constant="90" id="OD1-Zy-Gvh"/>
                             <constraint firstAttribute="trailing" secondItem="Jym-DH-tdD" secondAttribute="trailing" id="Oy8-JD-Az4"/>
                             <constraint firstAttribute="trailing" secondItem="p9E-v0-Rt6" secondAttribute="trailing" id="UtJ-Ea-CLv"/>
                             <constraint firstItem="NE9-ru-uJw" firstAttribute="top" secondItem="p9E-v0-Rt6" secondAttribute="bottom" identifier="Lane Views Top Constraint" id="VHU-Yr-eQL" userLabel="Lane Views Top Constraint"/>
                             <constraint firstAttribute="bottom" secondItem="nNr-30-cGD" secondAttribute="bottom" id="Wir-eN-QUd"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="drb-do-FoT" secondAttribute="trailing" constant="20" id="Y9d-Eh-5kY"/>
                             <constraint firstItem="NE9-ru-uJw" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="ayw-dM-DXC"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="trailing" secondItem="p9E-v0-Rt6" secondAttribute="trailing" id="azG-Bi-6NR"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="bottom" secondItem="p9E-v0-Rt6" secondAttribute="bottom" id="djD-Ab-lfr"/>

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13168.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="2bw-kK-8r6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13178.6" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="2bw-kK-8r6">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13147.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13156.2"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -72,10 +72,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="324"/>
                                 <subviews>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="drb-do-FoT" userLabel="Way Name View" customClass="MBWayNameView">
-                                        <rect key="frame" x="141" y="213" width="94.5" height="21"/>
+                                        <rect key="frame" x="134.5" y="205" width="106.5" height="29"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcm-ca-nGv" customClass="MBWayNameLabel">
-                                                <rect key="frame" x="8" y="2" width="79" height="17"/>
+                                                <rect key="frame" x="14" y="6" width="78.5" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -91,10 +91,10 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="bcm-ca-nGv" secondAttribute="trailing" constant="8" id="16w-UW-7Y7"/>
-                                            <constraint firstAttribute="bottom" secondItem="bcm-ca-nGv" secondAttribute="bottom" constant="2" id="Hs4-ZE-bmP"/>
-                                            <constraint firstItem="bcm-ca-nGv" firstAttribute="top" secondItem="drb-do-FoT" secondAttribute="top" constant="2" id="N8i-oQ-85J"/>
-                                            <constraint firstItem="bcm-ca-nGv" firstAttribute="leading" secondItem="drb-do-FoT" secondAttribute="leading" constant="8" id="gei-Oh-7XJ"/>
+                                            <constraint firstAttribute="trailing" secondItem="bcm-ca-nGv" secondAttribute="trailing" constant="14" id="16w-UW-7Y7"/>
+                                            <constraint firstAttribute="bottom" secondItem="bcm-ca-nGv" secondAttribute="bottom" constant="6" id="Hs4-ZE-bmP"/>
+                                            <constraint firstItem="bcm-ca-nGv" firstAttribute="top" secondItem="drb-do-FoT" secondAttribute="top" constant="6" id="N8i-oQ-85J"/>
+                                            <constraint firstItem="bcm-ca-nGv" firstAttribute="leading" secondItem="drb-do-FoT" secondAttribute="leading" constant="14" id="gei-Oh-7XJ"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -102,6 +102,8 @@
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="drb-do-FoT" secondAttribute="bottom" constant="90" id="0ay-99-AQJ"/>
                                     <constraint firstItem="drb-do-FoT" firstAttribute="centerX" secondItem="nNr-30-cGD" secondAttribute="centerX" id="TCg-jZ-7G3"/>
+                                    <constraint firstItem="drb-do-FoT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="nNr-30-cGD" secondAttribute="leading" constant="20" id="fHo-P2-05s"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="drb-do-FoT" secondAttribute="trailing" constant="20" id="mlv-9X-djl"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="showsUserLocation" value="YES"/>
@@ -314,10 +316,10 @@
                                 </connections>
                             </containerView>
                             <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5HY-QD-dBq" customClass="MBHighlightedButton">
-                                <rect key="frame" x="10" y="250" width="112" height="42"/>
+                                <rect key="frame" x="10" y="181.5" width="112" height="50"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="42" id="QGu-S5-V3G"/>
+                                    <constraint firstAttribute="height" constant="50" id="QGu-S5-V3G"/>
                                     <constraint firstAttribute="width" constant="112" id="auw-yF-4hd"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -331,14 +333,14 @@
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8P3-NB-IRq">
-                                <rect key="frame" x="10" y="164.5" width="44" height="96"/>
+                                <rect key="frame" x="10" y="195" width="50" height="108"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dry-gO-T7u" customClass="MBButton">
-                                        <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="44" id="Boe-Xa-uFI"/>
-                                            <constraint firstAttribute="height" constant="44" id="ybt-ny-GPN"/>
+                                            <constraint firstAttribute="width" constant="50" id="Boe-Xa-uFI"/>
+                                            <constraint firstAttribute="height" constant="50" id="ybt-ny-GPN"/>
                                         </constraints>
                                         <state key="normal" image="overview"/>
                                         <connections>
@@ -346,11 +348,11 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y2a-qB-86S" customClass="MBButton">
-                                        <rect key="frame" x="0.0" y="52" width="44" height="44"/>
+                                        <rect key="frame" x="0.0" y="58" width="50" height="50"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="DRa-a5-D9t"/>
-                                            <constraint firstAttribute="width" constant="44" id="Ejg-Q8-jZn"/>
+                                            <constraint firstAttribute="height" constant="50" id="DRa-a5-D9t"/>
+                                            <constraint firstAttribute="width" constant="50" id="Ejg-Q8-jZn"/>
                                         </constraints>
                                         <state key="normal" image="volume_up"/>
                                         <state key="selected" image="volume_off"/>
@@ -359,11 +361,11 @@
                                         </connections>
                                     </button>
                                     <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EeE-dV-610" customClass="MBButton">
-                                        <rect key="frame" x="0.0" y="96" width="44" height="44"/>
+                                        <rect key="frame" x="0.0" y="108" width="50" height="50"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="o37-gV-IxI"/>
-                                            <constraint firstAttribute="width" constant="44" id="vXa-Tt-AZm"/>
+                                            <constraint firstAttribute="height" constant="50" id="o37-gV-IxI"/>
+                                            <constraint firstAttribute="width" constant="50" id="vXa-Tt-AZm"/>
                                         </constraints>
                                         <inset key="imageEdgeInsets" minX="3" minY="2" maxX="0.0" maxY="0.0"/>
                                         <state key="normal" image="feedback"/>
@@ -647,10 +649,10 @@
                                 <blurEffect style="extraLight"/>
                             </visualEffectView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ecu-yz-M5j" userLabel="ContainerView">
-                                <rect key="frame" x="24" y="60" width="327" height="567"/>
+                                <rect key="frame" x="24" y="100" width="327" height="542"/>
                                 <subviews>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Sne-Dn-jdt">
-                                        <rect key="frame" x="8" y="10" width="311" height="457"/>
+                                        <rect key="frame" x="8" y="10" width="311" height="432"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="16" minimumInteritemSpacing="0.0" id="unA-43-4hX">
                                             <size key="itemSize" width="155" height="134"/>
@@ -727,7 +729,7 @@
                                         </connections>
                                     </collectionView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JMs-xU-Gfd">
-                                        <rect key="frame" x="20" y="487" width="287" height="60"/>
+                                        <rect key="frame" x="20" y="462" width="287" height="60"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="60" id="apY-WJ-qqF"/>
                                         </constraints>
@@ -763,8 +765,8 @@
                             <constraint firstItem="EC5-ge-nz1" firstAttribute="leading" secondItem="I7t-WT-lto" secondAttribute="leading" id="9Wv-Am-mxS"/>
                             <constraint firstAttribute="trailingMargin" secondItem="ecu-yz-M5j" secondAttribute="trailing" constant="8" id="Cyb-Eg-iSY"/>
                             <constraint firstItem="EC5-ge-nz1" firstAttribute="top" secondItem="I7t-WT-lto" secondAttribute="top" id="VgD-ac-RQ2"/>
-                            <constraint firstItem="ecu-yz-M5j" firstAttribute="top" secondItem="pGP-EB-Pif" secondAttribute="bottom" constant="40" id="cDD-7Q-8vJ"/>
-                            <constraint firstItem="hWX-uw-jMV" firstAttribute="top" secondItem="ecu-yz-M5j" secondAttribute="bottom" constant="40" id="rzg-dk-UOe"/>
+                            <constraint firstItem="ecu-yz-M5j" firstAttribute="top" secondItem="pGP-EB-Pif" secondAttribute="bottom" constant="80" id="cDD-7Q-8vJ"/>
+                            <constraint firstItem="hWX-uw-jMV" firstAttribute="top" secondItem="ecu-yz-M5j" secondAttribute="bottom" constant="25" id="rzg-dk-UOe"/>
                             <constraint firstAttribute="trailing" secondItem="EC5-ge-nz1" secondAttribute="trailing" id="wa9-2E-HRi"/>
                             <constraint firstItem="ecu-yz-M5j" firstAttribute="leading" secondItem="I7t-WT-lto" secondAttribute="leadingMargin" constant="8" id="xiW-Wm-SI7"/>
                         </constraints>

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -110,7 +110,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-guidance-day-v2"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Stack View">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Stack View" customClass="MBLanesView">
                                 <rect key="frame" x="0.0" y="114.5" width="375" height="40"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="D9e-aq-442" userLabel="Lane Stack View">

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -335,7 +335,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8P3-NB-IRq">
                                 <rect key="frame" x="10" y="195" width="50" height="108"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dry-gO-T7u" customClass="MBButton">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dry-gO-T7u" customClass="MBFloatingButton">
                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
@@ -347,7 +347,7 @@
                                             <action selector="toggleOverview:" destination="3z2-H5-unA" eventType="touchUpInside" id="2Bc-fq-C2C"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y2a-qB-86S" customClass="MBButton">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y2a-qB-86S" customClass="MBFloatingButton">
                                         <rect key="frame" x="0.0" y="58" width="50" height="50"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
@@ -360,7 +360,7 @@
                                             <action selector="toggleMute:" destination="3z2-H5-unA" eventType="touchUpInside" id="2ZH-pI-vhy"/>
                                         </connections>
                                     </button>
-                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EeE-dV-610" customClass="MBButton">
+                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EeE-dV-610" customClass="MBFloatingButton">
                                         <rect key="frame" x="0.0" y="108" width="50" height="50"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -70,9 +70,9 @@ class RouteMapViewController: UIViewController {
         mapView.navigationMapDelegate = self
         mapView.manuallyUpdatesLocation = true
         
-        overviewButton.applyDefaultCornerRadiusShadow(cornerRadius: 22)
-        reportButton.applyDefaultCornerRadiusShadow(cornerRadius: 22)
-        muteButton.applyDefaultCornerRadiusShadow(cornerRadius: 22)
+        overviewButton.applyDefaultCornerRadiusShadow(cornerRadius: overviewButton.bounds.midX)
+        reportButton.applyDefaultCornerRadiusShadow(cornerRadius: reportButton.bounds.midX)
+        muteButton.applyDefaultCornerRadiusShadow(cornerRadius: muteButton.bounds.midX)
         recenterButton.applyDefaultCornerRadiusShadow()
         
         wayNameView.layer.borderWidth = 1.0 / UIScreen.main.scale

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -19,9 +19,8 @@ class RouteTableViewController: UIViewController {
         super.viewWillAppear(animated)
         setupTableView()
         dateFormatter.timeStyle = .short
-        dateComponentsFormatter.maximumUnitCount = 2
-        dateComponentsFormatter.allowedUnits = [.day, .hour, .minute]
-        dateComponentsFormatter.unitsStyle = .short
+        dateComponentsFormatter.allowedUnits = [.hour, .minute]
+        dateComponentsFormatter.unitsStyle = .abbreviated
         distanceFormatter.numberFormatter.locale = .nationalizedCurrent
     }
     
@@ -40,6 +39,8 @@ class RouteTableViewController: UIViewController {
         } else {
             headerView.distanceRemaining.text = distanceFormatter.string(from: routeProgress.distanceRemaining)
         }
+        
+        dateComponentsFormatter.unitsStyle = routeProgress.durationRemaining < 3600 ? .short : .abbreviated
         
         if routeProgress.durationRemaining < 60 {
             headerView.timeRemaining.text = String.localizedStringWithFormat(NSLocalizedString("LESS_THAN", bundle: .mapboxNavigation, value: "%@", comment: "Format string for less than; 1 = duration remaining"), dateComponentsFormatter.string(from: 61)!)

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -52,6 +52,11 @@ open class Style: NSObject {
     public var buttonTextColor: UIColor?
     
     /**
+     Sets the background color on the floating buttons.
+     */
+    public var floatingButtonBackgroundColor: UIColor?
+    
+    /**
      Sets the color of dividers and separators.
      */
     public var lineColor: UIColor?
@@ -249,6 +254,10 @@ open class Style: NSObject {
             TurnArrowView.appearance(for: traitCollection).secondaryColor = color
         }
         
+        if let color = floatingButtonBackgroundColor {
+            FloatingButton.appearance(for: traitCollection).backgroundColor = color
+        }
+        
         // Maneuver page view controller
         
         if let color = maneuverViewBackgroundColor {
@@ -351,6 +360,10 @@ open class Style: NSObject {
  */
 @objc(MBButton)
 public class Button: StylableButton { }
+
+/// :nodoc:
+@objc(MBFloatingButton)
+public class FloatingButton: Button { }
 
 /**
  :nodoc:

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -57,6 +57,11 @@ open class Style: NSObject {
     public var floatingButtonBackgroundColor: UIColor?
     
     /**
+     Sets the background color of the lanes view
+     */
+    public var lanesViewBackgroundColor: UIColor?
+    
+    /**
      Sets the color of dividers and separators.
      */
     public var lineColor: UIColor?
@@ -258,6 +263,10 @@ open class Style: NSObject {
             FloatingButton.appearance(for: traitCollection).backgroundColor = color
         }
         
+        if let color = lanesViewBackgroundColor {
+            LanesView.appearance(for: traitCollection).backgroundColor = color
+        }
+        
         // Maneuver page view controller
         
         if let color = maneuverViewBackgroundColor {
@@ -364,6 +373,11 @@ public class Button: StylableButton { }
 /// :nodoc:
 @objc(MBFloatingButton)
 public class FloatingButton: Button { }
+
+
+/// :nodoc:
+@objc(MBLanesView)
+public class LanesView: UIView { }
 
 /**
  :nodoc:


### PR DESCRIPTION
This PR supersedes #463 and fixes #478 by locking down a specific version of Pulley when installing with  CocoaPods.

- Added support for styling floating buttons and the background of the lane view.
- Increased size of the floating buttons.
- Minor tweaks on the feedback view.

<img src="https://user-images.githubusercontent.com/764476/29227866-e4b37fb2-7ed7-11e7-9c23-352139d75916.png" width=200><img src="https://user-images.githubusercontent.com/764476/29227880-f488bd80-7ed7-11e7-8b72-1e082c2e2564.png" width=200>

@ericrwolfe @bsudekum 