### PR TITLE
Various documentation fixes

### DIFF
--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
 
-  s.dependency "MapboxDirections.swift", "~> 0.15"
+  s.dependency "MapboxDirections.swift", "~> 0.16.0"
   s.dependency "Mapbox-iOS-SDK", "~> 3.6"
   s.dependency "SDWebImage", "~> 4.1"
   s.dependency "AWSPolly", "~> 2.6"

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -3,7 +3,7 @@ author: Mapbox
 author_url: https://www.mapbox.com/navigation-sdk/
 github_url: https://github.com/mapbox/mapbox-navigation-ios
 dash_url: https://www.mapbox.com/mapbox-navigation-ios/navigation/docsets/MapboxNavigation.xml
-copyright: '© 2014–2017 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-navigation-ios/blob/master/LICENSE.md) for more details.'
+copyright: '© 2014–2018 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-navigation-ios/blob/master/LICENSE.md) for more details.'
 
 head: |
   <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -29,7 +29,7 @@ BASE_URL="https://www.mapbox.com/mapbox-navigation-ios"
 
 # Link to directions documentation
 DIRECTIONS_VERSION="0.16.0"
-DIRECTIONS_SYMBOLS="Directions|Route|RouteStep|RouteLeg|RouteOptions|Waypoint"
+DIRECTIONS_SYMBOLS="Directions|Intersection|Lane|Route|RouteLeg|RouteOptions|RouteStep|SpokenInstruction|VisualInstruction|VisualInstructionComponent|Waypoint"
 
 rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -42,7 +42,7 @@ jazzy \
     --sdk iphonesimulator \
     --module-version ${SHORT_VERSION} \
     --github-file-prefix "https://github.com/mapbox/mapbox-navigation-ios/tree/${BRANCH}" \
-    --documentation=docs/{guides,examples}/*.md \
+    --documentation="docs/{guides,examples}/*.md" \
     --root-url "${BASE_URL}/navigation/${RELEASE_VERSION}/" \
     --theme ${THEME} \
     --output ${OUTPUT}


### PR DESCRIPTION
This PR contains various jazzy-related documentation fixes:

* Updated the MapboxDirections.swift version number and the list of MapboxDirections.swift classes to automatically link in this SDK’s jazzy documentation.
* Updated the copyright year in the footer of every documentation page.
* Restored the “Storyboards” guide (to fix #1014)

/cc @bsudekum @captainbarbosa