### PR TITLE
Fix camera stutter after completing maneuver

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -96,8 +96,6 @@ class RouteManeuverViewController: UIViewController {
         }
     }
     
-    var isPagingThroughStepList = false
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         turnArrowView.backgroundColor = .clear

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -528,10 +528,8 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
         maneuverViewController.updateStreetNameForStep()
         
         updateLaneViews(step: step, alertLevel: .high)
-        
-        maneuverViewController.isPagingThroughStepList = true
 
-        if !isInOverviewMode {
+        if !isInOverviewMode, mapView.userTrackingMode != .followWithCourse {
             if step == routeController.routeProgress.currentLegProgress.upComingStep {
                 view.layoutIfNeeded()
                 mapView.camera = tiltedCamera

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -529,7 +529,10 @@ extension RouteMapViewController: RoutePageViewControllerDelegate {
         
         updateLaneViews(step: step, alertLevel: .high)
 
-        if !isInOverviewMode, mapView.userTrackingMode != .followWithCourse {
+        
+        if !isInOverviewMode,
+            // This will be false when the user is swiping
+            mapView.userTrackingMode != .followWithCourse {
             if step == routeController.routeProgress.currentLegProgress.upComingStep {
                 view.layoutIfNeeded()
                 mapView.camera = tiltedCamera


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/515

`routePageViewController(:RoutePageViewController:willTransitionTo:)` gets called after each maneuver completion. Because of this, this chunk of code was executing:

```swift
if step == routeController.routeProgress.currentLegProgress.upComingStep {
  view.layoutIfNeeded()
  mapView.camera = tiltedCamera
  mapView.setUserTrackingMode(.followWithCourse, animated: true)
}
```

I'm unsure which one of these is the culprit, but if the user is already in follow with course mode, we should not re-set it or change the camera.

/cc @1ec5 @frederoni 