### PR TITLE
Account for current stepIndex as well

### DIFF
--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -314,18 +314,18 @@ open class RouteLegProgress: NSObject {
         var currentClosest: StepIndexDistance?
         let remainingSteps = leg.steps.suffix(from: stepIndex)
         
-        for (stepIndex, step) in remainingSteps.enumerated() {
+        for (currentStepIndex, step) in remainingSteps.enumerated() {
             guard let coords = step.coordinates else { continue }
             guard let closestCoordOnStep = Polyline(coords).closestCoordinate(to: coordinate) else { continue }
             
             // First time around, currentClosest will be `nil`.
             guard let currentClosestDistance = currentClosest?.distance else {
-                currentClosest = (index: stepIndex, distance: closestCoordOnStep.distance)
+                currentClosest = (index: currentStepIndex, distance: closestCoordOnStep.distance)
                 continue
             }
             
             if closestCoordOnStep.distance < currentClosestDistance {
-                currentClosest = (index: stepIndex, distance: closestCoordOnStep.distance)
+                currentClosest = (index: currentStepIndex + stepIndex, distance: closestCoordOnStep.distance)
             }
         }
         

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -59,6 +59,29 @@ class MapboxCoreNavigationTests: XCTestCase {
         }
     }
     
+    func testJumpAheadToLastStep() {
+        route.accessToken = "foo"
+        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.772701, longitude: -122.433378), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
+        
+        let locationManager = ReplayLocationManager(locations: [location])
+        let navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        
+        expectation(forNotification: RouteControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
+            XCTAssertEqual(notification.userInfo?.count, 1)
+            
+            let routeProgress = notification.userInfo![RouteControllerDidPassSpokenInstructionPointRouteProgressKey] as? RouteProgress
+            
+            return routeProgress?.currentLegProgress.stepIndex == 7
+        }
+        
+        navigation.resume()
+        navigation.routeProgress.currentLegProgress.stepIndex = 2
+        
+        waitForExpectations(timeout: waitForInterval) { (error) in
+            XCTAssertNil(error)
+        }
+    }
+    
     func testShouldReroute() {
         route.accessToken = "foo"
         let firstLocation = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 38, longitude: -123),


### PR DESCRIPTION
_Followup to: https://github.com/mapbox/mapbox-navigation-ios/pull/910_

In this final check, we are not accounting for the fact that we're are looking at the [slice](https://github.com/mapbox/mapbox-navigation-ios/compare/fix-reroute-future-check?expand=1#diff-851f438872328e98cbe395ac0733c16bR315) of the route's steps.

Take for example:

The current stepIndex is 5, we look at the remaining steps, find the closest to be 6. The closest step would be found in the iteration through this for loop, with a `currentStepIndex `. We Should return the index count in the for loop _plus_ the current stepIndex to get 6.

/cc @mapbox/navigation-ios 