### PR TITLE
Refactor arrival

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -159,3 +159,7 @@ public var RouteControllerOpportunisticReroutingInterval: TimeInterval = 120
 
 let FasterRouteFoundEvent = "navigation.fasterRoute"
 
+/**
+ The number of seconds remaining on the final step of a leg before the user is considered "arrived".
+ */
+public var RouteControllerDurationRemainingWaypointArrival: TimeInterval = 3


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1008

This cleans up the arrival logic into a single function and also exposes a TimeInterval that the developer can control to fine to when an arrival is triggered.

todo:

- [ ] make sure the telem arrival event is still triggered.

/cc @mapbox/navigation-ios 