### PR TITLE
Fix stutter

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -107,9 +107,12 @@ class RouteMapViewController: UIViewController {
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        
-        mapView.setUserLocationVerticalAlignment(.bottom, animated: false)
-        mapView.setContentInset(contentInsets, animated: false)
+        // For some reason, when completing a maneuver this function is called.
+        // If we try to set the insets/align twice, the UI locks momentarily.
+        if mapView.userLocationVerticalAlignment != .bottom {
+            mapView.setUserLocationVerticalAlignment(.bottom, animated: false)
+            mapView.setContentInset(contentInsets, animated: false)
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
For some reason, viewDidLayoutSubviews is called when a maneuver is completed. To prevent the UI updating the insets/alignment, we should prevent the calls if we already have the desired values.

ref https://github.com/mapbox/mapbox-navigation-ios/pull/482

/cc @ericrwolfe 