### PR TITLE
Reduce default volume

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -39,7 +39,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     /**
      SSML option that specifies the voice loudness.
      */
-    public var instructionVoiceVolume = "x-loud"
+    public var instructionVoiceVolume = "default"
     
     
     /**


### PR DESCRIPTION
Now that https://github.com/mapbox/mapbox-navigation-ios/pull/635 is in, we do not need to overcompensate by increasing the voice volume. https://github.com/mapbox/mapbox-navigation-ios/pull/635 itself does increase the volume slightly.

/cc @1ec5 @frederoni 