### PR TITLE
Move constraints from storyboard into components

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		35D457A71E2D253100A89946 /* MBRouteController.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D457A61E2D253100A89946 /* MBRouteController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35D825FC1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */; };
 		35D825FE1E6A2EC60088F83B /* MapboxNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35DA85791FC45787004092EC /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DA85781FC45787004092EC /* StatusView.swift */; };
 		35DC585D1FABC61100B5A956 /* InstructionsBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC585C1FABC61100B5A956 /* InstructionsBannerViewTests.swift */; };
 		35DC9D8D1F431E59001ECD64 /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
 		35DC9D8F1F4321CC001ECD64 /* route-with-lanes.json in Resources */ = {isa = PBXBuildFile; fileRef = 35DC9D8E1F4321CC001ECD64 /* route-with-lanes.json */; };
@@ -435,6 +436,7 @@
 		35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLMapView+MGLNavigationAdditions.h"; sourceTree = "<group>"; };
 		35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLMapView+MGLNavigationAdditions.m"; sourceTree = "<group>"; };
 		35D825FD1E6A2EC60088F83B /* MapboxNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MapboxNavigation.h; sourceTree = "<group>"; };
+		35DA85781FC45787004092EC /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		35DC585C1FABC61100B5A956 /* InstructionsBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionsBannerViewTests.swift; sourceTree = "<group>"; };
 		35DC9D8E1F4321CC001ECD64 /* route-with-lanes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "route-with-lanes.json"; sourceTree = "<group>"; };
 		35DC9D901F4323AA001ECD64 /* LanesContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanesContainerView.swift; sourceTree = "<group>"; };
@@ -859,6 +861,7 @@
 				353610CD1FAB6A8F00FB1746 /* BottomBannerView.swift */,
 				355ED36F1FAB724F00BCE1B8 /* BottomBannerViewLayout.swift */,
 				35F520BF1FB482A200FC9C37 /* NextBannerView.swift */,
+				35DA85781FC45787004092EC /* StatusView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1521,6 +1524,7 @@
 				351BEC011E5BCC63006FE110 /* ManeuverView.swift in Sources */,
 				35B1E2951F1FF8EC00A13D32 /* UserCourseView.swift in Sources */,
 				3531C2701F9E095400D92F9A /* InstructionsBannerView.swift in Sources */,
+				35DA85791FC45787004092EC /* StatusView.swift in Sources */,
 				35025F3F1F051DD2002BA3EA /* DialogViewController.swift in Sources */,
 				359A8AEF1FA7B25B00BDB486 /* LanesStyleKit.swift in Sources */,
 				355ED3701FAB724F00BCE1B8 /* BottomBannerViewLayout.swift in Sources */,

--- a/MapboxNavigation/LanesContainerView.swift
+++ b/MapboxNavigation/LanesContainerView.swift
@@ -2,15 +2,20 @@ import UIKit
 import MapboxCoreNavigation
 import MapboxDirections
 
-class LanesContainerView: LanesView {
-    var stackView: UIStackView!
+
+/// :nodoc:
+@IBDesignable
+@objc(MBLanesContainerView)
+public class LanesContainerView: LanesView {
+    weak var stackView: UIStackView!
+    weak var separatorView: SeparatorView!
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         commonInit()
     }
@@ -22,16 +27,33 @@ class LanesContainerView: LanesView {
     }
     
     func commonInit() {
-        stackView = UIStackView(arrangedSubviews: [])
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        let heightConstraint = heightAnchor.constraint(equalToConstant: 40)
+        heightConstraint.priority = 999
+        heightConstraint.isActive = true
+        
+        let stackView = UIStackView(arrangedSubviews: [])
         stackView.axis = .horizontal
         stackView.spacing = 4
         stackView.distribution = .equalCentering
         stackView.alignment = .center
         stackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stackView)
+        self.stackView = stackView
+        
+        let separatorView = SeparatorView()
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separatorView)
+        self.separatorView = separatorView
         
         addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[stackView]-0-|", options: [], metrics: nil, views: ["stackView": stackView]))
         addConstraint(NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal, toItem: stackView, attribute: .centerX, multiplier: 1, constant: 0))
+        
+        separatorView.heightAnchor.constraint(equalToConstant: 2).isActive = true
+        separatorView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        separatorView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2).isActive = true
+        separatorView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
     }
     
     func updateLaneViews(step: RouteStep, durationRemaining: TimeInterval) {

--- a/MapboxNavigation/LanesContainerView.swift
+++ b/MapboxNavigation/LanesContainerView.swift
@@ -52,7 +52,7 @@ public class LanesContainerView: LanesView {
         
         separatorView.heightAnchor.constraint(equalToConstant: 2).isActive = true
         separatorView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
-        separatorView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2).isActive = true
+        separatorView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
         separatorView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
     }
     

