### PR TITLE
Supply phonetic road names to AVSpeechSynthesizer

### DIFF
--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -31,14 +31,6 @@ extension String {
             ])
     }
     
-    var removingPunctuation: String {
-        return byReplacing([
-            ("(", ""),
-            (")", ""),
-            ("_", "")
-            ])
-    }
-    
     var asSSMLAddress: String {
         return "<say-as interpret-as=\"address\">\(self.addingXMLEscapes)</say-as>"
     }

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -198,7 +198,7 @@ public class PollyVoiceController: RouteVoiceController {
             
             // If the task is canceled, don't speak.
             // But if it's some sort of other error, use fallback voice.
-            if let error = error as NSError?, error.code == NSURLErrorCancelled {
+            if let error = error as? URLError, error.code == .cancelled {
                 return
             } else if let error = error {
                 // Cannot call super in a closure


### PR DESCRIPTION
This change provides AVSpeechSynthesizer with the same phonetic names that #622 provides Polly with. This way the AVSpeechSynthesizer fallback remains consistent with Polly in terms of its pronunciation of difficult names. The closer the two voices’ pronunciation, the less jarring it is when the fallback kicks in.

AVSpeechSynthesizer doesn’t support SSML; instead, on iOS 10 and above, it uses the native NSAttributedString type to hold attributes such as pronunciations. It turns out that the Alex voice (#612) does not support attributed strings, but it manages to correctly pronounce just about all the roads that are currently tagged with pronunciations anyways.

~~Depends on #621, mapbox/MapboxDirections.swift#174, and Project-OSRM/osrm-text-instructions.swift#39.~~

/cc @frederoni @bsudekum