### PR TITLE
Waypoints fix

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -520,9 +520,10 @@ extension RouteController: CLLocationManagerDelegate {
         let polyline = Polyline(routeProgress.currentLegProgress.currentStep.coordinates!)
         let userSnapToStepDistanceFromManeuver = polyline.distance(from: location.coordinate)
         let secondsToEndOfStep = userSnapToStepDistanceFromManeuver / location.speed
+        
+        print("userHasArrivedAtWaypoint", routeProgress.currentLegProgress.userHasArrivedAtWaypoint, "remainingWaypoints", routeProgress.remainingWaypoints.count)
 
-        guard !routeProgress.currentLegProgress.userHasArrivedAtWaypoint,
-            routeProgress.remainingWaypoints.count > 0 else {
+        guard routeProgress.remainingWaypoints.count > 0 else {
             NotificationCenter.default.post(name: RouteControllerProgressDidChange, object: self, userInfo: [
                 RouteControllerProgressDidChangeNotificationProgressKey: routeProgress,
                 RouteControllerProgressDidChangeNotificationLocationKey: location,
@@ -808,7 +809,6 @@ extension RouteController: CLLocationManagerDelegate {
         routeProgress.currentLegProgress.stepIndex += 1
 
         if routeProgress.currentLegProgress.userHasArrivedAtWaypoint,
-            routeProgress.remainingWaypoints.count > 1,
             (delegate?.routeController?(self, shouldIncrementLegWhenArrivingAtWaypoint: routeProgress.currentLeg.destination) ?? true) {
             routeProgress.legIndex += 1
         }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -520,8 +520,6 @@ extension RouteController: CLLocationManagerDelegate {
         let polyline = Polyline(routeProgress.currentLegProgress.currentStep.coordinates!)
         let userSnapToStepDistanceFromManeuver = polyline.distance(from: location.coordinate)
         let secondsToEndOfStep = userSnapToStepDistanceFromManeuver / location.speed
-        
-        print("userHasArrivedAtWaypoint", routeProgress.currentLegProgress.userHasArrivedAtWaypoint, "remainingWaypoints", routeProgress.remainingWaypoints.count)
 
         guard routeProgress.remainingWaypoints.count > 0 else {
             NotificationCenter.default.post(name: RouteControllerProgressDidChange, object: self, userInfo: [


### PR DESCRIPTION
This fixes an issue where we were not returning the delegate method for arriving at the final way point and also, while the user is not at the final waypoint, we should always be tracking user progress. Progress updates should only end when arriving at the final waypoint.

/cc @ericdeveloper @1ec5 @frederoni @ericrwolfe @JThramer 