### PR TITLE
Emit didArriveAt waypoint delegate for all waypoints

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -335,7 +335,7 @@ extension ViewController: NavigationViewControllerDelegate {
     // If however you would like to pause and allow the user to provide input, set this delegate method to false.
     // This does however require you to increment the leg count on your own. See the example below in `confirmationControllerDidConfirm()`.
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldIncrementLegWhenArrivingAtWaypoint waypoint: Waypoint) -> Bool {
-        return false
+        return exampleMode == .multipleWaypoints ? false : true
     }
 
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -536,6 +536,12 @@ extension NavigationViewController: RouteControllerDelegate {
             return
         }
         
+        // Do not show end of route feedback if the developer is implementing their own waypoint UI.
+        guard let shouldIncrement = delegate?.navigationViewController?(self, shouldIncrementLegWhenArrivingAtWaypoint: waypoint), shouldIncrement == true else {
+            delegate?.navigationViewController?(self, didArriveAt: waypoint)
+            return
+        }
+        
         let completion: (Bool) -> Void = { _ in self.delegate?.navigationViewController?(self, didArriveAt: waypoint) }
         if showsEndOfRouteFeedback {
             self.mapViewController?.showEndOfRoute( completion: completion)

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -531,13 +531,10 @@ extension NavigationViewController: RouteControllerDelegate {
     }
     
     public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) {
-        guard routeController.routeProgress.isFinalLeg else {
-            delegate?.navigationViewController?(self, didArriveAt: waypoint)
-            return
-        }
+        let isFinalLeg = routeController.routeProgress.isFinalLeg
+        let shouldIncrementLeg = delegate?.navigationViewController?(self, shouldIncrementLegWhenArrivingAtWaypoint: waypoint) ?? false
         
-        // Do not show end of route feedback if the developer is implementing their own waypoint UI.
-        guard let shouldIncrement = delegate?.navigationViewController?(self, shouldIncrementLegWhenArrivingAtWaypoint: waypoint), shouldIncrement == true else {
+        if !isFinalLeg || !shouldIncrementLeg {
             delegate?.navigationViewController?(self, didArriveAt: waypoint)
             return
         }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -532,7 +532,7 @@ extension NavigationViewController: RouteControllerDelegate {
     
     public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) {
         guard routeController.routeProgress.isFinalLeg else {
-            delegate?.navigationViewController!(self, didArriveAt: waypoint)
+            delegate?.navigationViewController?(self, didArriveAt: waypoint)
             return
         }
         

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -531,7 +531,10 @@ extension NavigationViewController: RouteControllerDelegate {
     }
     
     public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) {
-        guard routeController.routeProgress.isFinalLeg else { return }
+        guard routeController.routeProgress.isFinalLeg else {
+            delegate?.navigationViewController!(self, didArriveAt: waypoint)
+            return
+        }
         
         let completion: (Bool) -> Void = { _ in self.delegate?.navigationViewController?(self, didArriveAt: waypoint) }
         if showsEndOfRouteFeedback {


### PR DESCRIPTION
As of right now, this function is only returning didArriveAt waypoint for the last waypoint and not all waypoints.

/cc @mapbox/navigation-ios 