### PR TITLE
Restore < to format string

### DIFF
--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -16,8 +16,8 @@
 /* Feedback type for Unallowed Turn */
 "FEEDBACK_UNALLOWED_TURN" = "Not Allowed";
 
-/* Format string for less than; 1 = duration remaining */
-"LESS_THAN" = "%@";
+/* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
+"LESS_THAN" = "<%@";
 
 /* Indicates that rerouting is in progress */
 "REROUTING" = "Rerouting…";

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -43,7 +43,7 @@ class RouteTableViewController: UIViewController {
         dateComponentsFormatter.unitsStyle = routeProgress.durationRemaining < 3600 ? .short : .abbreviated
         
         if routeProgress.durationRemaining < 60 {
-            headerView.timeRemaining.text = String.localizedStringWithFormat(NSLocalizedString("LESS_THAN", bundle: .mapboxNavigation, value: "%@", comment: "Format string for less than; 1 = duration remaining"), dateComponentsFormatter.string(from: 61)!)
+            headerView.timeRemaining.text = String.localizedStringWithFormat(NSLocalizedString("LESS_THAN", bundle: .mapboxNavigation, value: "<%@", comment: "Format string for a short distance or time less than a minimum threshold; 1 = duration remaining"), dateComponentsFormatter.string(from: 61)!)
         } else {
             headerView.timeRemaining.text = dateComponentsFormatter.string(from: routeProgress.durationRemaining)
         }


### PR DESCRIPTION
Undid an unexplained change to a format string that changed the string’s meaning. A couple localizations had already localized the “<” to something locally appropriate, while others had removed the “<” in keeping with the base string.

/ref https://github.com/mapbox/mapbox-navigation-ios/pull/457#discussion_r132809331
/cc @frederoni @bsudekum