### PR TITLE
Show subsequent step under banner

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -119,7 +119,7 @@ public var NavigationMetricsDebugLoggingEnabled = "MBNavigationMetricsDebugLoggi
  
  A multiplier of `1.2` gives us a buffer of 3 seconds, enough time insert a new instruction.
  */
-let RouteControllerLinkedInstructionBufferMultiplier: Double = 1.2
+public let RouteControllerLinkedInstructionBufferMultiplier: Double = 1.2
 
 /**
  Approximately the number of meters in a mile.

--- a/MapboxCoreNavigation/Instruction.swift
+++ b/MapboxCoreNavigation/Instruction.swift
@@ -24,13 +24,13 @@ public struct Instruction: Equatable {
         public let network: String?
         public let number: String?
         public let direction: String?
-        public var includeThen: Bool?
+        public var prefix: String?
         
-        public init(_ text: String?, png: String? = nil, roadCode: String? = nil, includeThen: Bool? = false) {
+        public init(_ text: String?, png: String? = nil, roadCode: String? = nil, prefix: String? = nil) {
             self.text = text
             self.png = png
             self.roadCode = roadCode
-            self.includeThen = false
+            self.prefix = prefix
             
             guard let roadCode = roadCode else {
                 self.network = nil

--- a/MapboxCoreNavigation/Instruction.swift
+++ b/MapboxCoreNavigation/Instruction.swift
@@ -6,7 +6,7 @@ public struct Instruction: Equatable {
         return lhs.components == rhs.components
     }
     
-    public let components: [Instruction.Component]
+    public var components: [Instruction.Component]
     
     public struct Component: Equatable {
         
@@ -24,11 +24,13 @@ public struct Instruction: Equatable {
         public let network: String?
         public let number: String?
         public let direction: String?
+        public var includeThen: Bool?
         
-        public init(_ text: String?, png: String? = nil, roadCode: String? = nil) {
+        public init(_ text: String?, png: String? = nil, roadCode: String? = nil, includeThen: Bool? = false) {
             self.text = text
             self.png = png
             self.roadCode = roadCode
+            self.includeThen = false
             
             guard let roadCode = roadCode else {
                 self.network = nil

--- a/MapboxCoreNavigation/Instruction.swift
+++ b/MapboxCoreNavigation/Instruction.swift
@@ -25,12 +25,6 @@ public struct Instruction: Equatable {
         public let number: String?
         public let direction: String?
         
-        public var shieldKey: String? {
-            guard let roadCode = roadCode else { return nil }
-            let components = roadCode.components(separatedBy: " ")
-            return "\(components[0])\(components[1])"
-        }
-        
         public init(_ text: String?, png: String? = nil, roadCode: String? = nil) {
             self.text = text
             self.png = png

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		35DC9D911F4323AA001ECD64 /* LanesContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC9D901F4323AA001ECD64 /* LanesContainerView.swift */; };
 		35E407681F5625FF00EFC814 /* StyleKitMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E407671F5625FF00EFC814 /* StyleKitMarker.swift */; };
 		35E9B0AD1F9E0F8F00BF84AB /* MapboxNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */; };
+		35F520C01FB482A200FC9C37 /* NextBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F520BF1FB482A200FC9C37 /* NextBannerView.swift */; };
 		35F611C41F1E1C0500C43249 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F611C31F1E1C0500C43249 /* FeedbackViewController.swift */; };
 		35FF4B131F9A7463009A71C4 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FF4B121F9A7463009A71C4 /* UIImage.swift */; };
 		6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */; };
