### PR TITLE
Localize map labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Exposes `setOverheadCameraView(from:along:for:)` which is useful for fitting the camera to an overhead view for the remaining route coordinates.
 * Exposes `PollyVoiceController.speak(_:)` which would allow custom subclass of PollyVoiceController to override this method and pass a modified SpokenInstruction to our superclass implementation.
+* Added a `NavigationMapView.localizeLabels()` method that should be called within `MGLMapViewDelegate.mapView(_:didFinishLoading:)` for standalone `NavigationMapView`s to ensure that map labels are in the correct language. (#1111)
 
 ## v0.13.1 (February 7, 2018)
 

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -316,6 +316,8 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
     }
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+        self.mapView?.localizeLabels()
+        
         if let routes = routes, let coords = currentRoute?.coordinates, let coordCounts = currentRoute?.coordinateCount {
             mapView.setVisibleCoordinateBounds(MGLPolygon(coordinates: coords, count: coordCounts).overlayBounds, animated: false)
             self.mapView?.showRoutes(routes)

--- a/MapboxNavigation/MGLVectorSource.swift
+++ b/MapboxNavigation/MGLVectorSource.swift
@@ -1,11 +1,25 @@
 import Foundation
 import Mapbox
 
+// https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview
+let mapboxStreetsLanguages = Set(["ar", "de", "en", "es", "fr", "pt", "ru", "zh", "zh-Hans"])
+
 extension MGLVectorSource {
     var isMapboxStreets: Bool {
         guard let configurationURL = configurationURL else {
             return false
         }
         return configurationURL.scheme == "mapbox" && configurationURL.host!.components(separatedBy: ",").contains("mapbox.mapbox-streets-v7")
+    }
+    
+    static var preferredMapboxStreetsLanguage: String? {
+        let preferredLanguages = Bundle.preferredLocalizations(from: Array(mapboxStreetsLanguages), forPreferences: Locale.preferredLanguages)
+        var mostSpecificLanguage: String?
+        for language in preferredLanguages {
+            if language.count > mostSpecificLanguage?.count ?? 0 {
+                mostSpecificLanguage = language
+            }
+        }
+        return mostSpecificLanguage
     }
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -776,17 +776,18 @@ extension RouteMapViewController: MGLMapViewDelegate {
         // This method is called before the view is added to a window
         // (if the style is cached) preventing UIAppearance to apply the style.
         showRouteIfNeeded()
+        
+        self.mapView.localizeLabels()
     }
     
     func showRouteIfNeeded() {
         guard isViewLoaded && view.window != nil else { return }
-        let map = mapView as NavigationMapView
-        guard !map.showsRoute else { return }
-        map.showRoutes([routeController.routeProgress.route], legIndex: routeController.routeProgress.legIndex)
-        map.showWaypoints(routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex)
+        guard !mapView.showsRoute else { return }
+        mapView.showRoutes([routeController.routeProgress.route], legIndex: routeController.routeProgress.legIndex)
+        mapView.showWaypoints(routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex)
         
         if routeController.routeProgress.currentLegProgress.stepIndex + 1 <= routeController.routeProgress.currentLegProgress.leg.steps.count {
-            map.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
+            mapView.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
         }
         
         if annotatesSpokenInstructions {

--- a/languages.md
+++ b/languages.md
@@ -6,12 +6,19 @@ The Mapbox Navigation SDK’s user interface automatically matches your applicat
 
 Distances, travel times, and arrival times are displayed according to the system language and region settings by default, regardless of the application’s language. By default, the measurement system also matches the system region, which may not necessarily be the same region in which the user is traveling.
 
-The turn banner names the upcoming road or ramp destination in the local or national language. In some regions, the name may be given in multiple languages or scripts.
+The turn banner names the upcoming road or ramp destination in the local or national language. In some regions, the name may be given in multiple languages or scripts. A label near the bottom bar displays the current road name in the local language as well.
 
-By default, the map displays the Mapbox Navigation Guidance Day v2 and Navigation Guidance Night v2 styles, which labels roads in English wherever possible, falling back to the local language. A label near the bottom bar displays the current road name in the same language as the map. To force the labels into any of the eight other languages supported by the [Mapbox Streets source](https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview), falling back to the local language, use the following code:
+By default, the map inside `NavigationViewController` displays road labels in the local language, while points of interest and places are displayed in the system’s preferred language, if that language is one of the eight supported by the [Mapbox Streets source](https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview). The user can set the system’s preferred
+language in Settings, General Settings, Language & Region.
+
+A standalone `NavigationMapView` labels roads, points of interest, and places in the language specified by the current style. (The default Mapbox Navigation Guidance Day v2 style specifies English.) To match the behavior of the map inside `NavigationViewController`, call the `NavigationMapView.localizeLabels()` method from within `MGLMapViewDelegate.mapView(_:didFinishLoading:)`:
 
 ```swift
-navigationViewController.mapView?.style?.localizesLabels = true
+func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+    if let mapView = mapView as? NavigationMapView {
+        mapView.localizeLabels()
+    }
+}
 ```
 
 ## Spoken instructions


### PR DESCRIPTION
Added a public `localizeLabels()` method to NavigationMapView for localizing all the labels: road labels are localized into the local language (the `name` tag in OpenStreetMap, matching the Mapbox Directions API), while place and POI labels are localized into the system’s preferred language if supported by the Mapbox Streets source, falling back to the local language.

The map view embedded in NavigationViewController calls this method automatically, so no developer intervention is typically required for the turn-by-turn map. However, the developer is encouraged to call `localizesLabels()` on any standalone NavigationMapView from within `MGLMapViewDelegate.mapView(_:didFinishLoading:)`.

This change required porting about half of the `MGLStyle.localizesLabels` implementation from Objective-C to Swift. `MGLStyle.localizesLabels` isn’t quite adequate, because it’s a two-way option between the style’s original language (English in the case of the Mapbox Navigation Guidance styles) and the system’s preferred language, with no option to use the local language that matches signage. This map SDK API will be revamped as part of mapbox/mapbox-gl-native#10713.

<img src="https://user-images.githubusercontent.com/1231218/36184314-ce37ba80-10e7-11e8-9156-ac93b7216249.png" width="300" alt="preview"> <img src="https://user-images.githubusercontent.com/1231218/36184318-d233e866-10e7-11e8-800f-cfc601b40bc5.png" width="300" alt="turn-by-turn">

Fixes #755.

/cc @bsudekum @frederoni @nickidlugash