### PR TITLE
Omit needless words from delegate method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Renamed `RouteControllerDelegate.routeController(_:shouldIncrementLegWhenArrivingAtWaypoint:)` to `RouteControllerDelegate.routeController(_:shouldAdvanceToNextLegWhenArrivingAt:)`. (#1010)
+
 ## v0.12.2 (January 12, 2018)
 
 Beginning with this release, we’ve compiled [a set of examples](https://www.mapbox.com/mapbox-navigation-ios/navigation/0.12.2/Examples.html) showing how to accomplish common tasks with this SDK. You can also check out the [navigation-ios-examples](https://github.com/mapbox/navigation-ios-examples) project and run the included application on your device.

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -353,9 +353,10 @@ extension ViewController: WaypointConfirmationViewControllerDelegate {
 //MARK: NavigationViewControllerDelegate
 extension ViewController: NavigationViewControllerDelegate {
     // By default, when the user arrives at a waypoint, the next leg starts immediately.
-    // If however you would like to pause and allow the user to provide input, set this delegate method to false.
-    // This does however require you to increment the leg count on your own. See the example below in `confirmationControllerDidConfirm()`.
-    func navigationViewController(_ navigationViewController: NavigationViewController, shouldIncrementLegWhenArrivingAtWaypoint waypoint: Waypoint) -> Bool {
+    // If you implement this method, return true to preserve this behavior.
+    // Return false to remain on the current leg, for example to allow the user to provide input.
+    // If you return false, you must manually advance to the next leg. See the example above in `confirmationControllerDidConfirm(_:)`.
+    func navigationViewController(_ navigationViewController: NavigationViewController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool {
         return exampleMode == .multipleWaypoints ? false : true
     }
 
@@ -364,7 +365,7 @@ extension ViewController: NavigationViewControllerDelegate {
         guard exampleMode == .multipleWaypoints else { return }
 
         // When the user arrives, present a view controller that prompts the user to continue to their next destination
-        // This typ of screen could show information about a destination, pickup/dropoff confirmation, instructions upon arrival, etc.
+        // This type of screen could show information about a destination, pickup/dropoff confirmation, instructions upon arrival, etc.
         guard let confirmationController = self.storyboard?.instantiateViewController(withIdentifier: "waypointConfirmation") as? WaypointConfirmationViewController else { return }
 
         confirmationController.delegate = self

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -23,8 +23,14 @@ public protocol RouteControllerDelegate: class {
     @objc(routeController:shouldRerouteFromLocation:)
     optional func routeController(_ routeController: RouteController, shouldRerouteFrom location: CLLocation) -> Bool
 
-    @objc(routeController:shouldIncrementLegWhenArrivingAtWaypoint:)
-    optional func routeController(_ routeController: RouteController, shouldIncrementLegWhenArrivingAtWaypoint waypoint: Waypoint) -> Bool
+   /**
+     Called before the route controller arrives at a waypoint to allow the delegate to prevent the route controller from advancing to the next leg.
+     
+     - returns: True to advance to the next leg, or false to remain on the completed leg.
+     - postcondition: If you return false, you must manually advance to the next leg by obtaining the value of the `routeProgress` property and incrementing the `RouteProgress.legIndex` property.
+     */
+    @objc(routeController:shouldAdvanceToNextLegWhenArrivingAtWaypoint:)
+    optional func routeController(_ routeController: RouteController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool
 
     /**
      Called immediately before the route controller calculates a new route.
@@ -595,7 +601,7 @@ extension RouteController: CLLocationManagerDelegate {
             delegate?.routeController?(self, didArriveAt: currentDestination)
             
             if !routeProgress.isFinalLeg,
-                (delegate?.routeController?(self, shouldIncrementLegWhenArrivingAtWaypoint: routeProgress.currentLeg.destination) ?? true) {
+                (delegate?.routeController?(self, shouldAdvanceToNextLegWhenArrivingAt: routeProgress.currentLeg.destination) ?? true) {
                 routeProgress.legIndex += 1
             }
         }


### PR DESCRIPTION
Renamed `RouteControllerDelegate.routeController(_:shouldIncrementLegWhenArrivingAtWaypoint:)` to `RouteControllerDelegate.routeController(_:shouldAdvanceToNextLegWhenArrivingAt:)` to conform to Swift naming guidelines. (The Objective-C signature has changed to `-routeController:shouldAdvanceToNextLegWhenArrivingAtWaypoint:`.)

Fixes the easy part of #1009.

/cc @bsudekum @JThramer