### PR TITLE
Don't show seconds in ETA

### DIFF
--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -19,10 +19,6 @@ class RouteTableViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupTableView()
-        dateFormatter.timeStyle = .short
-        dateComponentsFormatter.allowedUnits = [.hour, .minute]
-        dateComponentsFormatter.unitsStyle = .abbreviated
-        distanceFormatter.numberFormatter.locale = .nationalizedCurrent
     }
     
     func setupTableView() {
@@ -34,6 +30,11 @@ class RouteTableViewController: UIViewController {
     func showETA(routeProgress: RouteProgress) {
         let arrivalDate = NSCalendar.current.date(byAdding: .second, value: Int(routeProgress.durationRemaining), to: Date())
         headerView.arrivalTimeLabel.text = dateFormatter.string(from: arrivalDate!)
+        
+        distanceFormatter.numberFormatter.locale = .nationalizedCurrent
+        dateFormatter.timeStyle = .short
+        dateComponentsFormatter.allowedUnits = [.hour, .minute]
+        dateComponentsFormatter.unitsStyle = .abbreviated
         
         if routeProgress.durationRemaining < 5 {
             headerView.distanceRemaining.text = nil


### PR DESCRIPTION
When the nav ui mounts, we momentarily show the ETA with the default `DateComponentsFormatter` options which includes seconds. It looks like setting the options in `viewWillAppear` is not early enough.

/cc @frederoni @1ec5 