### PR TITLE
Flip U-turn icon in right-side regions only

### DIFF
--- a/MapboxNavigation/ManeuverView.swift
+++ b/MapboxNavigation/ManeuverView.swift
@@ -120,7 +120,7 @@ public class ManeuverView: UIView {
                 flip = true
             case .uTurn:
                 ManeuversStyleKit.drawArrow180right(frame: bounds, resizing: resizing, primaryColor: primaryColor)
-                flip = angle < 0
+                flip = step.drivingSide == .right
             default:
                 ManeuversStyleKit.drawArrowstraight(frame: bounds, resizing: resizing, primaryColor: primaryColor)
             }


### PR DESCRIPTION
As far as I know, the U-turn icon is already flipped correctly in countries that drive on the left. But checking the turn angle is unintuitive compared to checking the driving side.

The only downside would be U-turns that turn to the wrong side, which are pretty uncommon as far as I know. I can only think of [one example](http://www.openstreetmap.org/way/524469535) of a U-turn to the right in a right-sided country, and that’s more of a fanciful turn lane indication than an actual U-turn.

<img width="558" alt="turn-u" src="https://user-images.githubusercontent.com/1231218/34236687-8c90f6ec-e5ad-11e7-8431-fdbe6513ecfa.png">

/cc @bsudekum