### PR TITLE
Refactoring appearance logic out of RMVC and into Views

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -123,7 +123,7 @@
 		35DC585D1FABC61100B5A956 /* InstructionsBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC585C1FABC61100B5A956 /* InstructionsBannerViewTests.swift */; };
 		35DC9D8D1F431E59001ECD64 /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
 		35DC9D8F1F4321CC001ECD64 /* route-with-lanes.json in Resources */ = {isa = PBXBuildFile; fileRef = 35DC9D8E1F4321CC001ECD64 /* route-with-lanes.json */; };
-		35DC9D911F4323AA001ECD64 /* LanesContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC9D901F4323AA001ECD64 /* LanesContainerView.swift */; };
+		35DC9D911F4323AA001ECD64 /* LanesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC9D901F4323AA001ECD64 /* LanesView.swift */; };
 		35E407681F5625FF00EFC814 /* StyleKitMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E407671F5625FF00EFC814 /* StyleKitMarker.swift */; };
 		35E9B0AD1F9E0F8F00BF84AB /* MapboxNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */; };
 		35F1F5931FD57EFD00F8E502 /* StyleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F1F5921FD57EFD00F8E502 /* StyleManagerTests.swift */; };
@@ -132,6 +132,8 @@
 		6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */; };
 		64847A041F04629D003F3A69 /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64847A031F04629D003F3A69 /* Feedback.swift */; };
 		8D391CE21FD71E78006BB91F /* Waypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D391CE11FD71E78006BB91F /* Waypoint.swift */; };
+		8D509F60200809C6007D2730 /* TopBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D509F5E200809C6007D2730 /* TopBannerViewController.swift */; };
+		8D509F61200809C6007D2730 /* TopBannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8D509F5F200809C6007D2730 /* TopBannerViewController.xib */; };
 		8DB63A3A1FBBCA2200928389 /* RatingControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB63A391FBBCA2200928389 /* RatingControl.swift */; };
 		8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE879651FBB9980002F06C0 /* EndOfRouteViewController.swift */; };
 		8DF399B21FB257B30034904C /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF399B11FB257B30034904C /* UIGestureRecognizer.swift */; };
@@ -429,7 +431,7 @@
 		35DA85781FC45787004092EC /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		35DC585C1FABC61100B5A956 /* InstructionsBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionsBannerViewTests.swift; sourceTree = "<group>"; };
 		35DC9D8E1F4321CC001ECD64 /* route-with-lanes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "route-with-lanes.json"; sourceTree = "<group>"; };
-		35DC9D901F4323AA001ECD64 /* LanesContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanesContainerView.swift; sourceTree = "<group>"; };
+		35DC9D901F4323AA001ECD64 /* LanesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanesView.swift; sourceTree = "<group>"; };
 		35E407671F5625FF00EFC814 /* StyleKitMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleKitMarker.swift; sourceTree = "<group>"; };
 		35F1F5921FD57EFD00F8E502 /* StyleManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleManagerTests.swift; sourceTree = "<group>"; };
 		35F520BF1FB482A200FC9C37 /* NextBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextBannerView.swift; sourceTree = "<group>"; };
@@ -437,6 +439,8 @@
 		6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaypointConfirmationViewController.swift; sourceTree = "<group>"; };
 		64847A031F04629D003F3A69 /* Feedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
 		8D391CE11FD71E78006BB91F /* Waypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Waypoint.swift; sourceTree = "<group>"; };
+		8D509F5E200809C6007D2730 /* TopBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewController.swift; sourceTree = "<group>"; };
+		8D509F5F200809C6007D2730 /* TopBannerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TopBannerViewController.xib; sourceTree = "<group>"; };
 		8DB63A391FBBCA2200928389 /* RatingControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingControl.swift; sourceTree = "<group>"; };
 		8DE879651FBB9980002F06C0 /* EndOfRouteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfRouteViewController.swift; sourceTree = "<group>"; };
 		8DF399B11FB257B30034904C /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -671,6 +675,8 @@
 				351BEBE01E5BCC63006FE110 /* Style.swift */,
 				35726EE71F0856E900AFA1B6 /* DayStyle.swift */,
 				351BEBEA1E5BCC63006FE110 /* NavigationViewController.swift */,
+				8D509F5E200809C6007D2730 /* TopBannerViewController.swift */,
+				8D509F5F200809C6007D2730 /* TopBannerViewController.xib */,
 				351BEBE41E5BCC63006FE110 /* RouteMapViewController.swift */,
 				8DE879651FBB9980002F06C0 /* EndOfRouteViewController.swift */,
 				35C9973E1E732C1B00544D1C /* RouteVoiceController.swift */,
