### PR TITLE
Fix lane arrows at forks

### DIFF
--- a/MapboxNavigation/LaneArrowView.swift
+++ b/MapboxNavigation/LaneArrowView.swift
@@ -36,25 +36,31 @@ open class LaneArrowView: UIView {
         if let lane = lane {
             var flipLane: Bool
             if lane.indications.isSuperset(of: [.straightAhead, .sharpRight]) || lane.indications.isSuperset(of: [.straightAhead, .right]) || lane.indications.isSuperset(of: [.straightAhead, .slightRight]) {
-                if !isValid {
-                    StyleKitArrows.drawLane_straight_right(primaryColor: appropriatePrimaryColor)
-                    alpha = invalidAlpha
-                } else if maneuverDirection == .straightAhead {
-                    StyleKitArrows.drawLane_straight_only(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
-                } else {
-                    StyleKitArrows.drawLane_right_only(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
-                }
                 flipLane = false
-            } else if lane.indications.isSuperset(of: [.straightAhead, .sharpLeft]) || lane.indications.isSuperset(of: [.straightAhead, .left]) || lane.indications.isSuperset(of: [.straightAhead, .slightLeft]) {
                 if !isValid {
                     StyleKitArrows.drawLane_straight_right(primaryColor: appropriatePrimaryColor)
                     alpha = invalidAlpha
                 } else if maneuverDirection == .straightAhead {
                     StyleKitArrows.drawLane_straight_only(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
+                } else if maneuverDirection == .sharpLeft || maneuverDirection == .left || maneuverDirection == .slightLeft {
+                    StyleKitArrows.drawLane_right_h(primaryColor: appropriatePrimaryColor)
+                    flipLane = true
                 } else {
                     StyleKitArrows.drawLane_right_only(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
                 }
+            } else if lane.indications.isSuperset(of: [.straightAhead, .sharpLeft]) || lane.indications.isSuperset(of: [.straightAhead, .left]) || lane.indications.isSuperset(of: [.straightAhead, .slightLeft]) {
                 flipLane = true
+                if !isValid {
+                    StyleKitArrows.drawLane_straight_right(primaryColor: appropriatePrimaryColor)
+                    alpha = invalidAlpha
+                } else if maneuverDirection == .straightAhead {
+                    StyleKitArrows.drawLane_straight_only(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
+                } else if maneuverDirection == .sharpRight || maneuverDirection == .right || maneuverDirection == .slightRight {
+                    StyleKitArrows.drawLane_right_h(primaryColor: appropriatePrimaryColor)
+                    flipLane = false
+                } else {
+                    StyleKitArrows.drawLane_right_only(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
+                }
             } else if lane.indications.description.components(separatedBy: ",").count >= 2 {
                 // Hack:
                 // Account for a configuation where there is no straight lane


### PR DESCRIPTION
If the maneuver direction appears to contradict the lane indication by going to the opposite side, it’s probably because of a fork in which a lane can be used to take either branch. In that case, ignore the invalid branch and show only the valid branch, going in the same direction as the maneuver.

Ideally, we’d show the invalid branch dimmed out, but we currently lack artwork for a left-right turn lane. So this is essentially a workaround for part of #576.

Here’s the before and after:

<img src="https://user-images.githubusercontent.com/1231218/30084740-76b39126-9248-11e7-8264-b1d15cbfeba5.png" width="300" alt="before"> <img src="https://user-images.githubusercontent.com/1231218/30084741-76b3f99a-9248-11e7-968c-ad46f4f7e00c.png" width="300" alt="after">

/cc @bsudekum @frederoni