### PR TITLE
Improve steps with short distances

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -292,9 +292,13 @@ open class RouteController: NSObject {
         
         var nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
         
-        // If the upcoming step is a roundabout, only look at the current step for snapping.
+        // If the upcoming maneuver a sharp turn, only look at the current step for snapping.
         // Otherwise, we may get false positives from nearby step coordinates
-        if let upcomingStep = routeProgress.currentLegProgress.upComingStep, upcomingStep.maneuverDirection == .uTurn, let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
+        if let upcomingStep = routeProgress.currentLegProgress.upComingStep,
+            let initialHeading = upcomingStep.initialHeading,
+            let finalHeading = upcomingStep.finalHeading,
+            differenceBetweenAngles(initialHeading, finalHeading) < RouteControllerMaxManipulatedCourseAngle,
+            let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
            nearByCoordinates = coordinates
         }
 
@@ -574,7 +578,7 @@ extension RouteController: CLLocationManagerDelegate {
         }
         
         // If the user is moving away from the maneuver location
-        // and they are close to the next step
+        // and they are close to the upcoming or follow on step,
         // we can safely say they have completed the maneuver.
         // This is intended to be a fallback case when we do find
         // that the users course matches the exit bearing.
@@ -582,6 +586,13 @@ extension RouteController: CLLocationManagerDelegate {
             let isCloseToUpComingStep = newLocation.isWithin(radius, of: upComingStep)
             if !isCloseToCurrentStep && isCloseToUpComingStep {
                 incrementRouteProgress(newAlert(from: upComingStep), location: location, updateStepIndex: true)
+                return true
+            }
+        }
+        if let followOnStep = routeProgress.currentLegProgress.followOnStep {
+            let isCloseToUpComingStep = newLocation.isWithin(radius, of: followOnStep)
+            if !isCloseToCurrentStep && isCloseToUpComingStep {
+                incrementRouteProgress(newAlert(from: followOnStep), location: location, updateStepIndex: true)
                 return true
             }
         }
@@ -805,15 +816,9 @@ extension RouteController: CLLocationManagerDelegate {
             
             let lastKnownUserAbsoluteDistance = routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation
             
-            // The objective here is to make sure the user is moving away from the maneuver location
-            // This helps on maneuvers where the difference between the exit and enter heading are similar
-            if  userAbsoluteDistance <= lastKnownUserAbsoluteDistance! {
-                routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation = userAbsoluteDistance
-            }
-            
             if routeProgress.currentLegProgress.upComingStep?.maneuverType == ManeuverType.arrive {
                 alertLevel = .arrive
-            } else if courseMatchesManeuverFinalHeading {
+            } else if courseMatchesManeuverFinalHeading || (userAbsoluteDistance > lastKnownUserAbsoluteDistance! && lastKnownUserAbsoluteDistance! > RouteControllerManeuverZoneRadius) {
                 updateStepIndex = true
                 
                 // Look at the following step to determine what the new alert level should be
@@ -823,6 +828,8 @@ extension RouteController: CLLocationManagerDelegate {
                     assert(false, "In this case, there should always be an upcoming step")
                 }
             }
+            
+            routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation = userAbsoluteDistance
         } else if secondsToEndOfStep <= RouteControllerHighAlertInterval {
             alertLevel = .high
         } else if secondsToEndOfStep <= RouteControllerMediumAlertInterval {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -806,19 +806,13 @@ extension RouteController: CLLocationManagerDelegate {
             // Use the currentStep if there is not a next step
             // This occurs when arriving
             let step = routeProgress.currentLegProgress.upComingStep?.maneuverLocation ?? routeProgress.currentLegProgress.currentStep.maneuverLocation
+            
             let userAbsoluteDistance = step - location.coordinate
-            
-            // userAbsoluteDistanceToManeuverLocation is set to nil by default
-            // If it's set to nil, we know the user has never entered the maneuver radius
-            if routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation == nil {
-                routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation = RouteControllerManeuverZoneRadius
-            }
-            
             let lastKnownUserAbsoluteDistance = routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation
             
             if routeProgress.currentLegProgress.upComingStep?.maneuverType == ManeuverType.arrive {
                 alertLevel = .arrive
-            } else if courseMatchesManeuverFinalHeading || (userAbsoluteDistance > lastKnownUserAbsoluteDistance! && lastKnownUserAbsoluteDistance! > RouteControllerManeuverZoneRadius) {
+            } else if courseMatchesManeuverFinalHeading || (userAbsoluteDistance > lastKnownUserAbsoluteDistance && lastKnownUserAbsoluteDistance > RouteControllerManeuverZoneRadius) {
                 updateStepIndex = true
                 
                 // Look at the following step to determine what the new alert level should be

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -370,7 +370,7 @@ open class RouteStepProgress: NSObject {
     /**
      Returns distance from user to end of step.
      */
-    public var userDistanceToManeuverLocation: CLLocationDistance? = nil
+    public var userDistanceToManeuverLocation: CLLocationDistance = Double.infinity
     
     /**
      Total distance in meters remaining on current step.

--- a/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -39,7 +39,7 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.distanceTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.durationRemaining, 101.7)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.fractionTraveled, 0)
-        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, nil)
+        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, Double.infinity)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.step.description, "Head south on Taylor Street")
     }
     
@@ -50,7 +50,7 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.distanceTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.durationRemaining, 288.9)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.fractionTraveled, 0)
-        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, nil)
+        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, Double.infinity)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.step.description, "Turn right onto California Street")
     }
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/659

I ran into a rough intersection (https://github.com/mapbox/mapbox-navigation-ios/issues/659) this weekend that surfaced a few issues. Noting, whether this intersection should only be one maneuver (it should) is outside of the scope of this PR.

1. Our final check before rerouting to see if the user is on the next step should also check on the followOnStep
1. Using `.uTurn` as the red flag to only snap to the current step, is false. it should be the angle of the maneuver. When sharp, look 
1. In some cases on shorter steps, location updates might be very scarce. Because of this, we don't have a user course to compare to see if they user has completed a maneuver. In this case, we can check if the user has first entered the maneuver zone and is moving away from the maneuver and has exited the maneuver zone. In this case, increment the step.

There is a lot to unpack here, but I like these changes. Going to test this a lot before merging.

/cc @1ec5 @ericrwolfe @frederoni 