### PR TITLE
Fix then banner

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -456,7 +456,7 @@ class RouteMapViewController: UIViewController {
         
         // If the followon step is short and the user is near the end of the current step, show the nextBanner.
         guard nextStep.expectedTravelTime <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier,
-            upcomingStep.expectedTravelTime <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier else {
+            routeProgress.currentLegProgress.currentStepProgress.durationRemaining <= RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier else {
                 hideNextBanner()
                 return
         }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1097

4th times a charm. We should be comparing the current step duration remaining, not the duration of the upcoming step (which does not change). This part of the bool ensures then is only shown near the end of the current step.

/cc @mapbox/navigation-ios 