### PR TITLE
Remove StatusView animations before starting another

### DIFF
--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -88,6 +88,7 @@ public class StatusView: UIView {
     }
     
     func show(_ title: String, showSpinner: Bool) {
+        layer.removeAllAnimations()
         textLabel.text = title
         activityIndicatorView.hidesWhenStopped = true
         if showSpinner {
@@ -106,7 +107,7 @@ public class StatusView: UIView {
     }
     
     func hide(delay: TimeInterval = 0, animated: Bool = true) {
-        
+        layer.removeAllAnimations()
         if animated {
             guard isHidden == false else { return }
             


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/973

It looks like stacking animations one after another caused the height to grow. It looks like we can prevent this by removing all animations on the layer before applying another.

/cc @mapbox/navigation-ios @frederoni 