### PR TITLE
Set waypoint accuracy

### DIFF
--- a/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -16,7 +16,7 @@ open class NavigationRouteOptions: RouteOptions {
      [RouteOptions](https://www.mapbox.com/mapbox-navigation-ios/directions/0.10.1/Classes/RouteOptions.html)
      */
     public override init(waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier? = .automobileAvoidingTraffic) {
-        super.init(waypoints: waypoints.map{
+        super.init(waypoints: waypoints.map {
             $0.coordinateAccuracy = -1
             return $0
         }, profileIdentifier: profileIdentifier)

--- a/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -16,7 +16,10 @@ open class NavigationRouteOptions: RouteOptions {
      [RouteOptions](https://www.mapbox.com/mapbox-navigation-ios/directions/0.10.1/Classes/RouteOptions.html)
      */
     public override init(waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier? = .automobileAvoidingTraffic) {
-        super.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
+        super.init(waypoints: waypoints.map{
+            $0.coordinateAccuracy = -1
+            return $0
+        }, profileIdentifier: profileIdentifier)
         includesSteps = true
         routeShapeResolution = .full
         attributeOptions = [.congestionLevel, .expectedTravelTime]


### PR DESCRIPTION
This ensures the directions API will always try and find a location to snap to. Without this option set to -1, the directions API will drop a few requests when long pressing in the example app.

/cc @1ec5 