### PR TITLE
Make bottomBannerView outlet optional

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -20,7 +20,7 @@ class RouteMapViewController: UIViewController {
     @IBOutlet weak var instructionsBannerContainerView: InstructionsBannerContentView!
     @IBOutlet weak var instructionsBannerView: InstructionsBannerView!
     @IBOutlet weak var nextBannerView: NextBannerView!
-    @IBOutlet weak var bottomBannerView: BottomBannerView!
+    @IBOutlet weak var bottomBannerView: BottomBannerView?
     @IBOutlet weak var statusView: StatusView!
     @IBOutlet weak var lanesView: LanesView!
     @IBOutlet weak var rerouteFeedbackTopConstraint: NSLayoutConstraint!
@@ -125,7 +125,7 @@ class RouteMapViewController: UIViewController {
         nextBannerView.isHidden = true
         isInOverviewMode = false
         instructionsBannerView.delegate = self
-        bottomBannerView.delegate = self
+        bottomBannerView?.delegate = self
         resumeNotifications()
     }
     
@@ -279,8 +279,9 @@ class RouteMapViewController: UIViewController {
     
     func updateVisibleBounds() {
         guard let userLocation = routeController.locationManager.location?.coordinate else { return }
+        guard let bottomHeight = bottomBannerView?.bounds.height else { return }
         
-        let overviewContentInset = UIEdgeInsets(top: instructionsBannerView.bounds.height, left: 20, bottom: bottomBannerView.bounds.height, right: 20)
+        let overviewContentInset = UIEdgeInsets(top: instructionsBannerView.bounds.height, left: 20, bottom: bottomHeight, right: 20)
         let slicedLine = Polyline(routeController.routeProgress.route.coordinates!).sliced(from: userLocation, to: routeController.routeProgress.route.coordinates!.last).coordinates
         let line = MGLPolyline(coordinates: slicedLine, count: UInt(slicedLine.count))
         
@@ -488,7 +489,7 @@ class RouteMapViewController: UIViewController {
         var margin: CGFloat = 0.0
         if #available(iOS 11.0, *) { margin = view.safeAreaInsets.bottom }
         let containerHeight = endOfRouteContainerView.frame.height - margin
-        let bottom = self.endOfRouteShowConstraint.isActive ? containerHeight : bottomBannerView.bounds.height
+        let bottom = self.endOfRouteShowConstraint.isActive ? containerHeight : bottomBannerView?.bounds.height ?? 40
         return UIEdgeInsets(top: instructionsBannerContainerView.bounds.height, left: 0, bottom: bottom, right: 0)
     }
     
@@ -759,7 +760,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
     
     @objc func updateETA() {
         guard isViewLoaded else { return }
-        bottomBannerView.updateETA(routeProgress: routeController.routeProgress)
+        bottomBannerView?.updateETA(routeProgress: routeController.routeProgress)
     }
     
     func resetETATimer() {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1060

We've had issues with this outlet for a while now. By making it optional when `bottomBannerView?.updateETA(routeProgress:)` is called and  `bottomBannerView` is nil, the function will not be called.

/cc @mapbox/navigation-ios 