### PR TITLE
Animate camera for maneuvers and motorways

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -123,9 +123,6 @@ class RouteMapViewController: UIViewController {
                 camera.heading = coordinates[0].direction(to: coordinates[1])
             }
             mapView.setCamera(camera, animated: false)
-            mapView.setCamera(cameraCurrentForRouteProgress, withDuration: 0.5, animationTimingFunction: nil, completionHandler: {
-                self.mapView.setUserLocationVerticalAlignment(.bottom, animated: true)
-            })
         }
     }
     


### PR DESCRIPTION
Fairly simple rules right now:

* If the current step is a motorway, keep pitch at 45 degrees and change the altitude to 2000 meters
* if the current step is not a motorway and the alert level is high, go into overhead mode
* Otherwise, set pitch to 45 degrees and altitude to 600 meters

![](https://user-images.githubusercontent.com/1058624/30837345-3b199ad0-a219-11e7-91bc-401a604c03fd.gif)

Until concurrent animations are fixed, this is not really actionable.

/cc @ericrwolfe @frederoni @1ec5 @kronick @d-prukop 