### PR TITLE
Localize conjunction

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		354A01ED1E6626EF00D765C2 /* Mapbox.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 35A1D3651E6624EF00A48FE8 /* Mapbox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		354BD4F51E6637D500AE1344 /* AWSPolly.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 354BD4F11E6634C500AE1344 /* AWSPolly.framework */; };
 		354D9F891EF2FE900006FAA8 /* tunnel.json in Resources */ = {isa = PBXBuildFile; fileRef = 354D9F871EF2FE900006FAA8 /* tunnel.json */; };
+		355242E11F68135F00C132BA /* StringExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355242E01F68135F00C132BA /* StringExt.swift */; };
 		355D20DC1EF30A6D0012B1E0 /* tunnel.route in Resources */ = {isa = PBXBuildFile; fileRef = 355D20DB1EF30A6D0012B1E0 /* tunnel.route */; };
 		355DB5751EFA78070091BFB7 /* GGPark-to-BernalHeights.route in Resources */ = {isa = PBXBuildFile; fileRef = 355DB5741EFA78070091BFB7 /* GGPark-to-BernalHeights.route */; };
 		355DB5771EFA780E0091BFB7 /* UnionSquare-to-GGPark.route in Resources */ = {isa = PBXBuildFile; fileRef = 355DB5761EFA780E0091BFB7 /* UnionSquare-to-GGPark.route */; };
@@ -356,6 +357,7 @@
 		354BD4F11E6634C500AE1344 /* AWSPolly.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AWSPolly.framework; path = Carthage/Build/iOS/AWSPolly.framework; sourceTree = "<group>"; };
 		354BD4F61E6638E800AE1344 /* AWSCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AWSCore.framework; path = Carthage/Build/iOS/AWSCore.framework; sourceTree = "<group>"; };
 		354D9F871EF2FE900006FAA8 /* tunnel.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tunnel.json; sourceTree = "<group>"; };
+		355242E01F68135F00C132BA /* StringExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExt.swift; sourceTree = "<group>"; };
 		355D20DB1EF30A6D0012B1E0 /* tunnel.route */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = tunnel.route; sourceTree = "<group>"; };
 		355DB5741EFA78070091BFB7 /* GGPark-to-BernalHeights.route */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = "GGPark-to-BernalHeights.route"; sourceTree = "<group>"; };
 		355DB5761EFA780E0091BFB7 /* UnionSquare-to-GGPark.route */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = "UnionSquare-to-GGPark.route"; sourceTree = "<group>"; };
@@ -775,6 +777,7 @@
 				C58159001EA6D02700FC6C3D /* MGLVectorSource.swift */,
 				351BEBF01E5BCC63006FE110 /* UIView.swift */,
 				35CF34B01F0A733200C2692E /* UIFont.swift */,
+				355242E01F68135F00C132BA /* StringExt.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1364,6 +1367,7 @@
 				C588C3C21F33882100520EF2 /* String.swift in Sources */,
 				351BEBFB1E5BCC63006FE110 /* RouteTableViewHeaderView.swift in Sources */,
 				C53208AB1E81FFB900910266 /* NavigationMapView.swift in Sources */,
+				355242E11F68135F00C132BA /* StringExt.swift in Sources */,
 				351BEBF61E5BCC63006FE110 /* RouteMapViewController.swift in Sources */,
 				35726EE81F0856E900AFA1B6 /* DayStyle.swift in Sources */,
 				35DC9D911F4323AA001ECD64 /* LanesContainerView.swift in Sources */,

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -1,4 +1,10 @@
-﻿/* Indicates a faster route was found */
+﻿/* Format for displaying a conjunction of two words or phrases */
+"CONJUNCTION_FORMAT" = "%1$@ and %2$@";
+
+/* Format for displaying two words or phrases where the right hand side starts with an AI sound */
+"CONJUNCTION_SUCCEEDING_AI_SOUND_FORMAT" = "%1$@ and %2$@";
+
+/* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Faster Route Found";
 
 /* Feedback type for Accident */
