### PR TITLE
Expose mapView(:ViewForAnnotation:)

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -32,6 +32,10 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     var exampleMode: ExampleMode?
     var nextWaypoint: CLLocationCoordinate2D?
     
+    // In this example, we show you how you can create custom UIView that is used to show the user's location.
+    // Set `showCustomUserPuck` to true to view the custom user puck.
+    var showCustomUserPuck = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -241,9 +245,11 @@ class ViewController: UIViewController, MGLMapViewDelegate {
 
         present(navigationViewController, animated: true, completion: nil)
     }
-    
+}
+
+extension ViewController: NavigationViewControllerDelegate {
     func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
-        guard annotation is MGLUserLocation else { return nil }
+        guard annotation is MGLUserLocation && showCustomUserPuck else { return nil }
         
         let reuseIdentifier = "userPuck"
         var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: reuseIdentifier)
@@ -256,23 +262,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         
         return annotationView
     }
-}
-
-class CustomAnnotationView: MGLUserLocationAnnotationView {
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        // Force the annotation view to maintain a constant size when the map is tilted.
-        scalesWithViewingDistance = false
-        
-        // Use CALayer’s corner radius to turn this view into a circle.
-        layer.cornerRadius = frame.width / 2
-        layer.borderWidth = 2
-        layer.borderColor = UIColor.white.cgColor
-    }
-}
-
-extension ViewController: NavigationViewControllerDelegate {
+    
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt destination: MGLAnnotation) {
         
         // Multiple waypoint demo
@@ -322,5 +312,19 @@ extension ViewController: WaypointConfirmationViewControllerDelegate {
             // Dismiss the confirmation screen
             confirmationController.dismiss(animated: true, completion: nil)
         }
+    }
+}
+
+class CustomAnnotationView: MGLUserLocationAnnotationView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        // Force the annotation view to maintain a constant size when the map is tilted.
+        scalesWithViewingDistance = false
+        
+        // Use CALayer’s corner radius to turn this view into a circle.
+        layer.cornerRadius = frame.width / 2
+        layer.borderWidth = 2
+        layer.borderColor = UIColor.white.cgColor
     }
 }

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -242,6 +242,34 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         present(navigationViewController, animated: true, completion: nil)
     }
     
+    func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+        guard annotation is MGLUserLocation else { return nil }
+        
+        let reuseIdentifier = "userPuck"
+        var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: reuseIdentifier)
+        
+        if annotationView == nil {
+            annotationView = CustomAnnotationView(reuseIdentifier: reuseIdentifier)
+            annotationView!.frame = CGRect(x: 0, y: 0, width: 40, height: 40)
+            annotationView!.backgroundColor = .red
+        }
+        
+        return annotationView
+    }
+}
+
+class CustomAnnotationView: MGLUserLocationAnnotationView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        // Force the annotation view to maintain a constant size when the map is tilted.
+        scalesWithViewingDistance = false
+        
+        // Use CALayer’s corner radius to turn this view into a circle.
+        layer.cornerRadius = frame.width / 2
+        layer.borderWidth = 2
+        layer.borderColor = UIColor.white.cgColor
+    }
 }
 
 extension ViewController: NavigationViewControllerDelegate {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -47,7 +47,35 @@ open class NavigationMapView: MGLMapView {
         }
     }
     
