### PR TITLE
Snap location and course when speed is low

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -140,3 +140,8 @@ let RouteControllerLinkedInstructionBufferMultiplier: Double = 1.2
  Approximately the number of meters in a mile.
  */
 let milesToMeters = 1609.34
+
+/**
+ The mimimum speed value before the user is snapped to the route. This is used to overcome inaccurate course values when a user's speed is low.
+ */
+public var RouteControllerMinimumSpeedThresholdForSnappingUserToRoute: CLLocationSpeed = 2

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -265,10 +265,6 @@ open class RouteController: NSObject {
         guard let stepCoordinates = routeProgress.currentLegProgress.currentStep.coordinates else { return nil }
         guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
         
-        guard location.speed >= 0 else {
-            return location
-        }
-        
         let nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
         guard let closest = closestCoordinate(on: nearByCoordinates, to: location.coordinate) else { return nil }
         
@@ -292,11 +288,10 @@ open class RouteController: NSObject {
         let averageRelativeAngle = (relativeAnglepointBehind + relativeAnglepointAhead) / 2
         let absoluteDirection = wrap(wrappedCourse + averageRelativeAngle, min: 0 , max: 360)
         
-        // If the course is inaccurate and the user is on the route,
-        // calculate a rough estimate as to what the course should be at that point on the route.
-        if location.course <= 0 && snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance {
-            let calculatedCourse = wrap((wrappedPointBehind + wrappedPointAhead) / 2, min: 0 , max: 360)
-            return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: calculatedCourse, speed: location.speed, timestamp: location.timestamp)
+        // If the course is inaccurate or the speed is low and the user is on the route,
+        // snap the users location and course since we know the snapped location and course is more accurate.
+        if location.course <= 0 || location.speed <= 2, snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance {
+            return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: absoluteDirection, speed: location.speed, timestamp: location.timestamp)
         }
 
         guard differenceBetweenAngles(absoluteDirection, location.course) < RouteControllerMaxManipulatedCourseAngle else {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -290,7 +290,7 @@ open class RouteController: NSObject {
         
         // If the course is inaccurate or the speed is low and the user is on the route,
         // snap the users location and course since we know the snapped location and course is more accurate.
-        if location.course <= 0 || location.speed <= 2, snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance {
+        if location.course <= 0 || location.speed <= RouteControllerMinimumSpeedThresholdForSnappingUserToRoute, snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance {
             return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: absoluteDirection, speed: location.speed, timestamp: location.timestamp)
         }
 


### PR DESCRIPTION
If the course is inaccurate or the speed is low and the user is on the route, we should just snap them. The case we're guarding against here is a user sitting in traffic where the course cannot be trusted.

/cc @1ec5 @frederoni @ericrwolfe 