### PR TITLE
Use value set on showsReportFeedback

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -268,7 +268,12 @@ public class NavigationViewController: NavigationPulleyViewController, RouteMapV
     /**
      Shows a button that allows drivers to report feedback such as accidents, closed roads,  poor instructions, etc. Defaults to `false`.
      */
-    public var showsReportFeedback: Bool = true
+    public var showsReportFeedback: Bool = true {
+        didSet {
+            mapViewController?.reportButton.isHidden = !showsReportFeedback
+        }
+    }
+    
     
     /**
      If true, the map style and UI will automatically be updated given the time of day.


### PR DESCRIPTION
The value set on showsReportFeedback is ignored as it is used only on init.
This PR fixes that.