### PR TITLE
Remove audio recording

### DIFF
--- a/Examples/Swift/Info.plist
+++ b/Examples/Swift/Info.plist
@@ -58,7 +58,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>The microphone is used if the user would like to share brief audio recordings while giving feedback</string>
 </dict>
 </plist>

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -217,7 +217,6 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
         exampleMode = .default
 
         let navigationViewController = NavigationViewController(for: route, locationManager: navigationLocationManager())
-        navigationViewController.recordsAudioFeedback = true
         navigationViewController.delegate = self
 
         present(navigationViewController, animated: true, completion: nil)

--- a/MapboxCoreNavigation/MMEEventsManager.swift
+++ b/MapboxCoreNavigation/MMEEventsManager.swift
@@ -381,13 +381,10 @@ class CoreFeedbackEvent: Hashable {
 }
 
 class FeedbackEvent: CoreFeedbackEvent {
-    func update(type: FeedbackType, source: FeedbackSource, description: String?, audio: Data?) {
+    func update(type: FeedbackType, source: FeedbackSource, description: String?) {
         eventDictionary["feedbackType"] = type.description
         eventDictionary["source"] = source.description
         eventDictionary["description"] = description
-        if let audio = audio {
-            eventDictionary["audio"] = audio.base64EncodedString()
-        }
     }
 }
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -399,9 +399,9 @@ open class RouteController: NSObject {
 
      Note that feedback is sent 20 seconds after being recorded, so you should promptly update the feedback metadata after the user discards any feedback UI.
      */
-    public func updateFeedback(feedbackId: String, type: FeedbackType, source: FeedbackSource, description: String?, audio: Data?) {
+    public func updateFeedback(feedbackId: String, type: FeedbackType, source: FeedbackSource, description: String?) {
         if let lastFeedback = outstandingFeedbackEvents.first(where: { $0.id.uuidString == feedbackId}) as? FeedbackEvent {
-            lastFeedback.update(type: type, source: source, description: description, audio: audio)
+            lastFeedback.update(type: type, source: source, description: description)
         }
     }
 

--- a/MapboxNavigation/FeedbackItem.swift
+++ b/MapboxNavigation/FeedbackItem.swift
@@ -12,7 +12,6 @@ struct FeedbackItem {
     var title: String
     var image: UIImage
     var feedbackType: FeedbackType
-    var audio: Data? = nil
     
     init(title: String, image: UIImage, feedbackType: FeedbackType) {
         self.title = title

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -20,16 +20,13 @@ extension FeedbackViewController: UIViewControllerTransitioningDelegate {
 
 typealias FeedbackSection = [FeedbackItem]
 
-class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollectionViewCellDelegate, AVAudioRecorderDelegate, UIGestureRecognizerDelegate {
+class FeedbackViewController: UIViewController, DismissDraggable, UIGestureRecognizerDelegate {
     
     typealias SendFeedbackHandler = (FeedbackItem) -> ()
     
-    var recordsAudioFeedback = false
     var sendFeedbackHandler: SendFeedbackHandler?
     var dismissFeedbackHandler: (() -> ())?
     var sections = [FeedbackSection]()
-    var recordingSession: AVAudioSession?
-    var audioRecorder: AVAudioRecorder?
     var activeFeedbackItem: FeedbackItem?
     
     let cellReuseIdentifier = "collectionViewCellId"
@@ -71,92 +68,11 @@ class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollec
         }
         
         enableAutoDismiss()
-        
-        if recordsAudioFeedback {
-            validateAudio()
-            enableAudioRecording()
-        }
-    }
-    
-    func validateAudio() {
-        guard Bundle.main.microphoneUsageDescription != nil else {
-            assert(false, "If `recordsAudioFeedback` is enabled, `NSMicrophoneUsageDescription` must be added in app plist")
-            return
-        }
-    }
-    
-    func enableAudioRecording() {
-        abortAutodismiss()
-        recordingSession = AVAudioSession.sharedInstance()
-        recordingSession?.requestRecordPermission() { [weak self] allowed in
-            self?.enableAutoDismiss()
-        }
     }
     
     func enableAutoDismiss() {
         abortAutodismiss()
         perform(#selector(dismissFeedback), with: nil, afterDelay: autoDismissInterval)
-    }
-    
-    func didLongPress(on cell: FeedbackCollectionViewCell, sender: UILongPressGestureRecognizer) {
-        guard sender.state == .began || sender.state == .ended else { return }
-        let touchLocation = sender.location(in: self.collectionView)
-        guard let indexPath = self.collectionView.indexPathForItem(at: touchLocation) else { return }
-        
-        abortAutodismiss()
-        activeFeedbackItem = sections[indexPath.section][indexPath.row]
-        
-        if sender.state == .began {
-            
-            reportIssueLabel.text = NSLocalizedString("RECORDING_AUDIO", bundle: .mapboxNavigation, value: "Recording Audio", comment: "Recording audio for feedback")
-            reportIssueLabel.textColor = .red
-            
-            reportIssueLabel.startRippleAnimation()
-            
-            if audioRecorder == nil {
-                startRecording()
-            }
-        }
-        
-        if sender.state == .ended {
-            finishRecording()
-        }
-    }
-    
-    func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
-        if let fileData = NSData(contentsOfFile: recorder.url.path) as Data? {
-            activeFeedbackItem!.audio = fileData
-            sendFeedbackHandler?(activeFeedbackItem!)
-        }
-        do {
-            try AVAudioSession.sharedInstance().setActive(false, with: [.notifyOthersOnDeactivation])
-        } catch {
-            print(error.localizedDescription)
-        }
-    }
-    
-    func startRecording() {
-        guard let audioFile = FileManager().cacheAudioFileLocation else { return }
-        
-        let settings = [
-            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
-            AVSampleRateKey: 12000,
-            AVNumberOfChannelsKey: 1,
-            AVEncoderAudioQualityKey: AVAudioQuality.low.rawValue
-        ]
-        
-        do {
-            audioRecorder = try AVAudioRecorder(url: audioFile, settings: settings)
-            audioRecorder?.delegate = self
-            audioRecorder?.record()
-        } catch {
-            print(error.localizedDescription)
-        }
-    }
-    
-    func finishRecording() {
-        audioRecorder?.stop()
-        audioRecorder = nil
     }
     
     func presentError(_ message: String) {
@@ -190,12 +106,6 @@ class FeedbackViewController: UIViewController, DismissDraggable, FeedbackCollec
     }
 }
 
-extension FileManager {
-    var cacheAudioFileLocation: URL? {
-        return self.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent("recording-\(Date().timeIntervalSince1970).m4a")
-    }
-}
-
 extension FeedbackViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath) as! FeedbackCollectionViewCell
@@ -204,7 +114,6 @@ extension FeedbackViewController: UICollectionViewDataSource {
         cell.titleLabel.text = item.title
         cell.imageView.tintColor = .clear
         cell.imageView.image = item.image
-        cell.delegate = self
         
         return cell
     }
@@ -238,27 +147,16 @@ extension FeedbackViewController: UICollectionViewDelegateFlowLayout {
     }
 }
 
-protocol FeedbackCollectionViewCellDelegate: class {
-    func didLongPress(on cell: FeedbackCollectionViewCell, sender: UILongPressGestureRecognizer)
-}
-
 class FeedbackCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var circleView: UIView!
     
-    weak var delegate: FeedbackCollectionViewCellDelegate?
     var longPress: UILongPressGestureRecognizer?
     var originalTransform: CGAffineTransform?
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        
-        if longPress == nil {
-            longPress = UILongPressGestureRecognizer(target: self, action: #selector(self.didLongPress(_:)))
-            longPress?.minimumPressDuration = 0.5
-            addGestureRecognizer(longPress!)
-        }
     }
     
     override func layoutSubviews() {
@@ -281,10 +179,6 @@ class FeedbackCollectionViewCell: UICollectionViewCell {
                 }
             }, completion: nil)
         }
-    }
-    
-    func didLongPress(_ sender: UILongPressGestureRecognizer) {
-        delegate?.didLongPress(on: self, sender: sender)
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -300,11 +300,6 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
      */
     public var annotatesSpokenInstructions = false
     
-    /**
-     A Boolean value that determines whether the user can long-press a feedback item to dictate feedback.
-     */
-    public var recordsAudioFeedback = false
-    
     let progressBar = ProgressBar()
     let routeStepFormatter = RouteStepFormatter()
     
@@ -563,10 +558,6 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
     
     func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool {
         return annotatesSpokenInstructions
-    }
-    
-    func mapViewControllerShouldRecordAudioFeedback(_ routeMapViewController: RouteMapViewController) -> Bool {
-        return recordsAudioFeedback
     }
 }
 

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -37,9 +37,6 @@
 /* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
 "LESS_THAN" = "<%@";
 
-/* Recording audio for feedback */
-"RECORDING_AUDIO" = "Recording Audio";
-
 /* Indicates that rerouting is in progress */
 "REROUTING" = "Rerouting…";
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -77,11 +77,6 @@ class RouteMapViewController: UIViewController {
      A Boolean value that determines whether the map annotates the locations at which instructions are spoken for debugging purposes.
      */
     var annotatesSpokenInstructions = false
-    
-    /**
-     A Boolean value that determines whether the user can long-press a feedback item to dictate feedback.
-     */
-    var recordsAudioFeedback = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -211,7 +206,6 @@ class RouteMapViewController: UIViewController {
         guard let parent = parent else { return }
     
         let controller = FeedbackViewController.loadFromStoryboard()
-        controller.recordsAudioFeedback = recordsAudioFeedback
         let sections: [FeedbackSection] = [[.turnNotAllowed, .closure, .reportTraffic], [.confusingInstructions, .generalMapError, .badRoute]]
         controller.sections = sections
         let feedbackId = routeController.recordFeedback()
@@ -219,7 +213,7 @@ class RouteMapViewController: UIViewController {
         controller.sendFeedbackHandler = { [weak self] (item) in
             guard let strongSelf = self else { return }
             strongSelf.delegate?.mapViewController(strongSelf, didSend: feedbackId, feedbackType: item.feedbackType)
-            strongSelf.routeController.updateFeedback(feedbackId: feedbackId, type: item.feedbackType, source: source, description: nil, audio: item.audio)
+            strongSelf.routeController.updateFeedback(feedbackId: feedbackId, type: item.feedbackType, source: source, description: nil)
             strongSelf.dismiss(animated: true) {
                 DialogViewController.present(on: parent)
             }
@@ -774,5 +768,4 @@ protocol RouteMapViewControllerDelegate: class {
     func mapViewController(_ mapViewController: RouteMapViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint?
     
     func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool
-    func mapViewControllerShouldRecordAudioFeedback(_ routeMapViewController: RouteMapViewController) -> Bool
 }


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-navigation-ios/issues/866

This removed audio recording since it was not used very much and it required developers to provide 
`NSMicrophoneUsageDescription` even if they were not using the feature.

/cc @frederoni @diegogarciar