@@ -436,6 +437,7 @@
 		35DC9D8E1F4321CC001ECD64 /* route-with-lanes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "route-with-lanes.json"; sourceTree = "<group>"; };
 		35DC9D901F4323AA001ECD64 /* LanesContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanesContainerView.swift; sourceTree = "<group>"; };
 		35E407671F5625FF00EFC814 /* StyleKitMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleKitMarker.swift; sourceTree = "<group>"; };
+		35F520BF1FB482A200FC9C37 /* NextBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextBannerView.swift; sourceTree = "<group>"; };
 		35F611C31F1E1C0500C43249 /* FeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		35FF4B121F9A7463009A71C4 /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaypointConfirmationViewController.swift; sourceTree = "<group>"; };
@@ -849,6 +851,7 @@
 				353280A01FA72871005175F3 /* InstructionLabel.swift */,
 				353610CD1FAB6A8F00FB1746 /* BottomBannerView.swift */,
 				355ED36F1FAB724F00BCE1B8 /* BottomBannerViewLayout.swift */,
+				35F520BF1FB482A200FC9C37 /* NextBannerView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1489,6 +1492,7 @@
 				359D283C1F9DC14F00FDE9C9 /* UICollectionView.swift in Sources */,
 				35CB1E131F97DD740011CC44 /* FeedbackItem.swift in Sources */,
 				35F611C41F1E1C0500C43249 /* FeedbackViewController.swift in Sources */,
+				35F520C01FB482A200FC9C37 /* NextBannerView.swift in Sources */,
 				C5A6B2DD1F4CE8E8004260EA /* StyleType.swift in Sources */,
 				35FF4B131F9A7463009A71C4 /* UIImage.swift in Sources */,
 				351BEC021E5BCC63006FE110 /* UIView.swift in Sources */,

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -88,7 +88,7 @@ open class DayStyle: Style {
         LaneView.appearance().primaryColor = .defaultLaneArrowPrimary
         LaneView.appearance().secondaryColor = .defaultLaneArrowSecondary
         LineView.appearance().lineColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.1)
-        ManeuverView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        ManeuverView.appearance().backgroundColor = .clear
         ManeuverView.appearance().primaryColor = .defaultTurnArrowPrimary
         ManeuverView.appearance().secondaryColor = .defaultTurnArrowSecondary
         NavigationMapView.appearance().routeAlternateColor      = .defaultAlternateLine
@@ -98,6 +98,9 @@ open class DayStyle: Style {
         NavigationMapView.appearance().trafficModerateColor     = .trafficModerate
         NavigationMapView.appearance().trafficSevereColor       = .trafficSevere
         NavigationMapView.appearance().trafficUnknownColor      = .trafficUnknown
+        NextBannerView.appearance().backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
+        NextInstructionLabel.appearance().font = UIFont.systemFont(ofSize: 20, weight: UIFontWeightMedium).adjustedFont
+        NextInstructionLabel.appearance().textColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
         PrimaryLabel.appearance().normalFont = UIFont.systemFont(ofSize: 30, weight: UIFontWeightMedium).adjustedFont
         PrimaryLabel.appearance().normalTextColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
         ReportButton.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
@@ -161,10 +164,12 @@ open class NightStyle: DayStyle {
         InstructionsBannerView.appearance().backgroundColor = backgroundColor
         LanesView.appearance().backgroundColor = backgroundColor
         LaneView.appearance().primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
-        ManeuverView.appearance().backgroundColor = backgroundColor
+        ManeuverView.appearance().backgroundColor = .clear
         ManeuverView.appearance().primaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         ManeuverView.appearance().secondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.3)
         NavigationMapView.appearance().routeAlternateColor = #colorLiteral(red: 0.7991961837, green: 0.8232284188, blue: 0.8481693864, alpha: 1)
+        NextBannerView.appearance().backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
+        NextInstructionLabel.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         PrimaryLabel.appearance().normalTextColor = #colorLiteral(red: 0.9996390939, green: 1, blue: 0.9997561574, alpha: 1)
         ReportButton.appearance().backgroundColor = backgroundColor
         ReportButton.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)

