### PR TITLE
Expose locationAccuracy on CLLocationManager

### DIFF
--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -17,6 +17,11 @@ open class NavigationLocationManager: CLLocationManager {
     
     var lastKnownLocation: CLLocation?
     
+    /**
+     The accuracy of the `CLLocationManager`.
+     */
+    @objc public var locationAccuracy: CLLocationAccuracy = kCLLocationAccuracyBestForNavigation
+    
     override public init() {
         super.init()
         
@@ -35,6 +40,6 @@ open class NavigationLocationManager: CLLocationManager {
             }
         }
         
-        desiredAccuracy = kCLLocationAccuracyBestForNavigation
+        desiredAccuracy = locationAccuracy
     }
 }


### PR DESCRIPTION
Exposes the value used for `desiredAccuracy` on `CLLocationManager` so it can be overridable.

/cc @mapbox/navigation-ios 