### PR TITLE
Eliminate imperative mood from property names

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -175,7 +175,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
         exampleMode = .default
         
         let navigationViewController = NavigationViewController(for: route, locationManager: navigationLocationManager())
-        navigationViewController.routeController.recordsAudioFeedback = true
+        navigationViewController.recordsAudioFeedback = true
         navigationViewController.delegate = self
         
         present(navigationViewController, animated: true, completion: nil)

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -175,7 +175,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
         exampleMode = .default
         
         let navigationViewController = NavigationViewController(for: route, locationManager: navigationLocationManager())
-        navigationViewController.routeController.allowRecordedAudioFeedback = true
+        navigationViewController.routeController.recordsAudioFeedback = true
         navigationViewController.delegate = self
         
         present(navigationViewController, animated: true, completion: nil)

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -151,4 +151,9 @@ public var RouteControllerMinimumNumberLocationUpdatesBackwards = 3
  */
 public var RouteControllerNumberOfSecondsForRerouteFeedback: TimeInterval = 10
 
+/**
+ The number of seconds between attempts to automatically calculate a more optimal route while traveling.
+ */
+public var RouteControllerOpportunisticReroutingInterval: TimeInterval = 120
+
 let FasterRouteFoundEvent = "navigation.fasterRoute"

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -120,21 +120,15 @@ open class RouteController: NSObject {
 
 
     /**
-     If true, every 2 minutes the `RouteController` will check for a faster route for the user.
+     If true, the `RouteController` attempts to calculate a more optimal route for the user on an interval defined by `RouteControllerOpportunisticReroutingInterval`.
      */
-    public var checkForFasterRouteInBackground = false
+    public var reroutesOpportunistically = false
     
     
     /**
      If true, users can long press a feedback item and allow for recorded audio to be included in the feedback
      */
-    public var allowRecordedAudioFeedback = false
-    
-    
-    /**
-     If true, spoken instructions for the route will be displayed on the map.
-     */
-    public var showDebugSpokenInstructionsOnMap = false
+    public var recordsAudioFeedback = false
     
 
     var didFindFasterRoute = false
@@ -554,7 +548,7 @@ extension RouteController: CLLocationManagerDelegate {
         monitorStepProgress(location)
 
         // Check for faster route given users current location
-        guard checkForFasterRouteInBackground else { return }
+        guard reroutesOpportunistically else { return }
         // Only check for faster alternatives if the user has plenty of time left on the route.
         guard routeProgress.durationRemaining > 600 else { return }
         // If the user is approaching a maneuver, don't check for a faster alternatives
@@ -629,8 +623,8 @@ extension RouteController: CLLocationManagerDelegate {
             return
         }
 
-        // Only check ever 2 minutes for faster route
-        guard location.timestamp.timeIntervalSince(lastLocationDate) >= 120 else { return }
+        // Only check every so often for a faster route.
+        guard location.timestamp.timeIntervalSince(lastLocationDate) >= RouteControllerOpportunisticReroutingInterval else { return }
         let durationRemaining = routeProgress.durationRemaining
 
         getDirections(from: location) { [weak self] (route, error) in

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -123,13 +123,6 @@ open class RouteController: NSObject {
      If true, the `RouteController` attempts to calculate a more optimal route for the user on an interval defined by `RouteControllerOpportunisticReroutingInterval`.
      */
     public var reroutesOpportunistically = false
-    
-    
-    /**
-     If true, users can long press a feedback item and allow for recorded audio to be included in the feedback
-     */
-    public var recordsAudioFeedback = false
-    
 
     var didFindFasterRoute = false
 

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -24,7 +24,7 @@ class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollec
     
     typealias SendFeedbackHandler = (FeedbackItem) -> ()
     
-    var allowRecordedAudioFeedback = false
+    var recordsAudioFeedback = false
     var sendFeedbackHandler: SendFeedbackHandler?
     var dismissFeedbackHandler: (() -> ())?
     var sections = [FeedbackSection]()
@@ -72,7 +72,7 @@ class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollec
         
         enableAutoDismiss()
         
-        if allowRecordedAudioFeedback {
+        if recordsAudioFeedback {
             validateAudio()
             enableAudioRecording()
         }
@@ -80,7 +80,7 @@ class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollec
     
     func validateAudio() {
         guard Bundle.main.microphoneUsageDescription != nil else {
-            assert(false, "If `allowRecordedAudioFeedback` is enabled, `NSMicrophoneUsageDescription` must be added in app plist")
+            assert(false, "If `recordsAudioFeedback` is enabled, `NSMicrophoneUsageDescription` must be added in app plist")
             return
         }
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -293,7 +293,23 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         return currentMinutesFromMidnight < sunriseMinutesFromMidnight || currentMinutesFromMidnight > sunsetMinutesFromMidnight
     }
     
-    var mapViewController: RouteMapViewController?
+    var mapViewController: RouteMapViewController? {
+        didSet {
+            annotatesSpokenInstructions = oldValue?.annotatesSpokenInstructions ?? false
+        }
+    }
+    
+    /**
+     A Boolean value that determines whether the map annotates the locations at which instructions are spoken for debugging purposes.
+     */
+    public var annotatesSpokenInstructions: Bool {
+        get {
+            return mapViewController?.annotatesSpokenInstructions ?? false
+        }
+        set {
+            mapViewController?.annotatesSpokenInstructions = annotatesSpokenInstructions
+        }
+    }
     
     let progressBar = ProgressBar()
     let routeStepFormatter = RouteStepFormatter()

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -293,23 +293,17 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         return currentMinutesFromMidnight < sunriseMinutesFromMidnight || currentMinutesFromMidnight > sunsetMinutesFromMidnight
     }
     
-    var mapViewController: RouteMapViewController? {
-        didSet {
-            annotatesSpokenInstructions = oldValue?.annotatesSpokenInstructions ?? false
-        }
-    }
+    var mapViewController: RouteMapViewController?
     
     /**
      A Boolean value that determines whether the map annotates the locations at which instructions are spoken for debugging purposes.
      */
-    public var annotatesSpokenInstructions: Bool {
-        get {
-            return mapViewController?.annotatesSpokenInstructions ?? false
-        }
-        set {
-            mapViewController?.annotatesSpokenInstructions = annotatesSpokenInstructions
-        }
-    }
+    public var annotatesSpokenInstructions = false
+    
+    /**
+     A Boolean value that determines whether the user can long-press a feedback item to dictate feedback.
+     */
+    public var recordsAudioFeedback = false
     
     let progressBar = ProgressBar()
     let routeStepFormatter = RouteStepFormatter()
@@ -566,6 +560,14 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
     
     func mapViewController(_ mapViewController: RouteMapViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint? {
         return delegate?.navigationViewController?(self, mapViewUserAnchorPoint: mapView)
+    }
+    
+    func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool {
+        return annotatesSpokenInstructions
+    }
+    
+    func mapViewControllerShouldRecordAudioFeedback(_ routeMapViewController: RouteMapViewController) -> Bool {
+        return recordsAudioFeedback
     }
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -71,6 +71,11 @@ class RouteMapViewController: UIViewController {
         }
     }
     var currentLegIndexMapped = 0
+    
+    /**
+     A Boolean value that determines whether the map annotates the locations at which instructions are spoken for debugging purposes.
+     */
+    var annotatesSpokenInstructions = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -200,7 +205,7 @@ class RouteMapViewController: UIViewController {
         guard let parent = parent else { return }
     
         let controller = FeedbackViewController.loadFromStoryboard()
-        controller.allowRecordedAudioFeedback = routeController.allowRecordedAudioFeedback
+        controller.recordsAudioFeedback = routeController.recordsAudioFeedback
         let sections: [FeedbackSection] = [[.turnNotAllowed, .closure, .reportTraffic], [.confusingInstructions, .generalMapError, .badRoute]]
         controller.sections = sections
         let feedbackId = routeController.recordFeedback()
@@ -260,7 +265,7 @@ class RouteMapViewController: UIViewController {
         mapView.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
         mapView.showRoutes([routeController.routeProgress.route], legIndex: routeController.routeProgress.legIndex)
         
-        if routeController.showDebugSpokenInstructionsOnMap {
+        if annotatesSpokenInstructions {
             mapView.showVoiceInstructionsOnMap(route: routeController.routeProgress.route)
         }
 
@@ -366,7 +371,7 @@ class RouteMapViewController: UIViewController {
             currentLegIndexMapped = routeProgress.legIndex
         }
         
-        if routeController.showDebugSpokenInstructionsOnMap {
+        if annotatesSpokenInstructions {
             mapView.showVoiceInstructionsOnMap(route: routeController.routeProgress.route)
         }
 
@@ -646,7 +651,7 @@ extension RouteMapViewController: MGLMapViewDelegate {
             map.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
         }
         
-        if routeController.showDebugSpokenInstructionsOnMap {
+        if annotatesSpokenInstructions {
             mapView.showVoiceInstructionsOnMap(route: routeController.routeProgress.route)
         }
     }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -76,6 +76,11 @@ class RouteMapViewController: UIViewController {
      A Boolean value that determines whether the map annotates the locations at which instructions are spoken for debugging purposes.
      */
     var annotatesSpokenInstructions = false
+    
+    /**
+     A Boolean value that determines whether the user can long-press a feedback item to dictate feedback.
+     */
+    var recordsAudioFeedback = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -205,7 +210,7 @@ class RouteMapViewController: UIViewController {
         guard let parent = parent else { return }
     
         let controller = FeedbackViewController.loadFromStoryboard()
-        controller.recordsAudioFeedback = routeController.recordsAudioFeedback
+        controller.recordsAudioFeedback = recordsAudioFeedback
         let sections: [FeedbackSection] = [[.turnNotAllowed, .closure, .reportTraffic], [.confusingInstructions, .generalMapError, .badRoute]]
         controller.sections = sections
         let feedbackId = routeController.recordFeedback()
@@ -760,4 +765,7 @@ protocol RouteMapViewControllerDelegate: class {
     func mapViewController(_ mapViewController: RouteMapViewController, didSend feedbackId: String, feedbackType: FeedbackType)
     
     func mapViewController(_ mapViewController: RouteMapViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint?
+    
+    func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool
+    func mapViewControllerShouldRecordAudioFeedback(_ routeMapViewController: RouteMapViewController) -> Bool
 }


### PR DESCRIPTION
Property names should never begin with an imperative verb, in part because that makes it impossible to distinguish a property from an action method in Objective-C. The same requirement [holds true in Swift](https://swift.org/documentation/api-design-guidelines/#boolean-assertions):

> Uses of Boolean methods and properties should read as assertions about the receiver when the use is nonmutating.

This PR also makes the opportunistic background rerouting interval configurable and moves the spoken instruction debugging option from RouteController to NavigationViewController, where UI options belong.

Fixes #756 and fixes #757.

/cc @bsudekum @JThramer