### PR TITLE
Consolidated arrival delegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Removed `RouteControllerDelegate.routeController(_:shouldIncrementLegWhenArrivingAtWaypoint:)` and `NavigationViewControllerDelegate.navigationViewController(_:shouldIncrementLegWhenArrivingAtWaypoint:)`. `RouteControllerDelegate.routeController(_:didArriveAt:)` and `NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:)` now return a Boolean that determines whether the route controller automatically advances to the next leg of the route. (#1038)
+* Fixed an issue where `NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:)` was called twice at the end of the route. (#1038)
 
 ## v0.12.2 (January 12, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-* Renamed `RouteControllerDelegate.routeController(_:shouldIncrementLegWhenArrivingAtWaypoint:)` to `RouteControllerDelegate.routeController(_:shouldAdvanceToNextLegWhenArrivingAt:)`. (#1010)
+* Removed `RouteControllerDelegate.routeController(_:shouldIncrementLegWhenArrivingAtWaypoint:)` and `NavigationViewControllerDelegate.navigationViewController(_:shouldIncrementLegWhenArrivingAtWaypoint:)`. `RouteControllerDelegate.routeController(_:didArriveAt:)` and `NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:)` now return a Boolean that determines whether the route controller automatically advances to the next leg of the route. (#1038)
 
 ## v0.12.2 (January 12, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Renamed `RouteControllerDelegate.routeController(_:shouldIncrementLegWhenArrivingAtWaypoint:)` to `RouteControllerDelegate.routeController(_:shouldAdvanceToNextLegWhenArrivingAt:)`. (#1010)
+
 ## v0.12.2 (January 12, 2018)
 
 Beginning with this release, we’ve compiled [a set of examples](https://www.mapbox.com/mapbox-navigation-ios/navigation/0.12.2/Examples.html) showing how to accomplish common tasks with this SDK. You can also check out the [navigation-ios-examples](https://github.com/mapbox/navigation-ios-examples) project and run the included application on your device.

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -356,21 +356,18 @@ extension ViewController: NavigationViewControllerDelegate {
     // If you implement this method, return true to preserve this behavior.
     // Return false to remain on the current leg, for example to allow the user to provide input.
     // If you return false, you must manually advance to the next leg. See the example above in `confirmationControllerDidConfirm(_:)`.
-    func navigationViewController(_ navigationViewController: NavigationViewController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool {
-        return exampleMode == .multipleWaypoints ? false : true
-    }
-
-    func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) {
+    func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool {
         // Multiple waypoint demo
-        guard exampleMode == .multipleWaypoints else { return }
+        guard exampleMode == .multipleWaypoints else { return true }
 
         // When the user arrives, present a view controller that prompts the user to continue to their next destination
         // This type of screen could show information about a destination, pickup/dropoff confirmation, instructions upon arrival, etc.
-        guard let confirmationController = self.storyboard?.instantiateViewController(withIdentifier: "waypointConfirmation") as? WaypointConfirmationViewController else { return }
+        guard let confirmationController = self.storyboard?.instantiateViewController(withIdentifier: "waypointConfirmation") as? WaypointConfirmationViewController else { return true }
 
         confirmationController.delegate = self
 
         navigationViewController.present(confirmationController, animated: true, completion: nil)
+        return false
     }
 }
 

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -353,9 +353,10 @@ extension ViewController: WaypointConfirmationViewControllerDelegate {
 //MARK: NavigationViewControllerDelegate
 extension ViewController: NavigationViewControllerDelegate {
     // By default, when the user arrives at a waypoint, the next leg starts immediately.
-    // If however you would like to pause and allow the user to provide input, set this delegate method to false.
-    // This does however require you to increment the leg count on your own. See the example below in `confirmationControllerDidConfirm()`.
-    func navigationViewController(_ navigationViewController: NavigationViewController, shouldIncrementLegWhenArrivingAtWaypoint waypoint: Waypoint) -> Bool {
+    // If you implement this method, return true to preserve this behavior.
+    // Return false to remain on the current leg, for example to allow the user to provide input.
+    // If you return false, you must manually advance to the next leg. See the example above in `confirmationControllerDidConfirm(_:)`.
+    func navigationViewController(_ navigationViewController: NavigationViewController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool {
         return exampleMode == .multipleWaypoints ? false : true
     }
 
@@ -364,7 +365,7 @@ extension ViewController: NavigationViewControllerDelegate {
         guard exampleMode == .multipleWaypoints else { return }
 
         // When the user arrives, present a view controller that prompts the user to continue to their next destination
-        // This typ of screen could show information about a destination, pickup/dropoff confirmation, instructions upon arrival, etc.
+        // This type of screen could show information about a destination, pickup/dropoff confirmation, instructions upon arrival, etc.
         guard let confirmationController = self.storyboard?.instantiateViewController(withIdentifier: "waypointConfirmation") as? WaypointConfirmationViewController else { return }
 
         confirmationController.delegate = self

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -23,8 +23,14 @@ public protocol RouteControllerDelegate: class {
     @objc(routeController:shouldRerouteFromLocation:)
     optional func routeController(_ routeController: RouteController, shouldRerouteFrom location: CLLocation) -> Bool
 
-    @objc(routeController:shouldIncrementLegWhenArrivingAtWaypoint:)
-    optional func routeController(_ routeController: RouteController, shouldIncrementLegWhenArrivingAtWaypoint waypoint: Waypoint) -> Bool
+   /**
+     Called before the route controller arrives at a waypoint to allow the delegate to prevent the route controller from advancing to the next leg.
+     
+     - returns: True to advance to the next leg, or false to remain on the completed leg.
+     - postcondition: If you return false, you must manually advance to the next leg by obtaining the value of the `routeProgress` property and incrementing the `RouteProgress.legIndex` property.
+     */
+    @objc(routeController:shouldAdvanceToNextLegWhenArrivingAtWaypoint:)
+    optional func routeController(_ routeController: RouteController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool
 
     /**
      Called immediately before the route controller calculates a new route.
@@ -595,7 +601,7 @@ extension RouteController: CLLocationManagerDelegate {
             delegate?.routeController?(self, didArriveAt: currentDestination)
             
             if !routeProgress.isFinalLeg,
-                (delegate?.routeController?(self, shouldIncrementLegWhenArrivingAtWaypoint: routeProgress.currentLeg.destination) ?? true) {
+                (delegate?.routeController?(self, shouldAdvanceToNextLegWhenArrivingAt: routeProgress.currentLeg.destination) ?? true) {
                 routeProgress.legIndex += 1
             }
         }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -23,15 +23,6 @@ public protocol RouteControllerDelegate: class {
     @objc(routeController:shouldRerouteFromLocation:)
     optional func routeController(_ routeController: RouteController, shouldRerouteFrom location: CLLocation) -> Bool
 
-   /**
-     Called before the route controller arrives at a waypoint to allow the delegate to prevent the route controller from advancing to the next leg.
-     
-     - returns: True to advance to the next leg, or false to remain on the completed leg.
-     - postcondition: If you return false, you must manually advance to the next leg by obtaining the value of the `routeProgress` property and incrementing the `RouteProgress.legIndex` property.
-     */
-    @objc(routeController:shouldAdvanceToNextLegWhenArrivingAtWaypoint:)
-    optional func routeController(_ routeController: RouteController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool
-
     /**
      Called immediately before the route controller calculates a new route.
 
@@ -90,11 +81,17 @@ public protocol RouteControllerDelegate: class {
     
     /**
      Called when the route controller arrives at a waypoint.
+     
+     You can implement this method to prevent the route controller from automatically advancing to the next leg. For example, you can and show an interstitial sheet upon arrival and pause navigation by returning `false`, then continue the route when the user dismisses the sheet. If this method is unimplemented, the route controller automatically advances to the next leg when arriving at a waypoint.
+     
+     - postcondition: If you return false, you must manually advance to the next leg: obtain the value of the `routeProgress` property, then increment the `RouteProgress.legIndex` property.
+     - parameter routeController: The route controller that has arrived at a waypoint.
      - parameter waypoint: The waypoint that the controller has arrived at.
      - parameter finalDestination: A boolean flag that signals that the waypoint is the final destination.
+     - returns: True to advance to the next leg, if any, or false to remain on the completed leg.
     */
     @objc(routeController:didArriveAtWaypoint:)
-    optional func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint)
+    optional func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) -> Bool
 }
 
 /**
@@ -598,10 +595,9 @@ extension RouteController: CLLocationManagerDelegate {
             previousArrivalWaypoint = currentDestination
             
             routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
-            delegate?.routeController?(self, didArriveAt: currentDestination)
+            let advancesToNextLeg = delegate?.routeController?(self, didArriveAt: currentDestination) ?? true
             
-            if !routeProgress.isFinalLeg,
-                (delegate?.routeController?(self, shouldAdvanceToNextLegWhenArrivingAt: routeProgress.currentLeg.destination) ?? true) {
+            if !routeProgress.isFinalLeg && advancesToNextLeg {
                 routeProgress.legIndex += 1
             }
         }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -14,11 +14,16 @@ public protocol NavigationViewControllerDelegate {
     @objc optional func navigationViewControllerDidCancelNavigation(_ navigationViewController : NavigationViewController)
     
     /**
-     Called when the user arrives at the destination waypoint for the route leg.
-     - parameter navigationViewController: The Navigation View Controller.
+     Called when the user arrives at the destination waypoint for a route leg.
+     
+     This method is called when the navigation view controller arrives at the waypoint. You can implement this method to prevent the navigation view controller from automatically advancing to the next leg. For example, you can and show an interstitial sheet upon arrival and pause navigation by returning `false`, then continue the route when the user dismisses the sheet. If this method is unimplemented, the navigation view controller automatically advances to the next leg when arriving at a waypoint.
+     
+     - postcondition: If you return `false` within this method, you must manually advance to the next leg: obtain the value of the `routeController` and its `RouteController.routeProgress` property, then increment the `RouteProgress.legIndex` property.
+     - parameter navigationViewController: The navigation view controller that has arrived at a waypoint.
      - parameter waypoint: The waypoint that the user has arrived at.
+     - returns: True to automatically advance to the next leg, or false to remain on the now completed leg.
      */
-    @objc optional func navigationViewController(_ navigationViewController : NavigationViewController, didArriveAt waypoint: Waypoint)
+    @objc optional func navigationViewController(_ navigationViewController : NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
 
     /**
      Returns whether the navigation view controller should be allowed to calculate a new route.
@@ -31,19 +36,6 @@ public protocol NavigationViewControllerDelegate {
     */
     @objc(navigationViewController:shouldRerouteFromLocation:)
     optional func navigationViewController(_ navigationViewController: NavigationViewController, shouldRerouteFrom location: CLLocation) -> Bool
-    
-    /**
-     Asks the reciever if the navigation view controller should automatically advance to the next leg of the route after arriving at the given waypoint.
-     
-     This method is called just before the navigation view controller arrives at the waypoint. To pause navigation and show an interstitial view controller upon arriving at the waypoint, implement this delegate method and return `false`.
-    
-     - postcondition: If you return `false` within this method, you must manually advance to the next leg: obtain the value of the `routeController` and its `RouteController.routeProgress` property, then increment the `RouteProgress.legIndex` property.
-     - parameter navigationViewController: The Navigation View Controller.
-     - parameter waypoint: The waypoint that the user has arrived at.
-     - returns: True to automatically advance to the next leg, or false to remain on the now completed leg.
-     */
-    @objc(navigationViewController:shouldAdvanceToNextLegWhenArrivingAtWaypoint:)
-    optional func navigationViewController(_ navigationViewController: NavigationViewController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool
     
     /**
      Called immediately before the navigation view controller calculates a new route.
@@ -511,10 +503,6 @@ extension NavigationViewController: RouteControllerDelegate {
         return delegate?.navigationViewController?(self, shouldRerouteFrom: location) ?? true
     }
     
-    @objc public func routeController(_ routeController: RouteController, shouldAdvanceToNextLegWhenArrivingAt waypoint: Waypoint) -> Bool {
-        return delegate?.navigationViewController?(self, shouldAdvanceToNextLegWhenArrivingAt: waypoint) ?? true
-    }
-    
     @objc public func routeController(_ routeController: RouteController, willRerouteFrom location: CLLocation) {
         delegate?.navigationViewController?(self, willRerouteFrom: location)
     }
@@ -547,21 +535,15 @@ extension NavigationViewController: RouteControllerDelegate {
         mapViewController?.statusView.show(title, showSpinner: false)
     }
     
-    public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) {
-        delegate?.navigationViewController?(self, didArriveAt: waypoint)
+    @objc public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) -> Bool {
+        let advancesToNextLeg = delegate?.navigationViewController?(self, didArriveAt: waypoint) ?? true
         
-        guard routeController.routeProgress.isFinalLeg else { return }
-        
-        // If the developer implements `NavigationViewController(_:shouldAdvanceToNextLegWhenArrivingAt:)` and sets it to false,
-        // we should emit `NavigationViewController(_:didArriveAt:)` and not show the end of route feedback UI.
-        if !(delegate?.navigationViewController?(self, shouldAdvanceToNextLegWhenArrivingAt: waypoint) ?? true) {
-            return
+        if routeController.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
+            self.mapViewController?.showEndOfRoute { _ in
+                self.delegate?.navigationViewController?(self, didArriveAt: waypoint)
+            }
         }
-        
-        let completion: (Bool) -> Void = { _ in self.delegate?.navigationViewController?(self, didArriveAt: waypoint) }
-        if showsEndOfRouteFeedback {
-            self.mapViewController?.showEndOfRoute( completion: completion)
-        }
+        return advancesToNextLeg
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -539,9 +539,7 @@ extension NavigationViewController: RouteControllerDelegate {
         let advancesToNextLeg = delegate?.navigationViewController?(self, didArriveAt: waypoint) ?? true
         
         if routeController.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
-            self.mapViewController?.showEndOfRoute { _ in
-                self.delegate?.navigationViewController?(self, didArriveAt: waypoint)
-            }
+            self.mapViewController?.showEndOfRoute { _ in }
         }
         return advancesToNextLeg
     }


### PR DESCRIPTION
Removed `RouteControllerDelegate.routeController(_:shouldIncrementLegWhenArrivingAtWaypoint:)` and `NavigationViewControllerDelegate.navigationViewController(_:shouldIncrementLegWhenArrivingAtWaypoint:)`. `RouteControllerDelegate.routeController(_:didArriveAt:)` and `NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:)` now return a Boolean that determines whether the route controller automatically advances to the next leg of the route.

Fixed an issue where `NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:)` was called twice at the end of the route, once immediately and once after the user dismissed the end-of-route feedback view controller.

Fixes #1009 and fixes #1037. Depends on #1010.

/cc @JThramer @bsudekum