### PR TITLE
Fix leaky timer

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -110,6 +110,7 @@ class RouteMapViewController: UIViewController {
     
     deinit {
         suspendNotifications()
+        removeTimer()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -151,7 +152,7 @@ class RouteMapViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground(notification:)), name: .UIApplicationWillEnterForeground, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(removeTimer), name: .UIApplicationWillResignActive, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(removeTimer), name: .UIApplicationDidEnterBackground, object: nil)
     }
     
     func suspendNotifications() {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -144,20 +144,21 @@ class RouteMapViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        updateETATimer?.invalidate()
-        updateETATimer = nil
+        removeTimer()
     }
-    
+
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: RouteControllerDidReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground(notification:)), name: .UIApplicationWillEnterForeground, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(removeTimer), name: .UIApplicationWillResignActive, object: nil)
     }
     
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: RouteControllerWillReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: RouteControllerDidReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: .UIApplicationWillEnterForeground, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .UIApplicationWillResignActive, object: nil)
     }
 
     @IBAction func recenter(_ sender: AnyObject) {
@@ -171,6 +172,11 @@ class RouteMapViewController: UIViewController {
                          stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
         
         removePreviewInstructions()
+    }
+    
+    @objc func removeTimer() {
+        updateETATimer?.invalidate()
+        updateETATimer = nil
     }
     
     func removePreviewInstructions() {
@@ -293,6 +299,7 @@ class RouteMapViewController: UIViewController {
     
     @objc func applicationWillEnterForeground(notification: NSNotification) {
         mapView.updateCourseTracking(location: routeController.location, animated: false)
+        resetETATimer()
     }
     
     @objc func willReroute(notification: NSNotification) {


### PR DESCRIPTION
We're getting a few crash reports that looks like

```
#0. Crashed: com.apple.main-thread
0  MapboxNavigation               0x10093eae4 RouteMapViewController.updateETA() (RouteMapViewController.swift:620)
1  MapboxNavigation               0x10093eb04 @objc RouteMapViewController.updateETA() (RouteMapViewController.swift)
2  Foundation                     0x19085e2e4 __NSFireTimer + 88
3  CoreFoundation                 0x18fcf71d8 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 28
4  CoreFoundation                 0x18fcf6eec __CFRunLoopDoTimer + 872
5  CoreFoundation                 0x18fcf67a8 __CFRunLoopDoTimers + 244
6  CoreFoundation                 0x18fcf43a4 __CFRunLoopRun + 1572
7  CoreFoundation                 0x18fc222b8 CFRunLoopRunSpecific + 444
8  GraphicsServices               0x1916d6198 GSEventRunModal + 180
9  UIKit                          0x195c697fc -[UIApplication _run] + 684
10 UIKit                          0x195c64534 UIApplicationMain + 208
11 Voyage                         0x100045a78 main (UIImage.swift:18)
12 libdispatch.dylib              0x18ec055b8 (Missing)
```

It looks like there can be errors with long standing timers specifically in the background, ref https://stackoverflow.com/questions/14802131/timer-loop-crashes-sporadically-after-returning-from-the-background

/cc @mapbox/navigation-ios 