### PR TITLE
Allow optional self

### DIFF
--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -88,8 +88,8 @@ class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollec
     func enableAudioRecording() {
         abortAutodismiss()
         recordingSession = AVAudioSession.sharedInstance()
-        recordingSession?.requestRecordPermission() { [unowned self] allowed in
-            self.enableAutoDismiss()
+        recordingSession?.requestRecordPermission() { [weak self] allowed in
+            self?.enableAutoDismiss()
         }
     }
     


### PR DESCRIPTION
We've seen a few crashes when requesting mic permissions. This change allows self to nil in some cases, ref [stack overflow](https://stackoverflow.com/questions/24177973/why-self-is-deallocated-when-calling-unowned-self).

/cc @frederoni @1ec5 @JThramer 