### PR TITLE
Simulate expected speed

### DIFF
--- a/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -22,7 +22,7 @@ open class NavigationRouteOptions: RouteOptions {
         }, profileIdentifier: profileIdentifier)
         includesSteps = true
         routeShapeResolution = .full
-        attributeOptions = [.congestionLevel, .expectedTravelTime]
+        attributeOptions = [.congestionLevel, .expectedTravelTime, .speed]
         includesExitRoundaboutManeuver = true
     }
     


### PR DESCRIPTION
Fixes #440 - Simulate expected speed

Falls back to turn penalty based speed if `RouteLeg.segmentSpeeds` is missing.

@bsudekum @1ec5 👀 