### PR TITLE
Unpin Mapbox iOS SDK

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -2,6 +2,6 @@ binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.6
 github "mapbox/MapboxDirections.swift" ~> 0.10
 github "52inc/Pulley" == 1.4
 github "rs/SDWebImage" ~> 4.1
-github "Project-OSRM/osrm-text-instructions.swift" == 0.3.1
+github "Project-OSRM/osrm-text-instructions.swift" ~> 0.3.1
 github "frederoni/aws-sdk-ios" "ac6a35f135aca73c9d308e960a501fcc16a586a8"
 github "mapbox/mapbox-telemetry-ios" ~> 0.2

--- a/Cartfile
+++ b/Cartfile
@@ -1,7 +1,7 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.6
 github "mapbox/MapboxDirections.swift" == 0.10.1
 github "52inc/Pulley" == 1.4
-github "rs/SDWebImage" == 4.1.0
-github "Project-OSRM/osrm-text-instructions.swift" == 0.3.1
+github "rs/SDWebImage" ~> 4.1
+github "Project-OSRM/osrm-text-instructions.swift" ~> 0.3
 github "frederoni/aws-sdk-ios" "ac6a35f135aca73c9d308e960a501fcc16a586a8"
-github "mapbox/mapbox-telemetry-ios" == 0.2.9
+github "mapbox/mapbox-telemetry-ios" ~> 0.2

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" == 3.6.1
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.6
 github "mapbox/MapboxDirections.swift" == 0.10.1
 github "52inc/Pulley" == 1.4
 github "rs/SDWebImage" == 4.1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,7 +1,7 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.6
-github "mapbox/MapboxDirections.swift" == 0.10.1
+github "mapbox/MapboxDirections.swift" ~> 0.10
 github "52inc/Pulley" == 1.4
 github "rs/SDWebImage" ~> 4.1
-github "Project-OSRM/osrm-text-instructions.swift" ~> 0.3
+github "Project-OSRM/osrm-text-instructions.swift" == 0.3.1
 github "frederoni/aws-sdk-ios" "ac6a35f135aca73c9d308e960a501fcc16a586a8"
 github "mapbox/mapbox-telemetry-ios" ~> 0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.6.1"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.6.2"
 github "52inc/Pulley" "1.4"
 github "Project-OSRM/osrm-text-instructions.swift" "v0.3.1"
 github "facebook/ios-snapshot-test-case" "2.1.4"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,8 +40,8 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxDirections.swift", "~> 0.10.1"
-  s.dependency "OSRMTextInstructions", "~> 0.3.1"
+  s.dependency "MapboxDirections.swift", "~> 0.10"
+  s.dependency "OSRMTextInstructions", "~> 0.3"
   s.dependency "MapboxMobileEvents", "~> 0.2"
 
 end

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -43,12 +43,12 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
 
-  s.dependency "MapboxDirections.swift", "0.10.1"
-  s.dependency "Mapbox-iOS-SDK", "3.6"
-  s.dependency "OSRMTextInstructions", "0.3.1"
+  s.dependency "MapboxDirections.swift", "~> 0.10"
+  s.dependency "Mapbox-iOS-SDK", "~> 3.6"
+  s.dependency "OSRMTextInstructions", "~> 0.3"
   s.dependency "Pulley", "1.4"
-  s.dependency "SDWebImage", "4.1.0"
-  s.dependency "AWSPolly", "2.5.10"
+  s.dependency "SDWebImage", "~> 4.1"
+  s.dependency "AWSPolly", "~> 2.5"
   s.dependency "MapboxMobileEvents", "~> 0.2"
 
 end

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxDirections.swift", "0.10.1"
-  s.dependency "Mapbox-iOS-SDK", "3.6.1"
+  s.dependency "Mapbox-iOS-SDK", "3.6"
   s.dependency "OSRMTextInstructions", "0.3.1"
   s.dependency "Pulley", "1.4"
   s.dependency "SDWebImage", "4.1.0"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "Mapbox-iOS-SDK", "3.6.1"
+  s.dependency "Mapbox-iOS-SDK", "3.6"
   s.dependency "Pulley", "1.4"
   s.dependency "SDWebImage", "4.1.0"
   s.dependency "AWSPolly", "2.5.10"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,9 +44,9 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "Mapbox-iOS-SDK", "3.6"
+  s.dependency "Mapbox-iOS-SDK", "~> 3.6"
   s.dependency "Pulley", "1.4"
-  s.dependency "SDWebImage", "4.1.0"
-  s.dependency "AWSPolly", "2.5.10"
+  s.dependency "SDWebImage", "~> 4.1"
+  s.dependency "AWSPolly", "~> 2.5"
 
 end


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/522

I don't think there is anything else we should unpin.

/cc @1ec5 @aodhol @frederoni 