### PR TITLE
Reload table view data after updating route manually

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -176,6 +176,7 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
                 routeController.routeProgress = RouteProgress(route: route)
             }
             mapViewController?.notifyDidReroute(route: route)
+            tableViewController?.tableView.reloadData()
             tableViewController?.updateETA(routeProgress: routeController.routeProgress)
         }
     }


### PR DESCRIPTION
Fixes #676 

We reload the table view’s data when the `RouteController` triggers a reroute but it was left out for manually setting a new route.

@bsudekum 👀 

/cc @AFcgi