### PR TITLE
Override string fromMeters

### DIFF
--- a/MapboxCoreNavigation/DistanceFormatter.swift
+++ b/MapboxCoreNavigation/DistanceFormatter.swift
@@ -112,6 +112,10 @@ public class DistanceFormatter: LengthFormatter {
         return formattedDistance(distance, modify: &unit)
     }
     
+    public override func string(fromMeters numberInMeters: Double) -> String {
+        return self.string(from: numberInMeters)
+    }
+    
     func formattedDistance(_ distance: CLLocationDistance, modify unit: inout LengthFormatter.Unit) -> String {
         var formattedDistance: String
         if usesMetric {
@@ -132,7 +136,7 @@ public class DistanceFormatter: LengthFormatter {
                     formattedDistance = string(fromValue: distance.feet, unit: unit)
                 }
             } else {
-                formattedDistance = string(fromMeters: distance)
+                formattedDistance = super.string(fromMeters: distance)
             }
         }
         


### PR DESCRIPTION
This PR avoids confusion like #606 by linking `string(from:)` and `string(fromMeters:)`.

`DistanceFormatter.string(fromMeters:)` previously used `NSLengthFormatter`’s default which could result in yards. `DistanceFormatter` is a replacement for `MKDistanceFormatter` which leverage some of `NSLengthFormatter`’s functionality but there's no reason why `string(fromMeters:)` shouldn't work the same way as `string(from:)`.

@ericrwolfe @bsudekum 