### PR TITLE
Add Spanish cardinal directions to ref parsing

### DIFF
--- a/MapboxNavigation/RouteManeuverViewController.swift
+++ b/MapboxNavigation/RouteManeuverViewController.swift
@@ -54,7 +54,7 @@ class RouteManeuverViewController: UIViewController {
                 return
             }
             
-            if components.count == 2 || (components.count == 3 && ["North", "South", "East", "West", "Nord", "Sud", "Est", "Ouest"].contains(components[2])) {
+            if components.count == 2 || (components.count == 3 && ["North", "South", "East", "West", "Nord", "Sud", "Est", "Ouest", "Norte", "Sur", "Este", "Oeste"].contains(components[2])) {
                 shieldAPIDataTask = dataTaskForShieldImage(network: components[0], number: components[1], height: 32 * UIScreen.main.scale) { [weak self] (image) in
                     self?.shieldImage = image
                 }


### PR DESCRIPTION
[Changeset 51,368,737](http://www.openstreetmap.org/changeset/51368737) adds the first occurrences of Spanish cardinal directions in `destination:ref` tags. This change adds the Spanish cardinal directions alongside the English and French ones, to facilitate shield selection. (Shields.plist currently includes a generic oval shield for Puerto Rico’s routes. In order to choose the correct design among the island’s three shield designs, OSRM would need to look at the route relations instead of the way `ref` tags.)

/ref Project-OSRM/osrm-text-instructions#119
/cc @bsudekum @frederoni