### PR TITLE
Only apply appropriate style on load

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -423,9 +423,11 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     }
     
     func applyStyle() {
-        styles?.forEach {
-            if $0.styleType == styleTypeForTimeOfDay {
-                $0.apply()
+        guard let styles = styles else { return }
+        
+        for style in styles {
+            if style.styleType == styleTypeForTimeOfDay {
+                style.apply()
             }
         }
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -423,7 +423,11 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     }
     
     func applyStyle() {
-        styles?.forEach { $0.apply() }
+        styles?.forEach {
+            if $0.styleType == styleTypeForTimeOfDay {
+                $0.apply()
+            }
+        }
     }
     
     func forceRefreshAppearanceIfNeeded() {


### PR DESCRIPTION
Follow up https://github.com/mapbox/mapbox-navigation-ios/pull/519

On load, we were applying all styles. We should only apply the styles that are needed for that time of day.

/cc @frederoni @1ec5 