### PR TITLE
Set AVAudioRecorderDelegate

### DIFF
--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -10,7 +10,7 @@ struct FeedbackItem {
     var audio: Data?
 }
 
-class FeedbackViewController: UIViewController, UIGestureRecognizerDelegate {
+class FeedbackViewController: UIViewController, UIGestureRecognizerDelegate, AVAudioRecorderDelegate {
     
     typealias FeedbackSection = [FeedbackItem]
     
@@ -160,6 +160,7 @@ class FeedbackViewController: UIViewController, UIGestureRecognizerDelegate {
         
         do {
             audioRecorder = try AVAudioRecorder(url: audioFile, settings: settings)
+            audioRecorder?.delegate = self
             audioRecorder?.record()
         } catch {
             print(error.localizedDescription)


### PR DESCRIPTION
We need to set the delegate here so we can listen on when the [audio recorder did finish](https://github.com/mapbox/mapbox-navigation-ios/blob/cbbf7f8696e9a445ded53269c2b6b18226255d34/MapboxNavigation/FeedbackViewController.swift#L143).

/cc @frederoni 