### PR TITLE
 Allow throttled FPS if upcoming maneuver is straight

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -161,7 +161,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let durationUntilNextManeuver = stepProgress.durationRemaining
         let durationSincePreviousManeuver = expectedTravelTime - durationUntilNextManeuver
         
-        guard isPluggedIn else {
+        guard !isPluggedIn else {
             frameInterval = FrameIntervalOptions.pluggedInFrameInterval
             return
         }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -161,9 +161,15 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let durationUntilNextManeuver = stepProgress.durationRemaining
         let durationSincePreviousManeuver = expectedTravelTime - durationUntilNextManeuver
         
-        if !isPluggedIn,
-            durationUntilNextManeuver > FrameIntervalOptions.durationUntilNextManeuver,
+        guard isPluggedIn else {
+            frameInterval = FrameIntervalOptions.pluggedInFrameInterval
+            return
+        }
+    
+        if durationUntilNextManeuver > FrameIntervalOptions.durationUntilNextManeuver,
             durationSincePreviousManeuver > FrameIntervalOptions.durationSincePreviousManeuver {
+            frameInterval = shouldPositionCourseViewFrameByFrame ? FrameIntervalOptions.defaultFrameInterval : FrameIntervalOptions.decreasedFrameInterval
+        } else if let upcomingStep = routeProgress.currentLegProgress.upComingStep, upcomingStep.maneuverDirection == .straightAhead {
             frameInterval = shouldPositionCourseViewFrameByFrame ? FrameIntervalOptions.defaultFrameInterval : FrameIntervalOptions.decreasedFrameInterval
         } else {
             frameInterval = FrameIntervalOptions.pluggedInFrameInterval

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -166,7 +166,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             return
         }
     
-        if durationUntilNextManeuver > FrameIntervalOptions.durationUntilNextManeuver,
+        if durationUntilNextManeuver > FrameIntervalOptions.durationUntilNextManeuver &&
             durationSincePreviousManeuver > FrameIntervalOptions.durationSincePreviousManeuver {
             frameInterval = shouldPositionCourseViewFrameByFrame ? FrameIntervalOptions.defaultFrameInterval : FrameIntervalOptions.decreasedFrameInterval
         } else if let upcomingStep = routeProgress.currentLegProgress.upComingStep, upcomingStep.maneuverDirection == .straightAhead {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/812

If the upcoming maneuver is easy and straight, we can remain in throttled fps mode.

/cc @1ec5 @frederoni 