### PR TITLE
Update delegate method argument documentation

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -87,7 +87,6 @@ public protocol RouteControllerDelegate: class {
      - postcondition: If you return false, you must manually advance to the next leg: obtain the value of the `routeProgress` property, then increment the `RouteProgress.legIndex` property.
      - parameter routeController: The route controller that has arrived at a waypoint.
      - parameter waypoint: The waypoint that the controller has arrived at.
-     - parameter finalDestination: A boolean flag that signals that the waypoint is the final destination.
      - returns: True to advance to the next leg, if any, or false to remain on the completed leg.
     */
     @objc(routeController:didArriveAtWaypoint:)

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1226,7 +1226,7 @@ public protocol NavigationMapViewDelegate: class {
     /**
      Asks the receiver to return an MGLShape that describes the geometry of the waypoint.
      - parameter mapView: The NavigationMapView.
-     - parameter waypoint: The waypoint that the sender is asking about.
+     - parameter waypoints: The waypoints to be displayed on the map.
      - returns: Optionally, a `MGLShape` that defines the shape of the waypoint, or `nil` to use default behavior.
      */
     @objc(navigationMapView:shapeDescribingWaypoints:)


### PR DESCRIPTION
Two delegate method documentation comments were outdated with respect to the arguments they documented. These issues showed up as compiler warnings when building the Objective-C example application, because documentation warnings are enabled by default in Objective-C but not in Swift.

/cc @JThramer @bsudekum