### PR TITLE
Fix U-turn detection

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -154,12 +154,12 @@ public var RouteControllerMinimumSpeedForLocationSnapping: CLLocationSpeed = 3
 /**
  The minimum distance threshold used for giving a "Continue" type instructions.
  */
-public var RouteControllerMinDistanceForContinueInstruction: CLLocationDistance = 2_000
+public var RouteControllerMinimumDistanceForContinueInstruction: CLLocationDistance = 2_000
 
 /**
- Distance in the opposite direction of travel before a reroute occurs.
+ The minimum distance in the opposite direction of travel that triggers rerouting.
  */
-public var RouteControllerMinimumBackupDistanceForRerouting: CLLocationDistance = 50
+public var RouteControllerMinimumBacktrackingDistanceForRerouting: CLLocationDistance = 50
 
 /**
  Minimum number of consecutive location updates moving backwards before the user is rerouted.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -563,10 +563,9 @@ extension RouteController: CLLocationManagerDelegate {
         if let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
             let userDistanceToManeuver = Polyline(coordinates).distance(from: location.coordinate)
             
-            if recentDistancesFromManeuver.reduce(0, +) < RouteControllerMinimumBackupDistanceForRerouting {
-                guard recentDistancesFromManeuver.count <= RouteControllerMinimumNumberLocationUpdatesBackwards else {
-                    return false
-                }
+            // If the location updates have been backtracking for a certain amount of time and over a certain distance, the user most likely turned around or made a wrong turn and need a new route.
+            if recentDistancesFromManeuver.count > RouteControllerMinimumNumberLocationUpdatesBackwards && recentDistancesFromManeuver.last! - recentDistancesFromManeuver.first! > RouteControllerMinimumBacktrackingDistanceForRerouting {
+                return false
             }
             
             if recentDistancesFromManeuver.isEmpty {

--- a/MapboxCoreNavigation/SpokenInstructionFormatter.swift
+++ b/MapboxCoreNavigation/SpokenInstructionFormatter.swift
@@ -74,7 +74,7 @@ public class SpokenInstructionFormatter: NSObject {
         // since the user will be approaching the maneuver location.
         let isStartingDeparture = routeProgress.currentLegProgress.currentStep.maneuverType == .depart && (alertLevel == .depart || alertLevel == .low)
         if let currentInstruction = currentInstruction, isStartingDeparture {
-            if routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinDistanceForContinueInstruction {
+            if routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinimumDistanceForContinueInstruction {
                 text = currentInstruction
             } else if upcomingStepDuration > linkedInstructionMultiplier {
                 // If the upcoming step is an .exitRoundabout or .exitRotary, don't link the instruction
@@ -98,7 +98,7 @@ public class SpokenInstructionFormatter: NSObject {
             } else {
                 text = upComingInstruction
             }
-        } else if routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinDistanceForContinueInstruction && routeProgress.currentLegProgress.alertUserLevel == .low {
+        } else if routeProgress.currentLegProgress.currentStep.distance > RouteControllerMinimumDistanceForContinueInstruction && routeProgress.currentLegProgress.alertUserLevel == .low {
             if isStartingDeparture && upcomingStepDuration < linkedInstructionMultiplier {
                 let phrase = escapeIfNecessary(routeStepFormatter.instructions.phrase(named: .twoInstructionsWithDistance))
                 text = phrase.replacingTokens { (tokenType) -> String in


### PR DESCRIPTION
Detect a U-turn or wrong turn based on the distance the user covered while backtracking; don’t compound the distance from the maneuver, which may be far away in the first place. For example, if the last three location updates are 51, 52, and 53 meters away from the maneuver, the user has backtracked by two or so meters, not 156 meters. Also renamed a couple constants.

This is a followup to #679 and #646.

/cc @cammace @bsudekum