### PR TITLE
Allow any UIView to be used as a custom user puck

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -317,7 +317,9 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         }, completion: nil)
         
         if let userCourseView = userCourseView as? UserCourseView {
-            userCourseView.update(location: location, pitch: camera.pitch, direction: direction, animated: animated, tracksUserCourse: tracksUserCourse)
+            userCourseView.update?(location: location, pitch: camera.pitch, direction: direction, animated: animated, tracksUserCourse: tracksUserCourse)
+        } else {
+            userCourseView?.updateCourseView(location: location, pitch: camera.pitch, direction: direction, animated: animated, tracksUserCourse: tracksUserCourse)
         }
     }
     

--- a/MapboxNavigation/UserCourseView.swift
+++ b/MapboxNavigation/UserCourseView.swift
@@ -13,14 +13,31 @@ public protocol UserCourseView {
     /**
      Updates the view to reflect the given location and other camera properties.
      */
-    func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, tracksUserCourse: Bool)
+    @objc optional func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, tracksUserCourse: Bool)
+}
+
+extension UIView {
+    func updateCourseView(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, tracksUserCourse: Bool) {
+        let duration: TimeInterval = animated ? 1 : 0
+        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveLinear], animations: {
+            let angle = tracksUserCourse ? 0 : CLLocationDegrees(direction - location.course)
+            let scale: CGFloat = tracksUserCourse ? 1 : 0.5
+            var t = CGAffineTransform.identity
+            t = t.rotated(by: -CGFloat(angle.toRadians()))
+            t = t.scaledBy(x: scale, y: scale)
+            self.layer.setAffineTransform(t)
+            var transform = CATransform3DRotate(CATransform3DIdentity, CGFloat(CLLocationDegrees(pitch).toRadians()), 1.0, 0, 0)
+            transform.m34 = -1.0 / 1000 // (-1 / distance to projection plane)
+            self.layer.sublayerTransform = transform
+        }, completion: nil)
+    }
 }
 
 /**
  A view representing the user’s location on screen.
  */
 @objc(MBUserPuckCourseView)
-public class UserPuckCourseView: UIView, UserCourseView {
+public class UserPuckCourseView: UIView {
     
     // Sets the color on the user puck
     @objc public dynamic var puckColor: UIColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 1) {


### PR DESCRIPTION
This change provides a default implementation for the user puck’s
rotation, perspective and scale transformations, making it as easy as:
```swift
mapView.userCourseView = UIImageView(image: UIImage(named: "car_icon"))
```
to use a custom user puck.

![car](https://user-images.githubusercontent.com/764476/34880059-81d5fab8-f7af-11e7-9668-eb20ea76a083.gif)

@mapbox/navigation-ios 👀 