### PR TITLE
Avoid redundantly clearing shield image view

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -507,7 +507,6 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
         let step = maneuverViewController.step!
 
         maneuverViewController.turnArrowView.step = step
-        maneuverViewController.shieldImage = nil
         maneuverViewController.distance = step.distance > 0 ? step.distance : nil
         maneuverViewController.roadCode = step.codes?.first ?? step.destinationCodes?.first ?? step.destinations?.first
         maneuverViewController.updateStreetNameForStep()


### PR DESCRIPTION
Fixed an issue causing the shield in the turn banner to go missing when swiping backwards. This redundant line was clearing the shield image; subsequently, the `roadCode` setter bailed because the `roadCode` had not changed. The `roadCode` setter is responsible for clearing the shield image when no shield should be displayed.

/cc @bhousel @frederoni