### PR TITLE
Prevent waypoints from overlapping maneuver arrows

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -640,6 +640,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             return
         }
         
+        guard step.maneuverType != .arrive else { return }
+        
         let minimumZoomLevel: Float = 14.5
         
         let shaftLength = max(min(30 * metersPerPoint(atLatitude: maneuverCoordinate.latitude), 30), 10)


### PR DESCRIPTION
We don't need a maneuver arrows when arriving at a waypoint.

/cc @mapbox/navigation-ios 