### PR TITLE
Rely less on vertical accuracy for filtering out bad locations

### DIFF
--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -9,7 +9,7 @@ extension CLLocation {
         #else
             return
                 0...100 ~= horizontalAccuracy &&
-                0...30 ~= verticalAccuracy &&
+                verticalAccuracy > 0 &&
                 speed >= 0
         #endif
     }


### PR DESCRIPTION
We're seeing strangely high vertical accuracy on the iPhone X. Vertical accuracy does not really help us determine whether or not a location is good except in the case it is -1 when the location is determined by wifi only.

/cc @1ec5 @frederoni @ericrwolfe @JThramer 


Example json:

```
{
    "locations": [
        {
            "altitude": 8.340122319829732,
            "course": 268.9399826448163,
            "horizontalAccuracy": 32,
            "lat": 38.912786807157765,
            "lng": -77.00992836558446,
            "speed": 6.848177433013916,
            "timestamp": "2017-11-10T03:09:36.011+0000",
            "verticalAccuracy": 48.44074249267578
        },
        {
            "altitude": 7.344383967021443,
            "course": 265.8569718572559,
            "horizontalAccuracy": 32,
            "lat": 38.912782113908065,
            "lng": -77.01002210271703,
            "speed": 7.3876190185546875,
            "timestamp": "2017-11-10T03:09:37.011+0000",
            "verticalAccuracy": 45.04840850830078
        },
        {
            "altitude": 6.649318325291304,
            "course": 262.98307414132466,
            "horizontalAccuracy": 32,
            "lat": 38.91276973202023,
            "lng": -77.01011601609537,
            "speed": 7.3876190185546875,
            "timestamp": "2017-11-10T03:09:38.011+0000",
            "verticalAccuracy": 46.155704498291016
        },
        {
            "altitude": 7.21891995823373,
            "course": 262.2535279756973,
            "horizontalAccuracy": 32,
            "lat": 38.91272464195428,
            "lng": -77.01022363737874,
            "speed": 7.971859931945801,
            "timestamp": "2017-11-10T03:09:39.011+0000",
            "verticalAccuracy": 51.35844802856445
        },
        {
            "altitude": 7.5498289766448465,
            "course": -1,
            "horizontalAccuracy": 32,
            "lat": 38.91271309340192,
            "lng": -77.01033260049991,
            "speed": -1,
            "timestamp": "2017-11-10T03:09:40.011+0000",
            "verticalAccuracy": 49.28700256347656
        },
        {
            "altitude": 7.860201917996065,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259826664502,
            "lng": -77.01042216712533,
            "speed": 7.784748077392578,
            "timestamp": "2017-11-10T03:09:41.011+0000",
            "verticalAccuracy": 44.32194519042969
        },
        {
            "altitude": 8.257042151062478,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259832091186,
            "lng": -77.01052428233046,
            "speed": 8.010412216186523,
            "timestamp": "2017-11-10T03:09:42.011+0000",
            "verticalAccuracy": 43.93929672241211
        },
        {
            "altitude": 9.749946649929228,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259840898531,
            "lng": -77.01069001222302,
            "speed": 8.010412216186523,
            "timestamp": "2017-11-10T03:09:43.011+0000",
            "verticalAccuracy": 39.602394104003906
        },
        {
            "altitude": 10.66073481658659,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259848010579,
            "lng": -77.01082384132359,
            "speed": 8.734957695007324,
            "timestamp": "2017-11-10T03:09:44.011+0000",
            "verticalAccuracy": 37.01474380493164
        },
        {
            "altitude": 11.049464957964208,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259853844799,
            "lng": -77.01093362520874,
            "speed": 8.734957695007324,
            "timestamp": "2017-11-10T03:09:45.011+0000",
            "verticalAccuracy": 36.095619201660156
        },
        {
            "altitude": 11.155971564540451,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259860098973,
            "lng": -77.01105131149555,
            "speed": 8.614250183105469,
            "timestamp": "2017-11-10T03:09:46.011+0000",
            "verticalAccuracy": 30.88082504272461
        },
        {
            "altitude": 11.202695254908686,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.912598667409924,
            "lng": -77.01117629594717,
            "speed": 8.614250183105469,
            "timestamp": "2017-11-10T03:09:47.011+0000",
            "verticalAccuracy": 29.014665603637695
        },
        {
            "altitude": 11.021561614504087,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.912598725178576,
            "lng": -77.01128500057959,
            "speed": 8.605345726013184,
            "timestamp": "2017-11-10T03:09:48.011+0000",
            "verticalAccuracy": 30.591716766357422
        },
        {
            "altitude": 10.74720186792645,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259877372945,
            "lng": -77.01137635991553,
            "speed": 7.468335151672363,
            "timestamp": "2017-11-10T03:09:49.011+0000",
            "verticalAccuracy": 29.296274185180664
        },
        {
            "altitude": 9.933817374170872,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259881727569,
            "lng": -77.01145830191625,
            "speed": 6.080639362335205,
            "timestamp": "2017-11-10T03:09:50.011+0000",
            "verticalAccuracy": 29.208084106445312
        },
        {
            "altitude": 9.14777054608184,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.91259886201516,
            "lng": -77.01154248921975,
            "speed": 6.2146406173706055,
            "timestamp": "2017-11-10T03:09:51.011+0000",
            "verticalAccuracy": 29.631271362304688
        },
        {
            "altitude": 8.789604600910643,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.912598903021305,
            "lng": -77.01161965146501,
            "speed": 6.2146406173706055,
            "timestamp": "2017-11-10T03:09:52.011+0000",
            "verticalAccuracy": 28.730144500732422
        },
        {
            "altitude": 8.517973323975422,
            "course": 270.0389709472656,
            "horizontalAccuracy": 32,
            "lat": 38.9125989031084,
            "lng": -77.01161981535512,
            "speed": 6.6948161125183105,
            "timestamp": "2017-11-10T03:09:53.011+0000",
            "verticalAccuracy": 30.222597122192383
        },
        {
            "altitude": 8.224981396524615,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91260412524407,
            "lng": -77.01178602166513,
            "speed": 6.793993949890137,
            "timestamp": "2017-11-10T03:09:54.011+0000",
            "verticalAccuracy": 29.781888961791992
        },
        {
            "altitude": 8.066567647561158,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.912606834004144,
            "lng": -77.01187087657637,
            "speed": 6.505770683288574,
            "timestamp": "2017-11-10T03:09:55.011+0000",
            "verticalAccuracy": 28.124082565307617
        },
        {
            "altitude": 8.196512857242112,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91260918091879,
            "lng": -77.01194439627861,
            "speed": 6.505770683288574,
            "timestamp": "2017-11-10T03:09:56.011+0000",
            "verticalAccuracy": 24.8518123626709
        },
        {
            "altitude": 8.36660269581919,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91261126156545,
            "lng": -77.01200957484119,
            "speed": 5.828501224517822,
            "timestamp": "2017-11-10T03:09:57.011+0000",
            "verticalAccuracy": 23.367326736450195
        },
        {
            "altitude": 8.13374391488513,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91261288067431,
            "lng": -77.01206029522038,
            "speed": 4.872931480407715,
            "timestamp": "2017-11-10T03:09:58.011+0000",
            "verticalAccuracy": 23.8239803314209
        },
        {
            "altitude": 7.7224476675308935,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91261435822385,
            "lng": -77.01210658109704,
            "speed": 3.546069622039795,
            "timestamp": "2017-11-10T03:09:59.011+0000",
            "verticalAccuracy": 22.49412727355957
        },
        {
            "altitude": 9.710666213945078,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.912615152328854,
            "lng": -77.01213145731651,
            "speed": 1.8638896942138672,
            "timestamp": "2017-11-10T03:10:00.011+0000",
            "verticalAccuracy": 20.960752487182617
        },
        {
            "altitude": 11.621638896948213,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.9126154674828,
            "lng": -77.0121413298631,
            "speed": 2.6979849338531494,
            "timestamp": "2017-11-10T03:10:01.011+0000",
            "verticalAccuracy": 21.351160049438477
        },
        {
            "altitude": 12.915817532077543,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91261550567338,
            "lng": -77.01214252622539,
            "speed": 2.6979849338531494,
            "timestamp": "2017-11-10T03:10:02.011+0000",
            "verticalAccuracy": 19.28587532043457
        },
        {
            "altitude": 14.144555055461275,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91261550567338,
            "lng": -77.01214252622539,
            "speed": 3.9878158569335938,
            "timestamp": "2017-11-10T03:10:03.011+0000",
            "verticalAccuracy": 17.83783531188965
        },
        {
            "altitude": 15.351974984676222,
            "course": 272.3397216796875,
            "horizontalAccuracy": 32,
            "lat": 38.91261550567338,
            "lng": -77.01214252622538,
            "speed": 5.0173139572143555,
            "timestamp": "2017-11-10T03:10:04.011+0000",
            "verticalAccuracy": 16.705961227416992
        },
        {
            "altitude": 16.48375869491902,
            "course": 270.7870178222656,
            "horizontalAccuracy": 32,
            "lat": 38.912618314652995,
            "lng": -77.01239824094876,
            "speed": 7.0142903327941895,
            "timestamp": "2017-11-10T03:10:05.011+0000",
            "verticalAccuracy": 16.392911911010742
        },
        {
            "altitude": 17.361327870324967,
            "course": 270.7870178222656,
            "horizontalAccuracy": 32,
            "lat": 38.91261930226363,
            "lng": -77.01249026167318,
            "speed": 7.816720962524414,
            "timestamp": "2017-11-10T03:10:06.011+0000",
            "verticalAccuracy": 18.46169090270996
        },
        {
            "altitude": 17.95987267511571,
            "course": 270.7870178222656,
            "horizontalAccuracy": 32,
            "lat": 38.912619749369014,
            "lng": -77.01253192076493,
            "speed": 7.816720962524414,
            "timestamp": "2017-11-10T03:10:07.011+0000",
            "verticalAccuracy": 17.3925838470459
        },
        {
            "altitude": 18.273969680590447,
            "course": 270.7870178222656,
            "horizontalAccuracy": 32,
            "lat": 38.91261966306536,
            "lng": -77.01252387941209,
            "speed": 7.816720962524414,
            "timestamp": "2017-11-10T03:10:08.011+0000",
            "verticalAccuracy": 16.982898712158203
        },
        {
            "altitude": 18.460815590242508,
            "course": 269.0204772949219,
            "horizontalAccuracy": 32,
            "lat": 38.912616161934196,
            "lng": -77.0128052032386,
            "speed": 7.34104585647583,
            "timestamp": "2017-11-10T03:10:09.011+0000",
            "verticalAccuracy": 20.410104751586914
        },
        {
            "altitude": 18.440103490151934,
            "course": 270.1611633300781,
            "horizontalAccuracy": 32,
            "lat": 38.91261569014726,
            "lng": -77.01288676103913,
            "speed": 4.916589736938477,
            "timestamp": "2017-11-10T03:10:10.011+0000",
            "verticalAccuracy": 22.730926513671875
        },
        {
            "altitude": 18.03622619167662,
            "course": 270.1611633300781,
            "horizontalAccuracy": 32,
            "lat": 38.9126158430983,
            "lng": -77.01295635484449,
            "speed": 4.916589736938477,
            "timestamp": "2017-11-10T03:10:11.011+0000",
            "verticalAccuracy": 23.893558502197266
        },
        {
            "altitude": 17.61133858088643,
            "course": 270.1611633300781,
            "horizontalAccuracy": 32,
            "lat": 38.912615965118505,
            "lng": -77.01301187490051,
            "speed": 4.412919044494629,
            "timestamp": "2017-11-10T03:10:12.011+0000",
            "verticalAccuracy": 24.227691650390625
        },
        {
            "altitude": 17.159084707796467,
            "course": 270.1611633300781,
            "horizontalAccuracy": 32,
            "lat": 38.91261606866067,
            "lng": -77.01305898731826,
            "speed": 3.4887306690216064,
            "timestamp": "2017-11-10T03:10:13.011+0000",
            "verticalAccuracy": 21.237491607666016
        },
        {
            "altitude": 16.629174641895432,
            "course": 270.1611633300781,
            "horizontalAccuracy": 32,
            "lat": 38.91261614342075,
            "lng": -77.0130930036836,
            "speed": 3.145989179611206,
            "timestamp": "2017-11-10T03:10:14.011+0000",
            "verticalAccuracy": 19.6142635345459
        }
    ],
    "route": "https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-77.00992836558446,38.912786807157765;-77.0130930036836,38.91261614342075.json?access_token=foo.bar&steps=true&overview=full&geometries=geojson"
}
```