### PR TITLE
Decouple waypoint arrival from voice announcements

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -761,7 +761,9 @@ extension RouteController: CLLocationManagerDelegate {
         if userSnapToStepDistanceFromManeuver <= RouteControllerManeuverZoneRadius {
             if routeProgress.currentLegProgress.upComingStep?.maneuverType == ManeuverType.arrive {
                 routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
-            } else if courseMatchesManeuverFinalHeading || (userAbsoluteDistance > lastKnownUserAbsoluteDistance && lastKnownUserAbsoluteDistance > RouteControllerManeuverZoneRadius) {
+            }
+            
+            if courseMatchesManeuverFinalHeading || (userAbsoluteDistance > lastKnownUserAbsoluteDistance && lastKnownUserAbsoluteDistance > RouteControllerManeuverZoneRadius) {
                 incrementRouteProgress()
             }
         }
@@ -775,10 +777,6 @@ extension RouteController: CLLocationManagerDelegate {
 
         for (voiceInstructionIndex, voiceInstruction) in spokenInstructions.enumerated() {
             if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep && voiceInstructionIndex >= routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex {
-                
-                if voiceInstructionIndex == spokenInstructions.count - 1 && routeProgress.currentLegProgress.upComingStep?.maneuverType == ManeuverType.arrive {
-                    routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
-                }
 
                 NotificationCenter.default.post(name: RouteControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
                     MBRouteControllerDidPassSpokenInstructionPointRouteProgressKey: routeProgress

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -303,6 +303,8 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
     let progressBar = ProgressBar()
     let routeStepFormatter = RouteStepFormatter()
     
+    var previousArrivalWaypoint: Waypoint?
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
@@ -407,6 +409,11 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         mapViewController?.notifyDidChange(routeProgress: routeProgress, location: location, secondsRemaining: secondsRemaining)
         
         progressBar.setProgress(routeProgress.currentLegProgress.userHasArrivedAtWaypoint ? 1 : CGFloat(routeProgress.fractionTraveled), animated: true)
+        
+        if routeProgress.currentLegProgress.userHasArrivedAtWaypoint && routeProgress.currentLegProgress.leg.destination != previousArrivalWaypoint {
+            delegate?.navigationViewController?(self, didArriveAt: routeProgress.currentLegProgress.leg.destination)
+            previousArrivalWaypoint = routeProgress.currentLegProgress.leg.destination
+        }
     }
     
     @objc func didPassInstructionPoint(notification: NSNotification) {
@@ -419,10 +426,6 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         
         if let upComingStep = routeProgress.currentLegProgress.upComingStep, routeProgress.currentLegProgress.currentStepProgress.durationRemaining < RouteControllerHighAlertInterval {
             scheduleLocalNotification(about: upComingStep, legIndex: routeProgress.legIndex, numberOfLegs: routeProgress.route.legs.count)
-        }
-        
-        if routeProgress.currentLegProgress.userHasArrivedAtWaypoint {
-            delegate?.navigationViewController?(self, didArriveAt: routeProgress.currentLegProgress.leg.destination)
         }
         
         forceRefreshAppearanceIfNeeded()


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/877

We were piggy backing off of voice announcements to trigger waypoint arrivals. This is not really a good idea in practice since we don't really know when a voice announcement will be given. Instead, when we know the user is within x meters of the waypoint, say that they are there.

/cc @TCOA @ashishke2m @mapbox/navigation-ios 