@@ -842,7 +848,7 @@
 				359A8AEE1FA7B25800BDB486 /* LanesStyleKit.swift */,
 				351BEBED1E5BCC63006FE110 /* ManeuversStyleKit.swift */,
 				351BEBEF1E5BCC63006FE110 /* ManeuverView.swift */,
-				35DC9D901F4323AA001ECD64 /* LanesContainerView.swift */,
+				35DC9D901F4323AA001ECD64 /* LanesView.swift */,
 				35E407671F5625FF00EFC814 /* StyleKitMarker.swift */,
 				3531C26F1F9E095400D92F9A /* InstructionsBannerView.swift */,
 				35D428281FA0B61F00176028 /* InstructionsBannerViewLayout.swift */,
@@ -1251,6 +1257,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8D509F61200809C6007D2730 /* TopBannerViewController.xib in Resources */,
 				DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */,
 				351BEC291E5BD530006FE110 /* Assets.xcassets in Resources */,
 				C520EE901EBB84F9008805BC /* Navigation.storyboard in Resources */,
@@ -1461,7 +1468,7 @@
 				8D391CE21FD71E78006BB91F /* Waypoint.swift in Sources */,
 				353EC9D71FB09708002EB0AB /* StepsViewController.swift in Sources */,
 				35726EE81F0856E900AFA1B6 /* DayStyle.swift in Sources */,
-				35DC9D911F4323AA001ECD64 /* LanesContainerView.swift in Sources */,
+				35DC9D911F4323AA001ECD64 /* LanesView.swift in Sources */,
 				8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */,
 				C57491DF1FACC42F006F97BC /* CGPoint.swift in Sources */,
 				C58159011EA6D02700FC6C3D /* MGLVectorSource.swift in Sources */,
@@ -1485,6 +1492,7 @@
 				35F611C41F1E1C0500C43249 /* FeedbackViewController.swift in Sources */,
 				353AA5601FCEF583009F0384 /* StyleManager.swift in Sources */,
 				35F520C01FB482A200FC9C37 /* NextBannerView.swift in Sources */,
+				8D509F60200809C6007D2730 /* TopBannerViewController.swift in Sources */,
 				C5A6B2DD1F4CE8E8004260EA /* StyleType.swift in Sources */,
 				351BEC021E5BCC63006FE110 /* UIView.swift in Sources */,
 				351BEBF21E5BCC63006FE110 /* Style.swift in Sources */,

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -71,6 +71,17 @@ open class BaseInstructionsBannerView: UIControl {
         delegate?.didTapInstructionsBanner(self)
     }
     
