### PR TITLE
Always send cancel event even when using mapbox-core-navigation

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -158,6 +158,18 @@ open class RouteController: NSObject {
             NotificationCenter.default.post(name: .routeControllerDidReroute, object: self, userInfo: userInfo)
         }
     }
+    
+    /**
+     :nodoc:
+     A star rating from 0 to 5 where 0 is the worst and 5 is the best.
+     */
+    public var endOfRouteStarRating: Int?
+    
+    /**
+     :nodoc:
+     The users comment amount their navigation experience.
+     */
+    public var endOfRouteComment: String?
 
     var isRerouting = false
     var lastRerouteLocation: CLLocation?
@@ -211,6 +223,7 @@ open class RouteController: NSObject {
 
     deinit {
         suspendLocationUpdates()
+        sendCancelEvent(rating: endOfRouteStarRating, comment: endOfRouteComment)
         checkAndSendOutstandingFeedbackEvents(forceAll: true)
         suspendNotifications()
         UIDevice.current.isBatteryMonitoringEnabled = false

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -159,17 +159,8 @@ open class RouteController: NSObject {
         }
     }
     
-    /**
-     :nodoc:
-     A star rating from 0 to 5 where 0 is the worst and 5 is the best.
-     */
-    public var endOfRouteStarRating: Int?
-    
-    /**
-     :nodoc:
-     The users comment amount their navigation experience.
-     */
-    public var endOfRouteComment: String?
+    var endOfRouteStarRating: Int?
+    var endOfRouteComment: String?
 
     var isRerouting = false
     var lastRerouteLocation: CLLocation?
@@ -440,6 +431,14 @@ open class RouteController: NSObject {
         if let index = outstandingFeedbackEvents.index(where: {$0.id.uuidString == feedbackId}) {
             outstandingFeedbackEvents.remove(at: index)
         }
+    }
+    
+    /**
+     Set the rating and any comment the user may have about their route. Only used when exiting navigaiton.
+     */
+    @objc public func setEndOfRoute(rating: Int, comment: String?) {
+        endOfRouteStarRating = rating
+        endOfRouteComment = comment
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -534,8 +534,9 @@ extension NavigationViewController: RouteControllerDelegate {
         guard routeController.routeProgress.isFinalLeg else { return }
         
         let completion: (Bool) -> Void = { _ in self.delegate?.navigationViewController?(self, didArriveAt: waypoint) }
-        let noEndOfRouteShow = { self.routeController.sendCancelEvent(); completion(true) }
-        showsEndOfRouteFeedback ? self.mapViewController?.showEndOfRoute( completion: completion) : noEndOfRouteShow()
+        if showsEndOfRouteFeedback {
+            self.mapViewController?.showEndOfRoute( completion: completion)
+        }
     }
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -576,8 +576,7 @@ class RouteMapViewController: UIViewController {
         
         endOfRouteVC.dismiss = { [weak self] (stars, comment) in
             guard let rating = self?.rating(for: stars) else { return }
-            self?.routeController.endOfRouteStarRating = rating
-            self?.routeController.endOfRouteComment = comment
+            self?.routeController.setEndOfRoute(rating: rating, comment: comment)
             self?.dismiss(animated: true, completion: nil)
         }
         endOfRouteViewController = endOfRouteVC

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -576,7 +576,8 @@ class RouteMapViewController: UIViewController {
         
         endOfRouteVC.dismiss = { [weak self] (stars, comment) in
             guard let rating = self?.rating(for: stars) else { return }
-            self?.routeController.sendCancelEvent(rating: rating, comment: comment)
+            self?.routeController.endOfRouteStarRating = rating
+            self?.routeController.endOfRouteComment = comment
             self?.dismiss(animated: true, completion: nil)
         }
         endOfRouteViewController = endOfRouteVC


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/964

This moves to call the cancel feedback event when the RouteController is deinited. Unfortunately had to make some properties public.

/cc @mapbox/navigation-ios @ericrwolfe 

