### PR TITLE
Fix crash adding pronunciation to instructions

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -26,17 +26,21 @@ extension SpokenInstruction {
     @available(iOS 10.0, *)
     func attributedText(for legProgress: RouteLegProgress) -> NSAttributedString {
         let attributedText = NSMutableAttributedString(string: text)
-        let step = legProgress.currentStep
-        if let name = step.names?.first,
-            let phoneticName = step.phoneticNames?.first {
-            let nameRange = attributedText.mutableString.range(of: name)
-            attributedText.replaceCharacters(in: nameRange, with: NSAttributedString(string: name).pronounced(phoneticName))
-        }
         if let step = legProgress.upComingStep,
             let name = step.names?.first,
             let phoneticName = step.phoneticNames?.first {
             let nameRange = attributedText.mutableString.range(of: name)
-            attributedText.replaceCharacters(in: nameRange, with: NSAttributedString(string: name).pronounced(phoneticName))
+            if (nameRange.location != NSNotFound) {
+                attributedText.replaceCharacters(in: nameRange, with: NSAttributedString(string: name).pronounced(phoneticName))
+            }
+        }
+        if let step = legProgress.followOnStep,
+            let name = step.names?.first,
+            let phoneticName = step.phoneticNames?.first {
+            let nameRange = attributedText.mutableString.range(of: name)
+            if (nameRange.location != NSNotFound) {
+                attributedText.replaceCharacters(in: nameRange, with: NSAttributedString(string: name).pronounced(phoneticName))
+            }
         }
         return attributedText
     }


### PR DESCRIPTION
The code applying pronunciation attributes to an instruction string in #624 was off by one step. It also crashed if the step’s street name was absent from the instruction for some reason.

/cc @bsudekum