### PR TITLE
Split turn arrow styling

### DIFF
--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -70,6 +70,8 @@ open class DayStyle: Style {
         
         TurnArrowView.appearance().primaryColor = .defaultTurnArrowPrimary
         TurnArrowView.appearance().secondaryColor = .defaultTurnArrowSecondary
+        CellTurnArrowView.appearance().primaryColor = .defaultTurnArrowPrimary
+        CellTurnArrowView.appearance().secondaryColor = .defaultTurnArrowSecondary
         
         LanesView.appearance().backgroundColor = #colorLiteral(red: 0.968627451, green: 0.968627451, blue: 0.968627451, alpha: 1)
         LaneArrowView.appearance().primaryColor = .defaultLaneArrowPrimary
@@ -148,6 +150,9 @@ open class NightStyle: DayStyle {
         TimeRemainingLabel.appearance().trafficUnknownColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         DistanceRemainingLabel.appearance().textColor = #colorLiteral(red: 0.7991961837, green: 0.8232284188, blue: 0.8481693864, alpha: 1)
         ArrivalTimeLabel.appearance().textColor = #colorLiteral(red: 0.7991961837, green: 0.8232284188, blue: 0.8481693864, alpha: 1)
+        
+        CellTurnArrowView.appearance().primaryColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
+        CellTurnArrowView.appearance().secondaryColor = #colorLiteral(red: 0.501960814, green: 0.501960814, blue: 0.501960814, alpha: 1)
         
         RouteTableViewHeaderView.appearance().backgroundColor = backgroundColor
         

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -643,7 +643,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="118"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gqs-fG-dsb" customClass="MBTurnArrowView">
+                                                <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gqs-fG-dsb" customClass="MBCellTurnArrowView">
                                                     <rect key="frame" x="8" y="40" width="50" height="50"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -75,6 +75,10 @@ open class FloatingButton: Button { }
 @objc(MBLanesView)
 public class LanesView: UIView { }
 
+/// :nodoc:
+@objc(MBCellTurnArrowView)
+public class CellTurnArrowView: TurnArrowView { }
+
 /**
  :nodoc:
  `HighlightedButton` sets the button’s titleColor for normal control state according to the style in addition to the styling behavior inherited from


### PR DESCRIPTION
Added a new class for turn arrows so we can style them separately based on if they are in the table view or the maneuver banner.

@bsudekum 👀 

<img src="https://user-images.githubusercontent.com/764476/29937003-2081e946-8e52-11e7-949b-2dc4b2fc3acc.png" width=200>