### PR TITLE
Re-enable kCLLocationAccuracyBestForNavigation while phone is plugged in

### DIFF
--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -17,6 +17,8 @@ open class NavigationLocationManager: CLLocationManager {
     
     var lastKnownLocation: CLLocation?
     
+    var batteryStateObservation: NSKeyValueObservation?
+    
     /**
      Indicates whether the device is plugged in or not.
      */
@@ -43,11 +45,15 @@ open class NavigationLocationManager: CLLocationManager {
         
         #if os(iOS)
             guard automaticallyUpdatesDesiredAccuracy else { return }
-            let _ = UIDevice.current.observe(\.batteryState) { [weak self] (device, changed) in
+            batteryStateObservation = UIDevice.current.observe(\.batteryState) { [weak self] (device, changed) in
                 guard let weakSelf = self else { return }
                 weakSelf.isPluggedIn = device.batteryState == .charging || device.batteryState == .full
                 weakSelf.desiredAccuracy = weakSelf.isPluggedIn ? kCLLocationAccuracyBestForNavigation : kCLLocationAccuracyBest
             }
         #endif
+    }
+    
+    deinit {
+        batteryStateObservation = nil
     }
 }

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -31,23 +31,12 @@ open class NavigationLocationManager: CLLocationManager {
     override public init() {
         super.init()
         
-        let always = Bundle.main.locationAlwaysUsageDescription
-        let both = Bundle.main.locationAlwaysAndWhenInUseUsageDescription
-        
-        if always != nil || both != nil {
-            requestAlwaysAuthorization()
-        } else {
-            requestWhenInUseAuthorization()
-        }
+        requestWhenInUseAuthorization()
         
         if #available(iOS 9.0, *) {
             if Bundle.main.backgroundModes.contains("location") {
                 allowsBackgroundLocationUpdates = true
             }
-        }
-        
-        if #available(iOS 11.0, *) {
-            showsBackgroundLocationIndicator = true
         }
         
         desiredAccuracy = kCLLocationAccuracyBest

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -17,13 +17,6 @@ open class NavigationLocationManager: CLLocationManager {
     
     var lastKnownLocation: CLLocation?
     
-    var batteryStateObservation: NSKeyValueObservation?
-    
-    /**
-     Indicates whether the device is plugged in or not.
-     */
-    public private(set) var isPluggedIn: Bool = false
-    
     /**
      Indicates whether the location manager’s desired accuracy should update
      when the battery state changes.
@@ -43,17 +36,7 @@ open class NavigationLocationManager: CLLocationManager {
         
         desiredAccuracy = kCLLocationAccuracyBest
         
-        #if os(iOS)
-            guard automaticallyUpdatesDesiredAccuracy else { return }
-            batteryStateObservation = UIDevice.current.observe(\.batteryState) { [weak self] (device, changed) in
-                guard let weakSelf = self else { return }
-                weakSelf.isPluggedIn = device.batteryState == .charging || device.batteryState == .full
-                weakSelf.desiredAccuracy = weakSelf.isPluggedIn ? kCLLocationAccuracyBestForNavigation : kCLLocationAccuracyBest
-            }
-        #endif
-    }
-    
-    deinit {
-        batteryStateObservation = nil
+        guard automaticallyUpdatesDesiredAccuracy else { return }
+        desiredAccuracy = UIDevice.current.isPluggedIn ? kCLLocationAccuracyBestForNavigation : kCLLocationAccuracyBest
     }
 }

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -17,6 +17,17 @@ open class NavigationLocationManager: CLLocationManager {
     
     var lastKnownLocation: CLLocation?
     
+    /**
+     Indicates whether the device is plugged in or not.
+     */
+    public private(set) var isPluggedIn: Bool = false
+    
+    /**
+     Indicates whether the location manager’s desired accuracy should update
+     when the battery state changes.
+     */
+    public var automaticallyUpdatesDesiredAccuracy = true
+    
     override public init() {
         super.init()
         
@@ -35,6 +46,30 @@ open class NavigationLocationManager: CLLocationManager {
             }
         }
         
-        desiredAccuracy = kCLLocationAccuracyBestForNavigation
+        if #available(iOS 11.0, *) {
+            showsBackgroundLocationIndicator = true
+        }
+        
+        desiredAccuracy = kCLLocationAccuracyBest
+        
+        #if os(iOS)
+            UIDevice.current.addObserver(self, forKeyPath: "batteryState", options: [.initial, .new], context: nil)
+        #endif
+    }
+    
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == "batteryState" {
+            let batteryState = UIDevice.current.batteryState
+            isPluggedIn = batteryState == .charging || batteryState == .full
+            
+            guard automaticallyUpdatesDesiredAccuracy else { return }
+            desiredAccuracy = isPluggedIn ? kCLLocationAccuracyBestForNavigation : kCLLocationAccuracyBest
+        }
+    }
+    
+    deinit {
+        #if os(iOS)
+            UIDevice.current.removeObserver(self, forKeyPath: "batteryState")
+        #endif
     }
 }

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -42,23 +42,12 @@ open class NavigationLocationManager: CLLocationManager {
         desiredAccuracy = kCLLocationAccuracyBest
         
         #if os(iOS)
-            UIDevice.current.addObserver(self, forKeyPath: "batteryState", options: [.initial, .new], context: nil)
-        #endif
-    }
-    
-    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        if keyPath == "batteryState" {
-            let batteryState = UIDevice.current.batteryState
-            isPluggedIn = batteryState == .charging || batteryState == .full
-            
             guard automaticallyUpdatesDesiredAccuracy else { return }
-            desiredAccuracy = isPluggedIn ? kCLLocationAccuracyBestForNavigation : kCLLocationAccuracyBest
-        }
-    }
-    
-    deinit {
-        #if os(iOS)
-            UIDevice.current.removeObserver(self, forKeyPath: "batteryState")
+            let _ = UIDevice.current.observe(\.batteryState) { [weak self] (device, changed) in
+                guard let weakSelf = self else { return }
+                weakSelf.isPluggedIn = device.batteryState == .charging || device.batteryState == .full
+                weakSelf.desiredAccuracy = weakSelf.isPluggedIn ? kCLLocationAccuracyBestForNavigation : kCLLocationAccuracyBest
+            }
         #endif
     }
 }

