### PR TITLE
Check if routeController is nil

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -666,7 +666,7 @@ extension RouteMapViewController: NavigationMapViewDelegate {
     }
     
     @objc func updateETA() {
-        guard isViewLoaded else { return }
+        guard isViewLoaded, routeController != nil else { return }
         bottomBannerView?.updateETA(routeProgress: routeController.routeProgress)
     }
     


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1060#issuecomment-367155913

We're still unclear in which situations `routeController` would be nil here, but we can apply a bandaid for this issue by first checking if it's nil.

### One hunch:

This property is set  here:

https://github.com/mapbox/mapbox-navigation-ios/blob/0275c068d09dbf0cde3cff99a6ea14de3a204216/MapboxNavigation/NavigationViewController.swift#L345

Which occurs after we start the routeController here:
https://github.com/mapbox/mapbox-navigation-ios/blob/0275c068d09dbf0cde3cff99a6ea14de3a204216/MapboxNavigation/NavigationViewController.swift#L328

Perhaps when the view is shown and the user is at the same time rerouted, we could be firing a `userDidReroute` notification (which triggers an updateETA()). In this case, routeController could be nil on the mapView.

We could set the RouteController on mapView before the `RouteController` on NavigationMapView.

/cc @mapbox/navigation-ios @zijiazhai 
