### PR TITLE
Set distanceFilter to kCLDistanceFilterNone

### DIFF
--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -33,5 +33,6 @@ open class NavigationLocationManager: CLLocationManager {
         }
         
         desiredAccuracy = kCLLocationAccuracyBestForNavigation
+        distanceFilter = kCLDistanceFilterNone
     }
 }


### PR DESCRIPTION
_Put on your tinfoil hats._

I'm unsure if this will have an impact, but [many](https://github.com/mapbox/mapbox-gl-native/blob/d4c569a0187d98bca6b71671fa5daf6ee09747da/platform/ios/src/MGLLocationManager.m#L65) different dependencies in the library set a value on `distanceFilter ` that is not  `kCLDistanceFilterNone`. The thinking here is that we inherit this distance.

This PR ensures it is always `kCLDistanceFilterNone.`

/cc @1ec5 @frederoni @ericrwolfe 