### PR TITLE
Avoid infinite loop when only using one style

### DIFF
--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -70,7 +70,7 @@ open class StyleManager: NSObject {
     func resetTimeOfDayTimer() {
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(timeOfDayChanged), object: nil)
         
-        guard automaticallyAdjustsStyleForTimeOfDay else { return }
+        guard automaticallyAdjustsStyleForTimeOfDay && styles.count > 1 else { return }
         guard let location = delegate?.locationFor(styleManager: self) else { return }
         
         guard let solar = Solar(date: date, coordinate: location.coordinate),


### PR DESCRIPTION
This fixes an infinite call to `timeOfDayChanged` when only using one style. There's no need to check when the time of day changes if only one style was provided.

@bsudekum 👀 