### PR TITLE
Prevent user puck spinning at end of route

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -377,7 +377,7 @@ open class RouteController: NSObject {
         var averageRelativeAngle: Double!
         // User is at the beginning of the route, there is no closest point behind the user.
         if pointBehindClosest.distance <= 0 && pointAheadClosest.distance > 0 {
-            averageRelativeAngle = relativeAnglepointBehind
+            averageRelativeAngle = relativeAnglepointAhead
         // User is at the end of the route, there is no closest point in front of the user.
         } else if pointAheadClosest.distance <= 0 && pointBehindClosest.distance > 0 {
             averageRelativeAngle = relativeAnglepointBehind

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -373,7 +373,18 @@ open class RouteController: NSObject {
         let wrappedCourse = location.course.wrap(min: -180, max: 180)
         let relativeAnglepointBehind = (wrappedPointBehind - wrappedCourse).wrap(min: -180, max: 180)
         let relativeAnglepointAhead = (wrappedPointAhead - wrappedCourse).wrap(min: -180, max: 180)
-        let averageRelativeAngle = pointBehindClosest.distance > 0 ? (relativeAnglepointBehind + relativeAnglepointAhead) / 2 : relativeAnglepointAhead
+        
+        var averageRelativeAngle: Double!
+        // User is at the beginning of the route, there is no closest point behind the user.
+        if pointBehindClosest.distance <= 0 && pointAheadClosest.distance > 0 {
+            averageRelativeAngle = relativeAnglepointBehind
+        // User is at the end of the route, there is no closest point in front of the user.
+        } else if pointAheadClosest.distance <= 0 && pointBehindClosest.distance > 0 {
+            averageRelativeAngle = relativeAnglepointBehind
+        } else {
+            averageRelativeAngle = (relativeAnglepointBehind + relativeAnglepointAhead) / 2
+        }
+        
         let calculatedCourseForLocationOnStep = (wrappedCourse + averageRelativeAngle).wrap(min: 0, max: 360)
         
         var userCourse = calculatedCourseForLocationOnStep

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -374,7 +374,7 @@ open class RouteController: NSObject {
         let relativeAnglepointBehind = (wrappedPointBehind - wrappedCourse).wrap(min: -180, max: 180)
         let relativeAnglepointAhead = (wrappedPointAhead - wrappedCourse).wrap(min: -180, max: 180)
         
-        var averageRelativeAngle: Double!
+        let averageRelativeAngle: Double
         // User is at the beginning of the route, there is no closest point behind the user.
         if pointBehindClosest.distance <= 0 && pointAheadClosest.distance > 0 {
             averageRelativeAngle = relativeAnglepointAhead


### PR DESCRIPTION
When snapping and looking at points ahead/behind user, we should not use the point ahead/behind if it has a distance of zero. In this case, the user is either at the beginning or end of the route. When using a point that has a distance of zero, the calculated course becomes wildly inaccurate causing spinning. 

/cc @mapbox/navigation-ios 