@@ -18,9 +24,6 @@
 
 /* Feedback type for Unallowed Turn */
 "FEEDBACK_UNALLOWED_TURN" = "Not Allowed";
-
-/* Format for displaying the first two major ways */
-"LEG_MAJOR_WAYS_FORMAT" = "%1$@ and %2$@";
 
 /* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
 "LESS_THAN" = "<%@";

--- a/MapboxNavigation/RouteTableViewController.swift
+++ b/MapboxNavigation/RouteTableViewController.swift
@@ -118,7 +118,7 @@ extension RouteTableViewController: UITableViewDelegate, UITableViewDataSource {
         let majorWays = leg.name.components(separatedBy: ", ")
         
         if let destinationName = destinationName?.nonEmptyString, majorWays.count > 1 {
-            let summary = String.localizedStringWithFormat(NSLocalizedString("LEG_MAJOR_WAYS_FORMAT", bundle: .mapboxNavigation, value: "%@ and %@", comment: "Format for displaying the first two major ways"), majorWays[0], majorWays[1])
+            let summary = String.localizedConjunction(lhs: majorWays[0], rhs: majorWays[1], rule: .succeedingAIsound)
             return String.localizedStringWithFormat(NSLocalizedString("WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT", bundle: .mapboxNavigation, value: "%@, via %@", comment: "Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations"), destinationName, summary)
         } else if let sourceName = sourceName?.nonEmptyString, let destinationName = destinationName?.nonEmptyString {
             return String.localizedStringWithFormat(NSLocalizedString("WAYPOINT_SOURCE_DESTINATION_FORMAT", bundle: .mapboxNavigation, value: "%@ and %@", comment: "Format for displaying start and endpoint for leg; 1 = source ; 2 = destination"), sourceName, destinationName)

--- a/MapboxNavigation/StringExt.swift
+++ b/MapboxNavigation/StringExt.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension String {
+    
+    enum ConjunctionRule {
+        case none
+        case succeedingAIsound
+    }
+    
+    static func localizedConjunction(lhs: String, rhs: String, rule: ConjunctionRule = .none) -> String {
+        switch rule {
+        case .none:
+            return String.localizedStringWithFormat(NSLocalizedString("CONJUNCTION_FORMAT", bundle: .mapboxNavigation, value: "%@ and %@", comment: "Format for displaying a conjunction of two words or phrases"), lhs, rhs)
+        case .succeedingAIsound:
+            if let char = rhs.first, char.isPronouncedAI {
+                return String.localizedStringWithFormat(NSLocalizedString("CONJUNCTION_SUCCEEDING_AI_SOUND_FORMAT", bundle: .mapboxNavigation, value: "%@ and %@", comment: "Format for displaying two words or phrases where the right hand side starts with an AI sound"), lhs, rhs)
+            }
+            
+            return String.localizedStringWithFormat(NSLocalizedString("CONJUNCTION_FORMAT", bundle: .mapboxNavigation, value: "%@ and %@", comment: "Format for displaying a conjunction of two words or phrases"), lhs, rhs)
+        }
+    }
+}
+
+extension Character {
+    var isPronouncedAI: Bool {
+        return ["i", "y"].contains(Character(String(self).lowercased()))
+    }
+}


### PR DESCRIPTION
Work in progress for #600 

This PR adds a special case for localizing a conjunction of two words or phrases where the conjunction word depends on the following letter _or_ pronunciation.

In addition to replacing "y" with "e" if the following letter is "y" or "i", we should also use this rule if the following pronunciation is /EYE/. e.g. "Necesito aguja e hilo" ← silent H, while "La mesa es de madera y hierro" uses "y". (Thanks @Guardiola31337)

I added a new string to handle the new rule instead of checking if the language is set to Spanish. A downside of this implementation is that we need to localize the conjunction format for both rules for all languages.

@1ec5 @bsudekum 