--- a/MapboxNavigation/LanesContainerView.swift
+++ b/MapboxNavigation/LanesContainerView.swift
@@ -47,8 +47,9 @@ public class LanesContainerView: LanesView {
         addSubview(separatorView)
         self.separatorView = separatorView
         
-        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[stackView]-0-|", options: [], metrics: nil, views: ["stackView": stackView]))
-        addConstraint(NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal, toItem: stackView, attribute: .centerX, multiplier: 1, constant: 0))
+        stackView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        stackView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         
         separatorView.heightAnchor.constraint(equalToConstant: 2).isActive = true
         separatorView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true

--- a/MapboxNavigation/LanesContainerView.swift
+++ b/MapboxNavigation/LanesContainerView.swift
@@ -30,7 +30,7 @@ public class LanesContainerView: LanesView {
         translatesAutoresizingMaskIntoConstraints = false
         
         let heightConstraint = heightAnchor.constraint(equalToConstant: 40)
-        heightConstraint.priority = 999
+        heightConstraint.priority = UILayoutPriority(rawValue: 999)
         heightConstraint.isActive = true
         
         let stackView = UIStackView(arrangedSubviews: [])

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -53,7 +53,9 @@ open class NextBannerView: UIView {
     }
     
     func setupLayout() {
-        heightAnchor.constraint(equalToConstant: 44).isActive = true
+        let heightConstraint = heightAnchor.constraint(equalToConstant: 44)
+        heightConstraint.priority = 999
+        heightConstraint.isActive = true
         
         let midX = BaseInstructionsBannerView.padding + BaseInstructionsBannerView.maneuverViewSize.width / 2
         maneuverView.centerXAnchor.constraint(equalTo: leftAnchor, constant: midX).isActive = true

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -56,7 +56,7 @@ open class NextBannerView: UIView {
     
     func setupLayout() {
         let heightConstraint = heightAnchor.constraint(equalToConstant: 44)
-        heightConstraint.priority = 999
+        heightConstraint.priority = UILayoutPriority(rawValue: 999)
         heightConstraint.isActive = true
         
         let midX = BaseInstructionsBannerView.padding + BaseInstructionsBannerView.maneuverViewSize.width / 2

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -28,6 +28,8 @@ open class NextBannerView: UIView {
     }
     
     func setupViews() {
+        translatesAutoresizingMaskIntoConstraints = false
+        
         let maneuverView = ManeuverView()
         maneuverView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(maneuverView)

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -95,66 +95,27 @@
                                 <color key="backgroundColor" red="0.4858537946" green="0.87731584819999997" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Eeb-3z-AWG">
-                                <rect key="frame" x="0.0" y="116.5" width="375" height="70"/>
+                                <rect key="frame" x="0.0" y="116.5" width="375" height="114"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Container View" customClass="LanesContainerView" customModule="MapboxNavigation" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Container View" customClass="MBLanesContainerView">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="40"/>
-                                        <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YOs-u9-Vze" customClass="MBSeparatorView">
-                                                <rect key="frame" x="0.0" y="40" width="375" height="2"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="2" id="Mkc-cj-A6R"/>
-                                                </constraints>
-                                            </view>
-                                        </subviews>
                                         <color key="backgroundColor" red="0.9700858161" green="0.9700858161" blue="0.9700858161" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="YOs-u9-Vze" secondAttribute="bottom" constant="-2" id="0Xh-Gu-bSp"/>
-                                            <constraint firstItem="YOs-u9-Vze" firstAttribute="leading" secondItem="NE9-ru-uJw" secondAttribute="leading" id="3gB-jE-wVp"/>
-                                            <constraint firstAttribute="trailing" secondItem="YOs-u9-Vze" secondAttribute="trailing" id="4O1-Y5-NIJ"/>
-                                            <constraint firstAttribute="height" priority="999" constant="40" id="vE6-3z-p4c"/>
-                                        </constraints>
                                         <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
                                     </view>
-                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvl-aX-s8B" customClass="MBNextBannerView">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvl-aX-s8B" customClass="MBNextBannerView">
                                         <rect key="frame" x="0.0" y="40" width="375" height="44"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="kg2-Il-mKD"/>
-                                        </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jym-DH-tdD" customClass="MBStatusView">
-                                        <rect key="frame" x="0.0" y="40" width="375" height="30"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rerouting…" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UpZ-gr-OKM">
-                                                <rect key="frame" x="141.5" y="5" width="92.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
-                                                <color key="textColor" red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="jgC-8q-YUu">
-                                                <rect key="frame" x="345" y="5" width="20" height="20"/>
-                                            </activityIndicatorView>
-                                        </subviews>
+                                        <rect key="frame" x="0.0" y="84" width="375" height="30"/>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.67473591549295775" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstItem="jgC-8q-YUu" firstAttribute="centerY" secondItem="Jym-DH-tdD" secondAttribute="centerY" id="Ghp-Pc-H3U"/>
-                                            <constraint firstAttribute="trailing" secondItem="jgC-8q-YUu" secondAttribute="trailing" constant="10" id="JTW-3W-9TJ"/>
-                                            <constraint firstItem="UpZ-gr-OKM" firstAttribute="centerX" secondItem="Jym-DH-tdD" secondAttribute="centerX" id="gSp-Qg-FgY"/>
-                                            <constraint firstAttribute="height" priority="999" constant="30" id="lnn-re-skW"/>
-                                            <constraint firstItem="UpZ-gr-OKM" firstAttribute="centerY" secondItem="Jym-DH-tdD" secondAttribute="centerY" id="uEG-1L-ErF"/>
-                                        </constraints>
-                                        <connections>
-                                            <outlet property="activityIndicatorView" destination="jgC-8q-YUu" id="mGB-sM-IEl"/>
-                                            <outlet property="textLabel" destination="UpZ-gr-OKM" id="aOh-bx-0nv"/>
-                                        </connections>
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="NE9-ru-uJw" firstAttribute="leading" secondItem="Eeb-3z-AWG" secondAttribute="leading" id="KYj-hp-PPs"/>
-                                    <constraint firstItem="NE9-ru-uJw" firstAttribute="top" secondItem="Eeb-3z-AWG" secondAttribute="top" id="Whw-yv-z8o"/>
-                                    <constraint firstAttribute="trailing" secondItem="NE9-ru-uJw" secondAttribute="trailing" id="sW3-fN-Taw"/>
+                                    <constraint firstItem="NE9-ru-uJw" firstAttribute="leading" secondItem="Eeb-3z-AWG" secondAttribute="leading" id="LSX-ah-yaX"/>
+                                    <constraint firstAttribute="trailing" secondItem="Jym-DH-tdD" secondAttribute="trailing" id="NxB-vc-wJN"/>
+                                    <constraint firstAttribute="trailing" secondItem="NE9-ru-uJw" secondAttribute="trailing" id="bW9-2b-3aA"/>
+                                    <constraint firstItem="Jym-DH-tdD" firstAttribute="leading" secondItem="Eeb-3z-AWG" secondAttribute="leading" id="kR4-1L-iSo"/>
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SKK-r5-nj0" customClass="MBResumeButton">

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -100,6 +100,7 @@ class RouteMapViewController: UIViewController {
         wayNameView.applyDefaultCornerRadiusShadow()
         laneViewsContainerView.isHidden = true
         statusView.isHidden = true
+        nextBannerView.isHidden = true
         isInOverviewMode = false
         instructionsBannerView.delegate = self
         bottomBannerView.delegate = self

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -291,6 +291,7 @@ class RouteMapViewController: UIViewController {
     
     @objc func willReroute(notification: NSNotification) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
+        hideLaneViews()
         statusView.show(title, showSpinner: true)
         statusView.hide(delay: 3, animated: true)
     }

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -26,13 +26,13 @@ public class StatusView: UIView {
         let textLabel = UILabel()
         textLabel.text = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         textLabel.translatesAutoresizingMaskIntoConstraints = false
-        textLabel.font = UIFont.systemFont(ofSize: 17, weight: UIFontWeightSemibold)
+        textLabel.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         textLabel.textColor = .white
         addSubview(textLabel)
         self.textLabel = textLabel
         
         let heightConstraint = heightAnchor.constraint(equalToConstant: 30)
-        heightConstraint.priority = 999
+        heightConstraint.priority = UILayoutPriority(rawValue: 999)
         heightConstraint.isActive = true
         textLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         textLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -24,6 +24,7 @@ public class StatusView: UIView {
         self.activityIndicatorView = activityIndicatorView
         
         let textLabel = UILabel()
+        textLabel.contentMode = .bottom
         textLabel.text = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         textLabel.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
@@ -54,6 +55,7 @@ public class StatusView: UIView {
         
         UIView.defaultAnimation(0.3, animations: {
             self.isHidden = false
+            self.textLabel.alpha = 1
             self.superview?.layoutIfNeeded()
         }, completion: nil)
     }
@@ -62,8 +64,10 @@ public class StatusView: UIView {
         
         if animated {
             guard isHidden == false else { return }
+            
             UIView.defaultAnimation(0.3, delay: delay, animations: {
                 self.isHidden = true
+                self.textLabel.alpha = 0
                 self.superview?.layoutIfNeeded()
             }, completion: { (completed) in
                 self.activityIndicatorView.stopAnimating()

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -1,0 +1,74 @@
+import UIKit
+
+/// :nodoc:
+@IBDesignable
+@objc(MBStatusView)
+public class StatusView: UIView {
+    weak var activityIndicatorView: UIActivityIndicatorView!
+    weak var textLabel: UILabel!
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    func commonInit() {
+        let activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .white)
+        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(activityIndicatorView)
+        self.activityIndicatorView = activityIndicatorView
+        
+        let textLabel = UILabel()
+        textLabel.text = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.font = UIFont.systemFont(ofSize: 17, weight: UIFontWeightSemibold)
+        textLabel.textColor = .white
+        addSubview(textLabel)
+        self.textLabel = textLabel
+        
+        let heightConstraint = heightAnchor.constraint(equalToConstant: 30)
+        heightConstraint.priority = 999
+        heightConstraint.isActive = true
+        textLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        textLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        
+        activityIndicatorView.rightAnchor.constraint(equalTo: safeRightAnchor, constant: -10).isActive = true
+        activityIndicatorView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+    }
+    
+    func show(_ title: String, showSpinner: Bool) {
+        textLabel.text = title
+        activityIndicatorView.hidesWhenStopped = true
+        if showSpinner {
+            activityIndicatorView.startAnimating()
+        } else {
+            activityIndicatorView.stopAnimating()
+        }
+        
+        guard isHidden == true else { return }
+        
+        UIView.defaultAnimation(0.3, animations: {
+            self.isHidden = false
+        }, completion: nil)
+    }
+    
+    func hide(delay: TimeInterval = 0, animated: Bool = true) {
+        
+        if animated {
+            guard isHidden == false else { return }
+            UIView.defaultAnimation(0.3, delay: delay, animations: {
+                self.isHidden = true
+            }, completion: { (completed) in
+                self.activityIndicatorView.stopAnimating()
+            })
+        } else {
+            activityIndicatorView.stopAnimating()
+            isHidden = true
+        }
+    }
+}

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -54,6 +54,7 @@ public class StatusView: UIView {
         
         UIView.defaultAnimation(0.3, animations: {
             self.isHidden = false
+            self.superview?.layoutIfNeeded()
         }, completion: nil)
     }
     
@@ -63,6 +64,7 @@ public class StatusView: UIView {
             guard isHidden == false else { return }
             UIView.defaultAnimation(0.3, delay: delay, animations: {
                 self.isHidden = true
+                self.superview?.layoutIfNeeded()
             }, completion: { (completed) in
                 self.activityIndicatorView.stopAnimating()
             })

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -445,43 +445,7 @@ open class InstructionsBannerContentView: UIView { }
 @objc(MBBottomBannerContentView)
 open class BottomBannerContentView: UIView { }
 
-/// :nodoc:
-@objc(MBStatusView)
-public class StatusView: UIView {
-    @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
-    @IBOutlet weak var textLabel: UILabel!
-    
-    func show(_ title: String, showSpinner: Bool) {
-        textLabel.text = title
-        activityIndicatorView.hidesWhenStopped = true
-        if showSpinner {
-            activityIndicatorView.startAnimating()
-        } else {
-            activityIndicatorView.stopAnimating()
-        }
-        
-        guard isHidden == true else { return }
-        
-        UIView.defaultAnimation(0.3, animations: {
-            self.isHidden = false
-        }, completion: nil)
-    }
-    
-    func hide(delay: TimeInterval = 0, animated: Bool = true) {
-        
-        if animated {
-            guard isHidden == false else { return }
-            UIView.defaultAnimation(0.3, delay: delay, animations: {
-                self.isHidden = true
-            }, completion: { (completed) in
-                self.activityIndicatorView.stopAnimating()
-            })
-        } else {
-            self.activityIndicatorView.stopAnimating()
-            self.isHidden = true
-        }
-    }
-}
+
 
 
 /// :nodoc:

--- a/MapboxNavigationTests/InstructionsBannerViewTests.swift
+++ b/MapboxNavigationTests/InstructionsBannerViewTests.swift
@@ -93,6 +93,7 @@ class InstructionsBannerViewTests: FBSnapshotTestCase {
         let instructionsBannerView = instructionsView()
         let nextBannerViewFrame = CGRect(x: 0, y: instructionsBannerView.frame.maxY, width: instructionsBannerView.bounds.width, height: 44)
         let nextBannerView = NextBannerView(frame: nextBannerViewFrame)
+        nextBannerView.translatesAutoresizingMaskIntoConstraints = true
         view.addSubview(instructionsBannerView)
         view.addSubview(nextBannerView)
         view.frame = CGRect(origin: .zero, size: CGSize(width: nextBannerViewFrame.width, height: nextBannerViewFrame.maxY))


### PR DESCRIPTION
Fixes #844 

This PR moves constraints responsible for the intrinsic content size away from the storyboard into each component (Next banner, status view, lanes).

@bsudekum @JThramer 👀 