### PR TITLE
Improve location snapping and filtering

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -80,7 +80,7 @@ public var RouteControllerMaximumDistanceBeforeRecalculating: CLLocationDistance
 /**
  Accepted deviation excluding horizontal accuracy before the user is considered to be off route.
  */
-public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 20
+public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 15
 
 /**
  Threshold user must be in within to count as completing a step. One of two heuristics used to know when a user completes a step, see `RouteControllerManeuverZoneRadius`.
@@ -127,7 +127,7 @@ public var RouteControllerDeadReckoningTimeInterval:TimeInterval = 1.0
 /**
  Maximum angle the user puck will be rotated when snapping the user's course to the route line.
  */
-public var RouteControllerMaxManipulatedCourseAngle:CLLocationDirection = 25
+public var RouteControllerMaxManipulatedCourseAngle:CLLocationDirection = 30
 
 /**
  :nodoc This is used internally for debugging metrics
@@ -147,11 +147,16 @@ let RouteControllerLinkedInstructionBufferMultiplier: Double = 1.2
 let milesToMeters = 1609.34
 
 /**
- The mimimum speed value before the user is snapped to the route. This is used to overcome inaccurate course values when a user's speed is low.
+ The minimum speed value before the user's actual location can be considered over the snapped location.
  */
-public var RouteControllerMinimumSpeedThresholdForSnappingUserToRoute: CLLocationSpeed = 2
+public var RouteControllerMinSpeedForLocationSnapping: CLLocationSpeed = 3
 
 /**
  The minimum distance threshold used for giving a "Continue" type instructions.
  */
 public var RouteControllerMinDistanceForContinueInstruction: CLLocationDistance = 2_000
+
+/**
+ Distance in the opposite direction of travel before a reroute occurs.
+ */
+public var RouteControllerMinDistanceForBackwardsProgressReroute: CLLocationDistance = 50

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -149,7 +149,7 @@ let milesToMeters = 1609.34
 /**
  The minimum speed value before the user's actual location can be considered over the snapped location.
  */
-public var RouteControllerMinSpeedForLocationSnapping: CLLocationSpeed = 3
+public var RouteControllerMinimumSpeedForLocationSnapping: CLLocationSpeed = 3
 
 /**
  The minimum distance threshold used for giving a "Continue" type instructions.
@@ -159,4 +159,9 @@ public var RouteControllerMinDistanceForContinueInstruction: CLLocationDistance 
 /**
  Distance in the opposite direction of travel before a reroute occurs.
  */
-public var RouteControllerMinDistanceForBackwardsProgressReroute: CLLocationDistance = 50
+public var RouteControllerMinimumBackupDistanceForRerouting: CLLocationDistance = 50
+
+/**
+ Minimum number of consecutive location updates moving backwards before the user is rerouted.
+ */
+public var RouteControllerMinimumNumberLocationUpdatesBackwards = 3

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -127,7 +127,7 @@ public var RouteControllerDeadReckoningTimeInterval:TimeInterval = 1.0
 /**
  Maximum angle the user puck will be rotated when snapping the user's course to the route line.
  */
