### PR TITLE
If audioPlayer is playing, don't also play fallback voice

### DIFF
--- a/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -39,7 +39,7 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.distanceTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.durationRemaining, 101.7)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.fractionTraveled, 0)
-        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, nil)
+        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, Double.infinity)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.step.description, "Head south on Taylor Street")
     }
     
@@ -50,7 +50,7 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.distanceTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.durationRemaining, 288.9)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.fractionTraveled, 0)
-        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, nil)
+        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, Double.infinity)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.step.description, "Turn right onto California Street")
     }
 }

--- a/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -39,7 +39,7 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.distanceTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.durationRemaining, 101.7)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.fractionTraveled, 0)
-        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, Double.infinity)
+        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, nil)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.step.description, "Head south on Taylor Street")
     }
     
@@ -50,7 +50,7 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.distanceTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.durationRemaining, 288.9)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.fractionTraveled, 0)
-        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, Double.infinity)
+        XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, nil)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.step.description, "Turn right onto California Street")
     }
 }

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -165,9 +165,9 @@ public class PollyVoiceController: RouteVoiceController {
             
             do {
                 strongSelf.audioPlayer = try AVAudioPlayer(data: data)
-                let prepared = strongSelf.audioPlayer?.prepareToPlay()
+                let prepared = strongSelf.audioPlayer?.prepareToPlay() ?? false
                 
-                guard let _ = prepared else {
+                guard prepared else {
                     strongSelf.callSuperSpeak(strongSelf.fallbackText, error: "Audio player failed to prepare")
                     return
                 }

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -122,6 +122,13 @@ public class PollyVoiceController: RouteVoiceController {
     }
     
     func callSuperSpeak(_ text: String, error: String) {
+        guard let audioPlayer = audioPlayer else {
+            super.speak(fallbackText, error: error)
+            return
+        }
+        
+        guard !audioPlayer.isPlaying else { return }
+        
         super.speak(fallbackText, error: error)
     }
     

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -99,7 +99,7 @@ public class PollyVoiceController: RouteVoiceController {
         case ("sv", _):
             input.voiceId = .astrid
         default:
-            super.speak(fallbackText, error: "Voice \(langCode)-\(countryCode) not found")
+            callSuperSpeak(fallbackText, error: "Voice \(langCode)-\(countryCode) not found")
             return
         }
         
@@ -122,6 +122,8 @@ public class PollyVoiceController: RouteVoiceController {
     }
     
     func callSuperSpeak(_ text: String, error: String) {
+        pollyTask?.cancel()
+        
         guard let audioPlayer = audioPlayer else {
             super.speak(fallbackText, error: error)
             return
@@ -134,12 +136,12 @@ public class PollyVoiceController: RouteVoiceController {
     
     func handle(_ awsTask: AWSTask<NSURL>) {
         guard awsTask.error == nil else {
-            super.speak(fallbackText, error: awsTask.error!.localizedDescription)
+            callSuperSpeak(fallbackText, error: awsTask.error!.localizedDescription)
             return
         }
         
         guard let url = awsTask.result else {
-            super.speak(fallbackText, error: "No polly response")
+            callSuperSpeak(fallbackText, error: "No polly response")
             return
         }
         

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -173,7 +173,7 @@ public class PollyVoiceController: RouteVoiceController {
                 }
                 
                 DispatchQueue.main.async {
-                    let played = strongSelf.audioPlayer?.play() ?? false // Play must be called on UI thread?
+                    let played = strongSelf.audioPlayer?.play() ?? false
                     
                     guard played else {
                         strongSelf.callSuperSpeak(strongSelf.fallbackText, error: "Audio player failed to play")

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -165,8 +165,15 @@ public class PollyVoiceController: RouteVoiceController {
                     
                     if let audioPlayer = strongSelf.audioPlayer {
                         try strongSelf.duckAudio()
-                        audioPlayer.volume = strongSelf.volume
-                        audioPlayer.play()
+                        
+                        let readyToyPlay = audioPlayer.prepareToPlay()
+                        
+                        if readyToyPlay {
+                            audioPlayer.volume = strongSelf.volume
+                            audioPlayer.play()
+                        } else {
+                            strongSelf.callSuperSpeak(strongSelf.fallbackText, error: "Could not play audio")
+                        }
                     }
                 } catch  let error as NSError {
                     strongSelf.callSuperSpeak(strongSelf.fallbackText, error: error.localizedDescription)


### PR DESCRIPTION
We're getting reports of overlapping polly and speech synth instructions. This perhaps is a sledgehammer approach to fixing the bug, however at some point this addition makes sense.

This also makes sure the audio player is ready to play before playing the audio.

/cc @1ec5 @frederoni 