### PR TITLE
Don't allow advancing to non-existent  step

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -805,7 +805,9 @@ extension RouteController: CLLocationManagerDelegate {
     }
 
     func advanceStepIndex(to: Array<RouteStep>.Index? = nil) {
+        
         if let forcedStepIndex = to {
+            guard forcedStepIndex < routeProgress.currentLeg.steps.count else { return }
             routeProgress.currentLegProgress.stepIndex = forcedStepIndex
         } else {
             routeProgress.currentLegProgress.stepIndex += 1


### PR DESCRIPTION
Seeing crashes that look like:

```
Crashed: com.apple.main-thread
0  MapboxCoreNavigation           0x10284b8c8 RouteController.advanceStepIndex(to:) (RouteController.swift:810)
1  MapboxCoreNavigation           0x102856754 specialized RouteController.userIsOnRoute(_:) (RouteController.swift:616)
2  MapboxCoreNavigation           0x10284b8fc @objc RouteController.userIsOnRoute(_:) (RouteController.swift)
3  MapboxCoreNavigation           0x102855d94 specialized RouteController.locationManager(_:didUpdateLocations:) (RouteController.swift:556)
4  MapboxCoreNavigation           0x10284b3f4 @objc RouteController.locationManager(_:didUpdateLocations:) (RouteController.swift)
5  CoreLocation                   0x18cf68d48 CLClientRetrieveData + 77436
6  CoreLocation                   0x18cf685a8 CLClientRetrieveData + 75484
7  CoreLocation                   0x18cf50c28 CLClientInvalidate + 1004
8  CoreFoundation                 0x1869b416c __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 20
9  CoreFoundation                 0x1869b3a3c __CFRunLoopDoBlocks + 288
10 CoreFoundation                 0x1869b1728 __CFRunLoopRun + 1032
11 CoreFoundation                 0x1868d22d8 CFRunLoopRunSpecific + 436
12 GraphicsServices               0x188764f84 GSEventRunModal + 100
13 UIKit                          0x18fe91034 UIApplicationMain + 208
```

It looks like we're advancing to a non-existent step, we should not allow that.

/cc @mapbox/navigation-ios 