### PR TITLE
Hide Weak GPS signal after showing

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -543,6 +543,7 @@ extension NavigationViewController: RouteControllerDelegate {
         if shouldDiscard {
             let title = NSLocalizedString("WEAK_GPS", bundle: .mapboxNavigation, value: "Weak GPS signal", comment: "Inform user about weak GPS signal")
             mapViewController?.statusView.show(title, showSpinner: false)
+            mapViewController?.statusView.hide(delay: 3, animated: true)
             return true
         }
         


### PR DESCRIPTION
After showing the weak gps statusView, we're no longer hiding it after this change:

https://github.com/mapbox/mapbox-navigation-ios/pull/1141/files#diff-ab5a908dc637e51fa78cf2be28d033ecL539

Instead of hiding the statusView on every location update, I've changed this to just hiding it after 3 seconds of it being visible.

In all honesty, I understand this view is meant to manage expectations, but I find it more stress inducing than helpful. I'd be interested in removing it if others are into this idea.

/cc @mapbox/navigation-ios 