### PR TITLE
Expose MGLMapView init(frame:styleURL:)

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -120,16 +120,20 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        
-        makeGestureRecognizersRespectCourseTracking()
-        makeGestureRecognizersUpdateCourseView()
-        
-        resumeNotifications()
+        commonInit()
     }
     
     public required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
-        
+        commonInit()
+    }
+    
+    public override init(frame: CGRect, styleURL: URL?) {
+        super.init(frame: frame, styleURL: styleURL)
+        commonInit()
+    }
+    
+    fileprivate func commonInit() {
         makeGestureRecognizersRespectCourseTracking()
         makeGestureRecognizersUpdateCourseView()
         


### PR DESCRIPTION
Fixes #847 

Unlike subclasses in Objective-C, Swift 4 subclasses do not inherit their superclass initializers by default, unless it's safe to do so, such as generic classes.

@bsudekum 👀 

/cc @ericdeveloper 