### PR TITLE
NavigationViewController Responsiveness

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -338,6 +338,12 @@ extension ViewController: NavigationViewControllerDelegate {
         return false
     }
 
+    // By default, the NavigationViewController will show a cancel button in the BottomBannerView when it is presented modally onto the screen.
+    // There are some situations where you may want to manually determine whether the cancel button should appear. If so, you can implement this delegate method.
+    func navigationViewController(_ navigationViewController: NavigationViewController, shouldShowCancelButtonIn bottomBanner: BottomBannerView) -> Bool {
+        return true
+    }
+    
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) {
         // Multiple waypoint demo
         guard exampleMode == .multipleWaypoints else { return }

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */; };
 		64847A041F04629D003F3A69 /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64847A031F04629D003F3A69 /* Feedback.swift */; };
 		8D391CE21FD71E78006BB91F /* Waypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D391CE11FD71E78006BB91F /* Waypoint.swift */; };
+		8D3931381FEC5F9400548FF2 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3931371FEC5F9400548FF2 /* Array.swift */; };
 		8DB63A3A1FBBCA2200928389 /* RatingControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB63A391FBBCA2200928389 /* RatingControl.swift */; };
 		8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE879651FBB9980002F06C0 /* EndOfRouteViewController.swift */; };
 		8DF399B21FB257B30034904C /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF399B11FB257B30034904C /* UIGestureRecognizer.swift */; };
@@ -437,6 +438,7 @@
 		6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaypointConfirmationViewController.swift; sourceTree = "<group>"; };
 		64847A031F04629D003F3A69 /* Feedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
 		8D391CE11FD71E78006BB91F /* Waypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Waypoint.swift; sourceTree = "<group>"; };
+		8D3931371FEC5F9400548FF2 /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		8DB63A391FBBCA2200928389 /* RatingControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingControl.swift; sourceTree = "<group>"; };
 		8DE879651FBB9980002F06C0 /* EndOfRouteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfRouteViewController.swift; sourceTree = "<group>"; };
 		8DF399B11FB257B30034904C /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -811,6 +813,7 @@
 			isa = PBXGroup;
 			children = (
 				C5000A921EC25C6E00563EA9 /* Abbreviations.swift */,
+				8D3931371FEC5F9400548FF2 /* Array.swift */,
 				351BEC081E5BCC72006FE110 /* Bundle.swift */,
 				8DF399B11FB257B30034904C /* UIGestureRecognizer.swift */,
 				351BEC041E5BCC6C006FE110 /* ManeuverDirection.swift */,
@@ -1455,6 +1458,7 @@
 				8D391CE21FD71E78006BB91F /* Waypoint.swift in Sources */,
 				353EC9D71FB09708002EB0AB /* StepsViewController.swift in Sources */,
 				35726EE81F0856E900AFA1B6 /* DayStyle.swift in Sources */,
+				8D3931381FEC5F9400548FF2 /* Array.swift in Sources */,
 				35DC9D911F4323AA001ECD64 /* LanesContainerView.swift in Sources */,
 				8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */,
 				C57491DF1FACC42F006F97BC /* CGPoint.swift in Sources */,

--- a/MapboxNavigation/Array.swift
+++ b/MapboxNavigation/Array.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UIKit
+
+extension Array where Iterator.Element == NSLayoutConstraint {
+    func activate() {
+        NSLayoutConstraint.activate(self)
+    }
+    func deactivate() {
+        NSLayoutConstraint.deactivate(self)
+    }
+    
+    var active: [NSLayoutConstraint] {
+        return self.filter({ $0.isActive })
+    }
+}

--- a/MapboxNavigation/BottomBannerView.swift
+++ b/MapboxNavigation/BottomBannerView.swift
@@ -3,7 +3,7 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 protocol BottomBannerViewDelegate: class {
-    func didCancel()
+    func bottomBannerViewDidCancel(_ banner: BottomBannerView)
 }
 
 /// :nodoc:
