### PR TITLE
Include roundabout exits

### DIFF
--- a/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -28,6 +28,7 @@ open class NavigationRouteOptions: RouteOptions {
         locale = Locale.nationalizedCurrent
         distanceMeasurementSystem = Locale.current.usesMetricSystem ? .metric : .imperial
         includesVisualInstructions = true
+        includesExitRoundaboutManeuver = true
     }
 
 


### PR DESCRIPTION
By default, this is false.

/cc @mapbox/navigation 