### PR TITLE
Add MapboxCoreNavigation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Alternatively, to install Mapbox Navigation using [Carthage](https://github.com/
 
 ```swift
 import MapboxDirections
+import MapboxCoreNavigation
 import MapboxNavigation
 ```
 


### PR DESCRIPTION
It's necessary to `import MapboxCoreNavigation` because `NavigationRouteOptions` depends on it.

/cc @ericrwolfe 