### PR TITLE
Don't increment legIndex if there are none left

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -836,6 +836,7 @@ extension RouteController: CLLocationManagerDelegate {
         }
 
         if routeProgress.currentLegProgress.userHasArrivedAtWaypoint,
+            routeProgress.remainingWaypoints.count > 0,
             (delegate?.routeController?(self, shouldIncrementLegWhenArrivingAtWaypoint: routeProgress.currentLeg.destination) ?? true) {
             routeProgress.legIndex += 1
         }


### PR DESCRIPTION
This fixes the following crash:

```
#0. Crashed: com.apple.main-thread
0  MapboxCoreNavigation           0x104c0f4c0 RouteController.advanceStepIndex(to:) (RouteController.swift:840)
1  MapboxCoreNavigation           0x104c1a0a0 specialized RouteController.userIsOnRoute(_:) (RouteController.swift:644)
2  MapboxCoreNavigation           0x104c0f4f8 @objc RouteController.userIsOnRoute(_:) (RouteController.swift)
3  MapboxCoreNavigation           0x104c196fc specialized RouteController.locationManager(_:didUpdateLocations:) (RouteController.swift:587)
4  MapboxCoreNavigation           0x104c0eee4 @objc RouteController.locationManager(_:didUpdateLocations:) (RouteController.swift)
5  CoreLocation                   0x1886a07bc (null) + 77412
6  CoreLocation                   0x1886a001c (null) + 75460
7  CoreLocation                   0x1886886b4 (null) + 1004
8  CoreFoundation                 0x18204e790 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 20
9  CoreFoundation                 0x18204e060 __CFRunLoopDoBlocks + 288
10 CoreFoundation                 0x18204c2c8 __CFRunLoopRun + 2436
11 CoreFoundation                 0x181f6be58 CFRunLoopRunSpecific + 436
12 GraphicsServices               0x183e18f84 GSEventRunModal + 100
13 UIKit                          0x18b5eb67c UIApplicationMain + 236
```

We should not be incrementing the `legIndex` if there are not any legs left.

/cc @mapbox/navigation-ios 
