### PR TITLE
Add more RouteController tests

### DIFF
--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -56,4 +56,16 @@ class RouteControllerTests: XCTestCase {
         let initialHeadingOnFirstStep = navigation.routeProgress.currentLegProgress.currentStepProgress.step.finalHeading!
         XCTAssertTrue(calculatedCourse - initialHeadingOnFirstStep < 1, "At the beginning of the route, the final heading of the departure step should be very similar to the caclulated course of the first location update.")
     }
+    
+    func testShouldSnap() {
+        let navigation = setup.routeController
+        let firstLocation = setup.firstLocation
+        let initialHeadingOnFirstStep = navigation.routeProgress.currentLegProgress.currentStepProgress.step.finalHeading!
+        
+        XCTAssertTrue(navigation.shouldSnap(firstLocation, toRouteWith: initialHeadingOnFirstStep), "Should snap")
+        
+        let differentCourseAndAccurateLocation = CLLocation(coordinate: firstLocation.coordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: 0, speed: 10, timestamp: Date())
+        
+        XCTAssertFalse(navigation.shouldSnap(differentCourseAndAccurateLocation, toRouteWith: initialHeadingOnFirstStep), "Should not snap when user course is different, the location is accurate and moving")
+    }
 }

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -30,6 +30,22 @@ class RouteControllerTests: XCTestCase {
         XCTAssertFalse(navigation.userIsOnRoute(locationOffRoute), "User should be off route")
     }
     
+    func testAdvancingToFutureStepAndNotRerouting() {
+        let navigation = setup.routeController
+        let firstLocation = setup.firstLocation
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
+        XCTAssertTrue(navigation.userIsOnRoute(firstLocation), "User should be on route")
+        XCTAssertEqual(navigation.routeProgress.currentLegProgress.stepIndex, 0, "User is on first step")
+        
+        let futureCoordinate = navigation.routeProgress.currentLegProgress.leg.steps[2].coordinates![10]
+        let futureLocation = CLLocation(latitude: futureCoordinate.latitude, longitude: futureCoordinate.longitude)
+        
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [futureLocation])
+        XCTAssertTrue(navigation.userIsOnRoute(futureLocation), "User should be on route")
+        
+        XCTAssertEqual(navigation.routeProgress.currentLegProgress.stepIndex, 2, "User should be on route and we should increment all the way to the 4th step")
+    }
+    
     func testSnappedLocation() {
         let navigation = setup.routeController
         let firstLocation = setup.firstLocation

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import MapboxDirections
+import Turf
+@testable import MapboxCoreNavigation
+
+class RouteControllerTests: XCTestCase {
+    
+    var setup: (routeController: RouteController, firstLocation: CLLocation) {
+        route.accessToken = "foo"
+        let navigation = RouteController(along: route, directions: directions)
+        let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
+        return (routeController: navigation, firstLocation: CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude))
+    }
+    
+    func testUserIsOnRoute() {
+        let navigation = setup.routeController
+        let firstLocation = setup.firstLocation
+        
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
+        XCTAssertTrue(navigation.userIsOnRoute(firstLocation), "User should be on route")
+    }
+    
+    func testUserIsOffRoute() {
+        let navigation = setup.routeController
+        let firstLocation = setup.firstLocation
+        
+        let coordinateOffRoute = firstLocation.coordinate.coordinate(at: 100, facing: 90)
+        let locationOffRoute = CLLocation(latitude: coordinateOffRoute.latitude, longitude: coordinateOffRoute.longitude)
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [locationOffRoute])
+        XCTAssertFalse(navigation.userIsOnRoute(locationOffRoute), "User should be off route")
+    }
+    
+    func testSnappedLocation() {
+        let navigation = setup.routeController
+        let firstLocation = setup.firstLocation
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
+        XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
+    }
+    
+    func testSnappedLocation100MetersAlongRoute() {
+        let navigation = setup.routeController
+        let firstLocation = setup.firstLocation
+        
+        let initialHeadingOnFirstStep = navigation.routeProgress.currentLegProgress.currentStep.finalHeading!
+        let coordinateAlongFirstStep = firstLocation.coordinate.coordinate(at: 100, facing: initialHeadingOnFirstStep)
+        let locationAlongFirstStep = CLLocation(latitude: coordinateAlongFirstStep.latitude, longitude: coordinateAlongFirstStep.longitude)
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [locationAlongFirstStep])
+        XCTAssertTrue(locationAlongFirstStep.distance(from: navigation.location!) < 1, "The location update is less than 1 meter away from the calculated snapped location")
+    }
+    
+    func testInterpolatedCourse() {
+        let navigation = setup.routeController
+        let firstLocation = setup.firstLocation
+        
+        let calculatedCourse = navigation.interpolatedCourse(from: firstLocation, along: navigation.routeProgress.currentLegProgress.currentStepProgress.step.coordinates!)!
+        let initialHeadingOnFirstStep = navigation.routeProgress.currentLegProgress.currentStepProgress.step.finalHeading!
+        XCTAssertTrue(calculatedCourse - initialHeadingOnFirstStep < 1, "At the beginning of the route, the final heading of the departure step should be very similar to the caclulated course of the first location update.")
+    }
+}

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		C5A6B2DE1F4DE57E004260EA /* Solar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C57607B01F4CC97D00C27423 /* Solar.framework */; };
 		C5A6B2DF1F4DE57E004260EA /* Solar.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C57607B01F4CC97D00C27423 /* Solar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5A7EC5C1FD610A80008B9BA /* VisualInstructionComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A7EC5B1FD610A80008B9BA /* VisualInstructionComponent.swift */; };
