### PR TITLE
Account for a few optionals

### DIFF
--- a/MapboxNavigation/BottomBannerView.swift
+++ b/MapboxNavigation/BottomBannerView.swift
@@ -77,8 +77,8 @@ open class BottomBannerView: UIView {
     }
     
     func updateETA(routeProgress: RouteProgress) {
-        let arrivalDate = NSCalendar.current.date(byAdding: .second, value: Int(routeProgress.durationRemaining), to: Date())
-        arrivalTimeLabel.text = dateFormatter.string(from: arrivalDate!)
+        guard let arrivalDate = NSCalendar.current.date(byAdding: .second, value: Int(routeProgress.durationRemaining), to: Date()) else { return }
+        arrivalTimeLabel.text = dateFormatter.string(from: arrivalDate)
 
         if routeProgress.durationRemaining < 5 {
             distanceRemainingLabel.text = nil
@@ -88,8 +88,8 @@ open class BottomBannerView: UIView {
 
         dateComponentsFormatter.unitsStyle = routeProgress.durationRemaining < 3600 ? .short : .abbreviated
 
-        if routeProgress.durationRemaining < 60 {
-            timeRemainingLabel.text = String.localizedStringWithFormat(NSLocalizedString("LESS_THAN", bundle: .mapboxNavigation, value: "<%@", comment: "Format string for a short distance or time less than a minimum threshold; 1 = duration remaining"), dateComponentsFormatter.string(from: 61)!)
+        if let hardcodedTime = dateComponentsFormatter.string(from: 61), routeProgress.durationRemaining < 60 {
+            timeRemainingLabel.text = String.localizedStringWithFormat(NSLocalizedString("LESS_THAN", bundle: .mapboxNavigation, value: "<%@", comment: "Format string for a short distance or time less than a minimum threshold; 1 = duration remaining"), hardcodedTime)
         } else {
             timeRemainingLabel.text = dateComponentsFormatter.string(from: routeProgress.durationRemaining)
         }


### PR DESCRIPTION
Seeing a few crashes come through that look like:

```
0  MapboxNavigation               0x103757004 RouteMapViewController.updateETA() (RouteMapViewController.swift:761)
1  MapboxNavigation               0x103757024 @objc RouteMapViewController.updateETA() (RouteMapViewController.swift)
2  Foundation                     0x183e7bd24 __NSFireTimer + 88
3  CoreFoundation                 0x18343292c __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 28
4  CoreFoundation                 0x183432650 __CFRunLoopDoTimer + 864
5  CoreFoundation                 0x183431e50 __CFRunLoopDoTimers + 248
6  CoreFoundation                 0x18342fa38 __CFRunLoopRun + 1928
7  CoreFoundation                 0x18334ffb8 CFRunLoopRunSpecific + 436
8  GraphicsServices               0x1851e7f84 GSEventRunModal + 100
9  UIKit                          0x18c9242e8 UIApplicationMain + 208
10 Voyage                         0x102e4180c main (UIImage.swift:18)
11 libdyld.dylib                  0x182e7256c start + 4
```

Which points to this line: https://github.com/mapbox/mapbox-navigation-ios/blob/d69d05ed67f05f329180eccd8fc53b95da83a945/MapboxNavigation/RouteMapViewController.swift#L761

This PR moves to safely check for a few values before assuming they are not nil.

/cc @mapbox/navigation-ios 