### PR TITLE
Share some extension files with MapboxNavigation pod

### DIFF
--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxNavigation/*", "MapboxCoreNavigation/Geometry.swift"]
+  s.source_files = ["MapboxNavigation/*", "MapboxCoreNavigation/{Date,Geometry,String}.swift"]
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
Added some Swift files that contain extensions on standard library classes to the MapboxNavigation podspec, reflecting the fact that these same files are shared between the MapboxCoreNavigation and MapboxNavigation targets in the Xcode project.

By selectively sharing files between targets (and now pods), we can avoid unnecessarily making symbols public just because they need to be used by both libraries. However, we should keep this technique to a minimum, since usually anything that’s worth exposing to MapboxNavigation is also worth exposing publicly to dependents of Core Navigation.

I slipped this change into MapboxNavigation.podspec before pushing v0.8.0 to CocoaPods trunk. This PR makes the change permanent.

/cc @bsudekum @frederoni