### PR TITLE
Dont show reroute UI when failing to reroute

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -128,13 +128,11 @@ class RouteMapViewController: UIViewController {
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidFailToReroute, object: nil)
     }
     
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: RouteControllerDidReroute, object: nil)
-        NotificationCenter.default.removeObserver(self, name: RouteControllerDidFailToReroute, object: nil)
     }
 
     @IBAction func recenter(_ sender: AnyObject) {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/582

When failing to reroute, we were showing the reroute UI. Since this notification user object is different from the reroute key, we'd get a crash. This was introduced in https://github.com/mapbox/mapbox-navigation-ios/commit/7334aa565a22b8ab62e027943db529dc019544d2

If we'd like to show something in the UI when failing to reroute, `RouteControllerDidFailToReroute` should call it's own unique function.

/cc @1ec5 @frederoni @ericrwolfe 