### PR TITLE
Pluralize star accessibility values in stringsdict

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ To add or update text that the user may see in the navigation SDK:
    ```swift
    String.localizedStringWithFormat(NSLocalizedString("UNIQUE_IDENTIFIER", bundle: .mapboxNavigation, value: "What English speakers see with %@ for each embedded string", comment: "Format string for a string with an embedded string; 1 = the first embedded string"), embeddedString)
    ```
-1. _(Optional.)_ When dealing with a number followed by a pluralized word, do not split the string. Instead, use a format string and make `val` ambiguous, like `%d file(s)`. Then pluralize for English in the appropriate [.stringsdict file](https://developer.apple.com/library/ios/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html). See [platform/darwin/resources/en.lproj/Foundation.stringsdict](../darwin/resources/en.lproj/Foundation.stringsdict) in the Mapbox Maps SDK for an example. Localizers should do likewise for their languages.
+1. _(Optional.)_ When dealing with a number followed by a pluralized word, do not split the string. Instead, use a format string and make `val` ambiguous, like `%d file(s)`. Then pluralize for English in the appropriate [.stringsdict file](https://developer.apple.com/library/ios/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html). See [MapboxNavigation/Resources/en.lproj/Localizable.stringsdict](MapboxNavigation/Resources/en.lproj/Localizable.stringsdict) for an example. Localizers should do likewise for their languages.
 1. Run `scripts/extract_localizable.sh` to add the new text to the .strings files.
 1. Open a pull request with your changes. Once the pull request is merged, Transifex will pick up the changes within a few hours.
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		C5EA98721F19414C00C8AA16 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C549F8311F17F2C5001A0A2D /* MapboxMobileEvents.framework */; };
 		DA23C9611F4FC05C00BA9522 /* MGLMapView+MGLNavigationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA23C9641F4FC0A600BA9522 /* MGLMapView+CustomAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA23C9631F4FC0A600BA9522 /* MGLMapView+CustomAdditions.m */; };
+		DA3525702010A5210048DDFC /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DA35256E2010A5200048DDFC /* Localizable.stringsdict */; };
 		DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DAAE5F321EAE4C4700832871 /* Localizable.strings */; };
 		DAB2CCE71DF7AFDF001B2FE1 /* dc-line.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DAB2CCE61DF7AFDE001B2FE1 /* dc-line.geojson */; };
 		DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */; };
@@ -488,6 +489,7 @@
 		DA33273D1F50C7CA00C5EE88 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Main.strings; sourceTree = "<group>"; };
 		DA33273E1F50C7D800C5EE88 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Main.strings; sourceTree = "<group>"; };
 		DA33273F1F50C7E400C5EE88 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Navigation.strings; sourceTree = "<group>"; };
+		DA35256F2010A5200048DDFC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = Resources/en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA545ABA1FA993DF0090908E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
 		DA545ABB1FA993FB0090908E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
 		DA545ABC1FA9941F0090908E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 				351BEC281E5BD530006FE110 /* Assets.xcassets */,
 				C520EE921EBB84F9008805BC /* Navigation.storyboard */,
 				DAAE5F321EAE4C4700832871 /* Localizable.strings */,
+				DA35256E2010A5200048DDFC /* Localizable.stringsdict */,
 				C5212B571EC4BE97009538EB /* Abbreviations.plist */,
 			);
 			name = Resources;
@@ -1254,6 +1257,7 @@
 				DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */,
 				351BEC291E5BD530006FE110 /* Assets.xcassets in Resources */,
 				C520EE901EBB84F9008805BC /* Navigation.storyboard in Resources */,