+    func update(progress: RouteLegProgress, location: CLLocation, secondsRemaining: TimeInterval) {
+        let stepProgress = progress.currentStepProgress
+        let distanceRemaining = stepProgress.distanceRemaining
+        
+        guard let visualInstruction = progress.currentStep.instructionsDisplayedAlongStep?.last else { return }
+        
+        set(visualInstruction.primaryTextComponents, secondaryInstruction: visualInstruction.secondaryTextComponents)
+        distance = distanceRemaining > 5 ? distanceRemaining : 0
+        maneuverView.step = progress.upComingStep
+    }
+    
     func set(_ primaryInstruction: [VisualInstructionComponent]?, secondaryInstruction: [VisualInstructionComponent]?) {
         primaryLabel.numberOfLines = secondaryInstruction == nil ? 2 : 1
         

--- a/MapboxNavigation/LanesView.swift
+++ b/MapboxNavigation/LanesView.swift
@@ -10,8 +10,8 @@ public class LanesView: UIView {
     weak var stackView: UIStackView!
     weak var separatorView: SeparatorView!
     
-    var count: Int {
-        return stackView.arrangedSubviews.count
+    var hasLanes: Bool {
+        return !stackView.arrangedSubviews.isEmpty
     }
     
     override init(frame: CGRect) {

--- a/MapboxNavigation/LanesView.swift
+++ b/MapboxNavigation/LanesView.swift
@@ -5,10 +5,14 @@ import MapboxDirections
 
 /// :nodoc:
 @IBDesignable
-@objc(MBLanesContainerView)
-public class LanesContainerView: LanesView {
+@objc(MBLanesView)
+public class LanesView: UIView {
     weak var stackView: UIStackView!
     weak var separatorView: SeparatorView!
+    
+    var count: Int {
+        return stackView.arrangedSubviews.count
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import MapboxDirections
 
 /// :nodoc:
 @objc(MBNextInstructionLabel)
@@ -68,6 +69,11 @@ open class NextBannerView: UIView {
         instructionLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: 70).isActive = true
         instructionLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
         instructionLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -16).isActive = true
+    }
+    
+    func update(step: RouteStep, instruction: VisualInstruction) {
+        maneuverView.step = step
+        instructionLabel.instruction = instruction.primaryTextComponents
     }
     
 }

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -44,7 +44,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I8f-iR-MZm" customClass="MBReportButton">
-                                <rect key="frame" x="121.5" y="240.5" width="132" height="38"/>
+                                <rect key="frame" x="121.5" y="266.5" width="132" height="38"/>
                                 <color key="backgroundColor" red="0.14901960784313725" green="0.23921568627450979" blue="0.3411764705882353" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                 <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
@@ -84,26 +84,38 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gx9-Bj-wuQ" userLabel="Bottom Banner Content View" customClass="MBBottomBannerContentView">
                                 <rect key="frame" x="0.0" y="420" width="375" height="80"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="mCw-pS-Qas"/>
+                                </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sDs-aU-EMQ" customClass="MBBottomBannerView">
                                 <rect key="frame" x="0.0" y="420" width="375" height="80"/>
                                 <color key="backgroundColor" red="0.4858537946" green="0.87731584819999997" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Eeb-3z-AWG" userLabel="Lanes/Next/Status Stack View">
-                                <rect key="frame" x="0.0" y="116.5" width="375" height="114"/>
+                                <rect key="frame" x="0.0" y="116.5" width="375" height="140"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Container View" customClass="MBLanesContainerView">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-ru-uJw" userLabel="Lanes Container View" customClass="MBLanesView">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="40"/>
                                         <color key="backgroundColor" red="0.9700858161" green="0.9700858161" blue="0.9700858161" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="40" id="37K-6b-zhg"/>
+                                        </constraints>
                                         <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvl-aX-s8B" customClass="MBNextBannerView">
-                                        <rect key="frame" x="0.0" y="40" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="40" width="375" height="50"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="y1w-PW-C5X"/>
+                                        </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jym-DH-tdD" customClass="MBStatusView">
-                                        <rect key="frame" x="0.0" y="84" width="375" height="30"/>
+                                        <rect key="frame" x="0.0" y="90" width="375" height="50"/>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.67473591549295775" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="giq-MN-YWs"/>
+                                        </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
@@ -125,7 +137,7 @@
                                 </connections>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8P3-NB-IRq" userLabel="Floating Stack View">
-                                <rect key="frame" x="315" y="240.5" width="50" height="108"/>
+                                <rect key="frame" x="315" y="266.5" width="50" height="108"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dry-gO-T7u" customClass="MBFloatingButton">
                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -552,7 +564,7 @@ Label  </string>
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lll-SJ-8q4">
-                                                    <rect key="frame" x="37" y="86" width="50" height="43"/>
+                                                    <rect key="frame" x="38" y="86" width="50" height="43"/>
                                                     <string key="text">Label 
 Label  </string>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
@@ -606,7 +618,7 @@ Label  </string>
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pt1-9i-cSt">
-                                                    <rect key="frame" x="38" y="86" width="50" height="43"/>
+                                                    <rect key="frame" x="37" y="86" width="50" height="43"/>
                                                     <string key="text">Label 
 Label  </string>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
@@ -660,7 +672,7 @@ Label  </string>
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yPS-fp-q2X">
-                                                    <rect key="frame" x="38" y="86" width="50" height="43"/>
+                                                    <rect key="frame" x="37" y="86" width="50" height="43"/>
                                                     <string key="text">Label 
 Label  </string>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -24,7 +24,7 @@ class RouteMapViewController: UIViewController {
     @IBOutlet weak var nextBannerView: NextBannerView!
     @IBOutlet weak var bottomBannerView: BottomBannerView!
     @IBOutlet weak var statusView: StatusView!
-    @IBOutlet weak var laneViewsContainerView: LanesContainerView!
+    @IBOutlet weak var laneViewsContainerView: LanesView!
     @IBOutlet weak var rerouteFeedbackTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var endOfRouteContainerView: UIView!
     @IBOutlet weak var endOfRouteShowConstraint: NSLayoutConstraint!

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -301,7 +301,7 @@ class RouteMapViewController: UIViewController {
         updateETA()
         
         if let location = routeController.location {
-            updateInstructions(routeProgress: routeController.routeProgress, location: location, secondsRemaining: 0)
+            instructionsBannerView.update(progress: routeController.routeProgress.currentLegProgress, location: location, secondsRemaining: 0)
         }
         
         mapView.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
@@ -413,7 +413,7 @@ class RouteMapViewController: UIViewController {
         }
         
         previousStep = step
-        updateInstructions(routeProgress: routeProgress, location: location, secondsRemaining: secondsRemaining)
+        instructionsBannerView.update(progress: routeProgress.currentLegProgress, location: location, secondsRemaining: secondsRemaining)
         updateNextBanner(routeProgress: routeProgress)
         
         if currentLegIndexMapped != routeProgress.legIndex {
@@ -434,16 +434,6 @@ class RouteMapViewController: UIViewController {
         updateVisibleBounds()
     }
     
-    func updateInstructions(routeProgress: RouteProgress, location: CLLocation, secondsRemaining: TimeInterval) {
-        let stepProgress = routeProgress.currentLegProgress.currentStepProgress
-        let distanceRemaining = stepProgress.distanceRemaining
-        
-        guard let visualInstruction = routeProgress.currentLegProgress.currentStep.instructionsDisplayedAlongStep?.last else { return }
-        
-        instructionsBannerView.set(visualInstruction.primaryTextComponents, secondaryInstruction: visualInstruction.secondaryTextComponents)
-        instructionsBannerView.distance = distanceRemaining > 5 ? distanceRemaining : 0
-        instructionsBannerView.maneuverView.step = routeProgress.currentLegProgress.upComingStep
-    }
     
     func updateNextBanner(routeProgress: RouteProgress) {
     

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -434,31 +434,21 @@ class RouteMapViewController: UIViewController {
         updateVisibleBounds()
     }
     
-    
     func updateNextBanner(routeProgress: RouteProgress) {
-    
-        guard let upcomingStep = routeProgress.currentLegProgress.upComingStep,
-            let nextStep = routeProgress.currentLegProgress.stepAfter(upcomingStep),
-            laneViewsContainerView.isHidden
-            else {
+        let tooLong = RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier
+        
+        guard let progress = routeProgress.currentLegProgress,
+            let upcoming = progress.upComingStep,
+            let next = progress.stepAfter(upcoming),
+            laneViewsContainerView.isHidden, //banner should not show if the lane view is visible
+            next.expectedTravelTime <= tooLong, //banner should not show if the current step's completion is time-consuming.
+            upcoming.expectedTravelTime <= tooLong,  //banner should not show if the upcoming step is time-consuming.
+            let instruction = upcoming.instructionsDisplayedAlongStep?.last else {  //banner should not show if the upcoming step contains no instructions.
                 hideNextBanner()
                 return
         }
         
-        // If the followon step is short and the user is near the end of the current step, show the nextBanner.
-        guard nextStep.expectedTravelTime <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier,
-            upcomingStep.expectedTravelTime <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier else {
-                hideNextBanner()
-                return
-        }
-        
-        guard let instructions = upcomingStep.instructionsDisplayedAlongStep?.last else {
-            hideNextBanner()
-            return
-        }
-        
-        nextBannerView.maneuverView.step = nextStep
-        nextBannerView.instructionLabel.instruction = instructions.primaryTextComponents
+        nextBannerView.update(step: next, instruction: instruction)
         showNextBanner()
     }
     

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -87,7 +87,7 @@ public class StatusView: UIView {
         }
     }
     
-    func show(_ title: String, showSpinner: Bool) {
+    func show(_ title: String, showSpinner: Bool, animated: Bool = true) {
         textLabel.text = title
         activityIndicatorView.hidesWhenStopped = true
         if showSpinner {
@@ -98,28 +98,26 @@ public class StatusView: UIView {
         
         guard isHidden == true else { return }
         
-        UIView.defaultAnimation(0.3, animations: {
+        let show = {
             self.isHidden = false
             self.textLabel.alpha = 1
             self.superview?.layoutIfNeeded()
-        }, completion: nil)
+        }
+        
+        animated ? UIView.defaultAnimation(0.3, animations: show, completion: nil) : show()
     }
     
     func hide(delay: TimeInterval = 0, animated: Bool = true) {
-        
-        if animated {
-            guard isHidden == false else { return }
-            
-            UIView.defaultAnimation(0.3, delay: delay, animations: {
-                self.isHidden = true
-                self.textLabel.alpha = 0
-                self.superview?.layoutIfNeeded()
-            }, completion: { (completed) in
-                self.activityIndicatorView.stopAnimating()
-            })
-        } else {
-            activityIndicatorView.stopAnimating()
-            isHidden = true
+        let hide = {
+            self.isHidden = true
+            self.textLabel.alpha = 0
+            self.superview?.layoutIfNeeded()
         }
+        let complete: (Bool?) -> Void = { _ in
+            self.activityIndicatorView.stopAnimating()
+        }
+        let noAnimate = { hide(); complete(true) }
+        
+        animated ? UIView.defaultAnimation(0.3, animations: hide, completion: complete) : noAnimate()
     }
 }

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -64,10 +64,6 @@ open class DismissButton: Button { }
 open class FloatingButton: Button { }
 
 /// :nodoc:
-@objc(MBLanesView)
-public class LanesView: UIView { }
-
-/// :nodoc:
 @objc(MBReportButton)
 public class ReportButton: Button {
     

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -1,0 +1,122 @@
+//
+//  TopBannerViewController.swift
+//  MapboxNavigation
+//
+//  Created by Jerrad Thramer on 1/11/18.
+//  Copyright © 2018 Mapbox. All rights reserved.
+//
+
+import UIKit
+import MapboxCoreNavigation
+import MapboxDirections
+
+class TopBannerViewController: UIViewController, StatusViewDelegate, InstructionsBannerViewDelegate {
+    //MARK: - Class Constants
+    static let lanesBackgroundColor: UIColor = UIColor(white: 247/255, alpha: 1.0)
+    static let statusBackgroundColor: UIColor = UIColor.black.withAlphaComponent(2/3)
+    
+    //MARK: - Outlets
+    @IBOutlet weak var instructions: InstructionsBannerView!
+    @IBOutlet weak var lanes: LanesView!
+    @IBOutlet weak var nextBanner: NextBannerView!
+    @IBOutlet weak var status: StatusView!
+    
+    //MARK: - Properties
+    var delegate: TopBannerViewControllerDelegate?
+    var isSimulatedNavigation: Bool = false
+    
+    //MARK: - View Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setBackgroundColors()
+    }
+    
+    // MARK: - Initial State
+    private func setupUI() {
+        instructions.delegate = self
+        status.delegate = self
+        [lanes, nextBanner, status].forEach { $0.isHidden = true }
+    }
+    
+    private func setBackgroundColors() {
+        instructions.backgroundColor = .white
+        lanes.backgroundColor = TopBannerViewController.lanesBackgroundColor
+        nextBanner.backgroundColor = .white
+        status.backgroundColor = TopBannerViewController.statusBackgroundColor
+    }
+
+    // MARK: - Model Updating
+    func update(progress: RouteProgress, location: CLLocation, secondsRemaining: TimeInterval) {
+        //update banner
+        instructions.update(progress: progress.currentLegProgress, location: location, secondsRemaining: secondsRemaining)
+        
+        //update lanes
+        if let upComingStep = progress.currentLegProgress?.upComingStep, !progress.currentLegProgress.userHasArrivedAtWaypoint {
+            updateLaneViews(step: upComingStep, durationRemaining: progress.currentLegProgress.currentStepProgress.durationRemaining)
+        }
+        
+        //update next
+        updateNextBanner(routeProgress: progress)
+        
+    }
+
+    // MARK: - UI Manipulation
+    func showStatus(text: String, for duration: TimeInterval, showingSpinner: Bool = false, animated: Bool = true) {
+        status.show(text, showSpinner: showingSpinner, animated: animated)
+        status.hide(delay: duration, animated: animated)
+    }
+    
+    // MARK: Lane Views
+    func updateLaneViews(step: RouteStep, durationRemaining: TimeInterval) {
+        lanes.updateLaneViews(step: step, durationRemaining: durationRemaining)
+        lanes.count > 0 ? show(view: lanes) : hide(view: lanes)
+    }
+    
+    // MARK: Next Banner
+    func updateNextBanner(routeProgress: RouteProgress) {
+        //FIXME: Testing override - Remove this!
+        let tooLong = Double.greatestFiniteMagnitude //RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier
+        
+        guard let progress = routeProgress.currentLegProgress,
+            let upcoming = progress.upComingStep,
+            let next = progress.stepAfter(upcoming),
+            lanes.isHidden, //banner should not show if the lane view is visible
+            next.expectedTravelTime <= tooLong, //banner should not show if the current step's completion is time-consuming.
+            upcoming.expectedTravelTime <= tooLong,  //banner should not show if the upcoming step is time-consuming.
+            let instruction = upcoming.instructionsDisplayedAlongStep?.last else {  //banner should not show if the upcoming step contains no instructions.
+                hide(view: nextBanner)
+                return
+        }
+        
+        nextBanner.update(step: next, instruction: instruction)
+        show(view: nextBanner)
+    }
+    
+    
+    //MARK: - Utility Functions
+    func show(view: UIView, animated: Bool = true) {
+        guard view.isHidden else { return }
+        let show = { view.isHidden = false }
+        animated ? UIView.defaultAnimation(0.3, animations:show, completion: nil) : show()
+    }
+    
+    func hide(view: UIView, animated: Bool = true) {
+        guard !view.isHidden else { return }
+        let hide = { view.isHidden = true }
+        animated ? UIView.defaultAnimation(0.3, animations:hide, completion: nil) : hide()
+    }
+
+    //MARK: - InstructionsBannerViewDelegate
+    func didTapInstructionsBanner(_ sender: BaseInstructionsBannerView) {
+        delegate?.didTapInstructionsBanner(sender)
+    }
+
+    //MARK: StatusViewDelegate
+    func statusView(_ statusView: StatusView, valueChangedTo value: Double) {
+        delegate?.statusView(statusView, valueChangedTo: value)
+    }
+}
+
+//MARK: - TopBannerViewControllerDelegate
+protocol TopBannerViewControllerDelegate: StatusViewDelegate, InstructionsBannerViewDelegate {}

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -1,11 +1,3 @@
-//
-//  TopBannerViewController.swift
-//  MapboxNavigation
-//
-//  Created by Jerrad Thramer on 1/11/18.
-//  Copyright © 2018 Mapbox. All rights reserved.
-//
-
 import UIKit
 import MapboxCoreNavigation
 import MapboxDirections
@@ -13,17 +5,17 @@ import MapboxDirections
 class TopBannerViewController: UIViewController, StatusViewDelegate, InstructionsBannerViewDelegate {
     //MARK: - Class Constants
     static let lanesBackgroundColor: UIColor = UIColor(white: 247/255, alpha: 1.0)
-    static let statusBackgroundColor: UIColor = UIColor.black.withAlphaComponent(2/3)
+    static let statusBackgroundColor: UIColor = UIColor.black.withAlphaComponent(2.0/3.0)
     
     //MARK: - Outlets
-    @IBOutlet weak var instructions: InstructionsBannerView!
-    @IBOutlet weak var lanes: LanesView!
+    @IBOutlet weak var instructionsBanner: InstructionsBannerView!
+    @IBOutlet weak var laneGuidanceBanner: LanesView!
     @IBOutlet weak var nextBanner: NextBannerView!
-    @IBOutlet weak var status: StatusView!
+    @IBOutlet weak var statusBanner: StatusView!
     
     //MARK: - Properties
     var delegate: TopBannerViewControllerDelegate?
-    var isSimulatedNavigation: Bool = false
+    var isSimulatedNavigation = false
     
     //MARK: - View Lifecycle
     override func viewDidLoad() {
@@ -34,26 +26,26 @@ class TopBannerViewController: UIViewController, StatusViewDelegate, Instruction
     
     // MARK: - Initial State
     private func setupUI() {
-        instructions.delegate = self
-        status.delegate = self
-        [lanes, nextBanner, status].forEach { $0.isHidden = true }
+        instructionsBanner.delegate = self
+        statusBanner.delegate = self
+        [laneGuidanceBanner, nextBanner, statusBanner].forEach { $0.isHidden = true }
     }
     
     private func setBackgroundColors() {
-        instructions.backgroundColor = .white
-        lanes.backgroundColor = TopBannerViewController.lanesBackgroundColor
+        instructionsBanner.backgroundColor = .white
+        laneGuidanceBanner.backgroundColor = TopBannerViewController.lanesBackgroundColor
         nextBanner.backgroundColor = .white
-        status.backgroundColor = TopBannerViewController.statusBackgroundColor
+        statusBanner.backgroundColor = TopBannerViewController.statusBackgroundColor
     }
 
     // MARK: - Model Updating
     func update(progress: RouteProgress, location: CLLocation, secondsRemaining: TimeInterval) {
         //update banner
-        instructions.update(progress: progress.currentLegProgress, location: location, secondsRemaining: secondsRemaining)
+        instructionsBanner.update(progress: progress.currentLegProgress, location: location, secondsRemaining: secondsRemaining)
         
         //update lanes
-        if let upComingStep = progress.currentLegProgress?.upComingStep, !progress.currentLegProgress.userHasArrivedAtWaypoint {
-            updateLaneViews(step: upComingStep, durationRemaining: progress.currentLegProgress.currentStepProgress.durationRemaining)
+        if let upcomingStep = progress.currentLegProgress?.upComingStep, !progress.currentLegProgress.userHasArrivedAtWaypoint {
+            updateLaneGuidance(step: upcomingStep, durationRemaining: progress.currentLegProgress.currentStepProgress.durationRemaining)
         }
         
         //update next
@@ -63,45 +55,45 @@ class TopBannerViewController: UIViewController, StatusViewDelegate, Instruction
 
     // MARK: - UI Manipulation
     func showStatus(text: String, for duration: TimeInterval, showingSpinner: Bool = false, animated: Bool = true) {
-        status.show(text, showSpinner: showingSpinner, animated: animated)
-        status.hide(delay: duration, animated: animated)
+        statusBanner.show(text, showSpinner: showingSpinner, animated: animated)
+        statusBanner.hide(delay: duration, animated: animated)
     }
     
     // MARK: Lane Views
-    func updateLaneViews(step: RouteStep, durationRemaining: TimeInterval) {
-        lanes.updateLaneViews(step: step, durationRemaining: durationRemaining)
-        lanes.count > 0 ? show(view: lanes) : hide(view: lanes)
+    private func updateLaneGuidance(step: RouteStep, durationRemaining: TimeInterval) {
+        laneGuidanceBanner.updateLaneViews(step: step, durationRemaining: durationRemaining)
+        laneGuidanceBanner.hasLanes ? show(view: laneGuidanceBanner) : hide(view: laneGuidanceBanner)
     }
     
     // MARK: Next Banner
-    func updateNextBanner(routeProgress: RouteProgress) {
+    private func updateNextBanner(routeProgress: RouteProgress) {
         //FIXME: Testing override - Remove this!
         let tooLong = Double.greatestFiniteMagnitude //RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier
         
         guard let progress = routeProgress.currentLegProgress,
             let upcoming = progress.upComingStep,
-            let next = progress.stepAfter(upcoming),
-            lanes.isHidden, //banner should not show if the lane view is visible
-            next.expectedTravelTime <= tooLong, //banner should not show if the current step's completion is time-consuming.
+            let subsequent = progress.stepAfter(upcoming),
+            laneGuidanceBanner.isHidden, //banner should not show if the lane view is visible
             upcoming.expectedTravelTime <= tooLong,  //banner should not show if the upcoming step is time-consuming.
+            subsequent.expectedTravelTime <= tooLong, //banner should not show if the current step's completion is time-consuming.
             let instruction = upcoming.instructionsDisplayedAlongStep?.last else {  //banner should not show if the upcoming step contains no instructions.
                 hide(view: nextBanner)
                 return
         }
         
-        nextBanner.update(step: next, instruction: instruction)
+        nextBanner.update(step: subsequent, instruction: instruction)
         show(view: nextBanner)
     }
     
     
     //MARK: - Utility Functions
-    func show(view: UIView, animated: Bool = true) {
+    private func show(view: UIView, animated: Bool = true) {
         guard view.isHidden else { return }
         let show = { view.isHidden = false }
         animated ? UIView.defaultAnimation(0.3, animations:show, completion: nil) : show()
     }
     
-    func hide(view: UIView, animated: Bool = true) {
+    private func hide(view: UIView, animated: Bool = true) {
         guard !view.isHidden else { return }
         let hide = { view.isHidden = true }
         animated ? UIView.defaultAnimation(0.3, animations:hide, completion: nil) : hide()

--- a/MapboxNavigation/TopBannerViewController.xib
+++ b/MapboxNavigation/TopBannerViewController.xib
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TopBannerViewController" customModule="MapboxNavigation" customModuleProvider="target">
+            <connections>
+                <outlet property="instructions" destination="PtL-Gu-NOd" id="ETT-cc-3DN"/>
+                <outlet property="lanes" destination="MY7-Db-DRc" id="mZ0-UM-wuq"/>
+                <outlet property="nextBanner" destination="f6q-Jv-U8Z" id="jsT-3e-W0O"/>
+                <outlet property="status" destination="qh7-W8-qYQ" id="Twd-zD-XtI"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="238"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PtL-Gu-NOd" customClass="MBInstructionsBannerView">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>
+                    <color key="backgroundColor" red="0.84833441840000001" green="0.99809138559999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="96" id="9Hn-3s-cjb"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AOm-zG-luT" customClass="MBSeparatorView">
+                    <rect key="frame" x="0.0" y="96" width="375" height="2"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="2" id="xfg-qg-myw"/>
+                    </constraints>
+                </view>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="pmK-zc-XwM">
+                    <rect key="frame" x="0.0" y="98" width="375" height="140"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MY7-Db-DRc" customClass="MBLanesView">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="66"/>
+                            <color key="backgroundColor" red="1" green="0.83234566450000003" blue="0.47320586440000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f6q-Jv-U8Z" customClass="MBNextBannerView">
+                            <rect key="frame" x="0.0" y="66" width="375" height="44"/>
+                            <color key="backgroundColor" red="0.7037046267" green="0.98106676339999999" blue="0.86589570900000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="l1Y-AQ-60O"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qh7-W8-qYQ" customClass="MBStatusView">
+                            <rect key="frame" x="0.0" y="110" width="375" height="30"/>
+                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.67000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="30" id="v2g-Bh-N1B"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="f6q-Jv-U8Z" secondAttribute="trailing" id="Ult-2B-ekg"/>
+                        <constraint firstItem="f6q-Jv-U8Z" firstAttribute="leading" secondItem="pmK-zc-XwM" secondAttribute="leading" id="VKV-BV-fXv"/>
+                        <constraint firstItem="qh7-W8-qYQ" firstAttribute="leading" secondItem="pmK-zc-XwM" secondAttribute="leading" id="WJu-M8-s6q"/>
+                        <constraint firstAttribute="trailing" secondItem="qh7-W8-qYQ" secondAttribute="trailing" id="hAy-SD-86h"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="pmK-zc-XwM" secondAttribute="trailing" id="BH0-Wa-ibX"/>
+                <constraint firstAttribute="bottom" secondItem="pmK-zc-XwM" secondAttribute="bottom" id="GKP-T1-pjn"/>
+                <constraint firstItem="AOm-zG-luT" firstAttribute="top" secondItem="PtL-Gu-NOd" secondAttribute="bottom" id="JPc-7L-V6J"/>
+                <constraint firstItem="PtL-Gu-NOd" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Jkd-rT-alU"/>
+                <constraint firstItem="pmK-zc-XwM" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="nI9-5r-UIt"/>
+                <constraint firstItem="PtL-Gu-NOd" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="tOv-2h-f8h"/>
+                <constraint firstItem="AOm-zG-luT" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="tV7-jS-5SP"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="PtL-Gu-NOd" secondAttribute="trailing" id="tYx-EF-fmO"/>
+                <constraint firstAttribute="trailing" secondItem="AOm-zG-luT" secondAttribute="trailing" id="y7K-PD-91B"/>
+                <constraint firstItem="pmK-zc-XwM" firstAttribute="top" secondItem="AOm-zG-luT" secondAttribute="bottom" id="zCp-fo-Hj0"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="34.5" y="70.5"/>
+        </view>
+    </objects>
+</document>

--- a/MapboxNavigation/TopBannerViewController.xib
+++ b/MapboxNavigation/TopBannerViewController.xib
@@ -12,10 +12,10 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TopBannerViewController" customModule="MapboxNavigation" customModuleProvider="target">
             <connections>
-                <outlet property="instructions" destination="PtL-Gu-NOd" id="ETT-cc-3DN"/>
-                <outlet property="lanes" destination="MY7-Db-DRc" id="mZ0-UM-wuq"/>
+                <outlet property="instructionsBanner" destination="PtL-Gu-NOd" id="wfG-vx-S0m"/>
+                <outlet property="laneGuidanceBanner" destination="MY7-Db-DRc" id="Ndm-SK-sya"/>
                 <outlet property="nextBanner" destination="f6q-Jv-U8Z" id="jsT-3e-W0O"/>
-                <outlet property="status" destination="qh7-W8-qYQ" id="Twd-zD-XtI"/>
+                <outlet property="statusBanner" destination="qh7-W8-qYQ" id="T5h-Xc-cpB"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>


### PR DESCRIPTION
This PR concerns #994, where it is desired to refactor view-appearance logic out of the RMVC and into the appropriate views themselves. This makes things a bit more lonely coupled and easier to work with in a piecemeal fashion.

To-Do: 
- [x] InstructionsBannerView
- [x] NextBannerView
- [x] ~BottomBannerView?~ (already pretty well-encapsulated)

Phase 2 To-Do:
- [x] Create TopBannerViewController
- [ ] Plug it in to RMVC
- [ ] Investigate "seconds" ambiguity
- [ ] Make sure you remove all shims (such as `tooFar`)

/cc @bsudekum @1ec5 @frederoni @ericrwolfe 
  