### PR TITLE
Use Style for unknown eta color

### DIFF
--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -16,6 +16,8 @@ class RouteTableViewController: UIViewController {
     @IBOutlet var headerView: RouteTableViewHeaderView!
     @IBOutlet weak var tableView: UITableView!
     
+    var defaultTimeRemainingColor: UIColor!
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupTableView()
@@ -23,6 +25,10 @@ class RouteTableViewController: UIViewController {
         dateComponentsFormatter.allowedUnits = [.hour, .minute]
         dateComponentsFormatter.unitsStyle = .abbreviated
         distanceFormatter.numberFormatter.locale = .nationalizedCurrent
+    }
+    
+    override func viewDidLoad() {
+        defaultTimeRemainingColor = headerView.timeRemaining.textColor
     }
     
     func setupTableView() {
@@ -52,7 +58,7 @@ class RouteTableViewController: UIViewController {
         let coordinatesLeftOnStepCount = Int(floor((Double(routeProgress.currentLegProgress.currentStepProgress.step.coordinateCount)) * routeProgress.currentLegProgress.currentStepProgress.fractionTraveled))
         
         guard coordinatesLeftOnStepCount >= 0 else {
-            headerView.timeRemaining.textColor = TimeRemainingLabel.appearance(for: traitCollection).textColor
+            headerView.timeRemaining.textColor = defaultTimeRemainingColor
             return
         }
         
@@ -79,7 +85,7 @@ class RouteTableViewController: UIViewController {
         if let max = remainingStepCongestionTotals.max(by: { a, b in a.value < b.value }) {
             switch max.key {
             case .unknown:
-                headerView.timeRemaining.textColor = TimeRemainingLabel.appearance(for: traitCollection).textColor
+                headerView.timeRemaining.textColor = defaultTimeRemainingColor
             case .low:
                 headerView.timeRemaining.textColor = .trafficAlternateLow
             case .moderate:

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -28,6 +28,7 @@ class RouteTableViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         defaultTimeRemainingColor = headerView.timeRemaining.textColor
     }
     


### PR DESCRIPTION
We were not properly setting the ETA color according to the style when it was unknown.

@frederoni What do you think of this approach? Any other way we can fix this?

/cc @pveugen 