--- a/MapboxNavigation/InstructionLabel.swift
+++ b/MapboxNavigation/InstructionLabel.swift
@@ -29,7 +29,8 @@ open class InstructionLabel: StylableLabel {
             
             if let roadCode = component.roadCode, let network = component.network, let number = component.number {
                 // Check if shield image is cached, otherwise display road code in text
-                if let cachedImage = component.cachedShield {
+                let shieldKey = UIImage.shieldKey(network, number: number, height: shieldHeight)
+                if let cachedImage = UIImage.cachedShield(shieldKey) {
                     string.append(attributedString(with: cachedImage))
                     if let direction = component.direction {
                         string.append(NSAttributedString(string: " "+direction, attributes: attributes))
@@ -37,10 +38,9 @@ open class InstructionLabel: StylableLabel {
                 } else {
                     // Download shield and display road code in the meantime
                     string.append(NSAttributedString(string: joinChar+roadCode, attributes: attributes))
-                    let height = shieldHeight * UIScreen.main.scale
-                    UIImage.shieldImage(network, number: number, height: height, completion: { [unowned self] (image) in
+                    UIImage.shieldImage(network, number: number, height: shieldHeight, completion: { [unowned self] (image) in
                         // Reconstruct instructions if we did get a shield image
-                        guard image != nil, component.cachedShield != nil else { return }
+                        guard image != nil, UIImage.cachedShield(shieldKey) != nil else { return }
                         self.constructInstructions()
                     })
                 }
@@ -62,13 +62,6 @@ open class InstructionLabel: StylableLabel {
         attachment.font = font
         attachment.image = shieldImage
         return NSAttributedString(attachment: attachment)
-    }
-}
-
-extension Instruction.Component {
-    var cachedShield: UIImage? {
-        guard roadCode == roadCode, let shieldKey = shieldKey else { return nil }
-        return UIImage.shieldImageCache.object(forKey: shieldKey as NSString)
     }
 }
 

--- a/MapboxNavigation/InstructionLabel.swift
+++ b/MapboxNavigation/InstructionLabel.swift
@@ -27,9 +27,8 @@ open class InstructionLabel: StylableLabel {
             let isFirst = component == instruction.components.first
             let joinChar = !isFirst ? " " : ""
             
-            if let _ = component.includeThen {
-                let thenString = NSAttributedString(string: NSLocalizedString("THEN", bundle: .mapboxNavigation, value: "Then: ", comment: "Then"), attributes: nil)
-                string.append(thenString)
+            if let prefix = component.prefix {
+                string.append(NSAttributedString(string: prefix, attributes: attributes))
             }
             
             if let roadCode = component.roadCode, let network = component.network, let number = component.number {

--- a/MapboxNavigation/InstructionLabel.swift
+++ b/MapboxNavigation/InstructionLabel.swift
@@ -27,6 +27,11 @@ open class InstructionLabel: StylableLabel {
             let isFirst = component == instruction.components.first
             let joinChar = !isFirst ? " " : ""
             
+            if let _ = component.includeThen {
+                let thenString = NSAttributedString(string: NSLocalizedString("THEN", bundle: .mapboxNavigation, value: "Then: ", comment: "Then"), attributes: nil)
+                string.append(thenString)
+            }
+            
             if let roadCode = component.roadCode, let network = component.network, let number = component.number {
                 // Check if shield image is cached, otherwise display road code in text
                 let shieldKey = UIImage.shieldKey(network, number: number, height: shieldHeight)

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+/// :nodoc:
+@objc(MBNextInstructionLabel)
+class NextInstructionLabel: InstructionLabel { }
+
+/// :nodoc:
+@IBDesignable
+@objc(MBNextBannerView)
+class NextBannerView: UIView {
+    
+    weak var maneuverView: ManeuverView!
+    weak var instructionLabel: NextInstructionLabel!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    func commonInit() {
+        setupViews()
+        setupLayout()
+    }
+    
+    func setupViews() {
+        let maneuverView = ManeuverView()
+        maneuverView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(maneuverView)
+        self.maneuverView = maneuverView
+        
+        let instructionLabel = NextInstructionLabel()
+        instructionLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(instructionLabel)
+        self.instructionLabel = instructionLabel
+        
+        instructionLabel.availableBounds = {
+            let height = ("|" as NSString).size(attributes: [NSFontAttributeName: self.instructionLabel.font]).height
+            let availableWidth = self.bounds.width-self.maneuverView.frame.maxX-(16*2)
+            return CGRect(x: 0, y: 0, width: availableWidth, height: height)
+        }
+    }
+    
+    override func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+        maneuverView.isEnd = true
+        instructionLabel.text = "San Jose"
+    }
+    
+    func setupLayout() {
+        heightAnchor.constraint(equalToConstant: 44).isActive = true
+        
+        maneuverView.leftAnchor.constraint(equalTo: leftAnchor, constant: 16).isActive = true
+        maneuverView.heightAnchor.constraint(equalToConstant: 22).isActive = true
+        maneuverView.widthAnchor.constraint(equalToConstant: 22).isActive = true
+        maneuverView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        
+        instructionLabel.leftAnchor.constraint(equalTo: maneuverView.rightAnchor, constant: 16).isActive = true
+        instructionLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        instructionLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -16).isActive = true
+    }
+    
+}

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -34,7 +34,7 @@ class NextBannerView: UIView {
         self.maneuverView = maneuverView
         
         let instructionLabel = NextInstructionLabel()
-        instructionLabel.shieldHeight = NextInstructionLabel.appearance().font.pointSize
+        instructionLabel.shieldHeight = instructionLabel.font.pointSize
         instructionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(instructionLabel)
         self.instructionLabel = instructionLabel

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -34,6 +34,7 @@ class NextBannerView: UIView {
         self.maneuverView = maneuverView
         
         let instructionLabel = NextInstructionLabel()
+        instructionLabel.shieldHeight = NextInstructionLabel.appearance().font.pointSize
         instructionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(instructionLabel)
         self.instructionLabel = instructionLabel

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -43,6 +43,9 @@
 /* Button title for resume tracking */
 "RESUME" = "Resume";
 
+/* Then */
+"THEN" = "Then: ";
+
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
 "USER_IN_SIMULATION_MODE" = "Simulating Navigation";
 

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -49,7 +49,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I8f-iR-MZm" customClass="MBReportButton">
-                                <rect key="frame" x="121.5" y="196.5" width="132" height="38"/>
+                                <rect key="frame" x="121.5" y="240.5" width="132" height="38"/>
                                 <color key="backgroundColor" red="0.14901960784313725" green="0.23921568627450979" blue="0.3411764705882353" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                 <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
@@ -94,7 +94,7 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Eeb-3z-AWG">
-                                <rect key="frame" x="0.0" y="116.5" width="375" height="70"/>
+                                <rect key="frame" x="0.0" y="116.5" width="375" height="114"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Container View" customClass="LanesContainerView" customModule="MapboxNavigation" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="40"/>
@@ -116,8 +116,15 @@
                                         </constraints>
                                         <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
                                     </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvl-aX-s8B" customClass="MBNextBannerView">
+                                        <rect key="frame" x="0.0" y="40" width="375" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="kg2-Il-mKD"/>
+                                        </constraints>
+                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jym-DH-tdD" customClass="MBStatusView">
-                                        <rect key="frame" x="0.0" y="40" width="375" height="30"/>
+                                        <rect key="frame" x="0.0" y="84" width="375" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rerouting…" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UpZ-gr-OKM">
                                                 <rect key="frame" x="141.5" y="5" width="92.5" height="20.5"/>
@@ -161,7 +168,7 @@
                                 </connections>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8P3-NB-IRq" userLabel="Floating Stack View">
-                                <rect key="frame" x="315" y="197" width="50" height="108"/>
+                                <rect key="frame" x="315" y="241" width="50" height="108"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dry-gO-T7u" customClass="MBFloatingButton">
                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -265,6 +272,7 @@
                         <outlet property="laneViewsContainerView" destination="NE9-ru-uJw" id="Iy6-hg-9rK"/>
                         <outlet property="mapView" destination="nNr-30-cGD" id="Znv-B1-wdj"/>
                         <outlet property="muteButton" destination="Y2a-qB-86S" id="YK6-ak-WNw"/>
+                        <outlet property="nextBannerView" destination="Nvl-aX-s8B" id="mlR-y1-FBQ"/>
                         <outlet property="overviewButton" destination="Dry-gO-T7u" id="8s7-hO-rHP"/>
                         <outlet property="recenterButton" destination="SKK-r5-nj0" id="HRr-Uz-7Hk"/>
                         <outlet property="reportButton" destination="EeE-dV-610" id="C8S-JP-WAr"/>
@@ -393,7 +401,7 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qH5-Og-q0a">
-                                                    <rect key="frame" x="37" y="86" width="50" height="43"/>
+                                                    <rect key="frame" x="38" y="86" width="50" height="43"/>
                                                     <string key="text">Label 
 Label  </string>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
@@ -501,7 +509,7 @@ Label  </string>
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tgj-dm-1KN">
-                                                    <rect key="frame" x="38" y="86" width="50" height="43"/>
+                                                    <rect key="frame" x="37" y="86" width="50" height="43"/>
                                                     <string key="text">Label 
 Label  </string>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -397,8 +397,11 @@ class RouteMapViewController: UIViewController {
                 return
         }
     
-        let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
+        var instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
         nextBannerView.maneuverView.step = nextStep
+        if let _ = instructions.0?.components.first {
+            instructions.0?.components[0].includeThen = true
+        }
         nextBannerView.instructionLabel.instruction = instructions.0
         showNextBanner()
     }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -389,21 +389,18 @@ class RouteMapViewController: UIViewController {
     }
     
     func updateNextBanner(routeProgress: RouteProgress) {
-        let step = routeProgress.currentLegProgress.upComingStep ?? routeProgress.currentLegProgress.currentStep
-        guard let nextStep = routeProgress.currentLegProgress.stepAfter(step) else {
-            hideNextBanner()
-            return
+        guard let step = routeProgress.currentLegProgress.upComingStep,
+            routeProgress.currentLegProgress.currentStepProgress.durationRemaining <= RouteControllerHighAlertInterval,
+            let nextStep = routeProgress.currentLegProgress.stepAfter(step)
+            else {
+                hideNextBanner()
+                return
         }
     
-        let shouldShowNextBanner = nextStep.distance < RouteControllerMinimumDistanceForContinueInstruction
-        if shouldShowNextBanner {
-            showNextBanner()
-            let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
-            nextBannerView.maneuverView.step = nextStep
-            nextBannerView.instructionLabel.instruction = instructions.0
-        } else {
-            hideNextBanner()
-        }
+        let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
+        nextBannerView.maneuverView.step = nextStep
+        nextBannerView.instructionLabel.instruction = instructions.0
+        showNextBanner()
     }
     
     func showNextBanner() {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -390,9 +390,12 @@ class RouteMapViewController: UIViewController {
     
     func updateNextBanner(routeProgress: RouteProgress) {
         let step = routeProgress.currentLegProgress.upComingStep ?? routeProgress.currentLegProgress.currentStep
-        let nextStep = routeProgress.currentLegProgress.stepAfter(step)
-        let shouldShowNextBanner = nextStep != nil ? nextStep!.distance < 1000 : false
-        
+        guard let nextStep = routeProgress.currentLegProgress.stepAfter(step) else {
+            hideNextBanner()
+            return
+        }
+    
+        let shouldShowNextBanner = nextStep.distance < RouteControllerMinimumDistanceForContinueInstruction
         if shouldShowNextBanner {
             showNextBanner()
             let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -397,13 +397,15 @@ class RouteMapViewController: UIViewController {
                 return
         }
     
-        var instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
-        nextBannerView.maneuverView.step = nextStep
-        if let _ = instructions.0?.components.first {
-            instructions.0?.components[0].includeThen = true
+        let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
+        var instruction = instructions.0
+        
+        if let components = instruction?.components, components.count > 0 {
+            instruction?.components[0].prefix = NSLocalizedString("THEN", bundle: .mapboxNavigation, value: "Then: ", comment: "Then")
+            nextBannerView.maneuverView.step = nextStep
+            nextBannerView.instructionLabel.instruction = instruction
+            showNextBanner()
         }
-        nextBannerView.instructionLabel.instruction = instructions.0
-        showNextBanner()
     }
     
     func showNextBanner() {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -390,7 +390,7 @@ class RouteMapViewController: UIViewController {
     
     func updateNextBanner(routeProgress: RouteProgress) {
         guard let step = routeProgress.currentLegProgress.upComingStep,
-            routeProgress.currentLegProgress.currentStepProgress.durationRemaining <= RouteControllerHighAlertInterval,
+            routeProgress.currentLegProgress.currentStepProgress.durationRemaining <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier,
             let nextStep = routeProgress.currentLegProgress.stepAfter(step)
             else {
                 hideNextBanner()

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -10,7 +10,6 @@ class ArrowStrokePolyline: ArrowFillPolyline {}
 
 class RouteMapViewController: UIViewController {
     @IBOutlet weak var mapView: NavigationMapView!
-
     @IBOutlet weak var overviewButton: Button!
     @IBOutlet weak var reportButton: Button!
     @IBOutlet weak var rerouteReportButton: ReportButton!
@@ -20,6 +19,7 @@ class RouteMapViewController: UIViewController {
     @IBOutlet weak var wayNameView: UIView!
     @IBOutlet weak var instructionsBannerContainerView: InstructionsBannerContainerView!
     @IBOutlet weak var instructionsBannerView: InstructionsBannerView!
+    @IBOutlet weak var nextBannerView: NextBannerView!
     @IBOutlet weak var bottomBannerView: BottomBannerView!
     @IBOutlet weak var statusView: StatusView!
     @IBOutlet weak var laneViewsContainerView: LanesContainerView!
@@ -357,7 +357,7 @@ class RouteMapViewController: UIViewController {
         
         previousStep = step
         updateInstructions(routeProgress: routeProgress, location: location, secondsRemaining: secondsRemaining)
-        
+        updateNextBanner(routeProgress: routeProgress)
         
         if currentLegIndexMapped != routeProgress.legIndex {
             mapView.showWaypoints(routeProgress.route, legIndex: routeProgress.legIndex)
@@ -386,6 +386,35 @@ class RouteMapViewController: UIViewController {
         instructionsBannerView.set(instructions.0, secondaryInstruction: instructions.1)
         instructionsBannerView.distance = distanceRemaining > 5 ? distanceRemaining : 0
         instructionsBannerView.maneuverView.step = routeProgress.currentLegProgress.upComingStep
+    }
+    
+    func updateNextBanner(routeProgress: RouteProgress) {
+        let step = routeProgress.currentLegProgress.upComingStep ?? routeProgress.currentLegProgress.currentStep
+        let nextStep = routeProgress.currentLegProgress.stepAfter(step)
+        let shouldShowNextBanner = nextStep != nil ? nextStep!.distance < 1000 : false
+        
+        if shouldShowNextBanner {
+            showNextBanner()
+            let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
+            nextBannerView.maneuverView.step = nextStep
+            nextBannerView.instructionLabel.instruction = instructions.0
+        } else {
+            hideNextBanner()
+        }
+    }
+    
+    func showNextBanner() {
+        guard nextBannerView.isHidden else { return }
+        UIView.defaultAnimation(0.3, animations: {
+            self.nextBannerView.isHidden = false
+        }, completion: nil)
+    }
+    
+    func hideNextBanner() {
+        guard !nextBannerView.isHidden else { return }
+        UIView.defaultAnimation(0.3, animations: {
+            self.nextBannerView.isHidden = true
+        }, completion: nil)
     }
     
     var contentInsets: UIEdgeInsets {

--- a/MapboxNavigation/UIImage.swift
+++ b/MapboxNavigation/UIImage.swift
@@ -6,46 +6,53 @@ extension UIImage {
     static let shieldURLCache = NSCache<NSString, NSURL>()
     static let shieldImageCache = NSCache<NSString, UIImage>()
     
-    static func shieldImage(_ network: String, number: String, height: CGFloat, completion: @escaping (UIImage?) -> Void) {
+    static func shieldKey(_ network: String, number: String, height: CGFloat) -> String {
+        return "\(network)-\(number)-\(Int(height))"
+    }
+    
+    static func cachedShield(_ shieldKey: String) -> UIImage? {
+        return UIImage.shieldImageCache.object(forKey: shieldKey as NSString)
+    }
+    
+    static func shieldImage(_ network: String, number: String, height: CGFloat, scale: CGFloat = UIScreen.main.scale, completion: @escaping (UIImage?) -> Void) {
         
-        let key = "\(network)\(number)" as NSString
+        let shieldKey = self.shieldKey(network, number: number, height: height)
         
-        if let cachedImage = UIImage.shieldImageCache.object(forKey: key) {
+        if let cachedImage = UIImage.cachedShield(shieldKey) {
             completion(cachedImage)
             return
         }
         
-        if let cachedURL = UIImage.shieldURLCache.object(forKey: key) {
+        if let cachedURL = UIImage.shieldURLCache.object(forKey: shieldKey as NSString) {
             
             SDWebImageDownloader.shared().downloadImage(with: (cachedURL as URL), options: [], progress: nil, completed: { (image, data, error, successful) in
                 guard let imageData = data else { return }
-                guard let downscaledImage = UIImage(data: imageData, scale: UIScreen.main.scale) else {
+                guard let downscaledImage = UIImage(data: imageData, scale: scale) else {
                     completion(nil)
                     return
                 }
                 
-                UIImage.shieldImageCache.setObject(downscaledImage, forKey: key)
+                UIImage.shieldImageCache.setObject(downscaledImage, forKey: shieldKey as NSString)
                 completion(downscaledImage)
                 return
             })
         } else {
             
-            guard let shieldURL = URL.shieldURL(network: network, number: number, height: height) else {
+            guard let shieldURL = URL.shieldURL(network: network, number: number, height: height * scale) else {
                 completion(nil)
                 return
             }
             
             URL.shieldImageURL(shieldURL: shieldURL, completion: { (imageURL) in
-                UIImage.shieldURLCache.setObject(shieldURL as NSURL, forKey: key)
+                UIImage.shieldURLCache.setObject(shieldURL as NSURL, forKey: shieldKey as NSString)
                 
                 SDWebImageDownloader.shared().downloadImage(with: imageURL, options: [], progress: nil, completed: { (image, data, error, successful) in
                     guard let imageData = data else { return }
-                    guard let downscaledImage = UIImage(data: imageData, scale: UIScreen.main.scale) else {
+                    guard let downscaledImage = UIImage(data: imageData, scale: scale) else {
                         completion(nil)
                         return
                     }
-                    
-                    UIImage.shieldImageCache.setObject(downscaledImage, forKey: key)
+                    UIImage.shieldImageCache.setObject(downscaledImage, forKey: shieldKey as NSString)
                     completion(downscaledImage)
                 })
             })

--- a/MapboxNavigationTests/InstructionsBannerViewTests.swift
+++ b/MapboxNavigationTests/InstructionsBannerViewTests.swift
@@ -25,7 +25,8 @@ class InstructionsBannerViewTests: FBSnapshotTestCase {
         super.setUp()
         recordMode = false
         
-        UIImage.shieldImageCache.setObject(shieldImage, forKey: "I280")
+        let height = Int(instructionsView().primaryLabel.shieldHeight)
+        UIImage.shieldImageCache.setObject(shieldImage, forKey: "I-280-\(height)" as NSString)
     }
     
     func instructionsView() -> InstructionsBannerView {


### PR DESCRIPTION
Fixes #469 

Adds a banner for the subsequent step under the instructions banner.

<img src="https://user-images.githubusercontent.com/764476/32617669-df3c9b88-c575-11e7-93a8-085ccb1e7cb7.png" width=200>


@bsudekum @ericrwolfe @JThramer 