--- a/MapboxCoreNavigation/UIDevice.swift
+++ b/MapboxCoreNavigation/UIDevice.swift
@@ -1,0 +1,24 @@
+import Foundation
+import CoreLocation
+#if os(iOS)
+    import UIKit
+#endif
+
+#if os(iOS)
+    import UIKit
+#endif
+
+
+extension UIDevice {
+    
+    /**
+     Returns a `Bool` whether the device is plugged in. Returns false if not an iOS device.
+     */
+    @objc public var isPluggedIn: Bool {
+        #if os(iOS)
+            return [.charging, .full].contains(UIDevice.current.batteryState)
+        #else
+            return false
+        #endif
+    }
+}

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		C52D09CE1DEF5E5100BE3C5C /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = C52D09CD1DEF5E5100BE3C5C /* route.json */; };
 		C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52D09D21DEF636C00BE3C5C /* Fixture.swift */; };
 		C53208AB1E81FFB900910266 /* NavigationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53208AA1E81FFB900910266 /* NavigationMapView.swift */; };
+		C5381F02204E03B600A5493E /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5381F01204E03B600A5493E /* UIDevice.swift */; };
+		C5381F03204E052A00A5493E /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5381F01204E03B600A5493E /* UIDevice.swift */; };
 		C5387A9D1F8FDB13000D2E93 /* routeWithInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = C5387A9C1F8FDB13000D2E93 /* routeWithInstructions.json */; };
 		C53C196D1F38EA25008DB406 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = C53C196F1F38EA25008DB406 /* Localizable.strings */; };
 		C549F8321F17F2C5001A0A2D /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C549F8311F17F2C5001A0A2D /* MapboxMobileEvents.framework */; };