+				DA3525702010A5210048DDFC /* Localizable.stringsdict in Resources */,
 				C5212B551EC4BE97009538EB /* Abbreviations.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1763,6 +1767,14 @@
 			);
 			name = Localizable.strings;
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		DA35256E2010A5200048DDFC /* Localizable.stringsdict */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DA35256F2010A5200048DDFC /* en */,
+			);
+			name = Localizable.stringsdict;
 			sourceTree = "<group>";
 		};
 		DAAE5F321EAE4C4700832871 /* Localizable.strings */ = {

--- a/MapboxNavigation/RatingControl.swift
+++ b/MapboxNavigation/RatingControl.swift
@@ -70,10 +70,9 @@ class RatingControl: UIStackView {
             button.adjustsImageWhenHighlighted = false
             addButtonSizeConstraints(to: button)
             
-            let setRatingNumber = NSNumber(value: index + 1)
-            let setRatingString = NumberFormatter.localizedString(from: setRatingNumber, number: .none)
-            let localizedString = NSLocalizedString("RATING_ACCESSIBILITY_SET", bundle: .mapboxNavigation, value: "Set %@ star rating", comment: "Accessibility Star Label")
-            button.accessibilityLabel = String.localizedStringWithFormat(localizedString, setRatingString)
+            let setRatingNumber = index + 1
+            let localizedString = NSLocalizedString("RATING_ACCESSIBILITY_SET", bundle: .mapboxNavigation, value: "Set %ld-star rating", comment: "Format for accessibility label of button for setting a rating; 1 = number of stars")
+            button.accessibilityLabel = String.localizedStringWithFormat(localizedString, setRatingNumber)
             
             button.addTarget(self, action: #selector(RatingControl.ratingButtonTapped(button:)), for: .touchUpInside)
             
@@ -105,18 +104,7 @@ class RatingControl: UIStackView {
     private func setAccessibility(for button: UIButton, at index: Int) {
         setAccessibilityHint(for: button, at: index)
         
-        let value: String
-        
-        switch rating {
-        case 0:
-            value = NSLocalizedString("NO_RATING", bundle: .mapboxNavigation, value: "No rating set.", comment: "No Rating Set")
-        case 1:
-            value = NSLocalizedString("RATING_1_STAR", bundle: .mapboxNavigation, value: "1 star set.", comment: "One Star Set")
-        default:
-            value = String.localizedStringWithFormat(NSLocalizedString("RATING_STARS_FORMAT", bundle: .mapboxNavigation, value: "%li stars set.", comment: "Format for rating stars set"), rating)
-        }
-        
-        button.accessibilityValue = value
+        button.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("RATING_STARS_FORMAT", bundle: .mapboxNavigation, value: "%ld star(s) set.", comment: "Format for accessibility value of label indicating the existing rating; 1 = number of stars"), rating)
     }
     
     private func setAccessibilityHint(for button: UIButton, at index: Int) {

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -46,20 +46,14 @@
 /* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
 "LESS_THAN" = "<%@";
 
-/* No Rating Set */
-"NO_RATING" = "No rating set.";
-
-/* One Star Set */
-"RATING_1_STAR" = "1 star set.";
-
 /* Rating Reset To Zero Accessability Hint */
 "RATING_ACCESSIBILITY_RESET" = "Tap to reset the rating to zero.";
 
-/* Accessibility Star Label */
-"RATING_ACCESSIBILITY_SET" = "Set %@ star rating";
+/* Format for accessibility label of button for setting a rating; 1 = number of stars */
+"RATING_ACCESSIBILITY_SET" = "Set %ld-star rating";
 
-/* Format for rating stars set */
-"RATING_STARS_FORMAT" = "%li stars set.";
+/* Format for accessibility value of label indicating the existing rating; 1 = number of stars */
+"RATING_STARS_FORMAT" = "%ld star(s) set.";
 
 /* Indicates that rerouting is in progress */
 "REROUTING" = "Rerouting…";

--- a/MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
+++ b/MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>RATING_ACCESSIBILITY_SET</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>Set %ld-star rating</string>
+			<key>other</key>
+			<string>Set %ld-star rating</string>
+		</dict>
+	</dict>
+	<key>RATING_STARS_FORMAT</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>zero</key>
+			<string>No rating set.</string>
+			<key>one</key>
+			<string>%ld star set.</string>
+			<key>other</key>
+			<string>%ld stars set.</string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Use a stringsdict to correctly pluralize the star rating UI’s accessibility values. A localization that distinguishes one from two from many, such as Russian, will be able to translate these values accurately.

Fixes #971.

/cc @JThramer @frederoni