### PR TITLE
Prevent spinning when user is not moving

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -325,7 +325,7 @@ open class RouteController: NSObject {
         var userCourse = calculatedCourseForLocationOnStep
         var userCoordinate = snappedCoordinate.coordinate
         
-        if location.course >= 0 || location.speed >= RouteControllerMinimumSpeedForLocationSnapping {
+        if location.course >= 0 && location.speed >= RouteControllerMinimumSpeedForLocationSnapping {
             if calculatedCourseForLocationOnStep.differenceBetween(location.course) > RouteControllerMaxManipulatedCourseAngle && location.horizontalAccuracy < 20 {
                 userCourse = location.course
                 


### PR DESCRIPTION
I noticed quite a few times this weekend the user puck would spin when I was not moving at stop lights. This should prevent this while still allowing the actual course while rerouting.

/cc @1ec5 @frederoni @ericrwolfe 