### PR TITLE
Fix timer leak

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -481,7 +481,8 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     }
     
     func resetETATimer() {
-       updateETATimer = Timer.scheduledTimer(timeInterval: 30, target: self, selector: #selector(updateETA), userInfo: nil, repeats: true)
+        updateETATimer?.invalidate()
+        updateETATimer = Timer.scheduledTimer(timeInterval: 30, target: self, selector: #selector(updateETA), userInfo: nil, repeats: true)
     }
     
     func forceRefreshAppearanceIfNeeded() {


### PR DESCRIPTION
The timer needs to be invalidated before reseting it. This caused all sorts of memory leaks.

/cc @1ec5 @frederoni 