### PR TITLE
Constraint Fix

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -525,12 +525,12 @@ class RouteMapViewController: UIViewController {
     func showEndOfRoute(duration: TimeInterval = 0.3, completion: ((Bool) -> Void)? = nil) {
         view.layoutIfNeeded() //flush layout queue
         
+        bannerShowConstraint.isActive = false
+        bannerContainerShowConstraint.isActive = false
+        bannerHideConstraint.isActive = true
         endOfRouteContainerView.isHidden = false
         endOfRouteHideConstraint.isActive = false
         endOfRouteShowConstraint.isActive = true
-        bannerHideConstraint.isActive = true
-        bannerShowConstraint.isActive = false
-        bannerContainerShowConstraint.isActive = false
        
         
         mapView.enableFrameByFrameCourseViewTracking(for: duration)


### PR DESCRIPTION
Fixes #919, where an order-of-operations issue was causing UIKit to trigger for unsatisfiable constraints. This did not manifest at runtime before because the constraints "satisfied" themselves before the next layout pass.

* Changing constraint order-of-operations to avoid a `UIViewAlertForUnsatisfiableConstraints` breakpoint.