### PR TITLE
Make sure to set audio player delegate

### DIFF
--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -182,6 +182,7 @@ public class PollyVoiceController: RouteVoiceController {
                 }
                 
                 DispatchQueue.main.async {
+                    strongSelf.audioPlayer?.delegate = self
                     let played = strongSelf.audioPlayer?.play() ?? false
                     
                     guard played else {


### PR DESCRIPTION
We removed setting the delegate when playing Polly instructions. This prevents the audio from ducking and unducking.

ref https://github.com/mapbox/mapbox-navigation-ios/pull/661/files#diff-28c26f31f650815a074b41e628688918L157

/cc @1ec5 @frederoni 