### PR TITLE
Don't abbreviate when not necessary

### DIFF
--- a/MapboxNavigation/InstructionsBannerViewLayout.swift
+++ b/MapboxNavigation/InstructionsBannerViewLayout.swift
@@ -120,13 +120,13 @@ extension BaseInstructionsBannerView {
         // Abbreviate if the instructions do not fit on one line
         primaryLabel.availableBounds = {
             let height = ("|" as NSString).size(withAttributes: [.font: self.primaryLabel.font]).height
-            let availableWidth = self.bounds.width-self.maneuverView.frame.maxX-(8*2)
+            let availableWidth = self.bounds.width - (8*2)
             return CGRect(x: 0, y: 0, width: availableWidth, height: height)
         }
         
         secondaryLabel.availableBounds = {
             let height = ("|" as NSString).size(withAttributes: [.font: self.secondaryLabel.font]).height
-            let availableWidth = self.bounds.width-self.maneuverView.frame.maxX-(8*2)
+            let availableWidth = self.bounds.width - (8*2)
             return CGRect(x: 0, y: 0, width: availableWidth, height: height)
         }
     }


### PR DESCRIPTION
This fixes an issue where cardinal directions would be abbreviated until the shield was loaded causing some strange artifacts to the eye.

@frederoni I could be wrong here, but subtracting the `maxX` value from the width could produce some very small values (I'm getting 16px in some cases).

Don't we just need to know the width of the area minus any padding?