### PR TITLE
Stick to chosen route

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,3 +3,23 @@ Copyright © 2014–2018, Mapbox
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Copyright (c) 2016 Matthijs Hollemans and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -749,7 +749,7 @@ extension RouteController: CLLocationManagerDelegate {
                 return completion(nil, nil)
             }
 
-            if let route = self?.selectRouteBySimilarity(from: routes) {
+            if let route = self?.mostSimilarRoute(in: routes) {
                 return completion(route, error)
             } else if let route = routes.first {
                 return completion(route, error)
@@ -759,7 +759,7 @@ extension RouteController: CLLocationManagerDelegate {
         }
     }
     
-    func selectRouteBySimilarity(from routes: [Route]) -> Route? {
+    func mostSimilarRoute(in routes: [Route]) -> Route? {
         return routes.min { (left, right) -> Bool in
             let leftDistance = left.description.minimumEditDistance(to: routeProgress.route.description)
             let rightDistance = right.description.minimumEditDistance(to: routeProgress.route.description)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -744,11 +744,27 @@ extension RouteController: CLLocationManagerDelegate {
             if let error = error {
                 return completion(nil, error)
             }
-            guard let route = routes?.first else {
+            
+            guard let routes = routes else {
                 return completion(nil, nil)
             }
 
-            return completion(route, error)
+            if let route = self?.selectRouteBySimilarity(from: routes) {
+                return completion(route, error)
+            } else if let route = routes.first {
+                return completion(route, error)
+            } else {
+                return completion(nil, nil)
+            }
+        }
+    }
+    
+    func selectRouteBySimilarity(from routes: [Route]) -> Route? {
+        print(routes)
+        return routes.min { (left, right) -> Bool in
+            let leftDistance = left.description.minimumEditDistance(to: routeProgress.route.description)
+            let rightDistance = right.description.minimumEditDistance(to: routeProgress.route.description)
+            return leftDistance < rightDistance
         }
     }
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -760,7 +760,6 @@ extension RouteController: CLLocationManagerDelegate {
     }
     
     func selectRouteBySimilarity(from routes: [Route]) -> Route? {
-        print(routes)
         return routes.min { (left, right) -> Bool in
             let leftDistance = left.description.minimumEditDistance(to: routeProgress.route.description)
             let rightDistance = right.description.minimumEditDistance(to: routeProgress.route.description)

--- a/MapboxCoreNavigation/String.swift
+++ b/MapboxCoreNavigation/String.swift
@@ -50,4 +50,37 @@ extension String {
     var containsDecimalDigit: Bool {
         return self.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil
     }
+    
+    // Adapted from https://github.com/raywenderlich/swift-algorithm-club/blob/master/Minimum%20Edit%20Distance/MinimumEditDistance.playground/Contents.swift
+    func minimumEditDistance(to word: String) -> Int {
+        let fromWordCount = count
+        let toWordCount = word.count
+        var matrix = [[Int]](repeating: [Int](repeating: 0, count: toWordCount + 1), count: fromWordCount + 1)
+        
+        // initialize matrix
+        for index in 1...fromWordCount {
+            // the distance of any first string to an empty second string
+            matrix[index][0] = index
+        }
+        
+        for index in 1...toWordCount {
+            // the distance of any second string to an empty first string
+            matrix[0][index] = index
+        }
+        
+        // compute Levenshtein distance
+        for (i, selfChar) in enumerated() {
+            for (j, otherChar) in word.enumerated() {
+                if otherChar == selfChar {
+                    // substitution of equal symbols with cost 0
+                    matrix[i + 1][j + 1] = matrix[i][j]
+                } else {
+                    // minimum of the cost of insertion, deletion, or substitution
+                    // added to the already computed costs in the corresponding cells
+                    matrix[i + 1][j + 1] = Swift.min(matrix[i][j] + 1, matrix[i + 1][j] + 1, matrix[i][j + 1] + 1)
+                }
+            }
+        }
+        return matrix[fromWordCount][toWordCount]
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/818

This PR seeks to stick to the route the user has selected when rerouting. This occurs by comparing the previous route summary to the new route(s) summary. 

/cc @mapbox/navigation-ios @mapbox/navigation-android 