### PR TITLE
Post-reroute feedback

### DIFF
--- a/MapboxCoreNavigation/Feedback.swift
+++ b/MapboxCoreNavigation/Feedback.swift
@@ -80,3 +80,21 @@ public enum FeedbackType: Int, CustomStringConvertible {
         }
     }
 }
+
+@objc(MBFeedbackSource)
+public enum FeedbackSource: Int, CustomStringConvertible {
+    case user
+    case reroute
+    case unknown
+    
+    public var description: String {
+        switch self {
+        case .user:
+            return "user"
+        case .reroute:
+            return "reroute"
+        case .unknown:
+            return "unknown"
+        }
+    }
+}

--- a/MapboxCoreNavigation/MMEEventsManager.swift
+++ b/MapboxCoreNavigation/MMEEventsManager.swift
@@ -381,9 +381,10 @@ class CoreFeedbackEvent: Hashable {
 }
 
 class FeedbackEvent: CoreFeedbackEvent {
-    func update(type: FeedbackType, description: String?, audio: Data?) {
+    func update(type: FeedbackType, source: FeedbackSource, description: String?, audio: Data?) {
         eventDictionary["feedbackType"] = type.description
-        eventDictionary["description"] = description        
+        eventDictionary["source"] = source.description
+        eventDictionary["description"] = description
         if let audio = audio {
             eventDictionary["audio"] = audio.base64EncodedString()
         }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -412,9 +412,9 @@ open class RouteController: NSObject {
 
      Note that feedback is sent 20 seconds after being recorded, so you should promptly update the feedback metadata after the user discards any feedback UI.
      */
-    public func updateFeedback(feedbackId: String, type: FeedbackType, description: String?, audio: Data?) {
+    public func updateFeedback(feedbackId: String, type: FeedbackType, source: FeedbackSource, description: String?, audio: Data?) {
         if let lastFeedback = outstandingFeedbackEvents.first(where: { $0.id.uuidString == feedbackId}) as? FeedbackEvent {
-            lastFeedback.update(type: type, description: description, audio: audio)
+            lastFeedback.update(type: type, source: source, description: description, audio: audio)
         }
     }
 

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -81,6 +81,8 @@ open class DayStyle: Style {
         FloatingButton.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         
         UserPuckCourseView.appearance().puckColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 1)
+        ReportButton.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        ReportButton.appearance().textColor = tintColor!
         
         // Maneuver view (Page view)
         ManeuverView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
@@ -162,6 +164,8 @@ open class NightStyle: DayStyle {
         Button.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         ManeuverView.appearance().backgroundColor = backgroundColor
         InstructionsBannerView.appearance().backgroundColor = backgroundColor
+        ReportButton.appearance().backgroundColor = backgroundColor
+        ReportButton.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         
         DistanceLabel.appearance().valueTextColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         DistanceLabel.appearance().unitTextColor = #colorLiteral(red: 0.7991961837, green: 0.8232284188, blue: 0.8481693864, alpha: 1)

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -82,7 +82,7 @@
                                 <color key="backgroundColor" red="0.14901960784313725" green="0.23921568627450979" blue="0.3411764705882353" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                 <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
-                                <state key="normal" title="Report a Problem">
+                                <state key="normal" title="Report Problem">
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -78,16 +78,15 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I8f-iR-MZm" customClass="MBReportButton">
-                                <rect key="frame" x="96" y="194.5" width="183" height="52"/>
+                                <rect key="frame" x="115" y="194.5" width="145" height="38"/>
                                 <color key="backgroundColor" red="0.14901960784313725" green="0.23921568627450979" blue="0.3411764705882353" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
-                                <inset key="contentEdgeInsets" minX="18" minY="15" maxX="18" maxY="15"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
                                 <state key="normal" title="Report a Problem">
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="rerouteFeedback:" destination="3z2-H5-unA" eventType="touchUpInside" id="yRc-0Z-7Pz"/>
-                                    <outlet property="topContraint" destination="7KD-9u-9mi" id="izz-a0-PlP"/>
                                 </connections>
                             </button>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="drb-do-FoT" userLabel="Way Name View" customClass="MBWayNameView">
@@ -253,7 +252,7 @@
                             <constraint firstItem="nNr-30-cGD" firstAttribute="top" secondItem="Gvo-VD-DXF" secondAttribute="top" id="0tN-KV-QpL"/>
                             <constraint firstItem="nNr-30-cGD" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="4Si-h7-lL5"/>
                             <constraint firstItem="drb-do-FoT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Gvo-VD-DXF" secondAttribute="leading" constant="20" id="4oP-yz-9W5"/>
-                            <constraint firstItem="I8f-iR-MZm" firstAttribute="top" secondItem="Eeb-3z-AWG" secondAttribute="bottom" constant="10" id="7KD-9u-9mi"/>
+                            <constraint firstItem="I8f-iR-MZm" firstAttribute="top" secondItem="Eeb-3z-AWG" secondAttribute="bottom" constant="10" id="7KD-9u-9mi" userLabel="Reroute Slide Constraint"/>
                             <constraint firstItem="Eeb-3z-AWG" firstAttribute="top" secondItem="p9E-v0-Rt6" secondAttribute="bottom" id="81D-S0-3wU"/>
                             <constraint firstItem="p9E-v0-Rt6" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="DvR-Su-3GN"/>
                             <constraint firstItem="I8f-iR-MZm" firstAttribute="centerX" secondItem="Gvo-VD-DXF" secondAttribute="centerX" id="Eov-eD-C9L"/>
@@ -287,6 +286,7 @@
                         <outlet property="overviewButton" destination="Dry-gO-T7u" id="8s7-hO-rHP"/>
                         <outlet property="recenterButton" destination="SKK-r5-nj0" id="HRr-Uz-7Hk"/>
                         <outlet property="reportButton" destination="EeE-dV-610" id="C8S-JP-WAr"/>
+                        <outlet property="rerouteFeedbackTopConstraint" destination="7KD-9u-9mi" id="RTw-6U-QuS"/>
                         <outlet property="rerouteReportButton" destination="I8f-iR-MZm" id="pZV-kq-FBI"/>
                         <outlet property="statusView" destination="Jym-DH-tdD" id="9Hw-jY-J4n"/>
                         <outlet property="wayNameLabel" destination="bcm-ca-nGv" id="8Sy-Pk-fQZ"/>

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -77,6 +77,19 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-guidance-day-v2"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
+                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I8f-iR-MZm" customClass="MBReportButton">
+                                <rect key="frame" x="96" y="194.5" width="183" height="52"/>
+                                <color key="backgroundColor" red="0.14901960784313725" green="0.23921568627450979" blue="0.3411764705882353" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <inset key="contentEdgeInsets" minX="18" minY="15" maxX="18" maxY="15"/>
+                                <state key="normal" title="Report a Problem">
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="rerouteFeedback:" destination="3z2-H5-unA" eventType="touchUpInside" id="yRc-0Z-7Pz"/>
+                                    <outlet property="topContraint" destination="7KD-9u-9mi" id="izz-a0-PlP"/>
+                                </connections>
+                            </button>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="drb-do-FoT" userLabel="Way Name View" customClass="MBWayNameView">
                                 <rect key="frame" x="134" y="204.5" width="106.5" height="29"/>
                                 <subviews>
@@ -184,8 +197,8 @@
                                     <action selector="recenter:" destination="3z2-H5-unA" eventType="touchUpInside" id="nKF-cz-PBl"/>
                                 </connections>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8P3-NB-IRq">
-                                <rect key="frame" x="10" y="195" width="50" height="108"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8P3-NB-IRq" userLabel="Floating Stack View">
+                                <rect key="frame" x="315" y="195" width="50" height="108"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dry-gO-T7u" customClass="MBFloatingButton">
                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -240,8 +253,10 @@
                             <constraint firstItem="nNr-30-cGD" firstAttribute="top" secondItem="Gvo-VD-DXF" secondAttribute="top" id="0tN-KV-QpL"/>
                             <constraint firstItem="nNr-30-cGD" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="4Si-h7-lL5"/>
                             <constraint firstItem="drb-do-FoT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Gvo-VD-DXF" secondAttribute="leading" constant="20" id="4oP-yz-9W5"/>
+                            <constraint firstItem="I8f-iR-MZm" firstAttribute="top" secondItem="Eeb-3z-AWG" secondAttribute="bottom" constant="10" id="7KD-9u-9mi"/>
                             <constraint firstItem="Eeb-3z-AWG" firstAttribute="top" secondItem="p9E-v0-Rt6" secondAttribute="bottom" id="81D-S0-3wU"/>
                             <constraint firstItem="p9E-v0-Rt6" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="DvR-Su-3GN"/>
+                            <constraint firstItem="I8f-iR-MZm" firstAttribute="centerX" secondItem="Gvo-VD-DXF" secondAttribute="centerX" id="Eov-eD-C9L"/>
                             <constraint firstItem="C23-DT-v2t" firstAttribute="trailing" secondItem="p9E-v0-Rt6" secondAttribute="trailing" id="HsP-If-DXW"/>
                             <constraint firstItem="p9E-v0-Rt6" firstAttribute="top" secondItem="Gvo-VD-DXF" secondAttribute="top" id="K6m-Le-IeP"/>
                             <constraint firstItem="fVn-1d-beh" firstAttribute="top" secondItem="SKK-r5-nj0" secondAttribute="bottom" constant="92" id="KT2-TO-Mr4"/>
@@ -254,10 +269,10 @@
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="drb-do-FoT" secondAttribute="trailing" constant="20" id="Y9d-Eh-5kY"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="trailing" secondItem="p9E-v0-Rt6" secondAttribute="trailing" id="azG-Bi-6NR"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="bottom" secondItem="p9E-v0-Rt6" secondAttribute="bottom" id="djD-Ab-lfr"/>
+                            <constraint firstAttribute="trailing" secondItem="8P3-NB-IRq" secondAttribute="trailing" constant="10" id="fmF-D9-ZJO"/>
                             <constraint firstAttribute="trailing" secondItem="nNr-30-cGD" secondAttribute="trailing" id="gPI-GC-2rk"/>
                             <constraint firstItem="Eeb-3z-AWG" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" id="gfU-Wb-qye"/>
                             <constraint firstItem="C23-DT-v2t" firstAttribute="leading" secondItem="p9E-v0-Rt6" secondAttribute="leading" id="ijr-CB-GLx"/>
-                            <constraint firstItem="8P3-NB-IRq" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" constant="10" id="kcQ-AN-lKG"/>
                             <constraint firstItem="SKK-r5-nj0" firstAttribute="leading" secondItem="Gvo-VD-DXF" secondAttribute="leading" constant="10" id="pN3-Uj-cPZ"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="leading" secondItem="p9E-v0-Rt6" secondAttribute="leading" id="pfx-SS-Xux"/>
                             <constraint firstItem="76S-HP-bfy" firstAttribute="top" secondItem="p9E-v0-Rt6" secondAttribute="top" id="uLe-Ov-1yA"/>
@@ -272,6 +287,7 @@
                         <outlet property="overviewButton" destination="Dry-gO-T7u" id="8s7-hO-rHP"/>
                         <outlet property="recenterButton" destination="SKK-r5-nj0" id="HRr-Uz-7Hk"/>
                         <outlet property="reportButton" destination="EeE-dV-610" id="C8S-JP-WAr"/>
+                        <outlet property="rerouteReportButton" destination="I8f-iR-MZm" id="pZV-kq-FBI"/>
                         <outlet property="statusView" destination="Jym-DH-tdD" id="9Hw-jY-J4n"/>
                         <outlet property="wayNameLabel" destination="bcm-ca-nGv" id="8Sy-Pk-fQZ"/>
                         <outlet property="wayNameView" destination="drb-do-FoT" id="oby-w9-mC3"/>

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.strings
@@ -1,6 +1,6 @@
 
-/* Class = "UIButton"; normalTitle = "Report a Problem"; ObjectID = "I8f-iR-MZm"; */
-"I8f-iR-MZm.normalTitle" = "Report a Problem";
+/* Class = "UIButton"; normalTitle = "Report Problem"; ObjectID = "I8f-iR-MZm"; */
+"I8f-iR-MZm.normalTitle" = "Report Problem";
 
 /* Class = "UILabel"; text = "Rerouting…"; ObjectID = "UpZ-gr-OKM"; */
 "UpZ-gr-OKM.text" = "Rerouting…";

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.strings
@@ -1,4 +1,7 @@
 
+/* Class = "UIButton"; normalTitle = "Report a Problem"; ObjectID = "I8f-iR-MZm"; */
+"I8f-iR-MZm.normalTitle" = "Report a Problem";
+
 /* Class = "UILabel"; text = "Rerouting…"; ObjectID = "UpZ-gr-OKM"; */
 "UpZ-gr-OKM.text" = "Rerouting…";
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -22,6 +22,7 @@ class RouteMapViewController: UIViewController {
     @IBOutlet weak var maneuverContainerView: ManeuverContainerView!
     @IBOutlet weak var statusView: StatusView!
     @IBOutlet weak var laneViewsContainerView: LanesContainerView!
+    @IBOutlet weak var rerouteFeedbackTopConstraint: NSLayoutConstraint!
     
     var routePageViewController: RoutePageViewController!
     var routeTableViewController: RouteTableViewController?
@@ -84,6 +85,7 @@ class RouteMapViewController: UIViewController {
         mapView.navigationMapDelegate = self
         mapView.courseTrackingDelegate = self
         
+        rerouteReportButton.slideUp(constraint: rerouteFeedbackTopConstraint)
         rerouteReportButton.applyDefaultCornerRadiusShadow(cornerRadius: 4)
         overviewButton.applyDefaultCornerRadiusShadow(cornerRadius: overviewButton.bounds.midX)
         reportButton.applyDefaultCornerRadiusShadow(cornerRadius: reportButton.bounds.midX)
@@ -263,6 +265,10 @@ class RouteMapViewController: UIViewController {
     func didReroute(notification: NSNotification) {
         if !(routeController.locationManager is SimulatedLocationManager) {
             statusView.hide(delay: 0.5, animated: true)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: {
+                self.rerouteReportButton.slideDown(constraint: self.rerouteFeedbackTopConstraint, interval: 10)
+            })
         }
         
         if notification.userInfo![RouteControllerDidFindFasterRouteKey] as! Bool {
@@ -270,8 +276,6 @@ class RouteMapViewController: UIViewController {
             statusView.show(title, showSpinner: true)
             statusView.hide(delay: 5, animated: true)
         }
-        
-        rerouteReportButton.show(for: 10)
     }
 
     func updateMapOverlays(for routeProgress: RouteProgress) {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -163,7 +163,7 @@ class RouteMapViewController: UIViewController {
     }
     
     @IBAction func rerouteFeedback(_ sender: Any) {
-        showFeedback()
+        showFeedback(source: .reroute)
         delegate?.mapViewControllerDidOpenFeedback(self)
     }
     
@@ -172,7 +172,7 @@ class RouteMapViewController: UIViewController {
         delegate?.mapViewControllerDidOpenFeedback(self)
     }
     
-    func showFeedback() {
+    func showFeedback(source: FeedbackSource = .user) {
         guard let parent = parent else { return }
     
         let controller = FeedbackViewController.loadFromStoryboard()
@@ -184,7 +184,7 @@ class RouteMapViewController: UIViewController {
         controller.sendFeedbackHandler = { [weak self] (item) in
             guard let strongSelf = self else { return }
             strongSelf.delegate?.mapViewController(strongSelf, didSend: feedbackId, feedbackType: item.feedbackType)
-            strongSelf.routeController.updateFeedback(feedbackId: feedbackId, type: item.feedbackType, description: nil, audio: item.audio)
+            strongSelf.routeController.updateFeedback(feedbackId: feedbackId, type: item.feedbackType, source: source, description: nil, audio: item.audio)
             strongSelf.dismiss(animated: true) {
                 DialogViewController.present(on: parent)
             }

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -83,32 +83,31 @@ public class CellTurnArrowView: ManeuverView { }
 @objc(MBReportButton)
 public class ReportButton: Button {
     
-    @IBOutlet weak var topContraint: NSLayoutConstraint!
-    
     let padding: CGFloat = 10
+    let downConstant: CGFloat = 10
     
-    func show(for interval: TimeInterval) {
+    var upConstant: CGFloat {
+        return -bounds.height-(padding * 2)
+    }
+    
+    func slideDown(constraint: NSLayoutConstraint, interval: TimeInterval) {
         guard isHidden == true else { return }
         
         isHidden = false
-        
-        topContraint.constant = padding
+        constraint.constant = downConstant
         setNeedsUpdateConstraints()
-        
-        UIView.defaultAnimation(0.4, animations: {
+        UIView.defaultAnimation(0.5, animations: {
             self.superview?.layoutIfNeeded()
         }) { (completed) in
-            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(ReportButton.hide), object: nil)
-            self.perform(#selector(ReportButton.hide), with: nil, afterDelay: interval)
+            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(ReportButton.slideUp(constraint:)), object: nil)
+            self.perform(#selector(ReportButton.slideUp(constraint:)), with: constraint, afterDelay: interval)
         }
     }
     
-    @objc func hide() {
-        guard isHidden == false else { return }
-        
-        topContraint.constant = -bounds.height - (padding * 2)
+    @objc func slideUp(constraint: NSLayoutConstraint) {
+        constraint.constant = upConstant
         setNeedsUpdateConstraints()
-        UIView.defaultSpringAnimation(0.4, animations: {
+        UIView.defaultSpringAnimation(0.5, animations: {
             self.superview?.layoutIfNeeded()
         }) { (completed) in
             self.isHidden = true

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -79,6 +79,43 @@ public class LanesView: UIView { }
 @objc(MBCellTurnArrowView)
 public class CellTurnArrowView: ManeuverView { }
 
+/// :nodoc:
+@objc(MBReportButton)
+public class ReportButton: Button {
+    
+    @IBOutlet weak var topContraint: NSLayoutConstraint!
+    
+    let padding: CGFloat = 10
+    
+    func show(for interval: TimeInterval) {
+        guard isHidden == true else { return }
+        
+        isHidden = false
+        
+        topContraint.constant = padding
+        setNeedsUpdateConstraints()
+        
+        UIView.defaultAnimation(0.4, animations: {
+            self.superview?.layoutIfNeeded()
+        }) { (completed) in
+            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(ReportButton.hide), object: nil)
+            self.perform(#selector(ReportButton.hide), with: nil, afterDelay: interval)
+        }
+    }
+    
+    @objc func hide() {
+        guard isHidden == false else { return }
+        
+        topContraint.constant = -bounds.height - (padding * 2)
+        setNeedsUpdateConstraints()
+        UIView.defaultSpringAnimation(0.4, animations: {
+            self.superview?.layoutIfNeeded()
+        }) { (completed) in
+            self.isHidden = true
+        }
+    }
+}
+
 /**
  :nodoc:
  `HighlightedButton` sets the button’s titleColor for normal control state according to the style in addition to the styling behavior inherited from


### PR DESCRIPTION
Fixes #780 and right align floating buttons

- [x] set source to `reroute`

Note that the reroute items were removed after the recording.

![report](https://user-images.githubusercontent.com/764476/32327669-aca5b586-bfd7-11e7-9072-3191ac143024.gif)


@ericrwolfe @bsudekum 👀 