### PR TITLE
Prefetch audio instructions

### DIFF
--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -85,7 +85,7 @@ public class PollyVoiceController: RouteVoiceController {
         
         
         guard spokenInstructionsForRoute[instruction] == nil else {
-            sayInstruction(for: spokenInstructionsForRoute[instruction]!)
+            play(spokenInstructionsForRoute[instruction]!)
             return
         }
         
@@ -207,7 +207,7 @@ public class PollyVoiceController: RouteVoiceController {
                 return
             }
             
-            strongSelf.sayInstruction(for: data)
+            strongSelf.play(data)
         }
         
         pollyTask?.resume()
@@ -242,7 +242,7 @@ public class PollyVoiceController: RouteVoiceController {
         }
     }
     
-    func sayInstruction(for data: Data) {
+    func play(_ data: Data) {
         do {
             audioPlayer = try AVAudioPlayer(data: data)
             let prepared = audioPlayer?.prepareToPlay() ?? false

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -36,6 +36,11 @@ public class PollyVoiceController: RouteVoiceController {
     let sessionConfiguration = URLSessionConfiguration.default
     var urlSession: URLSession
     
+    var cacheURLSession: URLSession
+    var cachePollyTask: URLSessionDataTask?
+    
+    var spokenInstructionsForRoute: [String: Data] = [:]
+    
     public init(identityPoolId: String) {
         self.identityPoolId = identityPoolId
         
@@ -45,6 +50,7 @@ public class PollyVoiceController: RouteVoiceController {
         
         sessionConfiguration.timeoutIntervalForRequest = timeoutIntervalForRequest;
         urlSession = URLSession(configuration: sessionConfiguration)
+        cacheURLSession = URLSession(configuration: URLSessionConfiguration.default)
         
         super.init()
     }
@@ -57,14 +63,25 @@ public class PollyVoiceController: RouteVoiceController {
         
         pollyTask?.cancel()
         audioPlayer?.stop()
+        startAnnouncementTimer()
+        
+        guard spokenInstructionsForRoute[instruction] == nil else {
+            sayInStruction(for: spokenInstructionsForRoute[instruction]!)
+            return
+        }
         
         speak(instruction, error: nil)
-        startAnnouncementTimer()
+        
+        if let upcomingStep = routeProgresss.currentLegProgress.upComingStep, let instructions = upcomingStep.instructionsSpokenAlongStep {
+            for instruction in instructions {
+                guard spokenInstructionsForRoute[instruction.ssmlText] == nil else { continue }
+                
+                cacheSpokenInstruction(instruction: instruction.ssmlText)
+            }
+        }
     }
     
-    override func speak(_ text: String, error: String?) {
-        assert(!text.isEmpty)
-        
+    func pollyURL(for instruction: String) ->  AWSPollySynthesizeSpeechURLBuilderRequest {
         let input = AWSPollySynthesizeSpeechURLBuilderRequest()
         input.textType = .ssml
         input.outputFormat = .mp3
@@ -108,15 +125,22 @@ public class PollyVoiceController: RouteVoiceController {
         case ("tr", _):
             input.voiceId = .filiz
         default:
-            callSuperSpeak(fallbackText, error: "Voice \(langCode)-\(countryCode) not found")
-            return
+            input.voiceId = .joanna
         }
         
         if let voiceId = globalVoiceId {
             input.voiceId = voiceId
         }
         
-        input.text = text
+        input.text = instruction
+        
+        return input
+    }
+    
+    override func speak(_ text: String, error: String?) {
+        assert(!text.isEmpty)
+        
+        let input = pollyURL(for: text)
         
         let builder = AWSPollySynthesizeSpeechURLBuilder.default().getPreSignedURL(input)
         builder.continueWith { [weak self] (awsTask: AWSTask<NSURL>) -> Any? in
@@ -172,29 +196,62 @@ public class PollyVoiceController: RouteVoiceController {
                 return
             }
             
-            do {
-                strongSelf.audioPlayer = try AVAudioPlayer(data: data)
-                let prepared = strongSelf.audioPlayer?.prepareToPlay() ?? false
-                
-                guard prepared else {
-                    strongSelf.callSuperSpeak(strongSelf.fallbackText, error: "Audio player failed to prepare")
-                    return
-                }
-                
-                DispatchQueue.main.async {
-                    strongSelf.audioPlayer?.delegate = self
-                    let played = strongSelf.audioPlayer?.play() ?? false
-                    
-                    guard played else {
-                        strongSelf.callSuperSpeak(strongSelf.fallbackText, error: "Audio player failed to play")
-                        return
-                    }
-                }
-            } catch  let error as NSError {
-                strongSelf.callSuperSpeak(strongSelf.fallbackText, error: error.localizedDescription)
-            }
+            strongSelf.sayInStruction(for: data)
         }
         
         pollyTask?.resume()
+    }
+    
+    func cacheSpokenInstruction(instruction: String) {
+        
+        let pollyRequestURL = pollyURL(for: instruction)
+        
+        let builder = AWSPollySynthesizeSpeechURLBuilder.default().getPreSignedURL(pollyRequestURL)
+        builder.continueWith { [weak self] (awsTask: AWSTask<NSURL>) -> Any? in
+            guard let strongSelf = self else {
+                return nil
+            }
+            
+            guard let url = awsTask.result else { return nil }
+            
+            strongSelf.cachePollyTask = strongSelf.cacheURLSession.dataTask(with: url as URL) { (data, response, error) in
+                
+                if let error = error {
+                    print(error.localizedDescription)
+                }
+                
+                if let data = data {
+                    strongSelf.spokenInstructionsForRoute[instruction] = data
+                }
+            }
+            
+            strongSelf.cachePollyTask?.resume()
+            
+            return nil
+        }
+    }
+    
+    func sayInStruction(for data: Data) {
+        do {
+            audioPlayer = try AVAudioPlayer(data: data)
+            let prepared = audioPlayer?.prepareToPlay() ?? false
+            
+            guard prepared else {
+                callSuperSpeak(fallbackText, error: "Audio player failed to prepare")
+                return
+            }
+            
+            DispatchQueue.main.async {
+                self.audioPlayer?.delegate = self
+                let played = self.audioPlayer?.play() ?? false
+                
+                guard played else {
+                    self.callSuperSpeak(self.fallbackText, error: "Audio player failed to play")
+                    return
+                }
+            }
+        } catch  let error as NSError {
+            callSuperSpeak(fallbackText, error: error.localizedDescription)
+        }
     }
 }

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -73,7 +73,7 @@ public class PollyVoiceController: RouteVoiceController {
         for (stepIndex, step) in routeProgresss.currentLegProgress.leg.steps.suffix(from: routeProgresss.currentLegProgress.stepIndex).enumerated() {
             let adjustedStepIndex = stepIndex + routeProgresss.currentLegProgress.stepIndex
             
-            guard adjustedStepIndex < routeProgresss.currentLegProgress.stepIndex + 3 else { continue }
+            guard adjustedStepIndex < routeProgresss.currentLegProgress.stepIndex + stepsAheadToCache else { continue }
             guard let instructions = step.instructionsSpokenAlongStep else { continue }
             
             for instruction in instructions {
@@ -85,7 +85,7 @@ public class PollyVoiceController: RouteVoiceController {
         
         
         guard spokenInstructionsForRoute[instruction] == nil else {
-            sayInStruction(for: spokenInstructionsForRoute[instruction]!)
+            sayInstruction(for: spokenInstructionsForRoute[instruction]!)
             return
         }
         
@@ -207,7 +207,7 @@ public class PollyVoiceController: RouteVoiceController {
                 return
             }
             
-            strongSelf.sayInStruction(for: data)
+            strongSelf.sayInstruction(for: data)
         }
         
         pollyTask?.resume()
@@ -242,7 +242,7 @@ public class PollyVoiceController: RouteVoiceController {
         }
     }
     
-    func sayInStruction(for data: Data) {
+    func sayInstruction(for data: Data) {
         do {
             audioPlayer = try AVAudioPlayer(data: data)
             let prepared = audioPlayer?.prepareToPlay() ?? false

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -243,16 +243,16 @@ public class PollyVoiceController: RouteVoiceController {
     }
     
     func play(_ data: Data) {
-        do {
-            audioPlayer = try AVAudioPlayer(data: data)
-            let prepared = audioPlayer?.prepareToPlay() ?? false
-            
-            guard prepared else {
-                callSuperSpeak(fallbackText, error: "Audio player failed to prepare")
-                return
-            }
-            
-            DispatchQueue.main.async {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                self.audioPlayer = try AVAudioPlayer(data: data)
+                let prepared = self.audioPlayer?.prepareToPlay() ?? false
+                
+                guard prepared else {
+                    self.callSuperSpeak(self.fallbackText, error: "Audio player failed to prepare")
+                    return
+                }
+                
                 self.audioPlayer?.delegate = self
                 let played = self.audioPlayer?.play() ?? false
                 
@@ -260,9 +260,10 @@ public class PollyVoiceController: RouteVoiceController {
                     self.callSuperSpeak(self.fallbackText, error: "Audio player failed to play")
                     return
                 }
+                
+            } catch  let error as NSError {
+                self.callSuperSpeak(self.fallbackText, error: error.localizedDescription)
             }
-        } catch  let error as NSError {
-            callSuperSpeak(fallbackText, error: error.localizedDescription)
         }
     }
 }

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -65,13 +65,6 @@ public class PollyVoiceController: RouteVoiceController {
         audioPlayer?.stop()
         startAnnouncementTimer()
         
-        guard spokenInstructionsForRoute[instruction] == nil else {
-            sayInStruction(for: spokenInstructionsForRoute[instruction]!)
-            return
-        }
-        
-        speak(instruction, error: nil)
-        
         if let upcomingStep = routeProgresss.currentLegProgress.upComingStep, let instructions = upcomingStep.instructionsSpokenAlongStep {
             for instruction in instructions {
                 guard spokenInstructionsForRoute[instruction.ssmlText] == nil else { continue }
@@ -79,6 +72,13 @@ public class PollyVoiceController: RouteVoiceController {
                 cacheSpokenInstruction(instruction: instruction.ssmlText)
             }
         }
+        
+        guard spokenInstructionsForRoute[instruction] == nil else {
+            sayInStruction(for: spokenInstructionsForRoute[instruction]!)
+            return
+        }
+        
+        speak(instruction, error: nil)
     }
     
     func pollyURL(for instruction: String) ->  AWSPollySynthesizeSpeechURLBuilderRequest {


### PR DESCRIPTION
_Prerequisite https://github.com/mapbox/mapbox-navigation-ios/pull/614_

It's relatively dumb right now, when we fire the notification to say something:

1. Check if the instruction is a key on `RouteProgress.spokenInstructionsForRoute` and has data.
1. If so, use this data to give the instruction
1. If not, first say the instruction using the normal methods
1. After we say it, we then look and see if the user has any upcoming steps
1. If so, get all instructions for step, download the data and add it to `RouteProgress.spokenInstructionsForRoute`
1. Repeat

/cc @1ec5 @frederoni @ericrwolfe @JThramer 