### PR TITLE
Guard out of bounds

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -240,6 +240,10 @@ open class NavigationMapView: MGLMapView {
                 return shape(describingCasing: route, legIndex: legIndex)
             }
             
+            guard legCongestion.count + 1 <= coordinates.count else {
+                return shape(describingCasing: route, legIndex: legIndex)
+            }
+            
             let coordsForLeg = coordinates[previousLegCongestionIndex..<previousLegCongestionIndex + legCongestion.count + 1]
             let destination = coordinates.suffix(from: previousLegCongestionIndex + 1)
             let segment = zip(coordsForLeg, destination).map { [$0.0, $0.1] }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/695 & https://github.com/mapbox/mapbox-navigation-ios/issues/691

I'm uncertain in which cases this can occur, but we should check and guard first before making this lookup.

/cc @1ec5 @frederoni 