### PR TITLE
Animate user puck along route

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -315,15 +315,18 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let duration: TimeInterval = animated ? 1 : 0
         
         if let route = routes?.first, let coordinates = route.coordinates, let previousLocation = previousLocation {
+            
             let points = Polyline(coordinates).sliced(from: previousLocation.coordinate, to: location.coordinate).coordinates.map {
                 return self.convert($0, toPointTo: self)
             }
             
-            UIView.animateKeyframes(withDuration: duration, delay: 0, options: .beginFromCurrentState, animations: {
+            let relativeDuration = Double(duration) / Double(points.count)
+            
+            UIView.animateKeyframes(withDuration: duration, delay: 0, options: [.calculationModeLinear, .beginFromCurrentState], animations: {
                 for (pointIndex, point) in points.enumerated() {
-                    UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: 0, initialSpringVelocity: 0, options: .beginFromCurrentState, animations: {
+                    UIView.addKeyframe(withRelativeStartTime: relativeDuration * Double(pointIndex), relativeDuration: Double(duration) / Double(points.count), animations: {
                         self.userCourseView?.center = point
-                    }, completion: nil)
+                    })
                 }
             }, completion: nil)
         } else {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -317,9 +317,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let duration: TimeInterval = animated ? 1 : 0
         
         if let coordinates = routeProgress?.route.coordinates, let previousLocation = previousLocation {
-            let points = Polyline(coordinates).sliced(from: previousLocation.coordinate, to: location.coordinate).coordinates.map {
+            var points = Polyline(coordinates).sliced(from: previousLocation.coordinate, to: location.coordinate).coordinates.map {
                 return self.convert($0, toPointTo: self)
             }
+            points.removeLast()
             
             let relativeDuration = Double(duration) / Double(points.count - 1)
             


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/939

Currently, when a location update comes in, we simply animate the user puck from where it is to the new location. This however can cause shortcuts when the points are on either side of sharp turn as seen below:

![image](https://user-images.githubusercontent.com/1058624/34741567-e8f120a8-f537-11e7-9817-77381700eef1.png)

This PR changes the user puck to animate along the route instead of in a straight line. 

todo:
- [ ] it'd probably be smart to allow straight line animations when the previous and current location are far enough apart
- [ ] fix jumping back and forth

/cc @mapbox/navigation-ios  @frederoni   