@@ -474,6 +476,7 @@
 		C52D09CD1DEF5E5100BE3C5C /* route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = route.json; sourceTree = "<group>"; };
 		C52D09D21DEF636C00BE3C5C /* Fixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
 		C53208AA1E81FFB900910266 /* NavigationMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NavigationMapView.swift; sourceTree = "<group>"; };
+		C5381F01204E03B600A5493E /* UIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDevice.swift; sourceTree = "<group>"; };
 		C5387A9C1F8FDB13000D2E93 /* routeWithInstructions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithInstructions.json; sourceTree = "<group>"; };
 		C53C19701F38EACD008DB406 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C53C19711F38EADB008DB406 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -972,6 +975,7 @@
 				35A5413A1EFC052700E49846 /* RouteOptions.swift */,
 				C57491DE1FACC42F006F97BC /* CGPoint.swift */,
 				C582FD5E203626E900A9086E /* CLLocationDirection.swift */,
+				C5381F01204E03B600A5493E /* UIDevice.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1578,6 +1582,7 @@
 				353AA5601FCEF583009F0384 /* StyleManager.swift in Sources */,
 				35F520C01FB482A200FC9C37 /* NextBannerView.swift in Sources */,
 				C5A6B2DD1F4CE8E8004260EA /* StyleType.swift in Sources */,
+				C5381F03204E052A00A5493E /* UIDevice.swift in Sources */,
 				351BEC021E5BCC63006FE110 /* UIView.swift in Sources */,
 				351BEBF21E5BCC63006FE110 /* Style.swift in Sources */,
 				C5D1C9941FB236900067C619 /* ErrorCode.swift in Sources */,
@@ -1646,6 +1651,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C5381F02204E03B600A5493E /* UIDevice.swift in Sources */,
 				C561735B1F182113005954F6 /* RouteStep.swift in Sources */,
 				C582FD5F203626E900A9086E /* CLLocationDirection.swift in Sources */,
 				35BF8CA21F28EB60003F6125 /* Array.swift in Sources */,

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -234,6 +234,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     
     deinit {
         suspendNotifications()
+        batteryStateObservation = nil
     }
     
     //MARK: - Overrides

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -85,8 +85,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     
     var userLocationForCourseTracking: CLLocation?
     var animatesUserLocation: Bool = false
-    var isPluggedIn: Bool = false
-    var batteryStateObservation: NSKeyValueObservation?
     var altitude: CLLocationDistance = defaultAltitude
     var routes: [Route]?
     
@@ -225,16 +223,11 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         makeGestureRecognizersRespectCourseTracking()
         makeGestureRecognizersUpdateCourseView()
         
-        batteryStateObservation = UIDevice.current.observe(\.batteryState) { [weak self] (device, changed) in
-            self?.isPluggedIn = device.batteryState == .charging || device.batteryState == .full
-        }
-        
         resumeNotifications()
     }
     
     deinit {
         suspendNotifications()
-        batteryStateObservation = nil
     }
     
     //MARK: - Overrides
@@ -300,8 +293,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let expectedTravelTime = stepProgress.step.expectedTravelTime
         let durationUntilNextManeuver = stepProgress.durationRemaining
         let durationSincePreviousManeuver = expectedTravelTime - durationUntilNextManeuver
-        
-        guard !isPluggedIn else {
+        guard !UIDevice.current.isPluggedIn else {
             preferredFramesPerSecond = FrameIntervalOptions.pluggedInFramesPerSecond
             return
         }


### PR DESCRIPTION
Through some first hand tests, I have come to the conclusion that `kCLLocationAccuracyBestForNavigation` is pretty dangerous if the phone is not held very still in, especially in environments where signal is bad. The result is many false positives. IMO, it's almost dangerous enough to warrant only using `kCLLocationAccuracyBest`, baby steps though.

This brings back logic (https://github.com/mapbox/mapbox-navigation-ios/pull/670) that checks whether the phone is plugged in before using `kCLLocationAccuracyBestForNavigation`. 

/cc @mapbox/navigation-ios 


