### PR TITLE
Fix puck jumps (#500)

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -518,6 +518,7 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
 
         if !isInOverviewMode {
             if step == routeController.routeProgress.currentLegProgress.upComingStep {
+                view.layoutIfNeeded()
                 mapView.camera = tiltedCamera
                 mapView.setUserTrackingMode(.followWithCourse, animated: true)
             } else {


### PR DESCRIPTION
Fixes #500 

The regression seems to be the removal of [superview.layoutIfNeeded()](https://github.com/mapbox/mapbox-navigation-ios/pull/490/files#diff-0d0ad16c83aae11e1bceb64204ae864cL627) before grabbing the camera and updating the userTrackingMode.

@bsudekum 👀 