### PR TITLE
Add  dynamic range compression (drc) ssml effect

### DIFF
--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -96,7 +96,7 @@ public class PollyVoiceController: RouteVoiceController {
             input.voiceId = voiceId
         }
         
-        input.text = "<speak><prosody volume='\(instructionVoiceVolume)' rate='\(instructionVoiceSpeedRate)'>\(text)</prosody></speak>"
+        input.text = "<speak><amazon:effect name=\"drc\"><prosody volume='\(instructionVoiceVolume)' rate='\(instructionVoiceSpeedRate)'>\(text)</prosody></amazon:effect></speak>"
         
         let builder = AWSPollySynthesizeSpeechURLBuilder.default().getPreSignedURL(input)
         builder.continueWith { [weak self] (awsTask: AWSTask<NSURL>) -> Any? in


### PR DESCRIPTION
Adds the a custom Polly ssml effect `<amazon:effect name="drc">`. From the docs:

> Depending on the text, language, and voice used in an audio file, the sounds range from soft to loud. Environmental sounds, such as the sound of a moving vehicle, can often mask the softer sounds, which makes the audio track difficult to hear clearly. To enhance the volume of certain sounds in your audio file, use the dynamic range compression (drc) tag.

[ref](https://docs.aws.amazon.com/polly/latest/dg/supported-ssml.html#drc-tag)

/cc @1ec5 @ericrwolfe 