@@ -14,8 +14,13 @@ open class BottomBannerView: UIView {
     weak var timeRemainingLabel: TimeRemainingLabel!
     weak var distanceRemainingLabel: DistanceRemainingLabel!
     weak var arrivalTimeLabel: ArrivalTimeLabel!
-    weak var cancelButton: CancelButton!
-    weak var dividerView: SeparatorView!
+    weak var cancelButton: CancelButton? {
+        didSet {
+            guard let cancel = cancelButton else { return }
+            cancel.addTarget(self, action: #selector(BottomBannerView.cancel(_:)), for: .touchUpInside)
+        }
+    }
+    weak var dividerView: SeparatorView?
     weak var routeController: RouteController!
     weak var delegate: BottomBannerViewDelegate?
     
@@ -23,8 +28,12 @@ open class BottomBannerView: UIView {
     let dateComponentsFormatter = DateComponentsFormatter()
     let distanceFormatter = DistanceFormatter(approximate: true)
     
-    var verticalCompactConstraints = [NSLayoutConstraint]()
-    var verticalRegularConstraints = [NSLayoutConstraint]()
+    var isShowingCancelButton: Bool = false {
+        didSet {
+            isShowingCancelButton ? addCancelButton() : removeCancelButton()
+            updateLayout(showingButton: isShowingCancelButton)
+        }
+    }
     
     var congestionLevel: CongestionLevel = .unknown {
         didSet {
@@ -60,17 +69,15 @@ open class BottomBannerView: UIView {
         dateComponentsFormatter.unitsStyle = .abbreviated
         
         setupViews()
-        
-        cancelButton.addTarget(self, action: #selector(BottomBannerView.cancel(_:)), for: .touchUpInside)
     }
     
     @IBAction func cancel(_ sender: Any) {
-        delegate?.didCancel()
+        delegate?.bottomBannerViewDidCancel(self)
     }
     
     override open func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
-        dividerView.backgroundColor = .red
+        dividerView?.backgroundColor = .red
         timeRemainingLabel.text = "22 min"
         distanceRemainingLabel.text = "4 mi"
         arrivalTimeLabel.text = "10:09"

--- a/MapboxNavigation/BottomBannerViewLayout.swift
+++ b/MapboxNavigation/BottomBannerViewLayout.swift
@@ -2,8 +2,8 @@ import UIKit
 
 extension BottomBannerView {
     
+    //MARK: - View Setup
     func setupViews() {
-        
         let timeRemainingLabel = TimeRemainingLabel()
         timeRemainingLabel.translatesAutoresizingMaskIntoConstraints = false
         timeRemainingLabel.font = .systemFont(ofSize: 28, weight: .medium)
@@ -21,6 +21,11 @@ extension BottomBannerView {
         addSubview(arrivalTimeLabel)
         self.arrivalTimeLabel = arrivalTimeLabel
         
+        if isShowingCancelButton { addCancelButton() }
+        updateLayout()
+    }
+    
+    func addCancelButton() {
         let cancelButton = CancelButton(type: .custom)
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.setImage(UIImage(named: "close", in: .mapboxNavigation, compatibleWith: nil), for: .normal)
@@ -31,65 +36,97 @@ extension BottomBannerView {
         dividerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(dividerView)
         self.dividerView = dividerView
-        
-        setupConstraints()
     }
     
-    fileprivate func setupConstraints() {
-        setupVerticalCompactLayout(&verticalCompactConstraints)
-        setupVerticalRegularLayout(&verticalRegularConstraints)
+    func removeCancelButton() {
+        let views: [UIView?] = [cancelButton, dividerView]
+        views.forEach { (view) in
+            view?.willMove(toSuperview: nil)
+            view?.removeFromSuperview()
+        }
+    
+        cancelButton = nil
+        dividerView = nil
     }
     
-    fileprivate func setupVerticalCompactLayout(_ c: inout [NSLayoutConstraint]) {
-        c.append(heightAnchor.constraint(equalToConstant: 50))
-        
-        c.append(cancelButton.widthAnchor.constraint(equalTo: heightAnchor))
-        c.append(cancelButton.topAnchor.constraint(equalTo: topAnchor))
-        c.append(cancelButton.rightAnchor.constraint(equalTo: rightAnchor))
-        c.append(cancelButton.bottomAnchor.constraint(equalTo: bottomAnchor))
-        
-        c.append(timeRemainingLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: 10))
-        c.append(timeRemainingLabel.centerYAnchor.constraint(equalTo: cancelButton.centerYAnchor))
-        
-        c.append(distanceRemainingLabel.leftAnchor.constraint(equalTo: timeRemainingLabel.rightAnchor, constant: 10))
-        c.append(distanceRemainingLabel.lastBaselineAnchor.constraint(equalTo: timeRemainingLabel.lastBaselineAnchor))
-        
-        c.append(dividerView.widthAnchor.constraint(equalToConstant: 1))
-        c.append(dividerView.heightAnchor.constraint(equalToConstant: 40))
-        c.append(dividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
-        c.append(dividerView.rightAnchor.constraint(equalTo: cancelButton.leftAnchor))
-        
-        c.append(arrivalTimeLabel.rightAnchor.constraint(equalTo: dividerView.leftAnchor, constant: -10))
-        c.append(arrivalTimeLabel.centerYAnchor.constraint(equalTo: cancelButton.centerYAnchor))
+    //MARK: - Computed Constraint Properties
+    fileprivate var commonConstraints: [NSLayoutConstraint] {
+        let constraints = [
+            timeRemainingLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: 10),
+        ]
+        return constraints
     }
     
-    fileprivate func setupVerticalRegularLayout(_ c: inout [NSLayoutConstraint]) {
-        c.append(heightAnchor.constraint(equalToConstant: 80))
-        
-        c.append(timeRemainingLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: 10))
-        c.append(timeRemainingLabel.lastBaselineAnchor.constraint(equalTo: centerYAnchor, constant: 0))
-        
-        c.append(distanceRemainingLabel.leftAnchor.constraint(equalTo: timeRemainingLabel.leftAnchor))
-        c.append(distanceRemainingLabel.topAnchor.constraint(equalTo: timeRemainingLabel.bottomAnchor, constant: 0))
-        
-        c.append(cancelButton.widthAnchor.constraint(equalToConstant: 80))
-        c.append(cancelButton.topAnchor.constraint(equalTo: topAnchor))
-        c.append(cancelButton.rightAnchor.constraint(equalTo: rightAnchor))
-        c.append(cancelButton.bottomAnchor.constraint(equalTo: bottomAnchor))
-        
-        c.append(dividerView.widthAnchor.constraint(equalToConstant: 1))
-        c.append(dividerView.heightAnchor.constraint(equalToConstant: 40))
-        c.append(dividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
-        c.append(dividerView.rightAnchor.constraint(equalTo: cancelButton.leftAnchor))
-        
-        c.append(arrivalTimeLabel.centerYAnchor.constraint(equalTo: centerYAnchor))
-        c.append(arrivalTimeLabel.rightAnchor.constraint(equalTo: dividerView.leftAnchor, constant: -10))
+    fileprivate var commonCompactConstraints: [NSLayoutConstraint] {
+        let constraints = [
+        heightAnchor.constraint(equalToConstant: 50),
+        distanceRemainingLabel.leftAnchor.constraint(equalTo: timeRemainingLabel.rightAnchor, constant: 10),
+        distanceRemainingLabel.lastBaselineAnchor.constraint(equalTo: timeRemainingLabel.lastBaselineAnchor),
+        timeRemainingLabel.centerYAnchor.constraint(equalTo: cancelButton?.centerYAnchor ?? centerYAnchor)
+        ]
+        return constraints + commonConstraints
     }
     
+    fileprivate var commonRegularConstraints: [NSLayoutConstraint] {
+        let constraints = [
+        heightAnchor.constraint(equalToConstant: 80),
+        timeRemainingLabel.lastBaselineAnchor.constraint(equalTo: centerYAnchor, constant: 0),
+        distanceRemainingLabel.leftAnchor.constraint(equalTo: timeRemainingLabel.leftAnchor),
+        distanceRemainingLabel.topAnchor.constraint(equalTo: timeRemainingLabel.bottomAnchor, constant: 0)
+        ]
+        timeRemainingLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
+        return constraints + commonConstraints
+    }
+    
+    fileprivate var cancelButtonShowConstraints: [NSLayoutConstraint] {
+        let constraints = [
+            cancelButton!.widthAnchor.constraint(equalTo: heightAnchor),
+            cancelButton!.topAnchor.constraint(equalTo: topAnchor),
+            cancelButton!.rightAnchor.constraint(equalTo: rightAnchor),
+            cancelButton!.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            dividerView!.widthAnchor.constraint(equalToConstant: 1),
+            dividerView!.heightAnchor.constraint(equalToConstant: 40),
+            dividerView!.centerYAnchor.constraint(equalTo: centerYAnchor),
+            dividerView!.rightAnchor.constraint(equalTo: cancelButton!.leftAnchor),
+            arrivalTimeLabel.rightAnchor.constraint(equalTo: dividerView!.leftAnchor, constant: -10),
+            arrivalTimeLabel.centerYAnchor.constraint(equalTo: cancelButton!.centerYAnchor)
+        ]
+        return constraints
+    }
+    
+    fileprivate var cancelButtonHideConstraints: [NSLayoutConstraint] {
+        let constraints = [
+            arrivalTimeLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -10),
+            arrivalTimeLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ]
+        return constraints
+    }
+    
+    //MARK: - Utility Methods
+    func layoutConstraints(for traits: UITraitCollection, showingButton show: Bool) -> [NSLayoutConstraint] {
+        let buttonConstraints = show ? cancelButtonShowConstraints : cancelButtonHideConstraints
+        
+        switch traits.verticalSizeClass {
+        case .compact:
+                return commonCompactConstraints + buttonConstraints
+            default:
+                return commonRegularConstraints + buttonConstraints
+        
+        }
+    }
+    
+    func updateLayout(with traitCollection: UITraitCollection? = nil, showingButton: Bool? = nil) {
+        let traits = traitCollection ?? self.traitCollection
+        let isShowing = showingButton ?? isShowingCancelButton
+        
+        let newConstraints = layoutConstraints(for: traits, showingButton: isShowing)
+        constraints.active.deactivate()
+        newConstraints.activate()
+    }
+    
+    //MARK: - UITraitEnvironment
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        verticalCompactConstraints.forEach { $0.isActive = traitCollection.verticalSizeClass == .compact }
-        verticalRegularConstraints.forEach { $0.isActive = traitCollection.verticalSizeClass != .compact }
+        updateLayout(with: traitCollection)
     }
 }
-

--- a/MapboxNavigation/BottomBannerViewLayout.swift
+++ b/MapboxNavigation/BottomBannerViewLayout.swift
@@ -74,7 +74,6 @@ extension BottomBannerView {
         distanceRemainingLabel.leftAnchor.constraint(equalTo: timeRemainingLabel.leftAnchor),
         distanceRemainingLabel.topAnchor.constraint(equalTo: timeRemainingLabel.bottomAnchor, constant: 0)
         ]
-        timeRemainingLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
         return constraints + commonConstraints
     }
     

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -162,14 +162,14 @@ public protocol NavigationViewControllerDelegate {
  It provides step by step instructions, an overview of all steps for the given route and support for basic styling.
  */
 @objc(MBNavigationViewController)
-public class NavigationViewController: UIViewController, RouteMapViewControllerDelegate {
+open class NavigationViewController: UIViewController, RouteMapViewControllerDelegate {
     
     /** 
      A `Route` object constructed by [MapboxDirections](https://mapbox.github.io/mapbox-navigation-ios/directions/).
      
      In cases where you need to update the route after navigation has started you can set a new `route` here and `NavigationViewController` will update its UI accordingly.
      */
-    @objc public var route: Route! {
+    @objc open var route: Route! {
         didSet {
             if routeController == nil {
                 routeController = RouteController(along: route, directions: directions, locationManager: NavigationLocationManager())
@@ -185,49 +185,49 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
      An instance of `MGLAnnotation` that will be shown on on the destination of your route. The last coordinate of the route will be used if no destination is given.
     */
     @available(*, deprecated, message: "Destination is no longer supported. A destination annotation will automatically be added to map given the route.")
-    @objc public var destination: MGLAnnotation!
+    @objc open var destination: MGLAnnotation!
     
     
     /**
      An instance of `Directions` need for rerouting. See [Mapbox Directions](https://mapbox.github.io/mapbox-navigation-ios/directions/) for further information.
      */
-    @objc public var directions: Directions!
+    @objc open var directions: Directions!
     
     /**
      An optional `MGLMapCamera` you can use to improve the initial transition from a previous viewport and prevent a trigger from an excessive significant location update.
      */
-    @objc public var pendingCamera: MGLMapCamera?
+    @objc open var pendingCamera: MGLMapCamera?
     
     /**
      An instance of `MGLAnnotation` representing the origin of your route.
      */
-    @objc public var origin: MGLAnnotation?
+    @objc open var origin: MGLAnnotation?
     
     /**
      The receiver’s delegate.
      */
-    @objc public weak var delegate: NavigationViewControllerDelegate?
+    @objc open weak var delegate: NavigationViewControllerDelegate?
     
     /**
      Provides access to various speech synthesizer options.
      
      See `RouteVoiceController` for more information.
      */
-    @objc public var voiceController: RouteVoiceController? = RouteVoiceController()
+    @objc open var voiceController: RouteVoiceController? = RouteVoiceController()
     
     /**
      Provides all routing logic for the user.
 
      See `RouteController` for more information.
      */
-    @objc public var routeController: RouteController!
+    @objc open var routeController: RouteController!
     
     /**
      The main map view displayed inside the view controller.
      
      - note: Do not change this map view’s delegate.
      */
-    @objc public var mapView: NavigationMapView? {
+    @objc open var mapView: NavigationMapView? {
         get {
             return mapViewController?.mapView
         }
@@ -238,17 +238,17 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
      
      By default, this property is set to `true`, causing the user location annotation to be snapped to the route.
      */
-    @objc public var snapsUserLocationAnnotationToRoute = true
+    @objc open var snapsUserLocationAnnotationToRoute = true
     
     /**
      Toggles sending of UILocalNotification upon upcoming steps when application is in the background. Defaults to `true`.
      */
-    @objc public var sendsNotifications: Bool = true
+    @objc open var sendsNotifications: Bool = true
     
     /**
      Shows a button that allows drivers to report feedback such as accidents, closed roads,  poor instructions, etc. Defaults to `true`.
      */
-    @objc public var showsReportFeedback: Bool = true {
+    @objc open var showsReportFeedback: Bool = true {
         didSet {
             mapViewController?.reportButton.isHidden = !showsReportFeedback
             showsEndOfRouteFeedback = showsReportFeedback
@@ -259,7 +259,7 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
     /**
     Shows End of route Feedback UI when the route controller arrives at the final destination. Defaults to `true.`
     */
-    @objc public var showsEndOfRouteFeedback: Bool = true {
+    @objc open var showsEndOfRouteFeedback: Bool = true {
         didSet {
             mapViewController?.showsEndOfRoute = showsEndOfRouteFeedback
         }
@@ -268,7 +268,7 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
     /**
      If true, the map style and UI will automatically be updated given the time of day.
      */
-    @objc public var automaticallyAdjustsStyleForTimeOfDay = true {
+    @objc open var automaticallyAdjustsStyleForTimeOfDay = true {
         didSet {
             styleManager.automaticallyAdjustsStyleForTimeOfDay = automaticallyAdjustsStyleForTimeOfDay
         }
@@ -279,7 +279,7 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
     /**
      A Boolean value that determines whether the map annotates the locations at which instructions are spoken for debugging purposes.
      */
-    @objc public var annotatesSpokenInstructions = false
+    @objc open var annotatesSpokenInstructions = false
     
     let progressBar = ProgressBar()
     var styleManager: StyleManager!
@@ -334,14 +334,14 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         suspendNotifications()
     }
     
-    override public func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         resumeNotifications()
         progressBar.dock(on: view)
         view.clipsToBounds = true
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
+    override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         UIApplication.shared.isIdleTimerDisabled = true
@@ -353,7 +353,7 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         }
     }
     
-    public override func viewWillDisappear(_ animated: Bool) {
+    override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         UIApplication.shared.isIdleTimerDisabled = false
@@ -541,7 +541,7 @@ extension NavigationViewController: RouteControllerDelegate {
 
 extension NavigationViewController: StyleManagerDelegate {
     
-    public func locationFor(styleManager: StyleManager) -> CLLocation {
+    open func locationFor(styleManager: StyleManager) -> CLLocation {
         guard let location = routeController.location else {
             if let coordinate = routeController.routeProgress.route.coordinates?.first {
                 return CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
@@ -553,14 +553,14 @@ extension NavigationViewController: StyleManagerDelegate {
         return location
     }
     
-    public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
+    open func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         if mapView?.styleURL != style.mapStyleURL {
             mapView?.style?.transition = MGLTransition(duration: 0.5, delay: 0)
             mapView?.styleURL = style.mapStyleURL
         }
     }
     
-    public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
+    open func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
         mapView?.reloadStyle(self)
     }
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -140,6 +140,9 @@ class RouteMapViewController: UIViewController {
         
         resetETATimer()
         
+        let isPresented = presentingViewController == nil
+        bottomBannerView.isShowingCancelButton = delegate?.mapViewController(self, shouldShowCancelButtonIn: bottomBannerView) ?? isPresented
+        
         muteButton.isSelected = NavigationSettings.shared.voiceMuted
         mapView.compassView.isHidden = true
         
@@ -887,7 +890,7 @@ extension RouteMapViewController: StepsViewControllerDelegate {
 // MARK: BottomBannerViewDelegate
 
 extension RouteMapViewController: BottomBannerViewDelegate {
-    func didCancel() {
+    func bottomBannerViewDidCancel(_ banner: BottomBannerView) {
         delegate?.mapViewControllerDidCancelNavigation(self)
     }
 }
@@ -961,6 +964,7 @@ extension RouteMapViewController: StatusViewDelegate {
     }
 }
 
+//MARK: - RouteMapViewControllerDelegate
 protocol RouteMapViewControllerDelegate: class {
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
@@ -976,9 +980,19 @@ protocol RouteMapViewControllerDelegate: class {
     func mapViewControllerDidOpenFeedback(_ mapViewController: RouteMapViewController)
     func mapViewControllerDidCancelFeedback(_ mapViewController: RouteMapViewController)
     func mapViewControllerDidCancelNavigation(_ mapViewController: RouteMapViewController)
+    func mapViewController(_ mapViewController: RouteMapViewController, shouldShowCancelButtonIn bottomBanner: BottomBannerView) -> Bool
     func mapViewController(_ mapViewController: RouteMapViewController, didSend feedbackId: String, feedbackType: FeedbackType)
     
     func mapViewController(_ mapViewController: RouteMapViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint?
     
     func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool
+}
+
+extension RouteMapViewControllerDelegate where Self: UIViewController {
+    
+    //default implementation -- Shows cancel button if RMVC (or ancestor) was presented.
+    func mapViewController(_ mapViewController: RouteMapViewController, shouldShowCancelButtonIn : BottomBannerView) -> Bool {
+        let isPresented = self.presentingViewController != nil
+        return isPresented
+    }
 }


### PR DESCRIPTION
This implements part of #830, where I'm creating a "Nav-bar" demo in [navigation-ios-examples](https://github.com/mapbox/navigation-ios-examples) where the NavigationViewController is pushed onto a `UINavigationController` VC stack. So far, there are three main issues that I see surrounding responsiveness:

- [x] NavigationViewController is not subclassable outside of the `MapboxNavigation` module.
- [x] NavigationViewController should be responsive to being pushed as opposed to presented ("X" button)
- [x] ~NavigationViewController should be able to be instantiated in Interface Builder.~ (punted to #968)
  