### PR TITLE
Link to mapbox/navigation-ios-examples, add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,6 @@ Before continuing, can you check if the answer is available within:
 
 -->
 
-<!-- Please not which version of the Mapbox Navigation SDK you are using. -->
+<!-- Please note which version of the Mapbox Navigation SDK you are using. -->
 
 **Mapbox Navigation SDK version:**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!--
+
+Hello and thanks for contributing!
+
+Before continuing, can you check if the answer is available within:
+
+* The documentation - https://www.mapbox.com/mapbox-navigation-ios/navigation/
+* The example app - https://github.com/mapbox/navigation-ios-examples
+
+-->
+
+<!-- Please not which version of the Mapbox Navigation SDK you are using. -->
+
+**Mapbox Navigation SDK version:**

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Directions.shared.calculate(options) { (waypoints, routes, error) in
 
 **The [example app](https://github.com/mapbox/mapbox-navigation-ios/blob/master/Examples/Swift/ViewController.swift) is also a great resource for referencing various APIs.**
 
+## More Examples
+
+Looking for more examples and use cases on how to the Mapbox Navigation SDK? Check out our example repository, [mapbox/navigation-ios-examples](https://github.com/mapbox/navigation-ios-examples).
+
 #### Required Info.plist Keys
 Mapbox Navigation requires a few additions to your `Info.plist`. Be sure to sign up or log in to your Mapbox account and grab a [Mapbox Access Token](https://www.mapbox.com/studio/account/tokens/).
 


### PR DESCRIPTION
This adds a few links to https://github.com/mapbox/navigation-ios-examples and also adds an issue template.

/cc @mapbox/navigation-ios 