### PR TITLE
Prevent statusView from being shown if it is already visible

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -535,10 +535,6 @@ extension NavigationViewController: RouteControllerDelegate {
             mapViewController?.mapView.updateCourseTracking(location: location, animated: true)
             mapViewController?.labelCurrentRoad(at: location)
         }
-    
-        if !(routeController.locationManager is SimulatedLocationManager) {
-            mapViewController?.statusView.hide(delay: 1.5, animated: true)
-        }
     }
     
     @objc public func routeController(_ routeController: RouteController, shouldDiscard location: CLLocation)  -> Bool {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -537,7 +537,7 @@ extension NavigationViewController: RouteControllerDelegate {
         }
     
         if !(routeController.locationManager is SimulatedLocationManager) {
-            mapViewController?.statusView.hide(delay: 3, animated: true)
+            mapViewController?.statusView.hide(delay: 1.5, animated: true)
         }
     }
     

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -322,14 +322,13 @@ class RouteMapViewController: UIViewController {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
         statusView.show(title, showSpinner: true)
-        statusView.hide(delay: 1.5, animated: true)
     }
     
     @objc func didReroute(notification: NSNotification) {
         guard self.isViewLoaded else { return }
         
         if !(routeController.locationManager is SimulatedLocationManager) {
-            statusView.hide(delay: 0.5, animated: true)
+            statusView.hide(delay: 2, animated: true)
             
             if !reportButton.isHidden {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -322,7 +322,7 @@ class RouteMapViewController: UIViewController {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
         statusView.show(title, showSpinner: true)
-        statusView.hide(delay: 3, animated: true)
+        statusView.hide(delay: 1.5, animated: true)
     }
     
     @objc func didReroute(notification: NSNotification) {
@@ -341,7 +341,7 @@ class RouteMapViewController: UIViewController {
         if notification.userInfo![RouteControllerNotificationUserInfoKey.isOpportunisticKey] as! Bool {
             let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
             statusView.show(title, showSpinner: true)
-            statusView.hide(delay: 5, animated: true)
+            statusView.hide(delay: 3, animated: true)
         }
     }
 

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -98,9 +98,7 @@ public class StatusView: UIView {
             activityIndicatorView.stopAnimating()
         }
         
-        if isCurrentlyVisible != nil, isCurrentlyVisible == true {
-            return
-        }
+        guard isCurrentlyVisible != true else { return }
         
         guard isHidden == true else { return }
         

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -30,6 +30,8 @@ public class StatusView: UIView {
         commonInit()
     }
     
+    var isCurrentlyVisible: Bool?
+    
     func commonInit() {
         let activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .white)
         activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
@@ -96,13 +98,19 @@ public class StatusView: UIView {
             activityIndicatorView.stopAnimating()
         }
         
+        if isCurrentlyVisible != nil, isCurrentlyVisible == true {
+            return
+        }
+        
         guard isHidden == true else { return }
         
         UIView.defaultAnimation(0.3, animations: {
             self.isHidden = false
             self.textLabel.alpha = 1
             self.superview?.layoutIfNeeded()
-        }, completion: nil)
+        }, completion: { (completed) in
+            self.isCurrentlyVisible = true
+        })
     }
     
     func hide(delay: TimeInterval = 0, animated: Bool = true) {
@@ -116,10 +124,12 @@ public class StatusView: UIView {
                 self.superview?.layoutIfNeeded()
             }, completion: { (completed) in
                 self.activityIndicatorView.stopAnimating()
+                self.isCurrentlyVisible = false
             })
         } else {
             activityIndicatorView.stopAnimating()
             isHidden = true
+            isCurrentlyVisible = false
         }
     }
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/973

If the `StatusView` is already shown, we should prevent other status updates from showing. The stacking updates caused the view to grow.

/cc @mapbox/navigation-ios 