### PR TITLE
Fix arrival delegates

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -531,10 +531,14 @@ extension NavigationViewController: RouteControllerDelegate {
     }
     
     public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) {
-        let isFinalLeg = routeController.routeProgress.isFinalLeg
-        let shouldIncrementLeg = delegate?.navigationViewController?(self, shouldIncrementLegWhenArrivingAtWaypoint: waypoint) ?? false
+        guard routeController.routeProgress.isFinalLeg else {
+            delegate?.navigationViewController?(self, didArriveAt: waypoint)
+            return
+        }
         
-        if !isFinalLeg || !shouldIncrementLeg {
+        // If the developer implements`NavigationViewController(shouldIncrementLegWhenArrivingAtWaypoint:)` and sets it to false,
+        // we should emit `NavigationViewController(didArriveAt:)` and not show the end of route feedback UI.
+        if let shouldIncrementLegWhenArrivingAtWaypoint = delegate?.navigationViewController?(self, shouldIncrementLegWhenArrivingAtWaypoint: waypoint), shouldIncrementLegWhenArrivingAtWaypoint == false {
             delegate?.navigationViewController?(self, didArriveAt: waypoint)
             return
         }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -531,10 +531,9 @@ extension NavigationViewController: RouteControllerDelegate {
     }
     
     public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) {
-        guard routeController.routeProgress.isFinalLeg else {
-            delegate?.navigationViewController?(self, didArriveAt: waypoint)
-            return
-        }
+        delegate?.navigationViewController?(self, didArriveAt: waypoint)
+        
+        guard routeController.routeProgress.isFinalLeg else { return }
         
         // If the developer implements`NavigationViewController(shouldIncrementLegWhenArrivingAtWaypoint:)` and sets it to false,
         // we should emit `NavigationViewController(didArriveAt:)` and not show the end of route feedback UI.

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -538,7 +538,6 @@ extension NavigationViewController: RouteControllerDelegate {
         // If the developer implements`NavigationViewController(shouldIncrementLegWhenArrivingAtWaypoint:)` and sets it to false,
         // we should emit `NavigationViewController(didArriveAt:)` and not show the end of route feedback UI.
         if let shouldIncrementLegWhenArrivingAtWaypoint = delegate?.navigationViewController?(self, shouldIncrementLegWhenArrivingAtWaypoint: waypoint), shouldIncrementLegWhenArrivingAtWaypoint == false {
-            delegate?.navigationViewController?(self, didArriveAt: waypoint)
             return
         }
         


### PR DESCRIPTION
Followup to https://github.com/mapbox/mapbox-navigation-ios/pull/969

In cases where the developer did not implement `shouldIncrementLegWhenArrivingAtWaypoint`, the didArriveAt delegate would never fire.

/cc @mapbox/navigation-ios 