### PR TITLE
Fix congestion segment and guard

### DIFF
--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -157,8 +157,14 @@ open class RouteProgress: NSObject {
             
             if let segmentCongestionLevels = leg.segmentCongestionLevels, let expectedSegmentTravelTimes = leg.expectedSegmentTravelTimes  {
                 
-                for step in leg.steps.dropFirst() {
-                    let stepCoordinatesCount = maneuverCoordinateIndex + Int(step.coordinateCount) - 1
+                for step in leg.steps {
+                    guard let coordinates = step.coordinates else { continue }
+                    let stepCoordinates = step.maneuverType == .arrive ? Int(step.coordinateCount) : coordinates.dropLast().count
+                    let stepCoordinatesCount = maneuverCoordinateIndex + stepCoordinates - 1
+                    
+                    guard stepCoordinatesCount < segmentCongestionLevels.count else { continue }
+                    guard stepCoordinatesCount < expectedSegmentTravelTimes.count else { continue }
+                    
                     let stepSegmentCongestionLevels = Array(segmentCongestionLevels[maneuverCoordinateIndex..<stepCoordinatesCount])
                     let stepSegmentTravelTimes = Array(expectedSegmentTravelTimes[maneuverCoordinateIndex..<stepCoordinatesCount])
                     maneuverCoordinateIndex = stepCoordinatesCount

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -159,15 +159,15 @@ open class RouteProgress: NSObject {
                 
                 for step in leg.steps {
                     guard let coordinates = step.coordinates else { continue }
-                    let stepCoordinates = step.maneuverType == .arrive ? Int(step.coordinateCount) : coordinates.dropLast().count
-                    let stepCoordinatesCount = maneuverCoordinateIndex + stepCoordinates - 1
+                    let stepCoordinateCount = step.maneuverType == .arrive ? Int(step.coordinateCount) : coordinates.dropLast().count
+                    let nextManeuverCoordinateIndex = maneuverCoordinateIndex + stepCoordinateCount - 1
                     
-                    guard stepCoordinatesCount < segmentCongestionLevels.count else { continue }
-                    guard stepCoordinatesCount < expectedSegmentTravelTimes.count else { continue }
+                    guard nextManeuverCoordinateIndex < segmentCongestionLevels.count else { continue }
+                    guard nextManeuverCoordinateIndex < expectedSegmentTravelTimes.count else { continue }
                     
-                    let stepSegmentCongestionLevels = Array(segmentCongestionLevels[maneuverCoordinateIndex..<stepCoordinatesCount])
-                    let stepSegmentTravelTimes = Array(expectedSegmentTravelTimes[maneuverCoordinateIndex..<stepCoordinatesCount])
-                    maneuverCoordinateIndex = stepCoordinatesCount
+                    let stepSegmentCongestionLevels = Array(segmentCongestionLevels[maneuverCoordinateIndex..<nextManeuverCoordinateIndex])
+                    let stepSegmentTravelTimes = Array(expectedSegmentTravelTimes[maneuverCoordinateIndex..<nextManeuverCoordinateIndex])
+                    maneuverCoordinateIndex = nextManeuverCoordinateIndex
                     
                     let stepTimedCongestionLevels = Array(zip(stepSegmentCongestionLevels, stepSegmentTravelTimes))
                     congestionTravelTimesSegmentsByLeg.append(stepTimedCongestionLevels)


### PR DESCRIPTION
If you add up all the step coordinates, it will be equal to the route geometry count plus the number of steps. This is because each step shares a coordinate with the next step. Previously, our lookups into this array were a little off since we were not removing the last coordinate which is shared. 

This also adds a guard to check that our array lookup is also within bounds.

/cc @1ec5 