### PR TITLE
Hide completed coordinates

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -399,6 +399,7 @@ public class NavigationViewController: UIViewController, RouteMapViewControllerD
         let secondsRemaining = routeProgress.currentLegProgress.currentStepProgress.durationRemaining
 
         mapViewController?.notifyDidChange(routeProgress: routeProgress, location: location, secondsRemaining: secondsRemaining)
+        mapViewController?.mapView.showRoutes([routeProgress.route], legIndex: routeProgress.legIndex)
         
         progressBar.setProgress(routeProgress.currentLegProgress.userHasArrivedAtWaypoint ? 1 : CGFloat(routeProgress.fractionTraveled), animated: true)
     }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -401,7 +401,6 @@ class RouteMapViewController: UIViewController {
         
         if currentLegIndexMapped != routeProgress.legIndex {
             mapView.showWaypoints(routeProgress.route, legIndex: routeProgress.legIndex)
-            mapView.showRoutes([routeProgress.route], legIndex: routeProgress.legIndex)
             
             currentLegIndexMapped = routeProgress.legIndex
         }


### PR DESCRIPTION
This removes coordinates from the map that the user has passed by.

todo: 

- [ ] Set a max zoom. Zooming past z17 shows some pitfalls with this technique. 
- [ ] Handle maneuver arrows
- [ ] Check for optimizations

![new3](https://user-images.githubusercontent.com/1058624/36700439-8c56eb3c-1b04-11e8-97b9-e7a63b18a6e0.gif)

/cc @mapbox/navigation-ios 
