### PR TITLE
clipsToBounds on wayNameLabel

### DIFF
--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -329,6 +329,7 @@ open class WayNameLabel: StylableLabel {
     
     override open func drawText(in rect: CGRect) {
         backgroundColor?.setFill()
+        clipsToBounds = true
         let ctx = UIGraphicsGetCurrentContext()
         ctx?.fill(rect)
         super.drawText(in: UIEdgeInsetsInsetRect(rect, textInsets))


### PR DESCRIPTION
This got dropped recently and caused the way name label to be square.

/cc @mapbox/navigation-ios