### PR TITLE
 Do not check to increment stepIndex if no steps remain

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -818,7 +818,8 @@ extension RouteController: CLLocationManagerDelegate {
     }
 
     func updateRouteStepProgress(for location: CLLocation) {
-
+        guard routeProgress.currentLegProgress.remainingSteps.count > 1 else { return }
+        
         let userSnapToStepDistanceFromManeuver = Polyline(routeProgress.currentLegProgress.currentStep.coordinates!).distance(from: location.coordinate)
         var courseMatchesManeuverFinalHeading = false
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -818,7 +818,7 @@ extension RouteController: CLLocationManagerDelegate {
     }
 
     func updateRouteStepProgress(for location: CLLocation) {
-        guard routeProgress.currentLegProgress.remainingSteps.count > 1 else { return }
+        guard routeProgress.currentLegProgress.remainingSteps.count > 0 else { return }
         
         let userSnapToStepDistanceFromManeuver = Polyline(routeProgress.currentLegProgress.currentStep.coordinates!).distance(from: location.coordinate)
         var courseMatchesManeuverFinalHeading = false

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -167,7 +167,7 @@ open class RouteLegProgress: NSObject {
      The remaining steps for user to complete.
      */
     @objc public var remainingSteps: [RouteStep] {
-        return Array(leg.steps.suffix(from: stepIndex))
+        return Array(leg.steps.suffix(from: stepIndex + 1))
     }
 
     /**
@@ -181,7 +181,7 @@ open class RouteLegProgress: NSObject {
      Duration remaining in seconds on current leg.
      */
     @objc public var durationRemaining: TimeInterval {
-        return leg.steps.suffix(from: stepIndex + 1).map { $0.expectedTravelTime }.reduce(0, +) + currentStepProgress.durationRemaining
+        return remainingSteps.map { $0.expectedTravelTime }.reduce(0, +) + currentStepProgress.durationRemaining
     }
 
     /**

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -162,6 +162,13 @@ open class RouteLegProgress: NSObject {
             currentStepProgress = RouteStepProgress(step: currentStep)
         }
     }
+    
+    /**
+     The reemaining steps for user to complete.
+     */
+    @objc public var remainingSteps: [RouteStep] {
+        return Array(leg.steps.suffix(from: stepIndex))
+    }
 
     /**
      Total distance traveled in meters along current leg.

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -164,7 +164,7 @@ open class RouteLegProgress: NSObject {
     }
     
     /**
-     The reemaining steps for user to complete.
+     The remaining steps for user to complete.
      */
     @objc public var remainingSteps: [RouteStep] {
         return Array(leg.steps.suffix(from: stepIndex))


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1081

If there are no more steps on a given leg, we should not check nor attempt to increment the step index.

/cc @mapbox/navigation-ios 