### PR TITLE
Update ETA info when stale

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -391,6 +391,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         super.viewWillDisappear(animated)
         
         UIApplication.shared.isIdleTimerDisabled = false
+        updateETATimer = nil
         routeController.suspendLocationUpdates()
     }
     

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -290,7 +290,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         super.init(coder: aDecoder)
     }
     
-    var updateETAInfoTimer: Timer!
+    var updateETATimer: Timer?
     
     required public init(contentViewController: UIViewController, drawerViewController: UIViewController) {
         fatalError("init(contentViewController:drawerViewController:) has not been implemented. " +
@@ -455,12 +455,12 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         }
     }
     
-    func ETAIsStale() {
+    func updateETA() {
         tableViewController?.updateETA(routeProgress: routeController.routeProgress)
     }
     
     func resetETATimer() {
-       updateETAInfoTimer = Timer.scheduledTimer(timeInterval: 30, target: self, selector: #selector(ETAIsStale), userInfo: nil, repeats: true)
+       updateETATimer = Timer.scheduledTimer(timeInterval: 30, target: self, selector: #selector(updateETA), userInfo: nil, repeats: true)
     }
     
     func forceRefreshAppearanceIfNeeded() {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -566,6 +566,7 @@ extension NavigationViewController: RouteControllerDelegate {
         scheduleLocalNotification(about: routeProgress.currentLegProgress.currentStep, legIndex: routeProgress.legIndex, numberOfLegs: route.legs.count)
         
         mapViewController?.notifyDidReroute(route: route)
+        tableViewController?.tableView.reloadData()
         tableViewController?.updateETA(routeProgress: routeController.routeProgress)
         
         navigationDelegate?.navigationViewController?(self, didRerouteAlong: route)

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -391,6 +391,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
         super.viewWillDisappear(animated)
         
         UIApplication.shared.isIdleTimerDisabled = false
+        updateETATimer?.invalidate()
         updateETATimer = nil
         routeController.suspendLocationUpdates()
     }

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -28,7 +28,7 @@ class RouteTableViewController: UIViewController {
         tableView.estimatedRowHeight = 80
     }
     
-    func showETA(routeProgress: RouteProgress) {
+    func updateETA(routeProgress: RouteProgress) {
         let arrivalDate = NSCalendar.current.date(byAdding: .second, value: Int(routeProgress.durationRemaining), to: Date())
         headerView.arrivalTimeLabel.text = dateFormatter.string(from: arrivalDate!)
         
@@ -84,15 +84,7 @@ class RouteTableViewController: UIViewController {
             }
         }
     }
-    
-    func notifyDidChange(routeProgress: RouteProgress) {
-        showETA(routeProgress: routeProgress)
-    }
-    
-    func notifyDidReroute() {
-        tableView.reloadData()
-    }
-    
+        
     func notifyAlertLevelDidChange() {
         if let visibleIndexPaths = tableView.indexPathsForVisibleRows {
             tableView.reloadRows(at: visibleIndexPaths, with: .fade)


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/594

When the user is not moving, we should still be able to give them accurate info about their trip.

This also removes a few functions that existed just to call another function.

/cc @1ec5 @frederoni @ericrwolfe 