### PR TITLE
UITapGestureRecognizer / UICollectionViewDelegate issues

### DIFF
--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -20,7 +20,7 @@ extension FeedbackViewController: UIViewControllerTransitioningDelegate {
 
 typealias FeedbackSection = [FeedbackItem]
 
-class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollectionViewCellDelegate, AVAudioRecorderDelegate {
+class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollectionViewCellDelegate, AVAudioRecorderDelegate, UIGestureRecognizerDelegate {
     
     typealias SendFeedbackHandler = (FeedbackItem) -> ()
     


### PR DESCRIPTION
Fixing issue where the FeedbackViewController never advertised itself as a `UIGestureRecognizerDelegate`, so it was never asked if the gesture recognizer `shouldRecieveTouch`.

/cc @frederoni @bsudekum @ericrwolfe