### PR TITLE
Show all banners along step

### DIFF
--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -425,6 +425,12 @@ open class RouteStepProgress: NSObject {
      */
     @objc public var spokenInstructionIndex:Int = 0
     
+    
+    /**
+     Index into `step.instructionsDisplayedAlongStep` representing the current visual instruction for the step.
+     */
+    @objc public var visualInstructionIndex:Int = 0
+    
     /**
      Current Instruction for the user's progress along a step.
      */

--- a/MapboxNavigation/ManeuverView.swift
+++ b/MapboxNavigation/ManeuverView.swift
@@ -27,6 +27,18 @@ public class ManeuverView: UIView {
         }
     }
     
+    public var maneuverType: ManeuverType? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    public var maneuverDirection: ManeuverDirection? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
     @objc public var isStart = false {
         didSet {
             setNeedsDisplay()
@@ -62,9 +74,9 @@ public class ManeuverView: UIView {
         }
         
         var flip: Bool = false
-        let type: ManeuverType = step.maneuverType ?? .turn
+        let type: ManeuverType = maneuverType ?? step.maneuverType ?? .turn
         let angle = ((step.finalHeading ?? 0) - (step.initialHeading ?? 0)).wrap(min: -180, max: 180)
-        let direction: ManeuverDirection = step.maneuverDirection ?? ManeuverDirection(angle: Int(angle))
+        let direction: ManeuverDirection = maneuverDirection ?? step.maneuverDirection ??  ManeuverDirection(angle: Int(angle))
 
         switch type {
         case .merge:

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -436,11 +436,22 @@ class RouteMapViewController: UIViewController {
         let stepProgress = routeProgress.currentLegProgress.currentStepProgress
         let distanceRemaining = stepProgress.distanceRemaining
         
-        guard let visualInstruction = routeProgress.currentLegProgress.currentStep.instructionsDisplayedAlongStep?.last else { return }
+        guard let visualInstructions = routeProgress.currentLegProgress.currentStep.instructionsDisplayedAlongStep else { return }
         
-        instructionsBannerView.set(visualInstruction.primaryTextComponents, secondaryInstruction: visualInstruction.secondaryTextComponents)
+        for (visualInstructionIndex, visualInstruction) in visualInstructions.enumerated() {
+            if routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= visualInstruction.distanceAlongStep && visualInstructionIndex >= routeProgress.currentLegProgress.currentStepProgress.visualInstructionIndex {
+                
+                instructionsBannerView.set(visualInstruction.primaryTextComponents, secondaryInstruction: visualInstruction.secondaryTextComponents)
+                instructionsBannerView.maneuverView.step = routeProgress.currentLegProgress.upComingStep
+                instructionsBannerView.maneuverView.maneuverType = visualInstruction.maneuverType
+                instructionsBannerView.maneuverView.maneuverDirection = visualInstruction.maneuverDirection
+                
+                routeProgress.currentLegProgress.currentStepProgress.visualInstructionIndex += 1
+                break
+            }
+        }
+        
         instructionsBannerView.distance = distanceRemaining > 5 ? distanceRemaining : 0
-        instructionsBannerView.maneuverView.step = routeProgress.currentLegProgress.upComingStep
     }
     
     func updateNextBanner(routeProgress: RouteProgress) {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -442,9 +442,7 @@ class RouteMapViewController: UIViewController {
             if routeProgress.currentLegProgress.currentStepProgress.distanceRemaining <= visualInstruction.distanceAlongStep && visualInstructionIndex >= routeProgress.currentLegProgress.currentStepProgress.visualInstructionIndex {
                 
                 instructionsBannerView.set(visualInstruction.primaryTextComponents, secondaryInstruction: visualInstruction.secondaryTextComponents)
-                instructionsBannerView.maneuverView.step = routeProgress.currentLegProgress.upComingStep
-                instructionsBannerView.maneuverView.maneuverType = visualInstruction.maneuverType
-                instructionsBannerView.maneuverView.maneuverDirection = visualInstruction.maneuverDirection
+                instructionsBannerView.maneuverView.maneuverTypeModifier = (maneuverType: visualInstruction.maneuverType, maneuverDirection: visualInstruction.maneuverDirection)
                 
                 routeProgress.currentLegProgress.currentStepProgress.visualInstructionIndex += 1
                 break
@@ -476,7 +474,7 @@ class RouteMapViewController: UIViewController {
             return
         }
         
-        nextBannerView.maneuverView.step = nextStep
+        nextBannerView.maneuverView.maneuverTypeModifier = (maneuverType: nextStep.maneuverType, maneuverDirection: nextStep.maneuverDirection)
         nextBannerView.instructionLabel.instruction = instructions.primaryTextComponents
         showNextBanner()
     }
@@ -879,7 +877,7 @@ extension RouteMapViewController: StepsViewControllerDelegate {
         instructionsView.backgroundColor = StepInstructionsView.appearance().backgroundColor
         instructionsView.delegate = self
         instructionsView.set(instructions.primaryTextComponents, secondaryInstruction: instructions.secondaryTextComponents)
-        instructionsView.maneuverView.step = maneuverStep
+        instructionsView.maneuverView.maneuverTypeModifier = (maneuverType: maneuverStep.maneuverType, maneuverDirection: maneuverStep.maneuverDirection)
         instructionsView.distance = distance
         
         instructionsBannerContainerView.backgroundColor = instructionsView.backgroundColor

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -197,7 +197,7 @@ extension StepsViewController: UITableViewDataSource {
     func updateCell(_ cell: StepTableViewCell, at indexPath: IndexPath) {
         let step = sections[indexPath.section][indexPath.row]
         
-        cell.instructionsView.maneuverView.step = step
+        cell.instructionsView.maneuverView.maneuverTypeModifier = (maneuverType: step.maneuverType, maneuverDirection: step.maneuverDirection)
        
         let usePreviousLeg = indexPath.section != 0 && indexPath.row == 0
         let leg = routeProgress.route.legs[indexPath.section]


### PR DESCRIPTION
Previously we were only showing a single banner along a step because we could not render the correct icon for a banner instruction which was not the actual maneuver. This will be solved once https://github.com/mapbox/MapboxDirections.swift/pull/225 is available and we can use the type/modifier to build an arrow. 

/cc @mapbox/navigation-ios @mapbox/guidance 