### PR TITLE
Improve departure announcement

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -150,3 +150,8 @@ let milesToMeters = 1609.34
  The mimimum speed value before the user is snapped to the route. This is used to overcome inaccurate course values when a user's speed is low.
  */
 public var RouteControllerMinimumSpeedThresholdForSnappingUserToRoute: CLLocationSpeed = 2
+
+/**
+ The minimum distance threshold used for giving a "Continue" type instructions.
+ */
+public var RouteControllerMinDistanceForContinueInstruction: CLLocationDistance = 2_000

--- a/MapboxCoreNavigation/SpokenInstructionFormatter.swift
+++ b/MapboxCoreNavigation/SpokenInstructionFormatter.swift
@@ -72,9 +72,9 @@ public class SpokenInstructionFormatter: NSObject {
         // We only want to announce this special depature announcement once.
         // Once it has been announced, all subsequnt announcements will not have an alert level of low
         // since the user will be approaching the maneuver location.
-        let isDeparture = routeProgress.currentLegProgress.currentStep.maneuverType == .depart && (alertLevel == .depart || alertLevel == .low)
-        if let currentInstruction = currentInstruction, isDeparture {
-            if routeProgress.currentLegProgress.currentStep.distance > 2_000 {
+        let isStartingDeparture = routeProgress.currentLegProgress.currentStep.maneuverType == .depart && (alertLevel == .depart || alertLevel == .low)
+        if let currentInstruction = currentInstruction, isStartingDeparture {
+            if routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinDistanceForContinueInstruction {
                 text = currentInstruction
             } else if upcomingStepDuration > linkedInstructionMultiplier {
                 // If the upcoming step is an .exitRoundabout or .exitRotary, don't link the instruction
@@ -98,8 +98,8 @@ public class SpokenInstructionFormatter: NSObject {
             } else {
                 text = upComingInstruction
             }
-        } else if routeProgress.currentLegProgress.currentStep.distance > 2_000 && routeProgress.currentLegProgress.alertUserLevel == .low {
-            if isDeparture && upcomingStepDuration < linkedInstructionMultiplier {
+        } else if routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinDistanceForContinueInstruction && routeProgress.currentLegProgress.alertUserLevel == .low {
+            if isStartingDeparture && upcomingStepDuration < linkedInstructionMultiplier {
                 let phrase = escapeIfNecessary(routeStepFormatter.instructions.phrase(named: .twoInstructionsWithDistance))
                 text = phrase.replacingTokens { (tokenType) -> String in
                     switch tokenType {


### PR DESCRIPTION
We've been omitting departure instructions like `Head west on foo street.`

This change now makes departure instructions:

* Upcoming maneuver is > 2000 meters: `Continue west on foo street for 5 miles.`
* Upcoming maneuver is relatively close, less than 2000 meters: `Head west on foo street, then in 0.7 miles, turn right onto bar street.`
* Upcoming maneuver is very close: `Turn right onto bar street`.

Note, this only can occur when on the departure step and the alert level is .depart or .low.

/cc @1ec5 @frederoni @ericrwolfe 