### PR TITLE
Reroute faster at intersections

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -526,8 +526,7 @@ extension RouteController: CLLocationManagerDelegate {
         let metersInFrontOfUser = location.speed * RouteControllerDeadReckoningTimeInterval
         let locationInfrontOfUser = location.coordinate.coordinate(at: metersInFrontOfUser, facing: location.course)
         let newLocation = CLLocation(latitude: locationInfrontOfUser.latitude, longitude: locationInfrontOfUser.longitude)
-        let radius = max(RouteControllerMaximumDistanceBeforeRecalculating,
-                         location.horizontalAccuracy + RouteControllerUserLocationSnappingDistance)
+        let radius = max(mofifiedRerouteDistanceGivenIntersectionLocation, location.horizontalAccuracy + RouteControllerUserLocationSnappingDistance)
 
         let isCloseToCurrentStep = newLocation.isWithin(radius, of: routeProgress.currentLegProgress.currentStep)
         
@@ -686,8 +685,8 @@ extension RouteController: CLLocationManagerDelegate {
         }
     }
     
-    func monitorIntersectionProgress(_ location: CLLocation) -> Bool {
-        guard var intersections = routeProgress.currentLegProgress.currentStepProgress.step.intersections else { return false }
+    func monitorIntersectionProgress(_ location: CLLocation) {
+        guard var intersections = routeProgress.currentLegProgress.currentStepProgress.step.intersections else { return }
         let currentStepProgress = routeProgress.currentLegProgress.currentStepProgress
         
         // The intersections array does not include the upcoming maneuver intersection.
@@ -708,8 +707,6 @@ extension RouteController: CLLocationManagerDelegate {
                 routeProgress.currentLegProgress.currentStepProgress.userIsNearAnIntersection = false
             }
         }
-
-        return false
     }
     
     func monitorStepProgress(_ location: CLLocation) {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -262,7 +262,7 @@ open class RouteController: NSObject {
      */
     var rawLocation: CLLocation?
     
-    public var mofifiedRerouteDistanceGivenIntersectionLocation: CLLocationDistance {
+    public var modifiedRerouteDistanceGivenIntersectionLocation: CLLocationDistance {
         guard let userIsNearAnIntersection = routeProgress.currentLegProgress.currentStepProgress.userIsNearAnIntersection else {
             return RouteControllerMaximumDistanceBeforeRecalculating
         }
@@ -526,7 +526,7 @@ extension RouteController: CLLocationManagerDelegate {
         let metersInFrontOfUser = location.speed * RouteControllerDeadReckoningTimeInterval
         let locationInfrontOfUser = location.coordinate.coordinate(at: metersInFrontOfUser, facing: location.course)
         let newLocation = CLLocation(latitude: locationInfrontOfUser.latitude, longitude: locationInfrontOfUser.longitude)
-        let radius = max(mofifiedRerouteDistanceGivenIntersectionLocation, location.horizontalAccuracy + RouteControllerUserLocationSnappingDistance)
+        let radius = max(modifiedRerouteDistanceGivenIntersectionLocation, location.horizontalAccuracy + RouteControllerUserLocationSnappingDistance)
 
         let isCloseToCurrentStep = newLocation.isWithin(radius, of: routeProgress.currentLegProgress.currentStep)
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -267,9 +267,9 @@ open class RouteController: NSObject {
         guard let userLocation = rawLocation else { return RouteControllerMaximumDistanceBeforeRecalculating }
         
         for intersection in intersections {
-            let distanceToIntersection = distance(along: routeProgress.currentLegProgress.currentStepProgress.step.coordinates!, from: userLocation.coordinate, to: intersection.location)
+            let absoluteDistanceToIntersection = userLocation.coordinate - intersection.location
             
-            if distanceToIntersection <= RouteControllerManeuverZoneRadius {
+            if absoluteDistanceToIntersection <= RouteControllerManeuverZoneRadius {
                 return RouteControllerMaximumDistanceBeforeRecalculating / 2
             }
         }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -269,7 +269,7 @@ open class RouteController: NSObject {
         for intersection in intersections {
             let distanceToIntersection = distance(along: routeProgress.currentLegProgress.currentStepProgress.step.coordinates!, from: userLocation.coordinate, to: intersection.location)
             
-            if distanceToIntersection <= 20 {
+            if distanceToIntersection <= RouteControllerManeuverZoneRadius {
                 return RouteControllerMaximumDistanceBeforeRecalculating / 2
             }
         }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -395,5 +395,24 @@ open class RouteStepProgress: NSObject {
      */
     public init(step: RouteStep) {
         self.step = step
+        self.intersectionIndex = 0
     }
+    
+    public var currentIntersection: Intersection? {
+        guard let intersections = step.intersections else { return nil }
+        return intersections[intersectionIndex]
+    }
+    
+    public var upcomingIntersection: Intersection? {
+        guard let intersections = step.intersections, intersectionIndex + 1 < intersections.endIndex else {
+            return nil
+        }
+        
+        return intersections[intersectionIndex]
+    }
+    
+    /**
+     Index representing the current step.
+     */
+    public var intersectionIndex: Int = 0
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -398,13 +398,15 @@ open class RouteStepProgress: NSObject {
         self.intersectionIndex = 0
     }
     
+    public var intersectionsIncludingUpcomingManeuverIntersection: [Intersection]?
+    
     public var currentIntersection: Intersection? {
-        guard let intersections = step.intersections else { return nil }
+        guard let intersections = intersectionsIncludingUpcomingManeuverIntersection else { return nil }
         return intersections[intersectionIndex]
     }
     
     public var upcomingIntersection: Intersection? {
-        guard let intersections = step.intersections, intersectionIndex + 1 < intersections.endIndex else {
+        guard let intersections = intersectionsIncludingUpcomingManeuverIntersection, intersectionIndex + 1 < intersections.endIndex else {
             return nil
         }
         

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -425,7 +425,7 @@ open class RouteStepProgress: NSObject {
     
     
     /**
-     If true, the user is near an intersection on the current step.
+     The distance in meters the user is to the next intersection they will pass through.
      */
-    public var userIsNearAnIntersection: Bool?
+    public var userDistanceToUpcomingIntersection: CLLocationDistance?
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -398,13 +398,18 @@ open class RouteStepProgress: NSObject {
         self.intersectionIndex = 0
     }
     
+    /**
+     All intersections on the current `RouteStep` and also the first intersection on the upcoming `RouteStep`.
+     
+     The upcoming `RouteStep` first `Intersection` is added because it is omitted from the current step.
+     */
     public var intersectionsIncludingUpcomingManeuverIntersection: [Intersection]?
     
-    public var currentIntersection: Intersection? {
-        guard let intersections = intersectionsIncludingUpcomingManeuverIntersection else { return nil }
-        return intersections[intersectionIndex]
-    }
-    
+    /**
+     The next intersection the user will travel through.
+     
+     The step must contains `Intersections` for this value not be `nil`.
+     */
     public var upcomingIntersection: Intersection? {
         guard let intersections = intersectionsIncludingUpcomingManeuverIntersection, intersectionIndex + 1 < intersections.endIndex else {
             return nil
@@ -414,9 +419,13 @@ open class RouteStepProgress: NSObject {
     }
     
     /**
-     Index representing the current step.
+     Index representing the current intersection.
      */
     public var intersectionIndex: Int = 0
     
+    
+    /**
+     If true, the user is near an intersection on the current step.
+     */
     public var userIsNearAnIntersection: Bool?
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -417,4 +417,6 @@ open class RouteStepProgress: NSObject {
      Index representing the current step.
      */
     public var intersectionIndex: Int = 0
+    
+    public var userIsNearAnIntersection: Bool?
 }


### PR DESCRIPTION
If the users course is within a few degrees of a heading at an intersection along a step, we can assume they are going off course and we can reroute them sooner. 

todo: 
- [x] check performance
- [x] We have to be very sure the user is going down the wrong road at intersection. Maybe we need another check in here to see their distance is increasing away from the intersection.
- [x] actually reroute

This will require a lot of real world testing.

/cc @1ec5 @ericrwolfe @frederoni 