### PR TITLE
Fix Solar dependency on minor version 2.0 to prevent from updating to 2.1

### DIFF
--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
   s.dependency "Pulley", "1.4"
   s.dependency "SDWebImage", "~> 4.1"
   s.dependency "AWSPolly", "~> 2.6"
-  s.dependency "Solar", "~> 2.0"
+  s.dependency "Solar", "2.0.0"
   s.dependency "Turf", "~> 0.0.3"
 
 end


### PR DESCRIPTION
Solar 2.1.0 breaks backwards compatibility, causes it to stop compiling:
```Incorrect argument labels in call (have 'latitude:longitude:', expected 'for:coordinate:'...```

So I fixed the dependency version on minor version 2.0.0