### PR TITLE
Allow audio while mute switch enabled

### DIFF
--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -255,6 +255,7 @@ public class PollyVoiceController: RouteVoiceController {
                 }
                 
                 self.audioPlayer?.delegate = self
+                try super.duckAudio()
                 let played = self.audioPlayer?.play() ?? false
                 
                 guard played else {


### PR DESCRIPTION
Since Polly is played via an `AudioPlayer`, we need to set it to the active audio session to allow it to play while the physical mute switch is enabled. `duckAudio`, does just accomplished this for us. I feel like I've re-added this line a few times now.

/cc @frederoni @ericrwolfe @JThramer 