### PR TITLE
Remove local notification after rerouting

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -599,9 +599,6 @@ extension NavigationViewController: RouteControllerDelegate {
     }
     
     public func routeController(_ routeController: RouteController, didRerouteAlong route: Route) {
-        let routeProgress = routeController.routeProgress
-        scheduleLocalNotification(about: routeProgress.currentLegProgress.currentStep, legIndex: routeProgress.legIndex, numberOfLegs: route.legs.count)
-        
         mapViewController?.notifyDidReroute(route: route)
         tableViewController?.tableView.reloadData()
         tableViewController?.updateETA(routeProgress: routeController.routeProgress)


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/651

It's just not necessary to give this notification. They should only be given when the user is approaching a maneuver.

/cc @1ec5 @frederoni 