### PR TITLE
Disable current road name if access token is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## v0.15.0 (tbd)
 
-#### Breaking Changes
+#### Breaking changes
 * `NavigationMapViewDelegate` and `RouteMapViewControllerDelegate`: `navigationMapView(_:didTap:)` is now `navigationMapView(_:didSelect:)` [#1063](https://github.com/mapbox/mapbox-navigation-ios/pull/1063)
 
-#### User Interface
+#### User interface
 * `StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public. ([#1167](https://github.com/mapbox/mapbox-navigation-ios/pull/1167))
+
+#### Other changes
+* Fixed a crash while navigating that affected applications that do not use Mapbox-hosted styles or vector tiles. [#1183](https://github.com/mapbox/mapbox-navigation-ios/pull/1183)
 
 ## v0.14.0 (February 22, 2018)
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -662,6 +662,13 @@ extension RouteMapViewController: NavigationViewDelegate {
                 return
         }
         
+        // Avoid aggressively opting the developer into Mapbox services if they
+        // haven’t provided an access token.
+        guard let _ = MGLAccountManager.accessToken() else {
+            navigationView.wayNameView.isHidden = true
+            return
+        }
+        
         let closestCoordinate = location.coordinate
         let roadLabelLayerIdentifier = "roadLabelLayer"
         var streetsSources = style.sources.flatMap {


### PR DESCRIPTION
Fixed a crash that occurred because the application didn’t provide an access token, yet the current road name label depended on force-adding the Mapbox Streets source to the style. Now if no access token is available, the current road name label is hidden.

This is a speculative fix for #735.

/cc @bsudekum