### PR TITLE
Allow zero feet

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -111,7 +111,7 @@ class RouteManeuverViewController: UIViewController {
         let stepProgress = routeProgress.currentLegProgress.currentStepProgress
         let distanceRemaining = stepProgress.distanceRemaining
         
-        distance = distanceRemaining > 10 ? distanceRemaining : nil
+        distance = distanceRemaining > 5 ? distanceRemaining : 0
         
         if routeProgress.currentLegProgress.alertUserLevel == .arrive {
             distance = nil


### PR DESCRIPTION
This snippet of code tries to remove `0 ft` from the UI. `0 ft` is actually not a bad thing, it indicates to the user that they are really doing something now. Additionally, removes a lot of UI changes that can be confusing.

## Before
![old](https://user-images.githubusercontent.com/1058624/29285171-68e301f2-80e2-11e7-8dc0-6497e22cab31.gif)

## After
![new](https://user-images.githubusercontent.com/1058624/29285170-68df3c84-80e2-11e7-96d0-fbe286161062.gif)

/cc @frederoni 