### PR TITLE
Increase snapped distance, don't use course if it is bad

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -80,7 +80,7 @@ public var RouteControllerMaximumDistanceBeforeRecalculating: CLLocationDistance
 /**
  Accepted deviation excluding horizontal accuracy before the user is considered to be off route.
  */
-public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 10
+public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 20
 
 /**
  Threshold user must be in within to count as completing a step. One of two heuristics used to know when a user completes a step, see `RouteControllerManeuverZoneRadius`.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -298,7 +298,8 @@ open class RouteController: NSObject {
         // If the course is inaccurate or the speed is low and the user is on the route,
         // snap the users location and course since we know the snapped location and course is more accurate.
         if location.course <= 0 || location.speed <= RouteControllerMinimumSpeedThresholdForSnappingUserToRoute, snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance {
-            return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: absoluteDirection, speed: location.speed, timestamp: location.timestamp)
+            let calculatedWrappedCourse = wrap((wrappedPointBehind + wrappedPointAhead) / 2, min: 0 , max: 360)
+            return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: calculatedWrappedCourse, speed: location.speed, timestamp: location.timestamp)
         }
 
         guard differenceBetweenAngles(absoluteDirection, location.course) < RouteControllerMaxManipulatedCourseAngle else {


### PR DESCRIPTION
We've noticed the user puck unsnapping from the route line in cases it should not be. Larger, wider roads can see this often. By increasing the max snapping distance, the user will be snapped more often. The downfall here is that when the user is actively leaving the route, the user will appear snapped to the route for a moment longer. In my testing, it looked fine.

This also moves to not use the user's course when we deem the course or speed invalid. In this case, we snap the users location and also use a calculated course. 