### PR TITLE
Cancel outstanding polly requests and stop player

### DIFF
--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -55,6 +55,9 @@ public class PollyVoiceController: RouteVoiceController {
         let userDistances = notification.userInfo![RouteControllerAlertLevelDidChangeNotificationDistanceToEndOfManeuverKey] as! CLLocationDistance
         let instruction = spokenInstructionFormatter.string(routeProgress: routeProgresss, userDistance: userDistances, markUpWithSSML: true)
         
+        pollyTask?.cancel()
+        audioPlayer?.stop()
+        
         speak(instruction, error: nil)
         startAnnouncementTimer()
     }


### PR DESCRIPTION
We need to make sure we stop the audio player and also cancel any outstanding polly requests before playing another instruction. 

I sincerely hope this is the last of the overlapping-voice-bug-reports.

/cc @1ec5 @frederoni 