### PR TITLE
Modified PollyVoiceController's speak method qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Exposes `setOverheadCameraView(from:along:for:)` which is useful for fitting the camera to an overhead view for the remaining route coordinates.
+* Exposes `PollyVoiceController.speak(_:)` which would allow custom subclass of PollyVoiceController to override this method and pass a modified SpokenInstruction to our superclass implementation.
 
 ## v0.13.1 (February 7, 2018)
 

--- a/MapboxNavigation/PollyVoiceController.swift
+++ b/MapboxNavigation/PollyVoiceController.swift
@@ -148,7 +148,7 @@ public class PollyVoiceController: RouteVoiceController {
         return input
     }
     
-    public override func speak(_ instruction: SpokenInstruction) {
+    open override func speak(_ instruction: SpokenInstruction) {
         assert(routeProgress != nil, "routeProgress should not be nil.")
         
         if let audioPlayer = audioPlayer, audioPlayer.isPlaying, let lastSpokenInstruction = lastSpokenInstruction {


### PR DESCRIPTION
Changes made to meet the expected behavior proposed in - [Issue #1026: Allow overriding speak() function for voice synthesis](https://github.com/mapbox/mapbox-navigation-ios/issues/1026)

**Intent**: The `open` access level applied to the `speak` method allows the method to be overridden by subclasses of the  `PollyVoiceController`class, which wasn't attainable with the previous `public` access level.

cc @mapbox/navigation-ios @1ec5 