### PR TITLE
Fix leaky announcement timer

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -80,6 +80,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     deinit {
         suspendNotifications()
         speechSynth.stopSpeaking(at: .word)
+        resetAnnouncementTimer()
     }
     
     func resumeNotifications() {

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -16,7 +16,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     let routeStepFormatter = RouteStepFormatter()
     var recentlyAnnouncedRouteStep: RouteStep?
     var fallbackText: String!
-    var announcementTimer: Timer!
+    var announcementTimer: Timer?
     
     /**
      A boolean value indicating whether instructions should be announced by voice or not.
@@ -148,12 +148,13 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     }
     
     func startAnnouncementTimer() {
+        announcementTimer?.invalidate()
         announcementTimer = Timer.scheduledTimer(timeInterval: bufferBetweenAnnouncements, target: self, selector: #selector(resetAnnouncementTimer), userInfo: nil, repeats: false)
     }
     
     func resetAnnouncementTimer() {
+        announcementTimer?.invalidate()
         recentlyAnnouncedRouteStep = nil
-        announcementTimer.invalidate()
     }
     
     open func alertLevelDidChange(notification: NSNotification) {


### PR DESCRIPTION
On longer routes, since we were not cleaning up timers correctly, a user could get two announcement voices. 

/cc @1ec5 @frederoni 