### PR TITLE
Allow developers to filter in locations

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -372,7 +372,7 @@ extension ViewController: NavigationMapViewDelegate {
     // If however you would like to filter these locations in,
     // you can conditionally return a Bool here according to your own heuristics.
     // See CLLocation.swift `isQualified` for what makes a location update unqualified.
-    func navigationViewController(_ navigationViewController: NavigationViewController, didDiscard location: CLLocation) -> Bool {
+    func navigationViewController(_ navigationViewController: NavigationViewController, shouldUpdateTo location: CLLocation) -> Bool {
         return true
     }
 }

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -367,6 +367,14 @@ extension ViewController: NavigationMapViewDelegate {
     func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction, routeProgress: RouteProgress) -> SpokenInstruction? {
         return SpokenInstruction(distanceAlongStep: instruction.distanceAlongStep, text: "New Instruction!", ssmlText: "<speak>New Instruction!</speak>")
     }
+    
+    // By default, the routeController will attempt to filter out bad locations.
+    // If however you would like to filter these locations in,
+    // you can conditionally return a Bool here according to your own heuristics.
+    // See CLLocation.swift `isQualified` for what makes a location update unqualified.
+    func navigationViewController(_ navigationViewController: NavigationViewController, didDiscard location: CLLocation) -> Bool {
+        return true
+    }
 }
 
 // MARK: WaypointConfirmationViewControllerDelegate

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -372,7 +372,7 @@ extension ViewController: NavigationMapViewDelegate {
     // If however you would like to filter these locations in,
     // you can conditionally return a Bool here according to your own heuristics.
     // See CLLocation.swift `isQualified` for what makes a location update unqualified.
-    func navigationViewController(_ navigationViewController: NavigationViewController, shouldUpdateTo location: CLLocation) -> Bool {
+    func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool {
         return true
     }
 }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -34,16 +34,16 @@ public protocol RouteControllerDelegate: class {
     optional func routeController(_ routeController: RouteController, willRerouteFrom location: CLLocation)
 
     /**
-     Called when a location has been discarded for being inaccurate.
+     Called when a location has been idenetified as unqualified to navigate on.
 
      See `CLLocation.isQualified` for more information about what qualifies a location.
 
      - parameter routeController: The route controller that discarded the location.
-     - parameter location: The location that was discarded
+     - parameter location: The location that will be discarded.
      - return: If `true`, the location is discarded and the `RouteController` will not consider it. If `false`, the location will not be thrown out.
      */
-    @objc(routeController:didDiscardLocation:)
-    optional func routeController(_ routeController: RouteController, didDiscard location: CLLocation) -> Bool
+    @objc(routeController:shouldUpdateToLocation:)
+    optional func routeController(_ routeController: RouteController, shouldUpdateTo location: CLLocation) -> Bool
 
     /**
      Called immediately after the route controller receives a new route.
@@ -538,7 +538,7 @@ extension RouteController: CLLocationManagerDelegate {
             potentialLocation = lastFiltered
         // `filteredLocations` does not contain good locations and we have found at least one good location previously.
         } else if hasFoundOneQualifiedLocation {
-            if let lastLocation = locations.last, delegate?.routeController?(self, didDiscard: lastLocation) ?? true {
+            if let lastLocation = locations.last, delegate?.routeController?(self, shouldUpdateTo: lastLocation) ?? true {
                 return
             }
         // This case handles the first location.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -40,9 +40,10 @@ public protocol RouteControllerDelegate: class {
 
      - parameter routeController: The route controller that discarded the location.
      - parameter location: The location that was discarded
+     - return: If `true`, the location is discarded and the `RouteController` will not consider it. If `false`, the location will not be thrown out.
      */
     @objc(routeController:didDiscardLocation:)
-    optional func routeController(_ routeController: RouteController, didDiscard location: CLLocation)
+    optional func routeController(_ routeController: RouteController, didDiscard location: CLLocation) -> Bool
 
     /**
      Called immediately after the route controller receives a new route.
@@ -537,8 +538,7 @@ extension RouteController: CLLocationManagerDelegate {
             potentialLocation = lastFiltered
         // `filteredLocations` does not contain good locations and we have found at least one good location previously.
         } else if hasFoundOneQualifiedLocation {
-            if let lastLocation = locations.last {
-                delegate?.routeController?(self, didDiscard: lastLocation)
+            if let lastLocation = locations.last, delegate?.routeController?(self, didDiscard: lastLocation) ?? true {
                 return
             }
         // This case handles the first location.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -42,8 +42,8 @@ public protocol RouteControllerDelegate: class {
      - parameter location: The location that will be discarded.
      - return: If `true`, the location is discarded and the `RouteController` will not consider it. If `false`, the location will not be thrown out.
      */
-    @objc(routeController:shouldUpdateToLocation:)
-    optional func routeController(_ routeController: RouteController, shouldUpdateTo location: CLLocation) -> Bool
+    @objc(routeController:shouldDiscardLocation:)
+    optional func routeController(_ routeController: RouteController, shouldDiscard location: CLLocation) -> Bool
 
     /**
      Called immediately after the route controller receives a new route.
@@ -538,7 +538,7 @@ extension RouteController: CLLocationManagerDelegate {
             potentialLocation = lastFiltered
         // `filteredLocations` does not contain good locations and we have found at least one good location previously.
         } else if hasFoundOneQualifiedLocation {
-            if let lastLocation = locations.last, delegate?.routeController?(self, shouldUpdateTo: lastLocation) ?? true {
+            if let lastLocation = locations.last, delegate?.routeController?(self, shouldDiscard: lastLocation) ?? true {
                 return
             }
         // This case handles the first location.

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -173,7 +173,7 @@ public protocol NavigationViewControllerDelegate {
      - parameter location: The location that will be discarded.
      - return: If `true`, the location is discarded and the `NavigationViewController` will not consider it. If `false`, the location will not be thrown out.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, shouldUpdateTo location: CLLocation) -> Bool
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool
 }
 
 /**
@@ -539,17 +539,12 @@ extension NavigationViewController: RouteControllerDelegate {
         }
     }
     
-    @objc public func routeController(_ routeController: RouteController, shouldUpdateTo location: CLLocation)  -> Bool {
-        func showWeakGPS() {
+    @objc public func routeController(_ routeController: RouteController, shouldDiscard location: CLLocation)  -> Bool {
+        let shouldDiscard = delegate?.navigationViewController?(self, shouldDiscard: location) ?? true
+        
+        if shouldDiscard {
             let title = NSLocalizedString("WEAK_GPS", bundle: .mapboxNavigation, value: "Weak GPS signal", comment: "Inform user about weak GPS signal")
             mapViewController?.statusView.show(title, showSpinner: false)
-        }
-        
-        if let shouldUpdateToIsImplemented = delegate?.navigationViewController?(self, shouldUpdateTo: location), shouldUpdateToIsImplemented {
-            showWeakGPS() // Implmeneted and true
-            return true
-        } else if delegate?.navigationViewController?(self, shouldUpdateTo: location) == nil {
-            showWeakGPS() // Unimplemented, default to always showing if called.
             return true
         }
         

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -165,15 +165,15 @@ public protocol NavigationViewControllerDelegate {
     @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint
     
     /**
-     Called when a location has been discarded for being inaccurate.
+     Called when a location has been idenetified as unqualified to navigate on.
      
      See `CLLocation.isQualified` for more information about what qualifies a location.
      
      - parameter navigationViewController: The navigation view controller that discarded the location.
-     - parameter location: The location that was discarded
+     - parameter location: The location that will be discarded.
      - return: If `true`, the location is discarded and the `NavigationViewController` will not consider it. If `false`, the location will not be thrown out.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, didDiscard location: CLLocation) -> Bool
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, shouldUpdateTo location: CLLocation) -> Bool
 }
 
 /**
@@ -539,16 +539,16 @@ extension NavigationViewController: RouteControllerDelegate {
         }
     }
     
-    @objc public func routeController(_ routeController: RouteController, didDiscard location: CLLocation)  -> Bool {
+    @objc public func routeController(_ routeController: RouteController, shouldUpdateTo location: CLLocation)  -> Bool {
         func showWeakGPS() {
             let title = NSLocalizedString("WEAK_GPS", bundle: .mapboxNavigation, value: "Weak GPS signal", comment: "Inform user about weak GPS signal")
             mapViewController?.statusView.show(title, showSpinner: false)
         }
         
-        if let didDiscardIsImplemented = delegate?.navigationViewController?(self, didDiscard: location), didDiscardIsImplemented {
+        if let shouldUpdateToIsImplemented = delegate?.navigationViewController?(self, shouldUpdateTo: location), shouldUpdateToIsImplemented {
             showWeakGPS() // Implmeneted and true
             return true
-        } else if delegate?.navigationViewController?(self, didDiscard: location) == nil {
+        } else if delegate?.navigationViewController?(self, shouldUpdateTo: location) == nil {
             showWeakGPS() // Unimplemented, default to always showing if called.
             return true
         }


### PR DESCRIPTION
This PR makes it so developers can inspect locations before they are thrown out and conditionally keep the location if they so choose.

/cc @mapbox/navigation-ios 