### PR TITLE
Making StepsViewController.init(routeProgress:) public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Breaking Changes
 * `NavigationMapViewDelegate` and `RouteMapViewControllerDelegate`: `navigationMapView(_:didTap:)` is now `navigationMapView(_:didSelect:)` [#1063](https://github.com/mapbox/mapbox-navigation-ios/pull/1063)
 
+#### User Interface
+*`StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public.
+
 ## v0.14.0 (February 22, 2018)
 
 #### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * `NavigationMapViewDelegate` and `RouteMapViewControllerDelegate`: `navigationMapView(_:didTap:)` is now `navigationMapView(_:didSelect:)` [#1063](https://github.com/mapbox/mapbox-navigation-ios/pull/1063)
 
 #### User Interface
-*`StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public.
+* `StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public.
 
 ## v0.14.0 (February 22, 2018)
 

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -29,7 +29,7 @@ open class StepsViewController: UIViewController {
     typealias StepSection = [RouteStep]
     var sections = [StepSection]()
     
-    convenience init(routeProgress: RouteProgress) {
+    public convenience init(routeProgress: RouteProgress) {
         self.init()
         self.routeProgress = routeProgress
     }

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -29,6 +29,12 @@ open class StepsViewController: UIViewController {
     typealias StepSection = [RouteStep]
     var sections = [StepSection]()
     
+    /**
+     Initializes StepsViewController with a RouteProgress object.
+     
+     - parameter routeProgress: The user's current route progress.
+     - SeeAlso: [RouteProgress](https://www.mapbox.com/mapbox-navigation-ios/navigation/0.14.1/Classes/RouteProgress.html)
+     */
     public convenience init(routeProgress: RouteProgress) {
         self.init()
         self.routeProgress = routeProgress


### PR DESCRIPTION
This fixes #1146, where a user was unable to use a convenience initializer because of its `internal` protection level.