### PR TITLE
Use correct linking multiplier

### DIFF
--- a/MapboxCoreNavigation/SpokenInstructionFormatter.swift
+++ b/MapboxCoreNavigation/SpokenInstructionFormatter.swift
@@ -56,7 +56,7 @@ public class SpokenInstructionFormatter: NSObject {
         var text: String
         
         // Prevent back to back instructions by adding a little more wiggle room
-        let linkedInstructionMultiplier = RouteControllerHighAlertInterval * RouteControllerMaxManipulatedCourseAngle
+        let linkedInstructionMultiplier = RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier
         
         // We only want to announce this special depature announcement once.
         // Once it has been announced, all subsequnt announcements will not have an alert level of low


### PR DESCRIPTION
I mixed up the constants name in a big way... 🤦‍♂️ 

We are were linking instructions when the next step had a duration of less than 225 seconds, yikes.

/cc @frederoni @ericrwolfe @1ec5 