### PR TITLE
Always update banner and voice instruction when beginning

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -923,7 +923,7 @@ extension RouteController: CLLocationManagerDelegate {
         guard let spokenInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions else { return }
         
         for voiceInstruction in spokenInstructions {
-            if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep {
+            if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep || routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex == 0 {
                 
                 NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
                     RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -105,7 +105,7 @@ open class BaseInstructionsBannerView: UIControl {
         guard let visualInstructions = stepProgress.remainingVisualInstructions else { return }
         
         for visualInstruction in visualInstructions {
-            if stepProgress.distanceRemaining <= visualInstruction.distanceAlongStep {
+            if stepProgress.distanceRemaining <= visualInstruction.distanceAlongStep || stepProgress.visualInstructionIndex == 0 {
                 
                 set(visualInstruction)
                 


### PR DESCRIPTION
Because of https://github.com/mapbox/mapbox-navigation-ios/issues/901, when starting a trip, the user may not cross the threshold of when a voice instruction or banner should be updated. 

This change ensures that at the beginning of any route, if the spoken/visual index is zero, we make sure to update the user. Otherwise, the banner instruction could be blank or we could delay the voice instruction if the user is standing still.

/cc @mapbox/navigation-ios 