### PR TITLE
Indicate to the user a faster route was found

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -43,6 +43,11 @@ public let RouteControllerNotificationRouteKey = MBRouteControllerNotificationRo
 public let RouteControllerNotificationErrorKey = MBRouteControllerNotificationErrorKey
 
 /**
+ Key used for accessing a `Bool` as to whether the reroute occurced because a faster route was found.
+ */
+public let RouteControllerDidFindFasterRouteKey = MBRouteControllerDidFindFasterRouteKey
+
+/**
  Emitted when the user moves along the route.
  */
 public let RouteControllerProgressDidChange = Notification.Name(MBRouteControllerNotificationProgressDidChange)

--- a/MapboxCoreNavigation/MBRouteController.h
+++ b/MapboxCoreNavigation/MBRouteController.h
@@ -17,3 +17,4 @@ extern NSString *const MBRouteControllerAlertLevelDidChange;
 extern NSString *const MBRouteControllerWillReroute;
 extern NSString *const MBRouteControllerDidReroute;
 extern NSString *const MBRouteControllerDidFailToReroute;
+extern NSString *const MBRouteControllerDidFindFasterRouteKey;

--- a/MapboxCoreNavigation/MBRouteController.m
+++ b/MapboxCoreNavigation/MBRouteController.m
@@ -17,3 +17,4 @@ NSString *const MBRouteControllerAlertLevelDidChange            = @"RouteControl
 NSString *const MBRouteControllerWillReroute                    = @"RouteControllerWillReroute";
 NSString *const MBRouteControllerDidReroute                     = @"RouteControllerDidReroute";
 NSString *const MBRouteControllerDidFailToReroute               = @"RouteControllerDidFailToReroute";
+NSString *const MBRouteControllerDidFindFasterRouteKey          = @"RouteControllerDidFindFasterRoute";

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -128,6 +128,8 @@ open class RouteController: NSObject {
      */
     public var checkForFasterRouteInBackground = false
     
+    var didFindFasterRoute = false
+    
     /**
      Details about the user’s progress along the current route, leg, and step.
      */
@@ -148,6 +150,7 @@ open class RouteController: NSObject {
             if let location = locationManager.location {
                 userInfo[MBRouteControllerNotificationLocationKey] = location
             }
+            userInfo[RouteControllerDidFindFasterRouteKey] = didFindFasterRoute
             NotificationCenter.default.post(name: RouteControllerDidReroute, object: self, userInfo: userInfo)
         }
     }
@@ -582,9 +585,11 @@ extension RouteController: CLLocationManagerDelegate {
                 firstStep.expectedTravelTime >= RouteControllerMediumAlertInterval,
                 currentUpcomingManeuver == firstLeg.steps[1],
                 route.expectedTravelTime <= 0.9 * durationRemaining {
+                strongSelf.didFindFasterRoute = true
                 // If the upcoming maneuver in the new route is the same as the current upcoming maneuver, don't announce it
                 strongSelf.routeProgress = RouteProgress(route: route, legIndex: 0, alertLevel: currentAlertLevel)
                 strongSelf.delegate?.routeController?(strongSelf, didRerouteAlong: route)
+                strongSelf.didFindFasterRoute = false
             }
         }
     }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -250,6 +250,12 @@ class RouteMapViewController: UIViewController {
         if !(routeController.locationManager is SimulatedLocationManager) {
             statusView.hide(delay: 0.5, animated: true)
         }
+        
+        if notification.userInfo![RouteControllerDidFindFasterRouteKey] as! Bool {
+            let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
+            statusView.show(title, showSpinner: true)
+            statusView.hide(delay: 5, animated: true)
+        }
     }
 
     func notifyAlertLevelDidChange(routeProgress: RouteProgress) {

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -84,7 +84,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(alertLevelDidChange(notification:)), name: RouteControllerAlertLevelDidChange, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(pauseSpeechAndPlayReroutingDing), name: RouteControllerWillReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(pauseSpeechAndPlayReroutingDing(notification:)), name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
     }
     
@@ -98,11 +98,11 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
         
         // Play reroute sound when a faster route is found
         if notification.userInfo?[RouteControllerDidFindFasterRouteKey] as! Bool {
-            pauseSpeechAndPlayReroutingDing()
+            pauseSpeechAndPlayReroutingDing(notification: notification)
         }
     }
     
-    func pauseSpeechAndPlayReroutingDing() {
+    func pauseSpeechAndPlayReroutingDing(notification: NSNotification) {
         speechSynth.stopSpeaking(at: .word)
         
         guard playRerouteSound && !NavigationSettings.shared.muted else {

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -84,21 +84,31 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(alertLevelDidChange(notification:)), name: RouteControllerAlertLevelDidChange, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(pauseSpeechAndPlayReroutingDing), name: RouteControllerWillReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
     }
     
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: RouteControllerAlertLevelDidChange, object: nil)
         NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
+        NotificationCenter.default.removeObserver(self, name: RouteControllerDidReroute, object: nil)
     }
     
-    func willReroute(notification: NSNotification) {
+    func didReroute(notification: NSNotification) {
+        
+        // Play reroute sound when a faster route is found
+        if notification.userInfo?[RouteControllerDidFindFasterRouteKey] as! Bool {
+            pauseSpeechAndPlayReroutingDing()
+        }
+    }
+    
+    func pauseSpeechAndPlayReroutingDing() {
         speechSynth.stopSpeaking(at: .word)
         
         guard playRerouteSound && !NavigationSettings.shared.muted else {
             return
         }
-
+        
         rerouteSoundPlayer.volume = volume
         rerouteSoundPlayer.play()
     }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/530

Gives a heads up to the user that the routeController has found a faster route.

/cc @1ec5 @ericrwolfe 