### PR TITLE
Resume tracking quickly when application will enter foreground

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -150,11 +150,13 @@ class RouteMapViewController: UIViewController {
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground(notification:)), name: .UIApplicationWillEnterForeground, object: nil)
     }
     
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: RouteControllerDidReroute, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .UIApplicationWillEnterForeground, object: nil)
     }
 
     @IBAction func recenter(_ sender: AnyObject) {
@@ -286,6 +288,10 @@ class RouteMapViewController: UIViewController {
             self.removePreviewInstructions()
             self.stepsViewController = nil
         }
+    }
+    
+    @objc func applicationWillEnterForeground(notification: NSNotification) {
+        mapView.updateCourseTracking(location: routeController.location, animated: false)
     }
     
     @objc func willReroute(notification: NSNotification) {


### PR DESCRIPTION
Fixes #880 

Update course tracking when the application will enter foreground.

@bsudekum @JThramer 👀 