### PR TITLE
Expose tracksUserCourse

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -345,7 +345,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
                               contentFrame.minY + contentFrame.height * 0.5))
     }
     
-    var tracksUserCourse: Bool = false {
+    /**
+     Determines whether the map should follow the user location and rotate when the course changes.
+     */
+    open var tracksUserCourse: Bool = false {
         didSet {
             if tracksUserCourse {
                 enableFrameByFrameCourseViewTracking(for: 3)


### PR DESCRIPTION
This change makes it possible to reuse `NavigationMapView`’s course tracking.

@mapbox/navigation-ios 