### PR TITLE
Fix voice instruction crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixes a bug where the `spokenInstructionIndex` was incremented beyond the number of instructions for a step. (#1080)
+
 ## v0.13.0 (January 22, 2018)
 
 ### Packaging

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -859,8 +859,8 @@ extension RouteController: CLLocationManagerDelegate {
             return
         }
 
-        for voiceInstruction in spokenInstructions.enumerated() {
-            if userSnapToStepDistanceFromManeuver <= voiceInstruction.element.distanceAlongStep {
+        for voiceInstruction in spokenInstructions {
+            if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep {
 
                 NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
                     MBRouteControllerDidPassSpokenInstructionPointRouteProgressKey: routeProgress

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -854,13 +854,13 @@ extension RouteController: CLLocationManagerDelegate {
 
         routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation = userAbsoluteDistance
 
-        guard let spokenInstructions = routeProgress.currentLegProgress.currentStep.instructionsSpokenAlongStep else {
+        guard let spokenInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions else {
             print("The directions request was made without `includesVoiceInstructions` enabled. This will prevent users from getting voice instructions. It's recommended to make your directions request via `NavigationRouteOptions()`.")
             return
         }
 
         for (voiceInstructionIndex, voiceInstruction) in spokenInstructions.enumerated() {
-            if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep && voiceInstructionIndex >= routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex {
+            if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep && voiceInstructionIndex + 1 >= routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex {
 
                 NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
                     MBRouteControllerDidPassSpokenInstructionPointRouteProgressKey: routeProgress

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -859,8 +859,8 @@ extension RouteController: CLLocationManagerDelegate {
             return
         }
 
-        for (voiceInstructionIndex, voiceInstruction) in spokenInstructions.enumerated() {
-            if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep && voiceInstructionIndex + 1 >= routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex {
+        for voiceInstruction in spokenInstructions.enumerated() {
+            if userSnapToStepDistanceFromManeuver <= voiceInstruction.element.distanceAlongStep {
 
                 NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
                     MBRouteControllerDidPassSpokenInstructionPointRouteProgressKey: routeProgress

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -406,6 +406,10 @@ open class RouteStepProgress: NSObject {
      */
     @objc public var spokenInstructionIndex: Int = 0
     
+    
+    /**
+     An `Array` of remaining `SpokenInstruction` for a step.
+     */
     @objc public var remainingSpokenInstructions: [SpokenInstruction]? {
         guard let instructions = step.instructionsSpokenAlongStep else { return nil }
         return Array(instructions.suffix(from: spokenInstructionIndex))

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -406,6 +406,11 @@ open class RouteStepProgress: NSObject {
      */
     @objc public var spokenInstructionIndex: Int = 0
     
+    @objc public var remainingSpokenInstructions: [SpokenInstruction]? {
+        guard let instructions = step.instructionsSpokenAlongStep else { return nil }
+        return Array(instructions.suffix(from: spokenInstructionIndex))
+    }
+    
     /**
      Current Instruction for the user's progress along a step.
      */


### PR DESCRIPTION
Seeing a few crashes that look like: 

```
#0. Crashed: com.apple.main-thread
0  MapboxCoreNavigation           0x104c30430 specialized RouteController.updateRouteStepProgress(for:) (RouteController.swift:869)
1  MapboxCoreNavigation           0x104c31ec0 specialized RouteController.locationManager(_:didUpdateLocations:) (RouteController.swift:568)
2  MapboxCoreNavigation           0x104c276c8 @objc RouteController.locationManager(_:didUpdateLocations:) (RouteController.swift)
3  CoreLocation                   0x188f4e62c CLClientRetrieveData + 72260
4  CoreLocation                   0x188f4de90 CLClientRetrieveData + 70312
5  CoreLocation                   0x188f37864 CLClientInvalidate + 1240
6  CoreFoundation                 0x18200c8ac <redacted> + 20
7  CoreFoundation                 0x18200c06c <redacted> + 264
8  CoreFoundation                 0x18200a0ac <redacted> + 2004
9  CoreFoundation                 0x181f2a498 CFRunLoopRunSpecific + 552
10 GraphicsServices               0x183eeb020 GSEventRunModal + 100
11 UIKit                          0x18c37421c UIApplicationMain + 236
```

Which occurs when we increment the `spokenInstructionIndex` beyond the number of available instructions. This change makes it so we're only evaluating and looping over the remaining instructions. Once the last instruction is spoken, we will no longer loop nor increment this index.

/cc @mapbox/navigation-ios 