### PR TITLE
add voiceController willSpeak delegate method

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -316,9 +316,8 @@ extension ViewController: NavigationMapViewDelegate {
         print(interruptedInstruction.text, interruptingInstruction.text)
     }
     
-    func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction) -> SpokenInstruction {
-        let newInstruction = SpokenInstruction(distanceAlongStep: instruction.distanceAlongStep, text: "New Instruction!", ssmlText: "<speak>New Instruction!</speak>")
-        return newInstruction
+    func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction) -> SpokenInstruction? {
+        return SpokenInstruction(distanceAlongStep: instruction.distanceAlongStep, text: "New Instruction!", ssmlText: "<speak>New Instruction!</speak>")
     }
 }
 

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -315,6 +315,11 @@ extension ViewController: NavigationMapViewDelegate {
     func voiceController(_ voiceController: RouteVoiceController, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction) {
         print(interruptedInstruction.text, interruptingInstruction.text)
     }
+    
+    func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction) -> SpokenInstruction {
+        let newInstruction = SpokenInstruction(distanceAlongStep: instruction.distanceAlongStep, text: "New Instruction!", ssmlText: "<speak>New Instruction!</speak>")
+        return newInstruction
+    }
 }
 
 //MARK: WaypointConfirmationViewControllerDelegate

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -278,7 +278,7 @@ public protocol VoiceControllerDelegate {
     @objc(voiceController:didInterruptSpokenInstruction:withInstruction:)
     optional func voiceController(_ voiceController: RouteVoiceController, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction)
     
-    /** Called when a spoken is about to speak. Useful if it is necessary to give a custom instruction instead.
+    /** Called when a spoken is about to speak. Useful if it is necessary to give a custom instruction instead. Noting, changing the `distanceAlongStep` property on `SpokenInstruction` will have no impact on when the instruction will be said.
      
      - parameter voiceController: The voice controller that experienced the interruption.
      - parameter instruction: The spoken instruction that will be said.

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -233,10 +233,12 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
             utterance!.voice = AVSpeechSynthesisVoice(identifier: AVSpeechSynthesisVoiceIdentifierAlex)
         }
         
+        let modifiedInstruction = voiceControllerDelegate?.voiceController?(self, willSpeak: instruction) ?? instruction
+        
         if #available(iOS 10.0, *), utterance?.voice == nil, let legProgress = legProgress {
-            utterance = AVSpeechUtterance(attributedString: instruction.attributedText(for: legProgress))
+            utterance = AVSpeechUtterance(attributedString: modifiedInstruction.attributedText(for: legProgress))
         } else {
-            utterance = AVSpeechUtterance(string: instruction.text)
+            utterance = AVSpeechUtterance(string: modifiedInstruction.text)
         }
         
         // Only localized languages will have a proper fallback voice
@@ -275,4 +277,12 @@ public protocol VoiceControllerDelegate {
      */
     @objc(voiceController:didInterruptSpokenInstruction:withInstruction:)
     optional func voiceController(_ voiceController: RouteVoiceController, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction)
+    
+    /** Called when a spoken is about to speak. Useful if it is necessary to give a custom instruction instead.
+     
+     - parameter voiceController: The voice controller that experienced the interruption.
+     - parameter instruction: The spoken instruction that will be said.
+     **/
+    @objc(voiceController:willSpeakSpokenInstruction:)
+    optional func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction) -> SpokenInstruction
 }

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -284,5 +284,5 @@ public protocol VoiceControllerDelegate {
      - parameter instruction: The spoken instruction that will be said.
      **/
     @objc(voiceController:willSpeakSpokenInstruction:)
-    optional func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction) -> SpokenInstruction
+    optional func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction) -> SpokenInstruction?
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/846

This adds a method for listening on when a voice instruction will be spoken and allows developers to change the instruction as needed. Some things to chew on:

- developers will be on their own when it comes to SSML. It'll be about as difficult or easy as they want to make it.
- I with the dev did not have to include `distanceAlongStep` since it will have no impact on when the instruction is said.

Other than that, I think this a pretty clean addition.

/cc @mapbox/navigation-ios 