+		C5ABB50E20408D2C00AFA92C /* RouteControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ABB50D20408D2C00AFA92C /* RouteControllerTests.swift */; };
 		C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADFBD71DDCC7840011824B /* MapboxCoreNavigationTests.swift */; };
 		C5C94C1B1DDCD22B0097296A /* MapboxCoreNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = C5ADFBCC1DDCC7840011824B /* MapboxCoreNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C5C94C1C1DDCD2340097296A /* RouteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADFBF91DDCC9580011824B /* RouteController.swift */; };
@@ -490,6 +491,7 @@
 		C5A6B2DC1F4CE8E8004260EA /* StyleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleType.swift; sourceTree = "<group>"; };
 		C5A7EC5B1FD610A80008B9BA /* VisualInstructionComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualInstructionComponent.swift; sourceTree = "<group>"; };
 		C5A9DDBD202E12EE007D52DA /* MapboxSpeech.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapboxSpeech.framework; path = Carthage/Build/iOS/MapboxSpeech.framework; sourceTree = "<group>"; };
+		C5ABB50D20408D2C00AFA92C /* RouteControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteControllerTests.swift; sourceTree = "<group>"; };
 		C5ADFBC91DDCC7840011824B /* MapboxCoreNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxCoreNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5ADFBCC1DDCC7840011824B /* MapboxCoreNavigation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapboxCoreNavigation.h; sourceTree = "<group>"; };
 		C5ADFBCD1DDCC7840011824B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1030,6 +1032,7 @@
 				C52AC1251DF0E48600396B9F /* RouteProgressTests.swift */,
 				C5ADFBD91DDCC7840011824B /* Info.plist */,
 				359574A91F28CCBB00838209 /* LocationTests.swift */,
+				C5ABB50D20408D2C00AFA92C /* RouteControllerTests.swift */,
 			);
 			path = MapboxCoreNavigationTests;
 			sourceTree = "<group>";
@@ -1669,6 +1672,7 @@
 				C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */,
 				359574AA1F28CCBB00838209 /* LocationTests.swift in Sources */,
 				C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */,
+				C5ABB50E20408D2C00AFA92C /* RouteControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This adds a few more tests for `RouteController`. I'm trying to extract these tests as far away from a particular route as possible so when a fixture update occurs, these tests should not be effected. Going to add a few more, this is just a start.

/cc @mapbox/navigation-ios 