### PR TITLE
Swift Example App - "Multiple Stops" bug

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -37,6 +37,12 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
     
     var alertController: UIAlertController!
     
+    lazy var multipleStopsAction: UIAlertAction = {
+        return UIAlertAction(title: "Multiple Stops", style: .default, handler: { (action) in
+            self.startMultipleWaypoints()
+        })
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -91,6 +97,9 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
         
         if waypoints.count > 1 {
             waypoints = Array(waypoints.suffix(1))
+            multipleStopsAction.isEnabled = true
+        } else { //single waypoint
+            multipleStopsAction.isEnabled = false
         }
         
         let coordinates = mapView.convert(sender.location(in: mapView), toCoordinateFrom: mapView)
@@ -98,10 +107,8 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
         waypoint.coordinateAccuracy = -1
         waypoints.append(waypoint)
         
-        if waypoints.count >= 2 {
-            alertController.addAction(UIAlertAction(title: "Multiple Stops", style: .default, handler: { (action) in
-                self.startMultipleWaypoints()
-            }))
+        if waypoints.count >= 2, !alertController.actions.contains(multipleStopsAction) {
+            alertController.addAction(multipleStopsAction)
         }
         
         requestRoute()
@@ -129,6 +136,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
         mapView.removeRoute()
         mapView.removeWaypoints()
         waypoints.removeAll()
+        multipleStopsAction.isEnabled = false
     }
     
     @IBAction func startButtonPressed(_ sender: Any) {


### PR DESCRIPTION
Fixing issue in Example swift app where a "Multiple Stops" action gets added multiple times and is selectable at inappropriate times.

Fun screenie:
![img_0276](https://user-images.githubusercontent.com/887225/31695894-fec4e602-b361-11e7-9e90-bf5822d4ed0c.PNG)