### PR TITLE
Set styleTypeForTimeOfDay on init

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -321,6 +321,8 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         
         tableViewController.routeController = routeController
         tableViewController.headerView.delegate = self
+        
+        self.currentStyleType = styleTypeForTimeOfDay
     }
     
     deinit {
@@ -428,7 +430,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     
     func forceRefreshAppearanceIfNeeded() {
         // Don't update the style if they are equal
-        guard currentStyleType != nil || currentStyleType != styleTypeForTimeOfDay else {
+        guard currentStyleType != styleTypeForTimeOfDay else {
             currentStyleType = styleTypeForTimeOfDay
             return
         }


### PR DESCRIPTION
This fixes an issue that caused the route line to not update after rerouting. This is a crazy codepath, but this guard was truthful too often https://github.com/mapbox/mapbox-navigation-ios/blob/e3860c9f388dd5de7b3599d984fadfe2c910024f/MapboxNavigation/NavigationViewController.swift#L433

[view.window here](https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxNavigation/RouteMapViewController.swift#L542) would then remain false as we update the UI by removing and adding views.

/cc @1ec5 @frederoni @willwhite @lxbarth 