### PR TITLE
 Remove speed from isQualified check

### DIFF
--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -9,7 +9,7 @@ extension CLLocation {
             return true
         #else
             return
-                0...80 ~= horizontalAccuracy &&
+                0...100 ~= horizontalAccuracy &&
                 0...30 ~= horizontalAccuracy
         #endif
     }

--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -9,9 +9,8 @@ extension CLLocation {
             return true
         #else
             return
-                0...100 ~= horizontalAccuracy &&
-                verticalAccuracy > 0 &&
-                speed >= 0
+                0...80 ~= horizontalAccuracy &&
+                0...30 ~= horizontalAccuracy
         #endif
     }
     

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -130,7 +130,7 @@ let milesToMeters = 1609.34
 /**
  The minimum speed value before the user's actual location can be considered over the snapped location.
  */
-public var RouteControllerMinimumSpeedForLocationSnapping: CLLocationSpeed = 2
+public var RouteControllerMinimumSpeedForLocationSnapping: CLLocationSpeed = 3
 
 /**
  The minimum distance threshold used for giving a "Continue" type instructions.

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -130,7 +130,7 @@ let milesToMeters = 1609.34
 /**
  The minimum speed value before the user's actual location can be considered over the snapped location.
  */
-public var RouteControllerMinimumSpeedForLocationSnapping: CLLocationSpeed = 3
+public var RouteControllerMinimumSpeedForLocationSnapping: CLLocationSpeed = 2
 
 /**
  The minimum distance threshold used for giving a "Continue" type instructions.


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1100

This removes `speed` from checking whether a location is qualified or not. Since speed is not necessary to know whether a user is on the route, where to snap, or if they have completed a maneuver, we can investigate more meaningful clues like the horizontal accuracy. 

/cc @mapbox/navigation-ios 