### PR TITLE
Check all future steps

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -584,9 +584,7 @@ extension RouteController: CLLocationManagerDelegate {
         let radius = max(reroutingTolerance, location.horizontalAccuracy + RouteControllerUserLocationSnappingDistance)
         let isCloseToCurrentStep = newLocation.isWithin(radius, of: routeProgress.currentLegProgress.currentStep)
         
-        if isCloseToCurrentStep {
-            return true
-        }
+        guard !isCloseToCurrentStep else { return true }
 
         // Check to see if the user is moving away from the maneuver.
         // Here, we store an array of distances. If the current distance is greater than the last distance,

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -397,7 +397,6 @@ open class RouteController: NSObject {
             guard let coords = step.coordinates else { continue }
             guard let closestCoordOnStep = Polyline(coords).closestCoordinate(to: coordinate) else { continue }
             
-            
             // First time around, currentClosest will be `nil`.
             guard let currentClosestDistance = currentClosest?.distance else {
                 currentClosest = (index: stepIndex, distance: closestCoordOnStep.distance)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -390,13 +390,12 @@ open class RouteController: NSObject {
     func closestStep(to coordinate: CLLocationCoordinate2D) -> (CLLocationDistance, Int)? {
         var closestStep = Int.max
         var lowestDistance = Double.infinity
-        
-        let remainingSteps = routeProgress.currentLeg.steps.suffix(routeProgress.currentLegProgress.stepIndex)
+        let remainingSteps = routeProgress.currentLeg.steps.suffix(from: routeProgress.currentLegProgress.stepIndex)
         
         for (stepIndex, step) in remainingSteps.enumerated() {
             guard let coords = step.coordinates else { continue }
             guard let closestCoordOnStep = Polyline(coords).closestCoordinate(to: coordinate) else { continue }
-            
+
             if closestCoordOnStep.distance < lowestDistance {
                 lowestDistance = closestCoordOnStep.distance
                 closestStep = stepIndex

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -176,8 +176,6 @@ open class RouteController: NSObject {
     var recentDistancesFromManeuver: [CLLocationDistance] = []
 
     var previousArrivalWaypoint: Waypoint?
-    
-    typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)
 
 
     /**
@@ -387,28 +385,6 @@ open class RouteController: NSObject {
         }
 
         return CLLocation(coordinate: userCoordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: userCourse, speed: location.speed, timestamp: location.timestamp)
-    }
-    
-    func closestStep(to coordinate: CLLocationCoordinate2D) -> StepIndexDistance? {
-        var currentClosest: StepIndexDistance?
-        let remainingSteps = routeProgress.currentLeg.steps.suffix(from: routeProgress.currentLegProgress.stepIndex)
-        
-        for (stepIndex, step) in remainingSteps.enumerated() {
-            guard let coords = step.coordinates else { continue }
-            guard let closestCoordOnStep = Polyline(coords).closestCoordinate(to: coordinate) else { continue }
-            
-            // First time around, currentClosest will be `nil`.
-            guard let currentClosestDistance = currentClosest?.distance else {
-                currentClosest = (index: stepIndex, distance: closestCoordOnStep.distance)
-                continue
-            }
-
-            if closestCoordOnStep.distance < currentClosestDistance {
-                currentClosest = (index: stepIndex, distance: closestCoordOnStep.distance)
-            }
-        }
-        
-        return currentClosest
     }
 
     /**
@@ -634,7 +610,7 @@ extension RouteController: CLLocationManagerDelegate {
         }
 
         // Check and see if the user is near a future step.
-        guard let nearestStep = closestStep(to: location.coordinate) else {
+        guard let nearestStep = routeProgress.currentLegProgress.closestStep(to: location.coordinate) else {
             return false
         }
         
@@ -824,7 +800,7 @@ extension RouteController: CLLocationManagerDelegate {
         }
     }
 
-    func advanceStepIndex(to: Int? = nil) {
+    func advanceStepIndex(to: Array<RouteStep>.Index? = nil) {
         if let forcedStepIndex = to {
             routeProgress.currentLegProgress.stepIndex = forcedStepIndex
         } else {

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MapboxDirections
+import Turf
 
 
 /**
@@ -305,6 +306,30 @@ open class RouteLegProgress: NSObject {
         let nearby = priorCoords + currentCoords + upcomingCoords
         assert(!nearby.isEmpty, "Step must have coordinates")
         return nearby
+    }
+    
+    typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)
+    
+    func closestStep(to coordinate: CLLocationCoordinate2D) -> StepIndexDistance? {
+        var currentClosest: StepIndexDistance?
+        let remainingSteps = leg.steps.suffix(from: stepIndex)
+        
+        for (stepIndex, step) in remainingSteps.enumerated() {
+            guard let coords = step.coordinates else { continue }
+            guard let closestCoordOnStep = Polyline(coords).closestCoordinate(to: coordinate) else { continue }
+            
+            // First time around, currentClosest will be `nil`.
+            guard let currentClosestDistance = currentClosest?.distance else {
+                currentClosest = (index: stepIndex, distance: closestCoordOnStep.distance)
+                continue
+            }
+            
+            if closestCoordOnStep.distance < currentClosestDistance {
+                currentClosest = (index: stepIndex, distance: closestCoordOnStep.distance)
+            }
+        }
+        
+        return currentClosest
     }
 }
 


### PR DESCRIPTION
We currently have a last ditch effort before rerouting to see if the user is somehow on the upcoming or follow on step.

This changes to check if the user is on any future step. If the user is with a certain radius to this new step, we increment the stepIndex to this new step.

/cc @mapbox/navigation 