### PR TITLE
Always send progress update except when location is unqualified

### DIFF
--- a/MapboxCoreNavigation/MBRouteController.h
+++ b/MapboxCoreNavigation/MBRouteController.h
@@ -3,7 +3,7 @@
 /**
  Posted when `MBRouteController` receives a user location update representing movement along the expected route.
  
- The user info dictionary contains the keys `MBRouteControllerRouteProgressKey`, `MBRouteControllerLocationKey`, and `MBRouteControllerEstimatedTimeUntilManeuverKey`.
+ The user info dictionary contains the keys `MBRouteControllerRouteProgressKey` and `MBRouteControllerLocationKey`.
  
  :nodoc:
  */
@@ -61,11 +61,6 @@ extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProg
  A key in the user info dictionary of a `Notification.Name.MBRouteControllerProgressDidChange` or `Notification.Name.RouteControllerWillReroute` notification. The corresponding value is a `CLLocation` object representing the current user location.
  */
 extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey;
-
-/**
- A key in the user info dictionary of a `Notification.Name.RouteControllerProgressDidChange` notification. The corresponding value is an `NSNumber` instance containing a double value indicating the estimated time remaining, in seconds, until the user reaches the next maneuver point.
- */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerEstimatedTimeUntilManeuverKey;
 
 /**
  A key in the user info dictionary of a `Notification.Name.RouteControllerDidFailToReroute` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.

--- a/MapboxCoreNavigation/MBRouteController.m
+++ b/MapboxCoreNavigation/MBRouteController.m
@@ -8,7 +8,6 @@ const NSNotificationName MBRouteControllerDidFailToRerouteNotification          
 
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProgressKey              = @"progress";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey                   = @"location";
-const MBRouteControllerNotificationUserInfoKey MBRouteControllerEstimatedTimeUntilManeuverKey = @"seconds";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey               = @"error";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerIsOpportunisticKey            = @"RouteControllerDidFindFasterRoute";
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -396,7 +396,7 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
     @objc func progressDidChange(notification: NSNotification) {
         let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
         let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
-        let secondsRemaining = notification.userInfo![RouteControllerNotificationUserInfoKey.estimatedTimeUntilManeuverKey] as! TimeInterval
+        let secondsRemaining = routeProgress.currentLegProgress.currentStepProgress.durationRemaining
 
         mapViewController?.notifyDidChange(routeProgress: routeProgress, location: location, secondsRemaining: secondsRemaining)
         


### PR DESCRIPTION
This removes the notification key `MBRouteControllerEstimatedTimeUntilManeuverKey` in favor of using durationRemaining on `currentStepProgress`, and makes sure progress updates are always fired when the location is deemed qualified.

When a user begins to go off route near a maneuver, this check `if distanceTraveled != currentStepProgress.distanceTraveled {` would fail because the distance traveled is a snapped distance. Although the distance is not changing, we still need to emit progress updates. This was not surfaced because we're updating the user puck via [this delegate method](https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxNavigation/NavigationViewController.swift#L530) instead of progress update notifications. This is important for developers who are implementing custom UIs.

/cc @mapbox/navigation-ios 