### PR TITLE
Fix when next banner is visible

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -423,14 +423,17 @@ class RouteMapViewController: UIViewController {
         }
 
         let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
-        var instruction = instructions.0
+        let instruction = instructions.0
         
-        if let components = instruction?.components, components.count > 0 {
-            instruction?.components[0].prefix = NSLocalizedString("THEN", bundle: .mapboxNavigation, value: "Then: ", comment: "Then")
-            nextBannerView.maneuverView.step = nextStep
-            nextBannerView.instructionLabel.instruction = instruction
-            showNextBanner()
+        guard let components = instruction?.components, var firstComponent = components.first else {
+            hideNextBanner()
+            return
         }
+        
+        firstComponent.prefix = NSLocalizedString("THEN", bundle: .mapboxNavigation, value: "Then: ", comment: "Then")
+        nextBannerView.maneuverView.step = nextStep
+        nextBannerView.instructionLabel.instruction = instruction
+        showNextBanner()
     }
     
     func showNextBanner() {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -406,15 +406,22 @@ class RouteMapViewController: UIViewController {
     }
     
     func updateNextBanner(routeProgress: RouteProgress) {
-        guard let step = routeProgress.currentLegProgress.upComingStep,
-            routeProgress.currentLegProgress.currentStepProgress.durationRemaining <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier,
-            let nextStep = routeProgress.currentLegProgress.stepAfter(step),
+    
+        guard let upcomingStep = routeProgress.currentLegProgress.upComingStep,
+            let nextStep = routeProgress.currentLegProgress.stepAfter(upcomingStep),
             laneViewsContainerView.isHidden
             else {
                 hideNextBanner()
                 return
         }
     
+        // If the followon step is short and the user is near the end of the current step, show the nextBanner.
+        guard nextStep.expectedTravelTime <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier,
+            routeProgress.currentLegProgress.durationRemaining <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier else {
+            hideNextBanner()
+            return
+        }
+
         let instructions = visualInstructionFormatter.instructions(leg: routeProgress.currentLeg, step: nextStep)
         var instruction = instructions.0
         


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/862

We want to show the nextBanner when:

* the user is close to the end of their current step
* The follow on step is short

This cleans up the logic to make it a little more clear.

/cc @1ec5 @ericrwolfe @JThramer @frederoni 