### PR TITLE
Reset floating button color properly

### DIFF
--- a/MapboxNavigation/DefaultStyle.swift
+++ b/MapboxNavigation/DefaultStyle.swift
@@ -68,6 +68,7 @@ open class DefaultStyle: Style {
         laneViewSecondaryColor = .defaultLaneArrowSecondary
         
         floatingButtonBackgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        floatingButtonTintColor = tintColor
         lanesViewBackgroundColor = #colorLiteral(red: 0.968627451, green: 0.968627451, blue: 0.968627451, alpha: 1)
         
         // Maneuver view (Page view)


### PR DESCRIPTION
If the dark style is loaded before the light style, the button tint color will not reset without this line.
