### PR TITLE
Use user heading sparingly when speed is low [Controversial!]

### DIFF
--- a/MapboxCoreNavigation/CLHeading.swift
+++ b/MapboxCoreNavigation/CLHeading.swift
@@ -1,0 +1,11 @@
+import Foundation
+import CoreLocation
+
+extension CLHeading {
+    var preferredHeading: CLLocationDirection {
+        guard trueHeading <= 0 || headingAccuracy > 45 else {
+            return magneticHeading
+        }
+        return trueHeading
+    }
+}

--- a/MapboxCoreNavigation/CLHeading.swift
+++ b/MapboxCoreNavigation/CLHeading.swift
@@ -3,7 +3,7 @@ import CoreLocation
 
 extension CLHeading {
     var preferredHeading: CLLocationDirection {
-        guard trueHeading <= 0 || headingAccuracy > 45 else {
+        guard trueHeading >= 0 || headingAccuracy > 45 else {
             return magneticHeading
         }
         return trueHeading

--- a/MapboxCoreNavigation/CLHeading.swift
+++ b/MapboxCoreNavigation/CLHeading.swift
@@ -3,7 +3,7 @@ import CoreLocation
 
 extension CLHeading {
     var preferredHeading: CLLocationDirection {
-        guard trueHeading >= 0 || headingAccuracy > 45 else {
+        guard trueHeading >= 0 || headingAccuracy < 45 else {
             return magneticHeading
         }
         return trueHeading

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		C5D9800F1EFBCDAD006DBF2E /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D9800E1EFBCDAD006DBF2E /* Date.swift */; };
 		C5EA98711F19414200C8AA16 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C549F8311F17F2C5001A0A2D /* MapboxMobileEvents.framework */; };
 		C5EA98721F19414C00C8AA16 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C549F8311F17F2C5001A0A2D /* MapboxMobileEvents.framework */; };
+		C5F07A951F3E135500C1129D /* CLHeading.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F07A941F3E135500C1129D /* CLHeading.swift */; };
 		DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DAAE5F321EAE4C4700832871 /* Localizable.strings */; };
 		DAB2CCE71DF7AFDF001B2FE1 /* dc-line.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DAB2CCE61DF7AFDE001B2FE1 /* dc-line.geojson */; };
 		DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */; };
@@ -445,6 +446,7 @@
 		C5CFE4871EF2FD4C006F48E8 /* MMEEventsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MMEEventsManager.swift; sourceTree = "<group>"; };
 		C5D9800C1EFA8BA9006DBF2E /* CustomViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomViewController.swift; sourceTree = "<group>"; };
 		C5D9800E1EFBCDAD006DBF2E /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		C5F07A941F3E135500C1129D /* CLHeading.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLHeading.swift; sourceTree = "<group>"; };
 		DA625E901F10557300FBE176 /* fa */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Main.strings; sourceTree = "<group>"; };
 		DA625E911F10559600FBE176 /* fa */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Main.strings; sourceTree = "<group>"; };
 		DA625E921F1055DE00FBE176 /* fa */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Navigation.strings; sourceTree = "<group>"; };
@@ -829,6 +831,7 @@
 				351927351F0FA072003A702D /* ScreenCapture.swift */,
 				35BF8CA31F28EBD8003F6125 /* String.swift */,
 				35A5413A1EFC052700E49846 /* RouteOptions.swift */,
+				C5F07A941F3E135500C1129D /* CLHeading.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1424,6 +1427,7 @@
 				351174F41EF1C0530065E248 /* ReplayLocationManager.swift in Sources */,
 				C5C94C1C1DDCD2340097296A /* RouteController.swift in Sources */,
 				359574A81F28CC5A00838209 /* CLLocation.swift in Sources */,
+				C5F07A951F3E135500C1129D /* CLHeading.swift in Sources */,
 				C5C94C1E1DDCD23A0097296A /* Geometry.swift in Sources */,
 				357826C31F1B7CCE005C54FB /* SpokenDistanceFormatter.swift in Sources */,
 				351927361F0FA072003A702D /* ScreenCapture.swift in Sources */,


### PR DESCRIPTION
This fixes a few things:

* During snapping, we were using the users speed to find two points near the user to interpret the users expected course for their given location on the route. This is huge trap, if the users speed is zero or near zero, the two points could be on top of each other. Our snapping math would produce a wildly inaccurate because of this. In the worst case, the new course would be zero, which is very bad.
* We've had a continuing reports of the course floating around when the user is at a stoplight. This can be due to the course being inaccurate while not moving. If the course is <= 0 or if the speed is <= 1, we should not use the users course to snap their course to the route. Instead, we can use the heading to see if they should be snapped.
  * We have also had issues with the users direction being off at the beginning of a route. This change will also help their since a lot of the time, a user will not start driving until they know which direction they are facing. In this case, heading is more useful to use since their course is most likely wrong (stand still).

This should be tested heavily. 

/cc @frederoni @1ec5 @ericrwolfe 