### PR TITLE
update currentManeuverPage with current values immediately after transition

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -73,9 +73,6 @@ class RouteMapViewController: UIViewController {
                     let remaining = self.routeController.routeProgress.currentLegProgress.currentStepProgress.durationRemaining
                     shown.notifyDidChange(routeProgress: progress, secondsRemaining: remaining)
                 }
-                
-               
-
             }
         }
     }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -68,7 +68,14 @@ class RouteMapViewController: UIViewController {
             
             if let controller = routePageViewController.currentManeuverPage {
                 controller.step = currentStep
-                routePageViewController.updateManeuverViewForStep()
+                routePageViewController.updateManeuverViewForStep { (shown) in
+                    let progress = self.routeController.routeProgress
+                    let remaining = self.routeController.routeProgress.currentLegProgress.currentStepProgress.durationRemaining
+                    shown.notifyDidChange(routeProgress: progress, secondsRemaining: remaining)
+                }
+                
+               
+
             }
         }
     }

--- a/MapboxNavigation/RoutePageViewController.swift
+++ b/MapboxNavigation/RoutePageViewController.swift
@@ -33,13 +33,16 @@ class RoutePageViewController: UIPageViewController {
         updateManeuverViewForStep()
     }
     
-    func updateManeuverViewForStep() {
+    typealias UpdateManeuverViewCompletion = (RouteManeuverViewController) -> Void
+    func updateManeuverViewForStep(completion complete: UpdateManeuverViewCompletion? = nil) {
+        
+        let completion = complete ?? { self.maneuverDelegate.routePageViewController(self, willTransitionTo: $0, didSwipe: false) }
         let step = maneuverDelegate.upComingStep ?? maneuverDelegate.currentStep
         let leg = maneuverDelegate.currentLeg
         let controller = routeManeuverViewController(with: step, leg: leg)!
         setViewControllers([controller], direction: .forward, animated: false, completion: nil)
         currentManeuverPage = controller
-        maneuverDelegate.routePageViewController(self, willTransitionTo: controller, didSwipe: false)
+        completion(controller)
     }
     
     func routeManeuverViewController(with step: RouteStep?, leg: RouteLeg?) -> RouteManeuverViewController? {


### PR DESCRIPTION
Implements #795. Not the most elegant solution in the world, but without `RouteManeuverViewController` knowing about the concept of `RouteProgress`/`StepProgress`, `notifyDidChange(routeProgress:stepProgress:)` is the only real way (without going down a rabbit hole) to prompt the RMVC to update the `InstructionsBannerView` to the correct values.

-  Fixing issue where carousel would display incorrect information momentarily when recentering by notifying current maneuver cell about it's progress immediately after presentation.

/cc @bsudekum @frederoni 