### PR TITLE
Force kCLLocationAccuracyBestForNavigation

### DIFF
--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -19,12 +19,6 @@ open class NavigationLocationManager: CLLocationManager {
      */
     public private(set) var isPluggedIn: Bool = false
     
-    /**
-     Indicates whether the location manager’s desired accuracy should update
-     when the battery state changes.
-     */
-    public var automaticallyUpdatesDesiredAccuracy = true
-    
     override public init() {
         super.init()
         
@@ -43,26 +37,6 @@ open class NavigationLocationManager: CLLocationManager {
             }
         }
         
-        desiredAccuracy = kCLLocationAccuracyBest
-        
-        #if os(iOS)
-            UIDevice.current.addObserver(self, forKeyPath: "batteryState", options: [.initial, .new], context: nil)
-        #endif
-    }
-    
-    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        if keyPath == "batteryState" {
-            let batteryState = UIDevice.current.batteryState
-            isPluggedIn = batteryState == .charging || batteryState == .full
-            
-            guard automaticallyUpdatesDesiredAccuracy else { return }
-            desiredAccuracy = isPluggedIn ? kCLLocationAccuracyBestForNavigation : kCLLocationAccuracyBest
-        }
-    }
-    
-    deinit {
-        #if os(iOS)
-            UIDevice.current.removeObserver(self, forKeyPath: "batteryState")
-        #endif
+        desiredAccuracy = kCLLocationAccuracyBestForNavigation
     }
 }

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -14,11 +14,6 @@ open class NavigationLocationManager: CLLocationManager {
     
     var lastKnownLocation: CLLocation?
     
-    /**
-     Indicates whether the device is plugged in or not.
-     */
-    public private(set) var isPluggedIn: Bool = false
-    
     override public init() {
         super.init()
         


### PR DESCRIPTION
We're getting reports that the user puck is drifting a lot when the device is unplugged. In this case, we `kCLLocationAccuracyBest`. Let's test using `kCLLocationAccuracyBestForNavigation` in all situations.

/cc @1ec5 @pveugen @frederoni @ericrwolfe 