-public var RouteControllerMaxManipulatedCourseAngle:CLLocationDirection = 30
+public var RouteControllerMaxManipulatedCourseAngle:CLLocationDirection = 25
 
 /**
  :nodoc This is used internally for debugging metrics

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -287,7 +287,7 @@ open class RouteController: NSObject {
      This property contains a `CLLocation` object located along the route line near the most recently received user location. This property is set to `nil` if the route controller is unable to snap the user’s location to the route line for some reason.
      */
     public var location: CLLocation? {
-        guard let location = rawLocation, userIsOnRoute(location) else { return nil }
+        guard let location = rawLocation else { return nil }
         guard let stepCoordinates = routeProgress.currentLegProgress.currentStep.coordinates else { return nil }
         guard let snappedCoordinate = Polyline(stepCoordinates).closestCoordinate(to: location.coordinate) else { return location }
         
@@ -324,26 +324,22 @@ open class RouteController: NSObject {
         let relativeAnglepointBehind = (wrappedPointBehind - wrappedCourse).wrap(min: -180, max: 180)
         let relativeAnglepointAhead = (wrappedPointAhead - wrappedCourse).wrap(min: -180, max: 180)
         let averageRelativeAngle = (relativeAnglepointBehind + relativeAnglepointAhead) / 2
-        let absoluteDirection = (wrappedCourse + averageRelativeAngle).wrap(min: 0, max: 360)
+        let calculatedCourseForLocationOnStep = (wrappedCourse + averageRelativeAngle).wrap(min: 0, max: 360)
         
-        // If the course is inaccurate or the speed is low and the user is on the route,
-        // snap the users location and course since we know the snapped location and course is more accurate.
-        if location.course <= 0 || location.speed <= RouteControllerMinimumSpeedThresholdForSnappingUserToRoute, snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance {
-            let calculatedWrappedCourse = ((wrappedPointBehind + wrappedPointAhead) / 2).wrap(min: 0, max: 360)
-            return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: calculatedWrappedCourse, speed: location.speed, timestamp: location.timestamp)
-        }
-
-        guard absoluteDirection.differenceBetween(location.course) < RouteControllerMaxManipulatedCourseAngle else {
-            return location
-        }
-
-        let course = averageRelativeAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion ? absoluteDirection : location.course
+        var userCourse = calculatedCourseForLocationOnStep
+        var userCoordinate = snappedCoordinate.coordinate
         
-        guard snappedCoordinate.distance < RouteControllerUserLocationSnappingDistance else {
-            return location
+        if location.course >= 0 || location.speed >= RouteControllerMinSpeedForLocationSnapping {
+            if calculatedCourseForLocationOnStep.differenceBetween(location.course) > RouteControllerMaxManipulatedCourseAngle && location.horizontalAccuracy < 20 {
+                userCourse = location.course
+                
+                if snappedCoordinate.distance > RouteControllerUserLocationSnappingDistance && location.horizontalAccuracy < 20 {
+                    userCoordinate =  location.coordinate
+                }
+            }
         }
 
-        return CLLocation(coordinate: snappedCoordinate.coordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: course, speed: location.speed, timestamp: location.timestamp)
+        return CLLocation(coordinate: userCoordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: userCourse, speed: location.speed, timestamp: location.timestamp)
     }
     
     /**
@@ -552,7 +548,7 @@ extension RouteController: CLLocationManagerDelegate {
      If the user is not on the route, they should be rerouted.
      */
     public func userIsOnRoute(_ location: CLLocation) -> Bool {
-        
+
         // Find future location of user
         let metersInFrontOfUser = location.speed * RouteControllerDeadReckoningTimeInterval
         let locationInfrontOfUser = location.coordinate.coordinate(at: metersInFrontOfUser, facing: location.course)
@@ -567,8 +563,12 @@ extension RouteController: CLLocationManagerDelegate {
         if let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
             let userDistanceToManeuver = Polyline(coordinates).distance(from: location.coordinate)
             
-            guard recentDistancesFromManeuver.count <= 3 else {
-                return false
+            let totalDistances = recentDistancesFromManeuver.reduce(0) { $0 + $1 }
+            
+            if totalDistances < RouteControllerMinDistanceForBackwardsProgressReroute {
+                guard recentDistancesFromManeuver.count <= 3 else {
+                    return false
+                }
             }
             
             if recentDistancesFromManeuver.isEmpty {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -329,7 +329,7 @@ open class RouteController: NSObject {
         var userCourse = calculatedCourseForLocationOnStep
         var userCoordinate = snappedCoordinate.coordinate
         
-        if location.course >= 0 || location.speed >= RouteControllerMinSpeedForLocationSnapping {
+        if location.course >= 0 || location.speed >= RouteControllerMinimumSpeedForLocationSnapping {
             if calculatedCourseForLocationOnStep.differenceBetween(location.course) > RouteControllerMaxManipulatedCourseAngle && location.horizontalAccuracy < 20 {
                 userCourse = location.course
                 
@@ -563,10 +563,8 @@ extension RouteController: CLLocationManagerDelegate {
         if let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
             let userDistanceToManeuver = Polyline(coordinates).distance(from: location.coordinate)
             
-            let totalDistances = recentDistancesFromManeuver.reduce(0) { $0 + $1 }
-            
-            if totalDistances < RouteControllerMinDistanceForBackwardsProgressReroute {
-                guard recentDistancesFromManeuver.count <= 3 else {
+            if recentDistancesFromManeuver.reduce(0, +) < RouteControllerMinimumBackupDistanceForRerouting {
+                guard recentDistancesFromManeuver.count <= RouteControllerMinimumNumberLocationUpdatesBackwards else {
                     return false
                 }
             }


### PR DESCRIPTION
This seeks to improve the user puck snapping feature. The goal here is to not allow bad location updates from moving the user puck off the route when the user is clearly on the route. There are two ideas here I'm moving towards:

1. Snapping should always snap. It should have to worry about filtering bad locations. We should just always snap.
1. Rerouting can occur while snapped. 

It's important though to allow movement when the user is actually moving off the route- taking a left instead of a right for example. I did add a bit of code to allow actual locations and course to be used. If the user's course/location is not what we expect it to be and their location accuracy is high, use the raw location/coordinate. 

Tested this today, it performed well.

/cc @1ec5 @frederoni @ericrwolfe 