### PR TITLE
Always map first location update

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -167,7 +167,7 @@ open class RouteController: NSObject {
     var sessionState:SessionState
     var outstandingFeedbackEvents = [CoreFeedbackEvent]()
     
-    var isFirstLocationUpdate = true
+    var hasFoundOneQualifiedLocation = false
     
     /**
      Intializes a new `RouteController`.
@@ -433,13 +433,15 @@ extension RouteController: CLLocationManagerDelegate {
         
         sessionState.pastLocations.push(location)
         
-        guard location.isQualified || isFirstLocationUpdate else {
+        if location.isQualified {
+            hasFoundOneQualifiedLocation = true
+        }
+        
+        if !location.isQualified && hasFoundOneQualifiedLocation {
             delegate?.routeController?(self, didDiscard: location)
             return
         }
-        
-        isFirstLocationUpdate = false
-        
+
         delegate?.routeController?(self, didUpdate: [location])
 
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(interpolateLocation), object: nil)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -167,6 +167,8 @@ open class RouteController: NSObject {
     var sessionState:SessionState
     var outstandingFeedbackEvents = [CoreFeedbackEvent]()
     
+    var isFirstLocationUpdate = true
+    
     /**
      Intializes a new `RouteController`.
      
@@ -431,10 +433,12 @@ extension RouteController: CLLocationManagerDelegate {
         
         sessionState.pastLocations.push(location)
         
-        guard location.isQualified else {
+        guard location.isQualified || isFirstLocationUpdate else {
             delegate?.routeController?(self, didDiscard: location)
             return
         }
+        
+        isFirstLocationUpdate = false
         
         delegate?.routeController?(self, didUpdate: [location])
 


### PR DESCRIPTION
If the first location update is not `isQualified` and the user is not moving, the user puck and other information is never shown. This makes sure we update the UI and user puck location at least once if it's the first location update.

/cc @1ec5 @ericrwolfe 