### PR TITLE
Better initial camera

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -260,7 +260,7 @@ open class RouteController: NSObject {
         
         let slicedLineBehind = polyline(along: nearByCoordinates.reversed(), from: closest.coordinate, to: nearByCoordinates.reversed().last)
         let slicedLineInfront = polyline(along: nearByCoordinates, from: closest.coordinate, to: nearByCoordinates.last)
-        let userDistanceBuffer: CLLocationDistance = location.speed * RouteControllerDeadReckoningTimeInterval / 2
+        let userDistanceBuffer: CLLocationDistance = max(location.speed * RouteControllerDeadReckoningTimeInterval / 2, 8)
         
         guard let pointBehind = coordinate(at: userDistanceBuffer, fromStartOf: slicedLineBehind) else { return nil }
         guard let pointBehindClosest = closestCoordinate(on: nearByCoordinates, to: pointBehind) else { return nil }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -260,7 +260,7 @@ open class RouteController: NSObject {
         
         let slicedLineBehind = polyline(along: nearByCoordinates.reversed(), from: closest.coordinate, to: nearByCoordinates.reversed().last)
         let slicedLineInfront = polyline(along: nearByCoordinates, from: closest.coordinate, to: nearByCoordinates.last)
-        let userDistanceBuffer: CLLocationDistance = max(location.speed * RouteControllerDeadReckoningTimeInterval / 2, 8)
+        let userDistanceBuffer: CLLocationDistance = max(location.speed * RouteControllerDeadReckoningTimeInterval / 2, RouteControllerUserLocationSnappingDistance / 2)
         
         guard let pointBehind = coordinate(at: userDistanceBuffer, fromStartOf: slicedLineBehind) else { return nil }
         guard let pointBehindClosest = closestCoordinate(on: nearByCoordinates, to: pointBehind) else { return nil }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -104,13 +104,18 @@ class RouteMapViewController: UIViewController {
             mapView.setCamera(camera, animated: false)
         }
     }
-
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        mapView.setUserLocationVerticalAlignment(.bottom, animated: false)
+        mapView.setContentInset(contentInsets, animated: false)
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         mapView.setUserTrackingMode(.followWithCourse, animated: false)
-        mapView.setUserLocationVerticalAlignment(.bottom, animated: false)
-        mapView.setContentInset(contentInsets, animated: false)
         
         showRouteIfNeeded()
     }


### PR DESCRIPTION
This tries to minimize the floating effect that occurs when initializing the navigation view. Although it's still not perfect, it is a great improvement.

/cc @frederoni @1ec5 @ericrwolfe 

## New rotating device
![newflip](https://user-images.githubusercontent.com/1058624/29230959-18967e4e-7e9a-11e7-91ed-82c9b55ebb47.gif)

## Old rotating device
![oldflip](https://user-images.githubusercontent.com/1058624/29230958-189523e6-7e9a-11e7-978a-4b14585f892e.gif)

## New initial view
![untitled](https://user-images.githubusercontent.com/1058624/29230975-2b23ce04-7e9a-11e7-93ba-f1eff36f89e5.gif)

## Old initial view

![old](https://user-images.githubusercontent.com/1058624/29230976-2b742ff2-7e9a-11e7-9970-ae02ea2cada5.gif)


