### PR TITLE
Specify Swift version in podspecs

### DIFF
--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -44,8 +44,8 @@ Pod::Spec.new do |s|
   s.dependency "MapboxMobileEvents", "~> 0.3"
   s.dependency "Turf", "~> 0.0.4"
 
-  # `swift_version` was introduced in CocoaPods 1.4.0. If a user directly specifies this
-  # podspec and they're using <1.4.0, ruby will throw an unknown method error.
+  # `swift_version` was introduced in CocoaPods 1.4.0. Without this check, if a user were to
+  # directly specify this podspec while using <1.4.0, ruby would throw an unknown method error.
   if s.respond_to?(:swift_version)
     s.swift_version = "4.0"
   end

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -39,6 +39,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
+  s.swift_version = "4.0"
 
   s.dependency "MapboxDirections.swift", "~> 0.17"
   s.dependency "MapboxMobileEvents", "~> 0.3"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -39,10 +39,20 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
-  s.swift_version = "4.0"
 
   s.dependency "MapboxDirections.swift", "~> 0.17"
   s.dependency "MapboxMobileEvents", "~> 0.3"
   s.dependency "Turf", "~> 0.0.4"
+
+  # The CocoaPods podspec spec is not backwards compatible, so, when they add new parameters
+  # (like `swift_version` in 1.4.0), older versions of CocoaPods blow up in confusion.
+  # Specifying a `cocoapods_version >= 1.4.0` does nothing to solve the problem, as Ruby
+  # interprets unknown parameters as low-level syntax errors.
+  #
+  # Instead, we're forced to use Ruby's built-in semver comparison before declaring parameters
+  # added in recent CocoaPods releases.
+  if Version.new(Pod::VERSION) >= Version.new("1.4.0")
+    s.swift_version = "4.0"
+  end
 
 end

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -44,14 +44,9 @@ Pod::Spec.new do |s|
   s.dependency "MapboxMobileEvents", "~> 0.3"
   s.dependency "Turf", "~> 0.0.4"
 
-  # The CocoaPods podspec spec is not backwards compatible, so, when they add new parameters
-  # (like `swift_version` in 1.4.0), older versions of CocoaPods blow up in confusion.
-  # Specifying a `cocoapods_version >= 1.4.0` does nothing to solve the problem, as Ruby
-  # interprets unknown parameters as low-level syntax errors.
-  #
-  # Instead, we're forced to use Ruby's built-in semver comparison before declaring parameters
-  # added in recent CocoaPods releases.
-  if Version.new(Pod::VERSION) >= Version.new("1.4.0")
+  # `swift_version` was introduced in CocoaPods 1.4.0. If a user directly specifies this
+  # podspec and they're using <1.4.0, ruby will throw an unknown method error.
+  if s.respond_to?(:swift_version)
     s.swift_version = "4.0"
   end
 

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -51,14 +51,9 @@ Pod::Spec.new do |s|
   s.dependency "Turf", "~> 0.0.4"
   s.dependency "MapboxSpeech", "~> 0.0.1"
 
-  # The CocoaPods podspec spec is not backwards compatible, so, when they add new parameters
-  # (like `swift_version` in 1.4.0), older versions of CocoaPods blow up in confusion.
-  # Specifying a `cocoapods_version >= 1.4.0` does nothing to solve the problem, as Ruby
-  # interprets unknown parameters as low-level syntax errors.
-  #
-  # Instead, we're forced to use Ruby's built-in semver comparison before declaring parameters
-  # added in recent CocoaPods releases.
-  if Version.new(Pod::VERSION) >= Version.new("1.4.0")
+  # `swift_version` was introduced in CocoaPods 1.4.0. If a user directly specifies this
+  # podspec and they're using <1.4.0, ruby will throw an unknown method error.
+  if s.respond_to?(:swift_version)
     s.swift_version = "4.0"
   end
 

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -42,7 +42,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
-  s.swift_version = "4.0"
 
   s.dependency "MapboxDirections.swift", "~> 0.17"
   s.dependency "Mapbox-iOS-SDK", "~> 3.6"
@@ -51,5 +50,16 @@ Pod::Spec.new do |s|
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.0.4"
   s.dependency "MapboxSpeech", "~> 0.0.1"
