### PR TITLE
Adjustable simulation speed

### DIFF
--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -36,6 +36,8 @@ public class SimulatedLocationManager: NavigationLocationManager {
     fileprivate var locations: [SimulatedLocation]!
     fileprivate var routeLine = [CLLocationCoordinate2D]()
     
+    public var speedMultiplier: Double = 1
+    
     @objc override public var location: CLLocation? {
         get {
             return currentLocation
@@ -148,18 +150,18 @@ public class SimulatedLocationManager: NavigationLocationManager {
         }
         
         let location = CLLocation(coordinate: newCoordinate,
-                                     altitude: 0,
-                                     horizontalAccuracy: horizontalAccuracy,
-                                     verticalAccuracy: verticalAccuracy,
-                                     course: newCoordinate.direction(to: lookAheadCoordinate).wrap(min: 0, max: 360),
-                                     speed: currentSpeed,
-                                     timestamp: Date())
+                                  altitude: 0,
+                                  horizontalAccuracy: horizontalAccuracy,
+                                  verticalAccuracy: verticalAccuracy,
+                                  course: newCoordinate.direction(to: lookAheadCoordinate).wrap(min: 0, max: 360),
+                                  speed: currentSpeed,
+                                  timestamp: Date())
         currentLocation = location
         lastKnownLocation = location
         
         delegate?.locationManager?(self, didUpdateLocations: [currentLocation])
-        currentDistance += currentSpeed
-        perform(#selector(tick), with: nil, afterDelay: 0.95)
+        currentDistance += currentSpeed * speedMultiplier
+        perform(#selector(tick), with: nil, afterDelay: 1)
     }
 }
 

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -36,7 +36,10 @@ public class SimulatedLocationManager: NavigationLocationManager {
     fileprivate var locations: [SimulatedLocation]!
     fileprivate var routeLine = [CLLocationCoordinate2D]()
     
-    public var speedMultiplier: Double = 1
+    /**
+     Specify the multiplier to use when calculating speed based on the RouteLeg’s `expectedSegmentTravelTimes`.
+     */
+    @objc public var speedMultiplier: Double = 1
     
     @objc override public var location: CLLocation? {
         get {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -385,7 +385,8 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         applyStyle()
         
         if routeController.locationManager is SimulatedLocationManager {
-            let title = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
+            let test = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
+            let title = String.localizedStringWithFormat(test, 1)
             mapViewController?.statusView.show(title, showSpinner: false)
         }
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -385,9 +385,8 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         applyStyle()
         
         if routeController.locationManager is SimulatedLocationManager {
-            let test = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
-            let title = String.localizedStringWithFormat(test, 1)
-            mapViewController?.statusView.show(title, showSpinner: false)
+            let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
+            mapViewController?.statusView.show(String.localizedStringWithFormat(format, 1), showSpinner: false)
         }
     }
     

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/* Dismiss button title on the steps view */
+/* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Close";
 
 /* Error message when the SDK is unable to read a spoken instruction. */
@@ -44,7 +44,7 @@
 "RESUME" = "Resume";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulating Navigation";
+"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %d×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.strings
@@ -2,9 +2,6 @@
 /* Class = "UIButton"; normalTitle = "Report Problem"; ObjectID = "I8f-iR-MZm"; */
 "I8f-iR-MZm.normalTitle" = "Report Problem";
 
-/* Class = "UILabel"; text = "Rerouting…"; ObjectID = "UpZ-gr-OKM"; */
-"UpZ-gr-OKM.text" = "Rerouting…";
-
 /* Class = "UILabel"; text = "Thank you for your report!"; ObjectID = "upm-fg-ffn"; */
 "upm-fg-ffn.text" = "Thank you for your report!";
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -72,6 +72,7 @@ class RouteMapViewController: UIViewController {
     }
     weak var routeController: RouteController! {
         didSet {
+            statusView.canChangeValue = routeController.locationManager is SimulatedLocationManager
             guard let destination = route.legs.last?.destination else { return }
             populateName(for: destination, populated: { self.destination = $0 })
         }
@@ -122,7 +123,6 @@ class RouteMapViewController: UIViewController {
         laneViewsContainerView.isHidden = true
         statusView.isHidden = true
         statusView.delegate = self
-        statusView.isSliderEnabled = true
         nextBannerView.isHidden = true
         isInOverviewMode = false
         instructionsBannerView.delegate = self
@@ -950,7 +950,7 @@ fileprivate extension UIViewAnimationOptions {
 }
 
 extension RouteMapViewController: StatusViewDelegate {
-    func statusView(_ statusView: StatusView, sliderValueChangedTo value: Double) {
+    func statusView(_ statusView: StatusView, valueChangedTo value: Double) {
         let displayValue = 1+min(Int(9 * value), 8)
         let title = String.localizedStringWithFormat(NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled."), displayValue)
         statusView.show(title, showSpinner: false)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -121,6 +121,8 @@ class RouteMapViewController: UIViewController {
         wayNameView.applyDefaultCornerRadiusShadow()
         laneViewsContainerView.isHidden = true
         statusView.isHidden = true
+        statusView.delegate = self
+        statusView.isSliderEnabled = true
         nextBannerView.isHidden = true
         isInOverviewMode = false
         instructionsBannerView.delegate = self
@@ -943,6 +945,18 @@ fileprivate extension UIViewAnimationOptions {
             self = .curveEaseInOut
         case .linear:
             self = .curveLinear
+        }
+    }
+}
+
+extension RouteMapViewController: StatusViewDelegate {
+    func statusView(_ statusView: StatusView, sliderValueChangedTo value: Double) {
+        let displayValue = 1+min(Int(9 * value), 8)
+        let title = String.localizedStringWithFormat(NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled."), displayValue)
+        statusView.show(title, showSpinner: false)
+        
+        if let locationManager = routeController.locationManager as? SimulatedLocationManager {
+            locationManager.speedMultiplier = Double(displayValue)
         }
     }
 }

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -68,7 +68,7 @@ public class StatusView: UIView {
         } else if sender.state == .changed {
             guard let startPoint = panStartPoint else { return }
             let offsetX = location.x - startPoint.x
-            let coefficient = (offsetX / bounds.width) / 50.0
+            let coefficient = (offsetX / bounds.width) / 20.0
             sliderValue = Double(min(max(CGFloat(sliderValue) + coefficient, 0), 1))
         }
     }


### PR DESCRIPTION
Fixes #694 

Slide left or right on the "Simulation Navigation" banner to increase or decrease the speed respectively.

The user puck is not really in sync at these high speeds.

![simspeed](https://user-images.githubusercontent.com/764476/33675566-486b8914-dab3-11e7-9083-b41f934878b8.gif)

@bsudekum @JThramer  👀 
