### PR TITLE
Convert language documentation into a guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@ Get up and running in a few minutes with our drop-in turn-by-turn navigation `Na
 
 ## Features
 
-- Drop-in turn-by-turn navigation UI
-- Automotive, cycling, and walking directions
-- Traffic avoidance
-- Maneuver announcements
-- Text instructions
-- Text to speech via Amazon Polly - no AWS key needed
-- Automatic rerouting
-- Snap to route
+* A full-fledged turn-by-turn navigation UI ready to drop into your application
+* [Professionally designed map styles](https://www.mapbox.com/maps/) for daytime and nighttime driving
+* Worldwide driving, cycling, and walking directions powered by [open data](https://www.mapbox.com/about/open/) and user feedback
+* Traffic avoidance and proactive rerouting based on current conditions in [over 30 countries](https://www.mapbox.com/api-documentation/pages/traffic-countries.html)
+* Natural-sounding turn instructions powered by [Amazon Polly](https://aws.amazon.com/polly/) (no configuration needed)
+* [Support for over a dozen languages](./docs/guides/Localization%20and%20Internationalization.md)
 
 ## [Documentation](https://www.mapbox.com/mapbox-navigation-ios/navigation/)
 
@@ -151,10 +149,6 @@ The library compares the user from the route and decides upon each one of these 
 ### Building your own custom navigation UI
 
 Looking for a more advanced use case? See our installation guide of [MapboxCoreNavigation](./custom-navigation.md).
-
-## Language support
-
-See [languages.md](./languages.md) for more information.
 
 ## Contributing
 

--- a/docs/guides/Localization and Internationalization.md
+++ b/docs/guides/Localization and Internationalization.md
@@ -1,4 +1,6 @@
-# Languages
+# Localization and Internationalization
+
+The Mapbox Navigation SDK supports over a dozen major languages as well as some other locale settings. For a seamless user experience, the SDK’s default behavior matches the standard iOS behavior as much as possible, but several customization options are also available for specialized use cases.
 
 ## User interface
 
@@ -56,7 +58,7 @@ The upcoming road or ramp destination is named according to the local or nationa
 
 ## Contributing
 
-See the [contributing guide](./CONTRIBUTING.md#adding-or-updating-a-localization) for instructions on adding a new localization or improving an existing localization.
+See the [contributing guide](https://github.com/mapbox/mapbox-navigation-ios/blob/master/CONTRIBUTING.md#adding-or-updating-a-localization) for instructions on adding a new localization or improving an existing localization.
 
 [osrmti]: https://github.com/Project-OSRM/osrm-text-instructions/
 [iossynth]: https://developer.apple.com/documentation/avfoundation/speech_synthesis

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -14,6 +14,7 @@ custom_categories:
   - name: Guides
     children:
       - Storyboards
+      - Localization and Internationalization
   - name: Examples
     children:
       - Basic

--- a/languages.md
+++ b/languages.md
@@ -4,7 +4,7 @@
 
 The Mapbox Navigation SDK’s user interface automatically matches your application’s language whenever possible. For the best user experience, you should localize your application fully rather than piecemeal. However, if you want to display a turn-by-turn navigation experience in a language without first localizing your application, you can add the language to your Xcode project’s languages and add a stub Localizable.strings file to your application target. For more information about preparing your application for additional languages, consult “[Localizing Your App](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/LocalizingYourApp/LocalizingYourApp.html)” in Apple developer documentation.
 
-Distances, travel times, and arrival times are displayed according to the system language and region settings by default, regardless of the application’s language. By default, the measurement system also matches the system region, which may not necessarily be the same region in which the user is traveling.
+Distances, travel times, and arrival times are displayed according to the system language and region settings by default, regardless of the application’s language. By default, the measurement system is that of the [spoken instructions](#spoken-instructions). To override the measurement system displayed in the user interface but not that of the spoken instructions, set the `NavigationSettings.distanceUnit` property.
 
 The turn banner names the upcoming road or ramp destination in the local or national language. In some regions, the name may be given in multiple languages or scripts. A label near the bottom bar displays the current road name in the local language as well.
 
@@ -25,7 +25,7 @@ func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
 
 Turn instructions are announced in the user interface language when turn instructions are available in that language. Otherwise, if turn instructions are unavailable in that language, they are announced in English instead. To have instructions announced in a language other than the user interface language, set the `RouteOptions.locale` property when calculating the route with which to start navigation.
 
-Turn instructions are primarily designed to be announced by either [Amazon Polly][polly] or the [Speech Synthesis framework][iossynth] built into iOS (also known as `AVSpeechSynthesizer`). `AVSpeechSynthesizer` is used by default. To have Polly announce the instructions, initialize a `MapboxVoiceController` using your AWS pool ID, then set `NavigationViewController.voiceController` to the `MapboxVoiceController` before presenting the `NavigationViewController`. If Polly lacks support for the turn instruction language, `AVSpeechSynthesizer` announces the instructions instead. Neither Polly nor `AVSpeechSynthesizer` supports Catalan or Vietnamese; for these languages, you must create a subclass of `RouteVoiceController` that uses a third-party speech synthesizer.
+Turn instructions are primarily designed to be announced by either the Mapbox Voice API (powered by [Amazon Polly](https://docs.aws.amazon.com/polly/latest/dg/SupportedLanguage.html)) or the [Speech Synthesis framework][iossynth] built into iOS (also known as `AVSpeechSynthesizer`). This SDK uses the Mapbox Voice API by default. If the Voice API lacks support for the turn instruction language, `AVSpeechSynthesizer` announces the instructions instead. The Voice API requires an Internet connection at various points along the route. To have `AVSpeechSynthesizer` announce the instructions regardless of the language, initialize a `RouteVoiceController`, then set `NavigationViewController.voiceController` to the `RouteVoiceController` before presenting the `NavigationViewController`. Neither the Voice API nor `AVSpeechSynthesizer` supports Catalan or Vietnamese; for these languages, you must create a subclass of `RouteVoiceController` that uses a third-party speech synthesizer.
 
 By default, distances are given in the predominant measurement system of the system region, which may not necessarily be the same region in which the user is traveling. To override the measurement system used in spoken instructions, set the `RouteOptions.measurementSystem` property when calculating the route with which to start navigation.
 
@@ -33,7 +33,7 @@ The upcoming road or ramp destination is named according to the local or nationa
 
 ## Supported languages
 
-| Language   | User interface | [Spoken instructions][osrmti] | [Amazon Polly][polly] | [`AVSpeechSynthesizer`][iossynth]<br>(iOS 11)
+| Language   | User interface | [Spoken instructions][osrmti] | Mapbox Voice API | [`AVSpeechSynthesizer`][iossynth]<br>(iOS 11)
 |------------|----------------|-------------------------------|-----------------------|----------------------------------
 | Catalan    | ✅              | ❌                             | ❌                     | ❌
 | Chinese    | ✅ Simplified   | ✅                             | ❌                     | ✅
@@ -59,5 +59,4 @@ The upcoming road or ramp destination is named according to the local or nationa
 See the [contributing guide](./CONTRIBUTING.md#adding-or-updating-a-localization) for instructions on adding a new localization or improving an existing localization.
 
 [osrmti]: https://github.com/Project-OSRM/osrm-text-instructions/
-[polly]: https://docs.aws.amazon.com/polly/latest/dg/SupportedLanguage.html
 [iossynth]: https://developer.apple.com/documentation/avfoundation/speech_synthesis


### PR DESCRIPTION
Converted this repository’s “Languages” Markdown file into a guide for inclusion in the jazzy-generated docset. Updated the guide to reflect the changes to spoken instructions in #617. Also rewrote the feature list in the readme to focus on differentiators.

Fixes #1073.

/cc @bsudekum @captainbarbosa