### PR TITLE
More robust distance formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### User Interface
 * `StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public. ([#1167](https://github.com/mapbox/mapbox-navigation-ios/pull/1167))
+* Fixed an issue preventing the distance from appearing in the turn banner when the system language was set to Hebrew and the system region was set to Israel or any other region that uses the metric system. ([#1176](https://github.com/mapbox/mapbox-navigation-ios/pull/1176))
 
 ## v0.14.0 (February 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### User Interface
 * `StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public. ([#1167](https://github.com/mapbox/mapbox-navigation-ios/pull/1167))
 * Fixed an issue preventing the distance from appearing in the turn banner when the system language was set to Hebrew and the system region was set to Israel or any other region that uses the metric system. ([#1176](https://github.com/mapbox/mapbox-navigation-ios/pull/1176))
+* The `DistanceFormatter.attributedString(for:)` method is now implemented. It returns an attributed string representation of the distance in which the `NSAttributedStringKey.quantity` attribute is applied to the numeric quantity. ([#1176](https://github.com/mapbox/mapbox-navigation-ios/pull/1176))
 
 ## v0.14.0 (February 22, 2018)
 

--- a/MapboxCoreNavigationTests/DistanceFormatterTests.swift
+++ b/MapboxCoreNavigationTests/DistanceFormatterTests.swift
@@ -31,9 +31,15 @@ class DistanceFormatterTests: XCTestCase {
         }
         
         var effectiveQuantityRange = NSRange(location: NSNotFound, length: 0)
-        let attrs = checkedAttributedString.attributes(at: checkedQuantityRange.lowerBound.encodedOffset, effectiveRange: &effectiveQuantityRange)
-        XCTAssertEqual(attrs[NSAttributedStringKey.quantity] as? NSNumber, distance as NSNumber, "'\(quantity)' should have quantity \(distance)")
+        let quantityAttrs = checkedAttributedString.attributes(at: checkedQuantityRange.lowerBound.encodedOffset, effectiveRange: &effectiveQuantityRange)
+        XCTAssertEqual(quantityAttrs[NSAttributedStringKey.quantity] as? NSNumber, distance as NSNumber, "'\(quantity)' should have quantity \(distance)")
         XCTAssertEqual(effectiveQuantityRange.length, quantity.count)
+        
+        guard checkedQuantityRange.upperBound.encodedOffset < checkedAttributedString.length else {
+            return
+        }
+        let unitAttrs = checkedAttributedString.attributes(at: checkedQuantityRange.upperBound.encodedOffset, effectiveRange: nil)
+        XCTAssertNil(unitAttrs[NSAttributedStringKey.quantity], "Unit should not be emphasized like a quantity")
     }
     
     func testDistanceFormatters_US() {

--- a/MapboxCoreNavigationTests/DistanceFormatterTests.swift
+++ b/MapboxCoreNavigationTests/DistanceFormatterTests.swift
@@ -14,74 +14,138 @@ class DistanceFormatterTests: XCTestCase {
         super.setUp()
     }
     
-    func assertDistance(_ distance: CLLocationDistance, displayed: String) {
+    func assertDistance(_ distance: CLLocationDistance, displayed: String, quantity: String) {
         let displayedString = distanceFormatter.string(from: distance)
         XCTAssertEqual(displayedString, displayed, "Displayed: '\(displayedString)' should be equal to \(displayed)")
+        
+        let attributedString = distanceFormatter.attributedString(for: distance as NSNumber)
+        XCTAssertEqual(attributedString?.string, displayed, "Displayed: '\(attributedString?.string ?? "")' should be equal to \(displayed)")
+        guard let checkedAttributedString = attributedString else {
+            return
+        }
+        
+        let quantityRange = checkedAttributedString.string.range(of: quantity)
+        XCTAssertNotNil(quantityRange, "Displayed: '\(checkedAttributedString.string)' should contain \(quantity)")
+        guard let checkedQuantityRange = quantityRange else {
+            return
+        }
+        
+        var effectiveQuantityRange = NSRange(location: NSNotFound, length: 0)
+        let attrs = checkedAttributedString.attributes(at: checkedQuantityRange.lowerBound.encodedOffset, effectiveRange: &effectiveQuantityRange)
+        XCTAssertEqual(attrs[NSAttributedStringKey.quantity] as? NSNumber, distance as NSNumber, "'\(quantity)' should have quantity \(distance)")
+        XCTAssertEqual(effectiveQuantityRange.length, quantity.count)
     }
     
     func testDistanceFormatters_US() {
         NavigationSettings.shared.distanceUnit = .mile
         distanceFormatter.numberFormatter.locale = Locale(identifier: "en-US")
         
-        assertDistance(0,               displayed: "0 ft")
-        assertDistance(oneFeet*50,      displayed: "50 ft")
-        assertDistance(oneFeet*100,     displayed: "100 ft")
-        assertDistance(oneFeet*249,     displayed: "250 ft")
-        assertDistance(oneFeet*305,     displayed: "300 ft")
-        assertDistance(oneMile*0.1,     displayed: "0.1 mi")
-        assertDistance(oneMile*0.24,    displayed: "0.2 mi")
-        assertDistance(oneMile*0.251,   displayed: "0.3 mi")
-        assertDistance(oneMile*0.75,    displayed: "0.8 mi")
-        assertDistance(oneMile,         displayed: "1 mi")
-        assertDistance(oneMile*2.5,     displayed: "2.5 mi")
-        assertDistance(oneMile*2.9,     displayed: "2.9 mi")
-        assertDistance(oneMile*3,       displayed: "3 mi")
-        assertDistance(oneMile*3.5,     displayed: "4 mi")
-        assertDistance(oneMile*5.4,     displayed: "5 mi")
+        assertDistance(0,               displayed: "0 ft",      quantity: "0")
+        assertDistance(oneFeet*50,      displayed: "50 ft",     quantity: "50")
+        assertDistance(oneFeet*100,     displayed: "100 ft",    quantity: "100")
+        assertDistance(oneFeet*249,     displayed: "250 ft",    quantity: "250")
+        assertDistance(oneFeet*305,     displayed: "300 ft",    quantity: "300")
+        assertDistance(oneMile*0.1,     displayed: "0.1 mi",    quantity: "0.1")
+        assertDistance(oneMile*0.24,    displayed: "0.2 mi",    quantity: "0.2")
+        assertDistance(oneMile*0.251,   displayed: "0.3 mi",    quantity: "0.3")
+        assertDistance(oneMile*0.75,    displayed: "0.8 mi",    quantity: "0.8")
+        assertDistance(oneMile,         displayed: "1 mi",      quantity: "1")
+        assertDistance(oneMile*2.5,     displayed: "2.5 mi",    quantity: "2.5")
+        assertDistance(oneMile*2.9,     displayed: "2.9 mi",    quantity: "2.9")
+        assertDistance(oneMile*3,       displayed: "3 mi",      quantity: "3")
+        assertDistance(oneMile*3.5,     displayed: "4 mi",      quantity: "4")
+        assertDistance(oneMile*5.4,     displayed: "5 mi",      quantity: "5")
     }
     
     func testDistanceFormatters_DE() {
         NavigationSettings.shared.distanceUnit = .kilometer
         distanceFormatter.numberFormatter.locale = Locale(identifier: "de-DE")
         
-        assertDistance(0,       displayed: "0 m")
-        assertDistance(4,       displayed: "5 m")
-        assertDistance(11,      displayed: "10 m")
-        assertDistance(15,      displayed: "15 m")
-        assertDistance(24,      displayed: "25 m")
-        assertDistance(89,      displayed: "100 m")
-        assertDistance(226,     displayed: "250 m")
-        assertDistance(275,     displayed: "300 m")
-        assertDistance(500,     displayed: "500 m")
-        assertDistance(949,     displayed: "950 m")
-        assertDistance(951,     displayed: "950 m")
-        assertDistance(1000,    displayed: "1 km")
-        assertDistance(1001,    displayed: "1 km")
-        assertDistance(2_500,   displayed: "2.5 km")
-        assertDistance(2_900,   displayed: "2.9 km")
-        assertDistance(3_000,   displayed: "3 km")
-        assertDistance(3_500,   displayed: "4 km")
+        assertDistance(0,       displayed: "0 m",       quantity: "0")
+        assertDistance(4,       displayed: "5 m",       quantity: "5")
+        assertDistance(11,      displayed: "10 m",      quantity: "10")
+        assertDistance(15,      displayed: "15 m",      quantity: "15")
+        assertDistance(24,      displayed: "25 m",      quantity: "25")
+        assertDistance(89,      displayed: "100 m",     quantity: "100")
+        assertDistance(226,     displayed: "250 m",     quantity: "250")
+        assertDistance(275,     displayed: "300 m",     quantity: "300")
+        assertDistance(500,     displayed: "500 m",     quantity: "500")
+        assertDistance(949,     displayed: "950 m",     quantity: "950")
+        assertDistance(951,     displayed: "950 m",     quantity: "950")
+        assertDistance(1000,    displayed: "1 km",      quantity: "1")
+        assertDistance(1001,    displayed: "1 km",      quantity: "1")
+        assertDistance(2_500,   displayed: "2.5 km",    quantity: "2.5")
+        assertDistance(2_900,   displayed: "2.9 km",    quantity: "2.9")
+        assertDistance(3_000,   displayed: "3 km",      quantity: "3")
+        assertDistance(3_500,   displayed: "4 km",      quantity: "4")
     }
     
     func testDistanceFormatters_GB() {
         NavigationSettings.shared.distanceUnit = .mile
         distanceFormatter.numberFormatter.locale = Locale(identifier: "en-GB")
         
-        assertDistance(0,               displayed: "0 yd")
-        assertDistance(oneYard*4,       displayed: "0 yd")
-        assertDistance(oneYard*5,       displayed: "10 yd")
-        assertDistance(oneYard*12,      displayed: "10 yd")
-        assertDistance(oneYard*24,      displayed: "25 yd")
-        assertDistance(oneYard*25,      displayed: "25 yd")
-        assertDistance(oneYard*38,      displayed: "50 yd")
-        assertDistance(oneYard*126,     displayed: "150 yd")
-        assertDistance(oneYard*150,     displayed: "150 yd")
-        assertDistance(oneYard*174,     displayed: "150 yd")
-        assertDistance(oneYard*175,     displayed: "200 yd")
-        assertDistance(oneMile/2,       displayed: "0.5 mi")
-        assertDistance(oneMile,         displayed: "1 mi")
-        assertDistance(oneMile*2.5,     displayed: "2.5 mi")
-        assertDistance(oneMile*3,       displayed: "3 mi")
-        assertDistance(oneMile*3.5,     displayed: "4 mi")
+        assertDistance(0,               displayed: "0 yd",      quantity: "0")
+        assertDistance(oneYard*4,       displayed: "0 yd",      quantity: "0")
+        assertDistance(oneYard*5,       displayed: "10 yd",     quantity: "10")
+        assertDistance(oneYard*12,      displayed: "10 yd",     quantity: "10")
+        assertDistance(oneYard*24,      displayed: "25 yd",     quantity: "25")
+        assertDistance(oneYard*25,      displayed: "25 yd",     quantity: "25")
+        assertDistance(oneYard*38,      displayed: "50 yd",     quantity: "50")
+        assertDistance(oneYard*126,     displayed: "150 yd",    quantity: "150")
+        assertDistance(oneYard*150,     displayed: "150 yd",    quantity: "150")
+        assertDistance(oneYard*174,     displayed: "150 yd",    quantity: "150")
+        assertDistance(oneYard*175,     displayed: "200 yd",    quantity: "200")
+        assertDistance(oneMile/2,       displayed: "0.5 mi",    quantity: "0.5")
+        assertDistance(oneMile,         displayed: "1 mi",      quantity: "1")
+        assertDistance(oneMile*2.5,     displayed: "2.5 mi",    quantity: "2.5")
+        assertDistance(oneMile*3,       displayed: "3 mi",      quantity: "3")
+        assertDistance(oneMile*3.5,     displayed: "4 mi",      quantity: "4")
+    }
+    
+    func testDistanceFormatters_he_IL() {
+        NavigationSettings.shared.distanceUnit = .kilometer
+        distanceFormatter.numberFormatter.locale = Locale(identifier: "he-IL")
+        
+        assertDistance(0,       displayed: "0 מ׳",       quantity: "0")
+        assertDistance(4,       displayed: "5 מ׳",       quantity: "5")
+        assertDistance(11,      displayed: "10 מ׳",      quantity: "10")
+        assertDistance(15,      displayed: "15 מ׳",      quantity: "15")
+        assertDistance(24,      displayed: "25 מ׳",      quantity: "25")
+        assertDistance(89,      displayed: "100 מ׳",     quantity: "100")
+        assertDistance(226,     displayed: "250 מ׳",     quantity: "250")
+        assertDistance(275,     displayed: "300 מ׳",     quantity: "300")
+        assertDistance(500,     displayed: "500 מ׳",     quantity: "500")
+        assertDistance(949,     displayed: "950 מ׳",     quantity: "950")
+        assertDistance(951,     displayed: "950 מ׳",     quantity: "950")
+        assertDistance(1000,    displayed: "1 ק״מ",      quantity: "1")
+        assertDistance(1001,    displayed: "1 ק״מ",      quantity: "1")
+        assertDistance(2_500,   displayed: "2.5 ק״מ",    quantity: "2.5")
+        assertDistance(2_900,   displayed: "2.9 ק״מ",    quantity: "2.9")
+        assertDistance(3_000,   displayed: "3 ק״מ",      quantity: "3")
+        assertDistance(3_500,   displayed: "4 ק״מ",      quantity: "4")
+    }
+    
+    func testDistanceFormatters_hi_IN() {
+        NavigationSettings.shared.distanceUnit = .kilometer
+        distanceFormatter.numberFormatter.locale = Locale(identifier: "hi-IN")
+    
+        assertDistance(0,       displayed: "० मी॰",       quantity: "०")
+        assertDistance(4,       displayed: "५ मी॰",       quantity: "५")
+        assertDistance(11,      displayed: "१० मी॰",      quantity: "१०")
+        assertDistance(15,      displayed: "१५ मी॰",      quantity: "१५")
+        assertDistance(24,      displayed: "२५ मी॰",      quantity: "२५")
+        assertDistance(89,      displayed: "१०० मी॰",     quantity: "१००")
+        assertDistance(226,     displayed: "२५० मी॰",     quantity: "२५०")
+        assertDistance(275,     displayed: "३०० मी॰",     quantity: "३००")
+        assertDistance(500,     displayed: "५०० मी॰",     quantity: "५००")
+        assertDistance(949,     displayed: "९५० मी॰",     quantity: "९५०")
+        assertDistance(951,     displayed: "९५० मी॰",     quantity: "९५०")
+        assertDistance(1000,    displayed: "१ कि॰मी॰",      quantity: "१")
+        assertDistance(1001,    displayed: "१ कि॰मी॰",      quantity: "१")
+        assertDistance(2_500,   displayed: "२.५ कि॰मी॰",    quantity: "२.५")
+        assertDistance(2_900,   displayed: "२.९ कि॰मी॰",    quantity: "२.९")
+        assertDistance(3_000,   displayed: "३ कि॰मी॰",      quantity: "३")
+        assertDistance(3_500,   displayed: "४ कि॰मी॰",      quantity: "४")
+        assertDistance(384_400_000, displayed: "३,८४,४०० कि॰मी॰", quantity: "३,८४,४००")
     }
 }

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -30,27 +30,10 @@ open class BaseInstructionsBannerView: UIControl {
     
     var distance: CLLocationDistance? {
         didSet {
-            distanceLabel.unitRange = nil
-            distanceLabel.valueRange = nil
-            distanceLabel.distanceString = nil
+            distanceLabel.attributedDistanceString = nil
             
             if let distance = distance {
-                let distanceString = distanceFormatter.string(from: distance)
-                var distanceUnit = distanceFormatter.unitString(fromValue: distance, unit: distanceFormatter.unit)
-                var unitRange = distanceString.range(of: distanceUnit)
-                // In Hebrew, “meters” looks different in the distance string than it does on its own. <rdar://problem/38028709>
-                // Fall back on splitting the string on whitespace.
-                if unitRange == nil, let spaceRange = distanceString.rangeOfCharacter(from: .whitespaces) {
-                    unitRange = spaceRange.upperBound..<distanceString.endIndex
-                    distanceUnit = String(distanceString[unitRange!])
-                }
-                guard unitRange != nil else { return }
-                let distanceValue = distanceString.replacingOccurrences(of: distanceUnit, with: "")
-                guard let valueRange = distanceString.range(of: distanceValue) else { return }
-
-                distanceLabel.unitRange = unitRange
-                distanceLabel.valueRange = valueRange
-                distanceLabel.distanceString = distanceString
+                distanceLabel.attributedDistanceString = distanceFormatter.attributedString(for: distance)
             } else {
                 distanceLabel.text = nil
             }

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -36,8 +36,15 @@ open class BaseInstructionsBannerView: UIControl {
             
             if let distance = distance {
                 let distanceString = distanceFormatter.string(from: distance)
-                let distanceUnit = distanceFormatter.unitString(fromValue: distance, unit: distanceFormatter.unit)
-                guard let unitRange = distanceString.range(of: distanceUnit) else { return }
+                var distanceUnit = distanceFormatter.unitString(fromValue: distance, unit: distanceFormatter.unit)
+                var unitRange = distanceString.range(of: distanceUnit)
+                // In Hebrew, “meters” looks different in the distance string than it does on its own. <rdar://problem/38028709>
+                // Fall back on splitting the string on whitespace.
+                if unitRange == nil, let spaceRange = distanceString.rangeOfCharacter(from: .whitespaces) {
+                    unitRange = spaceRange.upperBound..<distanceString.endIndex
+                    distanceUnit = String(distanceString[unitRange!])
+                }
+                guard unitRange != nil else { return }
                 let distanceValue = distanceString.replacingOccurrences(of: distanceUnit, with: "")
                 guard let valueRange = distanceString.range(of: distanceValue) else { return }
 

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -253,45 +253,46 @@ open class DistanceLabel: StylableLabel {
         didSet { update() }
     }
     
-    var valueRange: Range<String.Index>? {
-        didSet {
-            update()
-        }
-    }
-    
-    var unitRange: Range<String.Index>? {
-        didSet {
-            update()
-        }
-    }
-    
-    var distanceString: String? {
+    /**
+     An attributed string indicating the distance along with a unit.
+     
+     - precondition: `NSAttributedStringKey.quantity` should be applied to the
+        numeric quantity.
+     */
+    var attributedDistanceString: NSAttributedString? {
         didSet {
             update()
         }
     }
     
     fileprivate func update() {
-        guard let valueRange = valueRange, let unitRange = unitRange, let distanceString = distanceString else {
+        guard let attributedDistanceString = attributedDistanceString else {
             return
         }
-
-        let valueAttributes: [NSAttributedStringKey: Any] = [.foregroundColor: valueTextColor, .font: valueFont]
-        let unitAttributes: [NSAttributedStringKey: Any] = [.foregroundColor: unitTextColor, .font: unitFont]
-
-        let valueSubstring = distanceString[valueRange].trimmingCharacters(in: .whitespaces)
-        let unitSubstring = distanceString[unitRange].trimmingCharacters(in: .whitespaces)
-        let valueAttributedString = NSAttributedString(string: valueSubstring, attributes: valueAttributes)
-        let unitAttributedString = NSAttributedString(string: unitSubstring, attributes: unitAttributes)
-
-        let startsWithUnit = unitRange.lowerBound == distanceString.wholeRange.lowerBound
-        let attributedString = NSMutableAttributedString()
-
-        attributedString.append(startsWithUnit ? unitAttributedString : valueAttributedString)
-        attributedString.append(NSAttributedString(string: "\u{200A}", attributes: unitAttributes))
-        attributedString.append(startsWithUnit ? valueAttributedString : unitAttributedString)
-
-        attributedText = attributedString
+        
+        // Create a copy of the attributed string that emphasizes the quantity.
+        let emphasizedDistanceString = NSMutableAttributedString(attributedString: attributedDistanceString)
+        let wholeRange = NSRange(location: 0, length: emphasizedDistanceString.length)
+        emphasizedDistanceString.enumerateAttribute(.quantity, in: wholeRange, options: .longestEffectiveRangeNotRequired) { (value, range, stop) in
+            let foregroundColor: UIColor
+            let font: UIFont
+            if let _ = emphasizedDistanceString.attribute(NSAttributedStringKey.quantity, at: range.location, effectiveRange: nil) {
+                foregroundColor = valueTextColor
+                font = valueFont
+            } else {
+                foregroundColor = unitTextColor
+                font = unitFont
+            }
+            emphasizedDistanceString.addAttributes([.foregroundColor: foregroundColor, .font: font], range: range)
+        }
+        
+        // Replace spaces with hair spaces to economize on horizontal screen
+        // real estate. Formatting the distance with a short style would remove
+        // spaces, but in English it would also denote feet with a prime
+        // mark (′), which is typically used for heights, not distances.
+        emphasizedDistanceString.mutableString.replaceOccurrences(of: " ", with: "\u{200A}", options: [], range: wholeRange)
+        
+        attributedText = emphasizedDistanceString
     }
 }
 

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -273,17 +273,24 @@ open class DistanceLabel: StylableLabel {
         // Create a copy of the attributed string that emphasizes the quantity.
         let emphasizedDistanceString = NSMutableAttributedString(attributedString: attributedDistanceString)
         let wholeRange = NSRange(location: 0, length: emphasizedDistanceString.length)
+        var hasQuantity = false
         emphasizedDistanceString.enumerateAttribute(.quantity, in: wholeRange, options: .longestEffectiveRangeNotRequired) { (value, range, stop) in
             let foregroundColor: UIColor
             let font: UIFont
             if let _ = emphasizedDistanceString.attribute(NSAttributedStringKey.quantity, at: range.location, effectiveRange: nil) {
                 foregroundColor = valueTextColor
                 font = valueFont
+                hasQuantity = true
             } else {
                 foregroundColor = unitTextColor
                 font = unitFont
             }
             emphasizedDistanceString.addAttributes([.foregroundColor: foregroundColor, .font: font], range: range)
+        }
+        
+        // As a failsafe, if no quantity was found, emphasize the entire string.
+        if !hasQuantity {
+            emphasizedDistanceString.addAttributes([.foregroundColor: valueTextColor, .font: valueFont], range: wholeRange)
         }
         
         // Replace spaces with hair spaces to economize on horizontal screen


### PR DESCRIPTION
Implemented `DistanceFormatter.attributedString(for:)`, which applies a `quantity` attribute to the numeric quantity part of the returned attributed string. This method relies on finding the formatted number within the distance string, as opposed to finding the unit, which turned out to be unreliable in some locales.

Simplified `BaseInstructionsBannerView.distance`’s setter to pass this attributed string directly to DistanceLabel instead of attempting to split the distance string on its quantity and unit. DistanceLabel now emphasizes the quantity relative to the unit based on the presence of the quantity attribute.

All this is to work around [a Foundation bug](http://openradar.appspot.com/radar?id=5061404864282624) in which `LengthFormatter.unitString(fromValue:unit:)` is unreliable in metricated Hebrew locales, such as Hebrew (Israel).

<img src="https://user-images.githubusercontent.com/1231218/36863372-5ca9d2fa-1d3e-11e8-94d9-2778ca09baba.png" width="300" alt="hebrew"> <img src="https://user-images.githubusercontent.com/1231218/36863373-5cc2af8c-1d3e-11e8-8381-1bddf7eed859.png" width="300" alt="english">
_Left: The Hebrew (Israel) locale. Right: The English (United States) locale._

Original description:

~~Worked around [a Foundation bug](http://openradar.appspot.com/radar?id=5061404864282624) by splitting the distance string on whitespace if `LengthFormatter.unitString(fromValue:unit:)` doesn’t return the expected value. Now the distance to the upcoming maneuver appears in the turn banner, as expected, when the system language is set to Hebrew and the system region is set to a metricated region, such as Israel.~~

Fixes #1173.

/cc @JThramer @frederoni