### PR TITLE
Fix uturn step increment and snapping

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -288,13 +288,14 @@ open class RouteController: NSObject {
         guard let stepCoordinates = routeProgress.currentLegProgress.currentStep.coordinates else { return nil }
         guard let snappedCoordinate = closestCoordinate(on: stepCoordinates, to: location.coordinate) else { return location }
         
-        var nearByCoordinates = routeProgress.currentLegProgress.currentAndUpcomgingStepCoordinates
+        var nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
         
         // If the upcoming step is a roundabout, only look at the current step for snapping.
         // Otherwise, we may get false positives from nearby step coordinates
         if let upcomingStep = routeProgress.currentLegProgress.upComingStep, upcomingStep.maneuverDirection == .uTurn, let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
            nearByCoordinates = coordinates
         }
+
         guard let closest = closestCoordinate(on: nearByCoordinates, to: location.coordinate) else { return nil }
         
         let slicedLineBehind = polyline(along: nearByCoordinates.reversed(), from: closest.coordinate, to: nearByCoordinates.reversed().last)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -748,14 +748,6 @@ extension RouteController: CLLocationManagerDelegate {
             } else {
                 courseMatchesManeuverFinalHeading = differenceBetweenAngles(finalHeadingNormalized, userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
             }
-            
-            // In some cases, the finalHeading can be inaccurate.
-            // This is a last ditch effort to try and see if the user's course
-            // is equal to the opposite way they came into e uturn maneuver.
-            if let upcomingStep = routeProgress.currentLegProgress.upComingStep, upcomingStep.maneuverDirection == .uTurn, courseMatchesManeuverFinalHeading == false {
-                let calculatedFinalHeadingFromInitialHeading = wrap(-initialHeading, min: 0, max: 360)
-                courseMatchesManeuverFinalHeading = differenceBetweenAngles(calculatedFinalHeadingFromInitialHeading, userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
-            }
         }
 
         // When departing, `userSnapToStepDistanceFromManeuver` is most often less than `RouteControllerManeuverZoneRadius`

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -344,7 +344,7 @@ open class RouteLegProgress: NSObject {
         let upcomingCoords = upComingStep?.coordinates ?? []
         let currentCoords = currentStep.coordinates ?? []
         let nearby = priorCoords + currentCoords + upcomingCoords
-        assert(!nearby.isEmpty, "Polyline must coordinates")
+        assert(!nearby.isEmpty, "Step must have coordinates")
         return nearby
     }
     
@@ -355,7 +355,7 @@ open class RouteLegProgress: NSObject {
         let upcomingCoords = upComingStep?.coordinates ?? []
         let currentCoords = currentStep.coordinates ?? []
         let nearby = currentCoords + upcomingCoords
-        assert(!nearby.isEmpty, "Polyline must coordinates")
+        assert(!nearby.isEmpty, "Step must have coordinates")
         return nearby
     }
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -347,6 +347,17 @@ open class RouteLegProgress: NSObject {
         assert(!nearby.isEmpty, "Polyline must coordinates")
         return nearby
     }
+    
+    /**
+     Returns an array of `CLLocationCoordinate2D` of the current and upcoming step geometry.
+     */
+    public var currentAndUpcomgingStepCoordinates: [CLLocationCoordinate2D] {
+        let upcomingCoords = upComingStep?.coordinates ?? []
+        let currentCoords = currentStep.coordinates ?? []
+        let nearby = currentCoords + upcomingCoords
+        assert(!nearby.isEmpty, "Polyline must coordinates")
+        return nearby
+    }
 }
 
 /**

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -347,17 +347,6 @@ open class RouteLegProgress: NSObject {
         assert(!nearby.isEmpty, "Step must have coordinates")
         return nearby
     }
-    
-    /**
-     Returns an array of `CLLocationCoordinate2D` of the current and upcoming step geometry.
-     */
-    public var currentAndUpcomgingStepCoordinates: [CLLocationCoordinate2D] {
-        let upcomingCoords = upComingStep?.coordinates ?? []
-        let currentCoords = currentStep.coordinates ?? []
-        let nearby = currentCoords + upcomingCoords
-        assert(!nearby.isEmpty, "Step must have coordinates")
-        return nearby
-    }
 }
 
 /**


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/639

This addresses two issues:

1. When a step has coordinates that are close to the current step (think in a uturn), we sometimes snap to the wrong step coordinates. To fix this, when the upcoming maneuver modifier is a uturn, we only look at the current step coordinates for snapping
1. There is a bug in OSRM where exit bearings are calculated incorrectly. This prevents us from incrementing the step counter because the users course never is equal to the exit bearing. This hack should be removed when fixed upstream.

/cc @danpat @1ec5 @frederoni 