### PR TITLE
Always hide reroute UI

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -236,6 +236,7 @@ class RouteMapViewController: UIViewController {
     func willReroute(notification: NSNotification) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         statusView.show(title, showSpinner: true)
+        statusView.hide(delay: 3, animated: true)
     }
     
     func didReroute(notification: NSNotification) {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/702

It seems in some cases, `didReroute`  is not called after `willReroute`. To prevent the statusView from sticking around, we should hide it after a few seconds.

/cc @frederoni 