### PR TITLE
Remove exits from the map

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -143,6 +143,7 @@ class RouteMapViewController: UIViewController {
         
         showRouteIfNeeded()
         currentLegIndexMapped = routeController.routeProgress.legIndex
+        removeExits()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -335,6 +336,16 @@ class RouteMapViewController: UIViewController {
             mapView.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
         } else {
             mapView.removeArrow()
+        }
+    }
+    
+    func removeExits() {
+        guard let style = mapView.style else { return }
+        
+        for layer in style.layers {
+            if let symbolLayer = layer as? MGLSymbolStyleLayer, symbolLayer.sourceLayerIdentifier == "motorway_junction" {
+                style.removeLayer(layer)
+            }
         }
     }
 


### PR DESCRIPTION
This PR removes all exits from the style if present.

The exit identifiers on the map don't really help. If anything, they create noise since all exits, even those not on the route line, are shown. I also do not think adding exits for the current route is the answer here either.

/cc @mapbox/navigation-ios @aparlato @natslaughter 