### PR TITLE
Check if key in notification is true

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -480,13 +480,14 @@ extension RouteController {
     }
     
     @objc func didReroute(notification: NSNotification) {
-        if let _ = notification.userInfo?[RouteControllerDidFindFasterRouteKey] as? Bool {
+        if let didFindFasterRoute = notification.userInfo?[RouteControllerDidFindFasterRouteKey] as? Bool, didFindFasterRoute {
             _ = enqueueFoundFasterRouteEvent()
         }
         
         if let lastReroute = outstandingFeedbackEvents.map({$0 as? RerouteEvent }).last {
             lastReroute?.update(newRoute: routeProgress.route)
         }
+        
         recentDistancesFromManeuver.removeAll()
     }
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1025

We need to not only check for the presence of a key on the notification dictionary but also that it is true.

/cc @ericrwolfe @mapbox/navigation-ios 