### PR TITLE
Add Danish voice support

### DIFF
--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -97,6 +97,8 @@ public class PollyVoiceController: RouteVoiceController {
         }
         
         switch (langCode, countryCode) {
+        case ("da", _):
+            input.voiceId = .naja
         case ("de", _):
             input.voiceId = .marlene
         case ("en", "CA"):

--- a/languages.md
+++ b/languages.md
@@ -30,7 +30,7 @@ The upcoming road or ramp destination is named according to the local or nationa
 |------------|----------------|-------------------------------|-----------------------|----------------------------------
 | Catalan    | ✅              | ❌                             | ❌                     | ❌
 | Chinese    | ✅ Simplified   | ✅                             | ❌                     | ✅
-| Danish     | ✅              | ✅                             | ❌                     | ✅
+| Danish     | ✅              | ✅                             | ✅                     | ✅
 | Dutch      | ✅              | ✅                             | ✅                     | ✅
 | English    | ✅              | ✅                             | ✅                     | ✅
 | French     | ✅              | ✅                             | ✅                     | ✅


### PR DESCRIPTION
This PR adds Polly voice support for Danish. I’ve split it out from #1031 because the Directions API doesn’t yet incorporate the Danish instructions in Project-OSRM/osrm-text-instructions#208, falling back to English instructions instead. Once the Danish instructions are deployed in the Directions API, we can quickly land this PR and issue a patch release so that they are pronounced by a Danish voice. Alternatively, if we switch to the Mapbox Voice API first in #617, then this PR becomes unnecessary.

/cc @bsudekum