### PR TITLE
Reroute when the user is moving away from maneuver

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -169,7 +169,7 @@ open class RouteController: NSObject {
     
     var hasFoundOneQualifiedLocation = false
     
-    var previousDistancesFromManeuver: [CLLocationDistance] = []
+    var recentDistancesFromManeuver: [CLLocationDistance] = []
     
     /**
      Intializes a new `RouteController`.
@@ -550,14 +550,14 @@ extension RouteController: CLLocationManagerDelegate {
         if let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
             let userDistanceToManeuver = distance(along: coordinates, from: location.coordinate)
             
-            guard previousDistancesFromManeuver.count <= 3 else {
+            guard recentDistancesFromManeuver.count <= 3 else {
                 resetPreviousDistanceArray()
                 return false
             }
             
-            if previousDistancesFromManeuver.isEmpty {
-                previousDistancesFromManeuver.append(userDistanceToManeuver)
-            } else if let lastSpeed = previousDistancesFromManeuver.last, userDistanceToManeuver > lastSpeed {
+            if recentDistancesFromManeuver.isEmpty {
+                recentDistancesFromManeuver.append(userDistanceToManeuver)
+            } else if let lastSpeed = recentDistancesFromManeuver.last, userDistanceToManeuver > lastSpeed {
                 previousDistancesFromManeuver.append(userDistanceToManeuver)
             } else {
                 // If we get a descending distance, reset the counter

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -386,7 +386,7 @@ extension RouteController {
             sessionState.arrivalTimestamp = Date()
             sendArriveEvent()
         }
-        resetPreviousDistanceArray()
+        recentDistancesFromManeuver.removeAll()
     }
     
     func willReroute(notification: NSNotification) {
@@ -397,7 +397,7 @@ extension RouteController {
         if let lastReroute = outstandingFeedbackEvents.map({$0 as? RerouteEvent }).last {
             lastReroute?.update(newRoute: routeProgress.route)
         }
-        resetPreviousDistanceArray()
+        recentDistancesFromManeuver.removeAll()
     }
 }
 
@@ -553,17 +553,16 @@ extension RouteController: CLLocationManagerDelegate {
             let userDistanceToManeuver = distance(along: coordinates, from: location.coordinate)
             
             guard recentDistancesFromManeuver.count <= 3 else {
-                resetPreviousDistanceArray()
                 return false
             }
             
             if recentDistancesFromManeuver.isEmpty {
                 recentDistancesFromManeuver.append(userDistanceToManeuver)
-            } else if let lastSpeed = recentDistancesFromManeuver.last, userDistanceToManeuver > lastSpeed {
+            } else if let lastDistance = recentDistancesFromManeuver.last, userDistanceToManeuver > lastDistance {
                 recentDistancesFromManeuver.append(userDistanceToManeuver)
             } else {
                 // If we get a descending distance, reset the counter
-                resetPreviousDistanceArray()
+                recentDistancesFromManeuver.removeAll()
             }
         }
         
@@ -581,10 +580,6 @@ extension RouteController: CLLocationManagerDelegate {
         }
         
         return isCloseToCurrentStep
-    }
-    
-    func resetPreviousDistanceArray() {
-        recentDistancesFromManeuver.removeAll()
     }
     
     func incrementRouteProgress(_ newlyCalculatedAlertLevel: AlertLevel, location: CLLocation, updateStepIndex: Bool) {


### PR DESCRIPTION
If the user is moving away from the maneuver (whips a uturn on a country road half way down a step), we should reroute them once we know they are really moving away.

The gist:
* Calculate distance to maneuver
* add to an array
* check the last distance in the array. If it's greater than the previous distance, add it
* if this array grows to be greater than 3 distances, reroute.

/cc @1ec5 @frederoni @ericrwolfe 