### PR TITLE
Fix incrementing beyond steps.count

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -761,9 +761,7 @@ extension RouteController: CLLocationManagerDelegate {
         if userSnapToStepDistanceFromManeuver <= RouteControllerManeuverZoneRadius {
             if routeProgress.currentLegProgress.upComingStep?.maneuverType == ManeuverType.arrive {
                 routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
-            }
-            
-            if courseMatchesManeuverFinalHeading || (userAbsoluteDistance > lastKnownUserAbsoluteDistance && lastKnownUserAbsoluteDistance > RouteControllerManeuverZoneRadius) {
+            } else if courseMatchesManeuverFinalHeading || (userAbsoluteDistance > lastKnownUserAbsoluteDistance && lastKnownUserAbsoluteDistance > RouteControllerManeuverZoneRadius) {
                 incrementRouteProgress()
             }
         }


### PR DESCRIPTION
Reverts change in https://github.com/mapbox/mapbox-navigation-ios/pull/883/files#diff-1a2149692b3d7c58b6a0392120d6011aR764

We shouldn't be incrementing the steps/leg index if there are not any waypoints remaining. Without this, we crash.

/cc @mapbox/navigation-ios 