### PR TITLE
Limit interpret-as=address to numbers in road names

### DIFF
--- a/MapboxCoreNavigation/RouteStepFormatter.swift
+++ b/MapboxCoreNavigation/RouteStepFormatter.swift
@@ -25,11 +25,10 @@ public class RouteStepFormatter: Formatter {
             switch key {
             case .wayName, .destination, .rotaryName, .code:
                 let stringComponents = value.addingXMLEscapes.components(separatedBy: .whitespaces)
-                guard var firstRefComponent = stringComponents.first else { return value.asSSMLAddress }
                 
-                firstRefComponent = firstRefComponent.isUppercased ? firstRefComponent.asSSMLCharacters : firstRefComponent.asSSMLAddress
-                
-                return "\(firstRefComponent) \(stringComponents.suffix(from: 1).joined(separator: " ").asSSMLAddress)"
+                return stringComponents.map {
+                    $0.isInt ? $0.asSSMLAddress : $0
+                }.joined(separator: " ")
             default:
                 return value
             }

--- a/MapboxCoreNavigation/RouteStepFormatter.swift
+++ b/MapboxCoreNavigation/RouteStepFormatter.swift
@@ -23,15 +23,13 @@ public class RouteStepFormatter: Formatter {
         
         let modifyValueByKey = { (key: OSRMTextInstructions.TokenType, value: String) -> String in
             switch key {
-            case .code:
-                let refComponents = value.addingXMLEscapes.components(separatedBy: .whitespaces)
-                guard var firstRefComponent = refComponents.first else { return value.asSSMLAddress }
+            case .wayName, .destination, .rotaryName, .code:
+                let stringComponents = value.addingXMLEscapes.components(separatedBy: .whitespaces)
+                guard var firstRefComponent = stringComponents.first else { return value.asSSMLAddress }
                 
                 firstRefComponent = firstRefComponent.isUppercased ? firstRefComponent.asSSMLCharacters : firstRefComponent.asSSMLAddress
                 
-                return "\(firstRefComponent) \(refComponents.suffix(from: 1).joined(separator: " ").asSSMLAddress)"
-            case .wayName, .destination, .rotaryName:
-                return value.asSSMLAddress
+                return "\(firstRefComponent) \(stringComponents.suffix(from: 1).joined(separator: " ").asSSMLAddress)"
             default:
                 return value
             }

--- a/MapboxCoreNavigation/RouteStepFormatter.swift
+++ b/MapboxCoreNavigation/RouteStepFormatter.swift
@@ -27,7 +27,7 @@ public class RouteStepFormatter: Formatter {
                 let stringComponents = value.addingXMLEscapes.components(separatedBy: .whitespaces)
                 
                 return stringComponents.map {
-                    $0.containsInt ? $0.asSSMLAddress : $0
+                    $0.containsDecimalDigit ? $0.asSSMLAddress : $0
                 }.joined(separator: " ")
             default:
                 return value

--- a/MapboxCoreNavigation/RouteStepFormatter.swift
+++ b/MapboxCoreNavigation/RouteStepFormatter.swift
@@ -27,7 +27,7 @@ public class RouteStepFormatter: Formatter {
                 let stringComponents = value.addingXMLEscapes.components(separatedBy: .whitespaces)
                 
                 return stringComponents.map {
-                    $0.isInt ? $0.asSSMLAddress : $0
+                    $0.containsInt ? $0.asSSMLAddress : $0
                 }.joined(separator: " ")
             default:
                 return value

--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -53,7 +53,7 @@ extension String {
         return self == uppercased() && self != lowercased()
     }
     
-    var containsInt: Bool {
+    var containsDecimalDigit: Bool {
         return self.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil
     }
 }

--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -53,7 +53,7 @@ extension String {
         return self == uppercased() && self != lowercased()
     }
     
-    var isInt: Bool {
-        return Int(self) != nil
+    var containsInt: Bool {
+        return self.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil
     }
 }

--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -52,4 +52,8 @@ extension String {
     var isUppercased: Bool {
         return self == uppercased() && self != lowercased()
     }
+    
+    var isInt: Bool {
+        return Int(self) != nil
+    }
 }


### PR DESCRIPTION
Came across a case where polly speaks `N Street NW` as `North Street NW`. The if-first-word-in-ref code we had in place for refs should also be applied to `.wayName, .destination, .rotaryName`.

/cc @ericrwolfe @frederoni @1ec5 