### PR TITLE
Localize zero-rating accessibility label as separate string

### DIFF
--- a/MapboxNavigation/RatingControl.swift
+++ b/MapboxNavigation/RatingControl.swift
@@ -104,7 +104,14 @@ class RatingControl: UIStackView {
     private func setAccessibility(for button: UIButton, at index: Int) {
         setAccessibilityHint(for: button, at: index)
         
-        button.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("RATING_STARS_FORMAT", bundle: .mapboxNavigation, value: "%ld star(s) set.", comment: "Format for accessibility value of label indicating the existing rating; 1 = number of stars"), rating)
+        let value: String
+        if rating == 0 {
+            value = NSLocalizedString("NO_RATING", bundle: .mapboxNavigation, value: "No rating set.", comment: "Accessibility value of label indicating the absence of a rating")
+        } else {
+            value = String.localizedStringWithFormat(NSLocalizedString("RATING_STARS_FORMAT", bundle: .mapboxNavigation, value: "%ld star(s) set.", comment: "Format for accessibility value of label indicating the existing rating; 1 = number of stars"), rating)
+        }
+        
+        button.accessibilityValue = value
     }
     
     private func setAccessibilityHint(for button: UIButton, at index: Int) {

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -46,6 +46,9 @@
 /* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
 "LESS_THAN" = "<%@";
 
+/* Accessibility value of label indicating the absence of a rating */
+"NO_RATING" = "No rating set.";
+
 /* Rating Reset To Zero Accessability Hint */
 "RATING_ACCESSIBILITY_RESET" = "Tap to reset the rating to zero.";
 
@@ -54,6 +57,9 @@
 
 /* Format for accessibility value of label indicating the existing rating; 1 = number of stars */
 "RATING_STARS_FORMAT" = "%ld star(s) set.";
+
+/* Title on button that appears when a reroute occurs */
+"REROUTE_REPORT_TITLE" = "Report Problem";
 
 /* Indicates that rerouting is in progress */
 "REROUTING" = "Rerouting…";

--- a/MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
+++ b/MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
@@ -28,8 +28,6 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
-			<key>zero</key>
-			<string>No rating set.</string>
 			<key>one</key>
 			<string>%ld star set.</string>
 			<key>other</key>

--- a/MapboxNavigation/Resources/es.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/es.lproj/Localizable.strings
@@ -49,7 +49,7 @@
 /* No Rating Set */
 "NO_RATING" = "No hay calificación.";
 
-/* One Star Set */
+/* Accessibility value of label indicating the absence of a rating */
 "RATING_1_STAR" = "Ha calificado 1 estrella.";
 
 /* Rating Reset To Zero Accessability Hint */

--- a/MapboxNavigation/Resources/vi.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/vi.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 /* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
 "LESS_THAN" = "<%@";
 
-/* No Rating Set */
+/* Accessibility value of label indicating the absence of a rating */
 "NO_RATING" = "Chưa đánh giá.";
 
 /* One Star Set */


### PR DESCRIPTION
Restored a string that was removed in #1034 and removed the `zero` case from an English stringsdict file.

Fixes #1035.

/cc @JThramer