### PR TITLE
Correct usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ import MapboxNavigation
 let origin = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.9131752, longitude: -77.0324047), name: "Mapbox")
 let destination = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365), name: "White House")
 
-let options = NavigationRouteOptions(forNavigationWithWaypoints: [origin, destination])
+let options = NavigationRouteOptions(waypoints: [origin, destination])
 
 Directions.shared.calculate(options) { (waypoints, routes, error) in
     guard let route = routes?.first else { return }


### PR DESCRIPTION
A usage example in the readme referred to a non-existent initializer of NavigationRouteOptions.

/cc @bsudekum @captainbarbosa