### PR TITLE
Better initial view when completing leg

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -121,16 +121,17 @@ class RouteMapViewController: UIViewController {
         mapView.compassView.isHidden = true
         
         mapView.tracksUserCourse = true
-        mapView.updateCourseTracking(location: routeController.location, animated: false)
         mapView.enableFrameByFrameCourseViewTracking(for: 3)
-        
-        guard !isViewLoaded else { return }
 
         if let camera = pendingCamera {
             mapView.camera = camera
-        } else if let firstCoordinate = routeController.routeProgress.currentLegProgress.currentStep.coordinates?.first {
-            let location = CLLocation(latitude: firstCoordinate.latitude, longitude: firstCoordinate.longitude)
+        } else if let location = routeController.location, location.course > 0 {
             mapView.updateCourseTracking(location: location, animated: false)
+        } else if let coordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates, let firstCoordinate = coordinates.first, coordinates.count > 1 {
+            let secondCoordinate = coordinates[1]
+            let course = firstCoordinate.direction(to: secondCoordinate)
+            let newLocation = CLLocation(coordinate: routeController.location?.coordinate ?? firstCoordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: course, speed: 0, timestamp: Date())
+            mapView.updateCourseTracking(location: newLocation, animated: false)
         } else {
             mapView.setCamera(tiltedCamera, animated: false)
         }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -119,27 +119,28 @@ class RouteMapViewController: UIViewController {
         
         muteButton.isSelected = NavigationSettings.shared.muted
         mapView.compassView.isHidden = true
+        
+        mapView.tracksUserCourse = true
+        mapView.updateCourseTracking(location: routeController.location, animated: false)
+        mapView.enableFrameByFrameCourseViewTracking(for: 3)
+        
+        guard !isViewLoaded else { return }
 
         if let camera = pendingCamera {
             mapView.camera = camera
-        } else if let firstCoordinate = route.coordinates?.first {
+        } else if let firstCoordinate = routeController.routeProgress.currentLegProgress.currentStep.coordinates?.first {
             let location = CLLocation(latitude: firstCoordinate.latitude, longitude: firstCoordinate.longitude)
             mapView.updateCourseTracking(location: location, animated: false)
         } else {
             mapView.setCamera(tiltedCamera, animated: false)
         }
-        
-        mapView.enableFrameByFrameCourseViewTracking(for: 3)
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        mapView.tracksUserCourse = true
-        
         showRouteIfNeeded()
         currentLegIndexMapped = routeController.routeProgress.legIndex
-        mapView.enableFrameByFrameCourseViewTracking(for: 3)
     }
     
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Before, the user puck would float back to the beginning of the route and then jump back to the current location. Now:

![gif3](https://user-images.githubusercontent.com/1058624/33294948-d1dc170a-d387-11e7-9da7-b9512348be6b.gif)

/cc @mapbox/navigation-ios 