-    public weak var navigationMapDelegate: NavigationMapViewDelegate?
+    open override var delegate: MGLMapViewDelegate? {
+        didSet {
+            refreshShowsUserLocation()
+        }
+    }
+    
+    public weak var navigationMapDelegate: NavigationMapViewDelegate? {
+        didSet {
+            refreshShowsUserLocation()
+        }
+    }
+    
+    open override var showsUserLocation: Bool {
+        get {
+            return super.showsUserLocation
+        }
+        
+        set {
+            super.showsUserLocation = newValue
+        }
+    }
+    
+    /**
+     Force MGLMapView to ask its delegate for the user location annotation’s view, in case that previously happened before there was a delegate.
+     */
+    func refreshShowsUserLocation() {
+        showsUserLocation = false
+        showsUserLocation = true
+    }
     
     override open func locationManager(_ manager: CLLocationManager!, didUpdateLocations locations: [CLLocation]!) {
         guard let location = locations.first else { return }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -154,7 +154,11 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     /**
      The receiver’s delegate.
      */
-    public weak var navigationDelegate: NavigationViewControllerDelegate?
+    public weak var navigationDelegate: NavigationViewControllerDelegate? {
+        didSet {
+            mapViewController?.delegate = mapViewController?.delegate
+        }
+    }
     
     /**
      Provides access to various speech synthesizer options.

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -102,6 +102,11 @@ public protocol NavigationViewControllerDelegate {
      */
     @objc optional func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
     
+    /**
+     Returns a view object to mark the given point annotation object on the map.
+     
+     The user location annotation view can also be customized via this method. When annotation is an instance of `MGLUserLocation` (or equal to the map view’s userLocation property), return an instance of `MGLUserLocationAnnotationView` (or a subclass thereof).
+     */
     @objc optional func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -105,7 +105,7 @@ public protocol NavigationViewControllerDelegate {
     /**
      Returns a view object to mark the given point annotation object on the map.
      
-     The user location annotation view can also be customized via this method. When annotation is an instance of `MGLUserLocation` (or equal to the map view’s userLocation property), return an instance of `MGLUserLocationAnnotationView` (or a subclass thereof).
+     The user location annotation view can also be customized via this method. When annotation is an instance of `MGLUserLocation`, return an instance of `MGLUserLocationAnnotationView` (or a subclass thereof).
      */
     @objc optional func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -101,6 +101,8 @@ public protocol NavigationViewControllerDelegate {
      If this method is unimplemented, the navigation map view will represent the destination annotation with the default marker.
      */
     @objc optional func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
+    
+    @objc optional func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
 }
 
 /**
@@ -396,6 +398,10 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     
     func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
         return navigationDelegate?.navigationMapView?(mapView, imageFor: annotation)
+    }
+    
+    func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+        return navigationDelegate?.navigationMapView?(mapView, viewFor: annotation)
     }
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -249,6 +249,10 @@ class RouteMapViewController: UIViewController {
     func mapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
         return navigationMapView(mapView, imageFor: annotation)
     }
+    
+    func mapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+        return navigationMapView(mapView, viewFor: annotation)
+    }
 
     func notifyDidChange(routeProgress: RouteProgress, location: CLLocation, secondsRemaining: TimeInterval) {
         guard var controller = routePageViewController.currentManeuverPage else { return }
@@ -367,7 +371,11 @@ extension RouteMapViewController: NavigationMapViewDelegate {
     }
     
     func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
-        return delegate?.navigationMapView(mapView, imageFor:annotation)
+        return delegate?.navigationMapView(mapView, imageFor :annotation)
+    }
+    
+    func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
+        return delegate?.navigationMapView(mapView, viewFor: annotation)
     }
     
     func mapViewDidFinishLoadingMap(_ mapView: MGLMapView) {
@@ -575,4 +583,5 @@ protocol RouteMapViewControllerDelegate: class {
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
     func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
     func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
+    func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -54,7 +54,11 @@ class RouteMapViewController: UIViewController {
             return camera
         }
     }
-    weak var delegate: RouteMapViewControllerDelegate?
+    weak var delegate: RouteMapViewControllerDelegate? {
+        didSet {
+            mapView.delegate = mapView.delegate
+        }
+    }
     weak var routeController: RouteController!
     let distanceFormatter = DistanceFormatter(approximate: true)
     var arrowCurrentStep: RouteStep?


### PR DESCRIPTION
This exposes the ability to provide a view for any annotation on the map. In the example, I show how to provide a view for the user puck.

/cc @1ec5 @frederoni @ericrwolfe 