### PR TITLE
Let at least one location update through even if non-qualified

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -530,12 +530,12 @@ extension RouteController: CLLocationManagerDelegate {
             hasFoundOneQualifiedLocation = true
         }
         
-        var loc: CLLocation?
+        var potentialLocation: CLLocation?
         
         // `filteredLocations` contains qualified locations
         if let lastFiltered = filteredLocations.last {
-            loc = lastFiltered
-        // `filteredLocations` does not contain good locations and we have found at least one good location.
+            potentialLocation = lastFiltered
+        // `filteredLocations` does not contain good locations and we have found at least one good location previously.
         } else if hasFoundOneQualifiedLocation {
             if let lastLocation = locations.last {
                 delegate?.routeController?(self, didDiscard: lastLocation)
@@ -544,10 +544,10 @@ extension RouteController: CLLocationManagerDelegate {
         // This case handles the first location.
         // This location is not a good location, but we need the rest of the UI to update and at least show something.
         } else if let lastLocation = locations.last {
-            loc = lastLocation
+            potentialLocation = lastLocation
         }
         
-        guard let location = loc else { return }
+        guard let location = potentialLocation else { return }
         
         self.rawLocation = location
         sessionState.pastLocations.push(location)


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1072

We're throwing out the first location, which is often times not a great location. This let's the first location slip through so we update UI elements with some initial data.

/cc @mapbox/navigation-ios @zijiazhai @Sealos