### PR TITLE
Prevent flash when capturing screen

### DIFF
--- a/MapboxCoreNavigation/ScreenCapture.swift
+++ b/MapboxCoreNavigation/ScreenCapture.swift
@@ -9,7 +9,7 @@ extension UIWindow {
         
         UIGraphicsBeginImageContextWithOptions(frame.size, isOpaque, UIScreen.main.scale)
         
-        drawHierarchy(in: bounds, afterScreenUpdates: true)
+        drawHierarchy(in: bounds, afterScreenUpdates: false)
         
         guard let image = UIGraphicsGetImageFromCurrentImageContext() else { return nil }
         


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-navigation-ios/issues/592

Verifying we're still getting an image with this change:

![image](https://user-images.githubusercontent.com/1058624/30347990-af31b832-97c2-11e7-8c47-1fdc91bcedcb.png)


/cc @frederoni 