### PR TITLE
Filter out locations with big speed jumps

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -150,3 +150,8 @@ let milesToMeters = 1609.34
  The mimimum speed value before the user is snapped to the route. This is used to overcome inaccurate course values when a user's speed is low.
  */
 public var RouteControllerMinimumSpeedThresholdForSnappingUserToRoute: CLLocationSpeed = 2
+
+/**
+ Multiplier used to compare the current speed delta from the previous speed delta. When the difference in speed delta is greater than 3 times, the location is thrown out.
+ */
+public var RouteControllerDifferenceInSpeedDeltaMultiplier: CLLocationSpeed = 3

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -362,7 +362,7 @@ open class RouteController: NSObject {
             return false
         }
         
-        guard location.timestamp.timeIntervalSince(lastLocation.location.timestamp) < lastLocation.durationDelta * 3 else {
+        guard location.timestamp.timeIntervalSince(lastLocation.location.timestamp) <= lastLocation.durationDelta * 3 else {
             return false
         }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -354,7 +354,7 @@ open class RouteController: NSObject {
                 return false
         }
         
-        guard location.speed <= lastLocation.speedDelta * 3 else {
+        guard location.speed <= lastLocation.speedDelta * RouteControllerDifferenceInSpeedDeltaMultiplier else {
             return false
         }
         


### PR DESCRIPTION
This filters out new locations by comparing it to previous well known locations. If the new delta is greater that 3x the previous delta, throw out this location as the distance/time is too great.

/cc @1ec5 @frederoni @ericrwolfe 