### PR TITLE
Avoid mirroring lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public. ([#1167](https://github.com/mapbox/mapbox-navigation-ios/pull/1167))
 * Fixed an issue preventing the distance from appearing in the turn banner when the system language was set to Hebrew and the system region was set to Israel or any other region that uses the metric system. ([#1176](https://github.com/mapbox/mapbox-navigation-ios/pull/1176))
 * The `DistanceFormatter.attributedString(for:)` method is now implemented. It returns an attributed string representation of the distance in which the `NSAttributedStringKey.quantity` attribute is applied to the numeric quantity. ([#1176](https://github.com/mapbox/mapbox-navigation-ios/pull/1176))
+* Fixed an issue in which turn lanes were displayed in the wrong order when the system language was set to Hebrew. ([#1175](https://github.com/mapbox/mapbox-navigation-ios/pull/1175))
 
 ## v0.14.0 (February 22, 2018)
 

--- a/MapboxNavigation/LanesView.swift
+++ b/MapboxNavigation/LanesView.swift
@@ -43,6 +43,7 @@ public class LanesView: UIView {
         
         let stackView = UIStackView(arrangedSubviews: [])
         stackView.axis = .horizontal
+        stackView.semanticContentAttribute = .spatial
         stackView.spacing = 4
         stackView.distribution = .equalCentering
         stackView.alignment = .center


### PR DESCRIPTION
Prevent the lanes view from swapping the order of the lanes in right-to-left environments:

<img src="https://user-images.githubusercontent.com/1231218/36862911-16cca010-1d3d-11e8-9317-bdc00b291b49.png" width="300" alt="lanes">

Fixes #1174.

/cc @frederoni