### PR TITLE
Check spokenInstructionIndex is less than instructionsSpokenAlongStep

### DIFF
--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -390,14 +390,14 @@ open class RouteStepProgress: NSObject {
     /**
      Index into `step.instructionsSpokenAlongStep` representing the current instruction.
      */
-    public var spokenInstructionIndex = 0
+    public var spokenInstructionIndex:Int = 0
     
     /**
      Current Instruction for the user's progress along a step.
      */
     public var currentSpokenInstruction: SpokenInstruction? {
         guard let instructionsSpokenAlongStep = step.instructionsSpokenAlongStep else { return nil }
-        guard spokenInstructionIndex < instructionsSpokenAlongStep else { return nil }
+        guard spokenInstructionIndex < instructionsSpokenAlongStep.count else { return nil }
         return instructionsSpokenAlongStep[spokenInstructionIndex]
     }
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -397,6 +397,7 @@ open class RouteStepProgress: NSObject {
      */
     public var currentSpokenInstruction: SpokenInstruction? {
         guard let instructionsSpokenAlongStep = step.instructionsSpokenAlongStep else { return nil }
+        guard spokenInstructionIndex < instructionsSpokenAlongStep else { return nil }
         return instructionsSpokenAlongStep[spokenInstructionIndex]
     }
 }


### PR DESCRIPTION
We've been seeing a few crashes at this array lookup. This first to makes sure `spokenInstructionIndex` is not larger than `instructionsSpokenAlongStep` before doing a lookup .

/cc @frederoni @1ec5 