+
+  # The CocoaPods podspec spec is not backwards compatible, so, when they add new parameters
+  # (like `swift_version` in 1.4.0), older versions of CocoaPods blow up in confusion.
+  # Specifying a `cocoapods_version >= 1.4.0` does nothing to solve the problem, as Ruby
+  # interprets unknown parameters as low-level syntax errors.
+  #
+  # Instead, we're forced to use Ruby's built-in semver comparison before declaring parameters
+  # added in recent CocoaPods releases.
+  if Version.new(Pod::VERSION) >= Version.new("1.4.0")
+    s.swift_version = "4.0"
+  end
 
 end

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
+  s.swift_version = "4.0"
 
   s.dependency "MapboxDirections.swift", "~> 0.17"
   s.dependency "Mapbox-iOS-SDK", "~> 3.6"

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -51,8 +51,8 @@ Pod::Spec.new do |s|
   s.dependency "Turf", "~> 0.0.4"
   s.dependency "MapboxSpeech", "~> 0.0.1"
 
-  # `swift_version` was introduced in CocoaPods 1.4.0. If a user directly specifies this
-  # podspec and they're using <1.4.0, ruby will throw an unknown method error.
+  # `swift_version` was introduced in CocoaPods 1.4.0. Without this check, if a user were to
+  # directly specify this podspec while using <1.4.0, ruby would throw an unknown method error.
   if s.respond_to?(:swift_version)
     s.swift_version = "4.0"
   end

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -50,14 +50,9 @@ Pod::Spec.new do |s|
   s.dependency "Turf", "~> 0.0.4"
   s.dependency "MapboxSpeech", "~> 0.0.1"
 
-  # The CocoaPods podspec spec is not backwards compatible, so, when they add new parameters
-  # (like `swift_version` in 1.4.0), older versions of CocoaPods blow up in confusion.
-  # Specifying a `cocoapods_version >= 1.4.0` does nothing to solve the problem, as Ruby
-  # interprets unknown parameters as low-level syntax errors.
-  #
-  # Instead, we're forced to use Ruby's built-in semver comparison before declaring parameters
-  # added in recent CocoaPods releases.
-  if Version.new(Pod::VERSION) >= Version.new("1.4.0")
+  # `swift_version` was introduced in CocoaPods 1.4.0. If a user directly specifies this
+  # podspec and they're using <1.4.0, ruby will throw an unknown method error.
+  if s.respond_to?(:swift_version)
     s.swift_version = "4.0"
   end
 

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -50,8 +50,8 @@ Pod::Spec.new do |s|
   s.dependency "Turf", "~> 0.0.4"
   s.dependency "MapboxSpeech", "~> 0.0.1"
 
-  # `swift_version` was introduced in CocoaPods 1.4.0. If a user directly specifies this
-  # podspec and they're using <1.4.0, ruby will throw an unknown method error.
+  # `swift_version` was introduced in CocoaPods 1.4.0. Without this check, if a user were to
+  # directly specify this podspec while using <1.4.0, ruby would throw an unknown method error.
   if s.respond_to?(:swift_version)
     s.swift_version = "4.0"
   end

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -42,7 +42,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
-  s.swift_version = "4.0"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
   s.dependency "Mapbox-iOS-SDK", "~> 3.6"
@@ -50,5 +49,16 @@ Pod::Spec.new do |s|
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.0.4"
   s.dependency "MapboxSpeech", "~> 0.0.1"
+
+  # The CocoaPods podspec spec is not backwards compatible, so, when they add new parameters
+  # (like `swift_version` in 1.4.0), older versions of CocoaPods blow up in confusion.
+  # Specifying a `cocoapods_version >= 1.4.0` does nothing to solve the problem, as Ruby
+  # interprets unknown parameters as low-level syntax errors.
+  #
+  # Instead, we're forced to use Ruby's built-in semver comparison before declaring parameters
+  # added in recent CocoaPods releases.
+  if Version.new(Pod::VERSION) >= Version.new("1.4.0")
+    s.swift_version = "4.0"
+  end
 
 end

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
+  s.swift_version = "4.0"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
   s.dependency "Mapbox-iOS-SDK", "~> 3.6"


### PR DESCRIPTION
CocoaPods 1.4.0 supports a [`swift_version` setting in podspecs](https://blog.cocoapods.org/CocoaPods-1.4.0/#swift-version-dsl), so this adds that.

CocoaPods also says that the `.swift-version` file is being deprecated, but they’re not the only consumers of this file, so let's leave it around for the time being.

/cc @frederoni 