### PR TITLE
Show report feedback button for 5 seconds

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -298,7 +298,7 @@ class RouteMapViewController: UIViewController {
             statusView.hide(delay: 0.5, animated: true)
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: {
-                self.rerouteReportButton.slideDown(constraint: self.rerouteFeedbackTopConstraint, interval: 10)
+                self.rerouteReportButton.slideDown(constraint: self.rerouteFeedbackTopConstraint, interval: 5)
             })
         }
         


### PR DESCRIPTION
It's hanging around for too long. It gets awkward when you don't want to tap it after a reroute.

/cc @ericrwolfe 