### PR TITLE
Localize feedback

### DIFF
--- a/MapboxNavigation/EndOfRouteViewController.swift
+++ b/MapboxNavigation/EndOfRouteViewController.swift
@@ -46,8 +46,8 @@ class EndOfRouteViewController: UIViewController {
     @IBOutlet weak var ratingCommentsSpacing: NSLayoutConstraint!
     
     //MARK: - Properties
-    lazy var placeholder: String = NSLocalizedString("How can we improve?", bundle: .mapboxNavigation, comment: "Comment Placeholder Text")
-    lazy var endNavigation: String = NSLocalizedString("End Navigation", bundle: .mapboxNavigation, comment: "End Navigation Button Text")
+    lazy var placeholder: String = NSLocalizedString("END_OF_ROUTE_TITLE", bundle: .mapboxNavigation, value: "How can we improve?", comment: "Comment Placeholder Text")
+    lazy var endNavigation: String = NSLocalizedString("END_NAVIGATION", bundle: .mapboxNavigation, value: "End Navigation", comment: "End Navigation Button Text")
     
     var dismiss: ((Int, String?) -> Void)?
     var comment: String?
@@ -155,7 +155,7 @@ class EndOfRouteViewController: UIViewController {
     
     private func styleForUnnamedDestination() {
         staticYouHaveArrived.alpha = 0.0
-        primary.text = NSLocalizedString("You have arrived", bundle: .mapboxNavigation, comment:"")
+        primary.text = NSLocalizedString("END_OF_ROUTE_ARRIVED", bundle: .mapboxNavigation, value:"You have arrived", comment:"Title used for arrival")
     }
     
     private func setPlaceholderText() {

--- a/MapboxNavigation/RatingControl.swift
+++ b/MapboxNavigation/RatingControl.swift
@@ -72,9 +72,8 @@ class RatingControl: UIStackView {
             
             let setRatingNumber = NSNumber(value: index + 1)
             let setRatingString = NumberFormatter.localizedString(from: setRatingNumber, number: .none)
-            let localizedStarLabel = NSLocalizedString("Set %@ star rating", bundle: .mapboxNavigation, comment: "Accessibility Star Label")
-            button.accessibilityLabel = String.localizedStringWithFormat(localizedStarLabel, setRatingString)
-                
+            let localizedString = NSLocalizedString("RATING_ACCESSIBILITY_SET", bundle: .mapboxNavigation, value: "Set %@ star rating", comment: "Accessibility Star Label")
+            button.accessibilityLabel = String.localizedStringWithFormat(localizedString, setRatingString)
             
             button.addTarget(self, action: #selector(RatingControl.ratingButtonTapped(button:)), for: .touchUpInside)
             
@@ -110,12 +109,11 @@ class RatingControl: UIStackView {
         
         switch rating {
         case 0:
-            value = NSLocalizedString("No rating set.", bundle: .mapboxNavigation, comment: "No Rating Set")
+            value = NSLocalizedString("NO_RATING", bundle: .mapboxNavigation, value: "No rating set.", comment: "No Rating Set")
         case 1:
-            value = NSLocalizedString("1 star set.", bundle: .mapboxNavigation, comment: "One Star Set")
+            value = NSLocalizedString("RATING_1_STAR", bundle: .mapboxNavigation, value: "1 star set.", comment: "One Star Set")
         default:
-            let starsSet = NSLocalizedString("stars set.", bundle: .mapboxNavigation, comment:"(multiple) Stars Set, as in '30 stars set'")
-            value = String.localizedStringWithFormat("%li %@", rating, starsSet)
+            value = String.localizedStringWithFormat(NSLocalizedString("RATING_STARS_FORMAT", bundle: .mapboxNavigation, value: "%li stars set.", comment: "Format for rating stars set"), rating)
         }
         
         button.accessibilityValue = value
@@ -124,7 +122,7 @@ class RatingControl: UIStackView {
     private func setAccessibilityHint(for button: UIButton, at index: Int) {
         guard rating == (index + 1) else { return } //This applies only to the zero-resettable button.
         
-        button.accessibilityHint = NSLocalizedString("Tap to reset the rating to zero.", bundle: .mapboxNavigation, comment: "Rating Reset To Zero Accessability Hint")
+        button.accessibilityHint = NSLocalizedString("RATING_ACCESSIBILITY_RESET", bundle: .mapboxNavigation, value: "Tap to reset the rating to zero.", comment: "Rating Reset To Zero Accessability Hint")
     }
     
     

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -1,5 +1,14 @@
-/* Dismiss button title on the steps view */
+﻿/* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Close";
+
+/* End Navigation Button Text */
+"END_NAVIGATION" = "End Navigation";
+
+/* Title used for arrival */
+"END_OF_ROUTE_ARRIVED" = "You have arrived";
+
+/* Comment Placeholder Text */
+"END_OF_ROUTE_TITLE" = "How can we improve?";
 
 /* Error message when the SDK is unable to read a spoken instruction. */
 "FAILED_INSTRUCTION" = "Unable to read instruction aloud.";
@@ -36,6 +45,21 @@
 
 /* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
 "LESS_THAN" = "<%@";
+
+/* No Rating Set */
+"NO_RATING" = "No rating set.";
+
+/* One Star Set */
+"RATING_1_STAR" = "1 star set.";
+
+/* Rating Reset To Zero Accessability Hint */
+"RATING_ACCESSIBILITY_RESET" = "Tap to reset the rating to zero.";
+
+/* Accessibility Star Label */
+"RATING_ACCESSIBILITY_SET" = "Set %@ star rating";
+
+/* Format for rating stars set */
+"RATING_STARS_FORMAT" = "%li stars set.";
 
 /* Indicates that rerouting is in progress */
 "REROUTING" = "Rerouting…";

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -749,12 +749,28 @@ Label  </string>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.25098039220000001" green="0.36078431370000003" blue="0.47843137250000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
+                                        <attributedString key="userComments">
+                                            <fragment content="DO NOT TRANSLATE">
+                                                <attributes>
+                                                    <font key="NSFont" metaFont="smallSystem"/>
+                                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                </attributes>
+                                            </fragment>
+                                        </attributedString>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1773 Scott St" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I9w-ZT-7sx" customClass="MBEndOfRouteTitleLabel">
                                         <rect key="frame" x="0.0" y="17" width="375" height="43"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
+                                        <attributedString key="userComments">
+                                            <fragment content="DO NOT TRANSLATE">
+                                                <attributes>
+                                                    <font key="NSFont" metaFont="smallSystem"/>
+                                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                </attributes>
+                                            </fragment>
+                                        </attributedString>
                                     </label>
                                 </subviews>
                                 <constraints>
@@ -800,6 +816,14 @@ Label  </string>
                                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
+                                        <attributedString key="userComments">
+                                            <fragment content="DO NOT TRANSLATE">
+                                                <attributes>
+                                                    <font key="NSFont" metaFont="smallSystem"/>
+                                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                </attributes>
+                                            </fragment>
+                                        </attributedString>
                                         <connections>
                                             <outlet property="delegate" destination="WD9-Na-hrx" id="XeS-Fw-dv9"/>
                                         </connections>
@@ -823,6 +847,14 @@ Label  </string>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5f2-dT-la4" customClass="MBEndOfRouteButton">
                                         <rect key="frame" x="136" y="10" width="103" height="30"/>
                                         <state key="normal" title="End Navigation"/>
+                                        <attributedString key="userComments">
+                                            <fragment content="DO NOT TRANSLATE">
+                                                <attributes>
+                                                    <font key="NSFont" metaFont="smallSystem"/>
+                                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                </attributes>
+                                            </fragment>
+                                        </attributedString>
                                         <connections>
                                             <action selector="endNavigationPressed:" destination="WD9-Na-hrx" eventType="touchUpInside" id="WD3-dO-JvE"/>
                                         </connections>

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.strings
@@ -2,6 +2,9 @@
 /* Class = "UIButton"; normalTitle = "Report Problem"; ObjectID = "I8f-iR-MZm"; */
 "I8f-iR-MZm.normalTitle" = "Report Problem";
 
+/* Class = "UILabel"; text = "Rate your drive"; ObjectID = "W5U-cV-cDO"; */
+"W5U-cV-cDO.text" = "Rate your drive";
+
 /* Class = "UILabel"; text = "Thank you for your report!"; ObjectID = "upm-fg-ffn"; */
 "upm-fg-ffn.text" = "Thank you for your report!";
 


### PR DESCRIPTION
Minor tail work from https://github.com/mapbox/mapbox-navigation-ios/pull/848

- Add `DO NOT TRANSLATE` to placeholder labels in IB
- Provide a default translated string for `NSLocalizedString(_:tableName:bundle:value:comment:)`
- Run `extract_localizable`

@JThramer 👀 
  