### PR TITLE
Check if view is loaded before calling func on outlet

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -758,6 +758,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
     }
     
     @objc func updateETA() {
+        guard isViewLoaded else { return }
         bottomBannerView.updateETA(routeProgress: routeController.routeProgress)
     }
     

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -337,6 +337,8 @@ class RouteMapViewController: UIViewController {
     }
     
     @objc func didReroute(notification: NSNotification) {
+        guard self.isViewLoaded else { return }
+        
         if !(routeController.locationManager is SimulatedLocationManager) {
             statusView.hide(delay: 0.5, animated: true)
             


### PR DESCRIPTION
We need to make sure the view is loaded before we can call  `RouteMapViewController.updateETA(_:)`. Followup to https://github.com/mapbox/mapbox-navigation-ios/pull/958.

/cc @1ec5 