### PR TITLE
Improve voice delegates

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -16,7 +16,7 @@ enum ExampleMode {
     case multipleWaypoints
 }
 
-class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate {
+class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate, VoiceControllerDelegate {
 
     //MARK: - IBOutlets
     @IBOutlet weak var mapView: NavigationMapView!
@@ -306,14 +306,15 @@ extension ViewController: NavigationMapViewDelegate {
         self.present(actionSheet, animated: true, completion: nil)
     }
 
+    // To use these delegate methods, set the `VoiceControllerDelegate` on your `VoiceController`.
+    //
     // Called when there is an error with speaking a voice instruction.
     func voiceController(_ voiceController: RouteVoiceController, spokenInstructionsDidFailWith error: Error) {
         print(error.localizedDescription)
     }
-    
     // Called when an instruction is interrupted by a new voice instruction.
-    func voiceController(_ voiceController: RouteVoiceController, didInterrupt: String, with instruction: String) {
-        print("\(didInterrupt) interrupted by \(instruction)")
+    func voiceController(_ voiceController: RouteVoiceController, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction) {
+        print(interruptedInstruction.text, interruptingInstruction.text)
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -354,6 +354,7 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         mapViewController.reportButton.isHidden = !showsReportFeedback
 
         self.currentStyleType = styleTypeForTimeOfDay
+        self.voiceController?.routeController = self.routeController
         
         if !(route.routeOptions is NavigationRouteOptions) {
             print("`Route` was created using `RouteOptions` and not `NavigationRouteOptions`. Although not required, this may lead to a suboptimal navigation experience. Without `NavigationRouteOptions`, it is not guaranteed you will get congestion along the route line, better ETAs and ETA label color dependent on congestion.")

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -354,7 +354,6 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         mapViewController.reportButton.isHidden = !showsReportFeedback
 
         self.currentStyleType = styleTypeForTimeOfDay
-        self.voiceController?.routeController = self.routeController
         
         if !(route.routeOptions is NavigationRouteOptions) {
             print("`Route` was created using `RouteOptions` and not `NavigationRouteOptions`. Although not required, this may lead to a suboptimal navigation experience. Without `NavigationRouteOptions`, it is not guaranteed you will get congestion along the route line, better ETAs and ETA label color dependent on congestion.")

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -141,7 +141,7 @@ public class PollyVoiceController: RouteVoiceController {
     
     public override func speak(_ instruction: SpokenInstruction) {
         if let audioPlayer = audioPlayer, audioPlayer.isPlaying, let lastSpokenInstruction = lastSpokenInstruction {
-            voiceControllerDelegate?.voiceController?(self, didInterrupt: lastSpokenInstruction, with: instruction, routeProgress: routeController.routeProgress)
+            voiceControllerDelegate?.voiceController?(self, didInterrupt: lastSpokenInstruction, with: instruction)
         }
         pollyTask?.cancel()
         audioPlayer?.stop()
@@ -169,7 +169,7 @@ public class PollyVoiceController: RouteVoiceController {
     func speakWithoutPolly(_ instruction: SpokenInstruction, error: Error) {
         pollyTask?.cancel()
         
-        voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error, routeProgress: routeController.routeProgress)
+        voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
         
         guard let audioPlayer = audioPlayer else {
             super.speak(instruction)

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -58,8 +58,6 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
      */
     public weak var voiceControllerDelegate: VoiceControllerDelegate?
     
-    var routeController: RouteController!
-    
     var lastSpokenInstruction: SpokenInstruction?
     
     /**
@@ -116,7 +114,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
         do {
             try unDuckAudio()
         } catch {
-            voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error, routeProgress: routeController.routeProgress)
+            voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
         }
     }
     
@@ -124,7 +122,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
         do {
             try unDuckAudio()
         } catch {
-            voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error, routeProgress: routeController.routeProgress)
+            voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
         }
     }
     
@@ -160,13 +158,13 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
      */
     open func speak(_ instruction: SpokenInstruction) {
         if speechSynth.isSpeaking, let lastSpokenInstruction = lastSpokenInstruction {
-            voiceControllerDelegate?.voiceController?(self, didInterrupt: lastSpokenInstruction, with: instruction, routeProgress: routeController.routeProgress)
+            voiceControllerDelegate?.voiceController?(self, didInterrupt: lastSpokenInstruction, with: instruction)
         }
         
         do {
             try duckAudio()
         } catch {
-            voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error, routeProgress: routeController.routeProgress)
+            voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
         }
         
         let utterance = AVSpeechUtterance(string: instruction.text)
@@ -185,9 +183,9 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
 }
 
 @objc public protocol VoiceControllerDelegate {
-    @objc(voiceController:spokenInstrucionsDidFailWithError:routeProgress:)
-    optional func voiceController(_ voiceController: RouteVoiceController, spokenInstructionsDidFailWith error: Error, routeProgress: RouteProgress)
+    @objc(voiceController:spokenInstrucionsDidFailWithError:)
+    optional func voiceController(_ voiceController: RouteVoiceController, spokenInstructionsDidFailWith error: Error)
     
-    @objc(voiceController:didInterruptSpokenInstruction:withInstruction:routeProgress:)
-    optional func voiceController(_ voiceController: RouteVoiceController, didInterrupt: SpokenInstruction, with instruction: SpokenInstruction, routeProgress: RouteProgress)
+    @objc(voiceController:didInterruptSpokenInstruction:withInstruction:)
+    optional func voiceController(_ voiceController: RouteVoiceController, didInterrupt: SpokenInstruction, with instruction: SpokenInstruction)
 }

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -183,9 +183,16 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
 }
 
 @objc public protocol VoiceControllerDelegate {
+    
+    /**
+     Called when there is an error speaking a voice instruction.
+     */
     @objc(voiceController:spokenInstrucionsDidFailWithError:)
     optional func voiceController(_ voiceController: RouteVoiceController, spokenInstructionsDidFailWith error: Error)
     
+    /**
+     Called when an instruction interrupts another instruction.
+     */
     @objc(voiceController:didInterruptSpokenInstruction:withInstruction:)
-    optional func voiceController(_ voiceController: RouteVoiceController, didInterrupt: SpokenInstruction, with instruction: SpokenInstruction)
+    optional func voiceController(_ voiceController: RouteVoiceController, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction)
 }


### PR DESCRIPTION
Followup to https://github.com/mapbox/mapbox-navigation-ios/pull/800

This adds:
* ~~A routeProgress object to both voice delegate methods.~~
* Overlap will be triggered in `RouteVoiceController` as well.
* Improves the named arguments in the overlap method.

/cc @1ec5 