### PR TITLE
Issue with access control for a string extension on MapboxCoreNavigation

### DIFF
--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -12,7 +12,7 @@ extension String {
         return isEmpty ? nil : self
     }
     
-    var wholeRange: Range<String.Index> {
+    public var wholeRange: Range<String.Index> {
         return startIndex..<endIndex
     }
     


### PR DESCRIPTION
I get an compiler error that the `wholeRange` needs another access control to use them.