### PR TITLE
Allow step to increment before checking for reroute

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -553,13 +553,14 @@ extension RouteController: CLLocationManagerDelegate {
                     ])
             }
         }
+        
+        updateDistanceToIntersection(from: location)
+        monitorStepProgress(location)
+        
         guard userIsOnRoute(location) || !(delegate?.routeController?(self, shouldRerouteFrom: location) ?? true) else {
             reroute(from: location)
             return
         }
-
-        updateDistanceToIntersection(from: location)
-        monitorStepProgress(location)
 
         // Check for faster route given users current location
         guard reroutesOpportunistically else { return }

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -51,7 +51,6 @@ class MapboxCoreNavigationTests: XCTestCase {
         }
         
         navigation.resume()
-        navigation.routeProgress.currentLegProgress.stepIndex = 2
         
         waitForExpectations(timeout: waitForInterval) { (error) in
             XCTAssertNil(error)
@@ -60,9 +59,9 @@ class MapboxCoreNavigationTests: XCTestCase {
     
     func testJumpAheadToLastStep() {
         route.accessToken = "foo"
-        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.772701, longitude: -122.433378), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
+        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.77386, longitude: -122.43085), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
         
-        let locationManager = ReplayLocationManager(locations: [location])
+        let locationManager = ReplayLocationManager(locations: [location, location, location])
         let navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
         
         expectation(forNotification: RouteControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
@@ -70,11 +69,10 @@ class MapboxCoreNavigationTests: XCTestCase {
             
             let routeProgress = notification.userInfo![RouteControllerDidPassSpokenInstructionPointRouteProgressKey] as? RouteProgress
             
-            return routeProgress?.currentLegProgress.stepIndex == 7
+            return routeProgress?.currentLegProgress.stepIndex == 6
         }
         
         navigation.resume()
-        navigation.routeProgress.currentLegProgress.stepIndex = 2
         
         waitForExpectations(timeout: waitForInterval) { (error) in
             XCTAssertNil(error)

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -61,7 +61,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         route.accessToken = "foo"
         let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.77386, longitude: -122.43085), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
         
-        let locationManager = ReplayLocationManager(locations: [location, location, location])
+        let locationManager = ReplayLocationManager(locations: [location, location])
         let navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
         
         expectation(forNotification: RouteControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -38,8 +38,7 @@ class MapboxCoreNavigationTests: XCTestCase {
     
     func testNewStep() {
         route.accessToken = "foo"
-        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.79132445827303, longitude: -122.42229044437408),
-                                    altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
+        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.78895, longitude: -122.42543), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
         let locationManager = ReplayLocationManager(locations: [location, location])
         let navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
         
@@ -48,7 +47,7 @@ class MapboxCoreNavigationTests: XCTestCase {
             
             let routeProgress = notification.userInfo![RouteControllerDidPassSpokenInstructionPointRouteProgressKey] as? RouteProgress
             
-            return routeProgress?.currentLegProgress.stepIndex == 1
+            return routeProgress?.currentLegProgress.stepIndex == 2
         }
         
         navigation.resume()


### PR DESCRIPTION
While investigating https://github.com/mapbox/mapbox-navigation-ios/pull/937, I found another bug: we're often times doing the `ultimate-is-the-user-on-another-step` check too often. 

I was able to debug https://github.com/mapbox/mapbox-navigation-ios/pull/937 because when the user is moving quickly over straight maneuvers, we call the `ultimate-is-the-user-on-another-step`. This is totally unnecessary, we should only be doing this check when the user is not on the route. 

The change here, changes `monitorStepProgress ` to run before `userIsOnRoute `. This allows us to increment the step if the user has completed the step before checking if the user is on the route. This is important because when the user is moving quickly, the user can be beyond the last coordinate in on the step. In this case, we want to increment the step counter and not reroute them.

/cc @mapbox/navigation-ios 