### PR TITLE
Abbreviate and markup with SSML more robustly

### DIFF
--- a/MapboxCoreNavigation/RouteStepFormatter.swift
+++ b/MapboxCoreNavigation/RouteStepFormatter.swift
@@ -24,11 +24,18 @@ public class RouteStepFormatter: Formatter {
         let modifyValueByKey = { (key: OSRMTextInstructions.TokenType, value: String) -> String in
             switch key {
             case .wayName, .destination, .rotaryName, .code:
-                let stringComponents = value.addingXMLEscapes.components(separatedBy: .whitespaces)
-                
-                return stringComponents.map {
-                    $0.containsDecimalDigit ? $0.asSSMLAddress : $0
-                }.joined(separator: " ")
+                var value = value
+                value.enumerateSubstrings(in: value.wholeRange, options: .byWords) { (substring, substringRange, enclosingRange, stop) in
+                    guard var substring = substring?.addingXMLEscapes else {
+                        return
+                    }
+                    
+                    if substring.containsDecimalDigit {
+                        substring = substring.asSSMLAddress
+                    }
+                    value.replaceSubrange(substringRange, with: substring)
+                }
+                return value
             default:
                 return value
             }

--- a/MapboxCoreNavigation/RouteStepFormatter.swift
+++ b/MapboxCoreNavigation/RouteStepFormatter.swift
@@ -25,7 +25,7 @@ public class RouteStepFormatter: Formatter {
             switch key {
             case .wayName, .destination, .rotaryName, .code:
                 var value = value
-                value.enumerateSubstrings(in: value.wholeRange, options: .byWords) { (substring, substringRange, enclosingRange, stop) in
+                value.enumerateSubstrings(in: value.wholeRange, options: [.byWords, .reverse]) { (substring, substringRange, enclosingRange, stop) in
                     guard var substring = substring?.addingXMLEscapes else {
                         return
                     }

--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -13,9 +13,7 @@ extension String {
     }
     
     var wholeRange: Range<String.Index> {
-        get {
-            return range(of: self)!
-        }
+        return startIndex..<endIndex
     }
     
     typealias Replacement = (of: String, with: String)

--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -12,9 +12,9 @@ extension String {
         return isEmpty ? nil : self
     }
     
-    var wholeRange: NSRange {
+    var wholeRange: Range<String.Index> {
         get {
-            return NSRange(location: 0, length: characters.count)
+            return range(of: self)!
         }
     }
     

--- a/MapboxNavigation/Abbreviations.swift
+++ b/MapboxNavigation/Abbreviations.swift
@@ -18,19 +18,25 @@ struct StringAbbreviationOptions : OptionSet {
 extension String {
     /// Returns an abbreviated copy of the string.
     func abbreviated(by options: StringAbbreviationOptions) -> String {
-        return characters.split(separator: " ").map(String.init).map { (word) -> String in
-            let lowercaseWord = word.lowercased()
-            if let abbreviation = allAbbrevations!["abbreviations"]![lowercaseWord], options.contains(.Abbreviations) {
-                return abbreviation
+        var abbreviatedString = self
+        abbreviatedString.enumerateSubstrings(in: abbreviatedString.wholeRange, options: .byWords) { (substring, substringRange, enclosingRange, stop) in
+            guard var word = substring?.lowercased() else {
+                return
             }
-            if let direction = allAbbrevations!["directions"]![lowercaseWord], options.contains(.Directions) {
-                return direction
+            
+            if let abbreviation = allAbbrevations!["abbreviations"]![word], options.contains(.Abbreviations) {
+                word = abbreviation
+            } else if let direction = allAbbrevations!["directions"]![word], options.contains(.Directions) {
+                word = direction
+            } else if let classification = allAbbrevations!["classifications"]![word], options.contains(.Classifications) {
+                word = classification
+            } else {
+                return
             }
-            if let classification = allAbbrevations!["classifications"]![lowercaseWord], options.contains(.Classifications) {
-                return classification
-            }
-            return word
-            }.joined(separator: " ")
+            
+            abbreviatedString.replaceSubrange(substringRange, with: word)
+        }
+        return abbreviatedString
     }
     
     /// Returns the string abbreviated only as much as necessary to fit the given width and font.

--- a/MapboxNavigation/Abbreviations.swift
+++ b/MapboxNavigation/Abbreviations.swift
@@ -19,7 +19,7 @@ extension String {
     /// Returns an abbreviated copy of the string.
     func abbreviated(by options: StringAbbreviationOptions) -> String {
         var abbreviatedString = self
-        abbreviatedString.enumerateSubstrings(in: abbreviatedString.wholeRange, options: .byWords) { (substring, substringRange, enclosingRange, stop) in
+        abbreviatedString.enumerateSubstrings(in: abbreviatedString.wholeRange, options: [.byWords, .reverse]) { (substring, substringRange, enclosingRange, stop) in
             guard var word = substring?.lowercased() else {
                 return
             }


### PR DESCRIPTION
Rely on the standard library’s word enumeration functionality to more reliably abbreviate strings (for the road name in the turn banner) and insert SSML markup (for numbers in voice instructions). Now this code can correctly handle arbitrary punctuation surrounding words, as well as languages that don’t delimit words with spaces.

/cc @bsudekum @frederoni