### PR TITLE
Improve RouteController location mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * The `DistanceFormatter.attributedString(for:)` method is now implemented. It returns an attributed string representation of the distance in which the `NSAttributedStringKey.quantity` attribute is applied to the numeric quantity. ([#1176](https://github.com/mapbox/mapbox-navigation-ios/pull/1176))
 * Fixed an issue in which turn lanes were displayed in the wrong order when the system language was set to Hebrew. ([#1175](https://github.com/mapbox/mapbox-navigation-ios/pull/1175))
 
+#### MapboxCoreNavigation
+* `RouteController`'s `MBRouteControllerProgressDidChange` notification now exposes the raw location in it's update, accessible by `MBRouteControllerRawLocationKey`
+
 #### Other changes
 * Fixed a crash while navigating that affected applications that do not use Mapbox-hosted styles or vector tiles. [#1183](https://github.com/mapbox/mapbox-navigation-ios/pull/1183)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Breaking changes
 * `NavigationMapViewDelegate` and `RouteMapViewControllerDelegate`: `navigationMapView(_:didTap:)` is now `navigationMapView(_:didSelect:)` [#1063](https://github.com/mapbox/mapbox-navigation-ios/pull/1063)
+* The Constants that concern Route-Snapping logic have been re-named. The new names are: `RouteSnappingMinimumSpeed`, `RouteSnappingMaxManipulatedCourseAngle`, and `RouteSnappingMinimumHorizontalAccuracy`.
 
 #### User interface
 * `StepsViewController` 's convienence initalizer (`StepsViewController.init(routeProgress:)`) is now public. ([#1167](https://github.com/mapbox/mapbox-navigation-ios/pull/1167))
@@ -12,6 +13,7 @@
 * Fixed an issue in which turn lanes were displayed in the wrong order when the system language was set to Hebrew. ([#1175](https://github.com/mapbox/mapbox-navigation-ios/pull/1175))
 
 #### Core Navigation
+* `RoteController` now has a new property, `snappedLocation`. This property represents the raw location, snapped to the current route, if applicable. If not applicable, the value is `nil.`
 * `RouteController`'s `MBRouteControllerProgressDidChange` notification now exposes the raw location in it's update, accessible by `MBRouteControllerRawLocationKey`
 
 #### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * The `DistanceFormatter.attributedString(for:)` method is now implemented. It returns an attributed string representation of the distance in which the `NSAttributedStringKey.quantity` attribute is applied to the numeric quantity. ([#1176](https://github.com/mapbox/mapbox-navigation-ios/pull/1176))
 * Fixed an issue in which turn lanes were displayed in the wrong order when the system language was set to Hebrew. ([#1175](https://github.com/mapbox/mapbox-navigation-ios/pull/1175))
 
-#### MapboxCoreNavigation
+#### Core Navigation
 * `RouteController`'s `MBRouteControllerProgressDidChange` notification now exposes the raw location in it's update, accessible by `MBRouteControllerRawLocationKey`
 
 #### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Fixed an issue in which turn lanes were displayed in the wrong order when the system language was set to Hebrew. ([#1175](https://github.com/mapbox/mapbox-navigation-ios/pull/1175))
 
 #### Core Navigation
-* `RoteController` now has a new property, `snappedLocation`. This property represents the raw location, snapped to the current route, if applicable. If not applicable, the value is `nil.`
+* `RoteController` now has a new property, `snappedLocation`. This property represents the raw location, snapped to the current route, if applicable. If not applicable, the value is `nil`.
 * `RouteController`'s `MBRouteControllerProgressDidChange` notification now exposes the raw location in it's update, accessible by `MBRouteControllerRawLocationKey`
 
 #### Other changes

--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -75,6 +75,7 @@ extension CLLocation {
     }
     
     //MARK: - Route Snapping
+    
     func snapped(to legProgress: RouteLegProgress) -> CLLocation? {
         var nearByCoordinates = legProgress.nearbyCoordinates
         
@@ -86,7 +87,7 @@ extension CLLocation {
             let coordinates = legProgress.currentStep.coordinates {
             
             // The max here is 180. The closer it is to 180, the sharper the turn.
-            if initialHeading.clockwiseDifference(from: finalHeading) > 180 - RouteControllerMaxManipulatedCourseAngle {
+            if initialHeading.clockwiseDifference(from: finalHeading) > 180 - RouteSnappingMaxManipulatedCourseAngle {
                 nearByCoordinates = coordinates
             }
         }
@@ -148,8 +149,8 @@ extension CLLocation {
      */
     func shouldSnap(toRouteWith course: CLLocationDirection) -> Bool {
         if course >= 0 &&
-            speed >= RouteControllerMinimumSpeedForLocationSnapping &&
-            course.differenceBetween(self.course) > RouteControllerMaxManipulatedCourseAngle &&
+            speed >= RouteSnappingMinimumSpeed &&
+            course.differenceBetween(self.course) > RouteSnappingMaxManipulatedCourseAngle &&
             horizontalAccuracy < 20 {
             return false
         }

--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -151,7 +151,7 @@ extension CLLocation {
         if course >= 0 &&
             speed >= RouteSnappingMinimumSpeed &&
             course.differenceBetween(self.course) > RouteSnappingMaxManipulatedCourseAngle &&
-            horizontalAccuracy < 20 {
+            horizontalAccuracy < RouteSnappingMinimumHorizontalAccuracy {
             return false
         }
         return true

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -42,7 +42,7 @@ public var RouteControllerDeadReckoningTimeInterval: TimeInterval = 1.0
 /**
  Maximum angle the user puck will be rotated when snapping the user's course to the route line.
  */
-public var RouteControllerMaxManipulatedCourseAngle: CLLocationDirection = 25
+public var RouteSnappingMaxManipulatedCourseAngle: CLLocationDirection = 25
 
 /**
  :nodoc This is used internally for debugging metrics
@@ -59,7 +59,7 @@ public let RouteControllerLinkedInstructionBufferMultiplier: Double = 1.2
 /**
  The minimum speed value before the user's actual location can be considered over the snapped location.
  */
-public var RouteControllerMinimumSpeedForLocationSnapping: CLLocationSpeed = 3
+public var RouteSnappingMinimumSpeed: CLLocationSpeed = 3
 
 /**
  The minimum distance threshold used for giving a "Continue" type instructions.

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -2,15 +2,12 @@ import Foundation
 import CoreLocation
 import MapboxDirections
 
+
+// MARK: - RouteController
 /**
  Maximum number of meters the user can travel away from step before `RouteControllerShouldReroute` is emitted.
  */
 public var RouteControllerMaximumDistanceBeforeRecalculating: CLLocationDistance = 50
-
-/**
- Accepted deviation excluding horizontal accuracy before the user is considered to be off route.
- */
-public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 15
 
 /**
  Threshold user must be in within to count as completing a step. One of two heuristics used to know when a user completes a step, see `RouteControllerManeuverZoneRadius`.
@@ -39,10 +36,7 @@ public var RouteControllerManeuverZoneRadius: CLLocationDistance = 40
  */
 public var RouteControllerDeadReckoningTimeInterval: TimeInterval = 1.0
 
-/**
- Maximum angle the user puck will be rotated when snapping the user's course to the route line.
- */
-public var RouteSnappingMaxManipulatedCourseAngle: CLLocationDirection = 25
+
 
 /**
  :nodoc This is used internally for debugging metrics
@@ -92,3 +86,19 @@ let FasterRouteFoundEvent = "navigation.fasterRoute"
  The number of seconds remaining on the final step of a leg before the user is considered "arrived".
  */
 public var RouteControllerDurationRemainingWaypointArrival: TimeInterval = 3
+
+//MARK: - Route Snapping (CLLocation)
+/**
+ Accepted deviation excluding horizontal accuracy before the user is considered to be off route.
+ */
+public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 15
+
+/**
+ Maximum angle the user puck will be rotated when snapping the user's course to the route line.
+ */
+public var RouteSnappingMaxManipulatedCourseAngle: CLLocationDirection = 25
+
+/**
+ Minimum Accuracy (maximum deviation, in meters) that the route snapping engine will accept before it stops snapping.
+ */
+public var RouteSnappingMinimumHorizontalAccuracy: CLLocationAccuracy = 20.0

--- a/MapboxCoreNavigation/MBRouteController.h
+++ b/MapboxCoreNavigation/MBRouteController.h
@@ -58,9 +58,14 @@ typedef NSString *MBRouteControllerNotificationUserInfoKey NS_EXTENSIBLE_STRING_
 extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProgressKey;
 
 /**
- A key in the user info dictionary of a `Notification.Name.MBRouteControllerProgressDidChange` or `Notification.Name.RouteControllerWillReroute` notification. The corresponding value is a `CLLocation` object representing the current user location.
+ A key in the user info dictionary of a `Notification.Name.MBRouteControllerProgressDidChange` or `Notification.Name.RouteControllerWillReroute` notification. The corresponding value is a `CLLocation` object representing the current idealized user location.
  */
 extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey;
+
+/**
+ A key in the user info dictionary of a `Notification.Name.MBRouteControllerProgressDidChange` or `Notification.Name.RouteControllerWillReroute` notification. The corresponding value is a `CLLocation` object representing the current raw user location.
+ */
+extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocationKey;
 
 /**
  A key in the user info dictionary of a `Notification.Name.RouteControllerDidFailToReroute` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.

--- a/MapboxCoreNavigation/MBRouteController.m
+++ b/MapboxCoreNavigation/MBRouteController.m
@@ -8,6 +8,7 @@ const NSNotificationName MBRouteControllerDidFailToRerouteNotification          
 
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProgressKey              = @"progress";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey                   = @"location";
+const MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocationKey                = @"rawLocation";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey               = @"error";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerIsOpportunisticKey            = @"RouteControllerDidFindFasterRoute";
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -561,7 +561,8 @@ extension RouteController: CLLocationManagerDelegate {
             currentStepProgress.distanceTraveled = distanceTraveled
             NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: [
                 RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress,
-                RouteControllerNotificationUserInfoKey.locationKey: location
+                RouteControllerNotificationUserInfoKey.locationKey: self.location!, // Idealized location, raw is guaranteed
+                RouteControllerNotificationUserInfoKey.rawLocationKey: location //raw, from line 541
                 ])
         }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -36,7 +36,7 @@ extension Notification.Name {
     /**
      Posted when `RouteController` receives a user location update representing movement along the expected route.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.locationKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey`, `RouteControllerNotificationUserInfoKey.locationKey`, and `RouteControllerNotificationUserInfoKey.rawLocationKey`.
      */
     public static let routeControllerProgressDidChange = MBRouteControllerProgressDidChange
     

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -356,7 +356,7 @@ open class RouteController: NSObject {
     }
     
     /**
-     The most recently received user location. Snapped to the route line, if applicable, otherwise raw.
+     The idealized user location. Snapped to the route line, if applicable, otherwise raw.
      - seeAlso: snappedLocation, rawLocation
      */
     @objc public var location: CLLocation? {
@@ -364,7 +364,7 @@ open class RouteController: NSObject {
     }
     
     /**
-     The most recently recieved user location, snapped to the route line, if applicable.
+     The raw location, snapped to the current route.
      - important: If the rawLocation is outside of the route snapping tolerances, this value is nil.
      */
     var snappedLocation: CLLocation? {
@@ -561,8 +561,8 @@ extension RouteController: CLLocationManagerDelegate {
             currentStepProgress.distanceTraveled = distanceTraveled
             NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: [
                 RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress,
-                RouteControllerNotificationUserInfoKey.locationKey: self.location!, // Idealized location, raw is guaranteed
-                RouteControllerNotificationUserInfoKey.rawLocationKey: location //raw, from line 541
+                RouteControllerNotificationUserInfoKey.locationKey: self.location!, //guaranteed value
+                RouteControllerNotificationUserInfoKey.rawLocationKey: location //raw
                 ])
         }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -356,9 +356,24 @@ open class RouteController: NSObject {
     }
     
     /**
+     The most recently received user location. Snapped to the route line, if applicable, otherwise raw.
+     - seeAlso: snappedLocation, rawLocation
+     */
+    @objc public var location: CLLocation? {
+        return snappedLocation ?? rawLocation
+    }
+    
+    /**
+     The most recently recieved user location, snapped to the route line, if applicable.
+     - important: If the rawLocation is outside of the route snapping tolerances, this value is nil.
+     */
+    var snappedLocation: CLLocation? {
+        return rawLocation?.snapped(to: routeProgress.currentLegProgress)
+    }
+
+    /**
      The most recently received user location.
-     
-     This is a raw location received from `locationManager`. To obtain an idealized location, use the `location` property.
+     - note: This is a raw location received from `locationManager`. To obtain an idealized location, use the `location` property.
      */
     var rawLocation: CLLocation? {
         didSet {
@@ -382,35 +397,6 @@ open class RouteController: NSObject {
             }
         }
         return RouteControllerMaximumDistanceBeforeRecalculating
-    }
-
-    var snappedLocation: CLLocation? {
-        return rawLocation?.snapped(to: routeProgress.currentLegProgress)
-    }
-    /**
-     The most recently received user location, snapped to the route line.
-
-     This property contains a `CLLocation` object located along the route line near the most recently received user location. This property is set to `nil` if the route controller is unable to snap the user’s location to the route line for some reason.
-     */
-    
-    //TODO: move this into an extension, CLLocation.snapped(to: RouteLegProgress) -> CLLocation
-    @objc public var location: CLLocation? {
-        return snappedLocation ?? rawLocation
-    }
-    
-    
-    
-    /**
-     Determines if the a location is qualified enough to allow the user puck to become unsnapped.
-     */
-    func shouldSnap(_ location: CLLocation, toRouteWith course: CLLocationDirection) -> Bool {
-        if location.course >= 0 &&
-            location.speed >= RouteControllerMinimumSpeedForLocationSnapping &&
-            course.differenceBetween(location.course) > RouteControllerMaxManipulatedCourseAngle &&
-            location.horizontalAccuracy < 20 {
-                return false
-        }
-        return true
     }
 
     /**

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -384,81 +384,21 @@ open class RouteController: NSObject {
         return RouteControllerMaximumDistanceBeforeRecalculating
     }
 
+    var snappedLocation: CLLocation? {
+        return rawLocation?.snapped(to: routeProgress.currentLegProgress)
+    }
     /**
      The most recently received user location, snapped to the route line.
 
      This property contains a `CLLocation` object located along the route line near the most recently received user location. This property is set to `nil` if the route controller is unable to snap the user’s location to the route line for some reason.
      */
+    
+    //TODO: move this into an extension, CLLocation.snapped(to: RouteLegProgress) -> CLLocation
     @objc public var location: CLLocation? {
-        guard let location = rawLocation else { return nil }
-
-        var nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
-
-        // If the upcoming maneuver a sharp turn, only look at the current step for snapping.
-        // Otherwise, we may get false positives from nearby step coordinates
-        if let upcomingStep = routeProgress.currentLegProgress.upComingStep,
-            let initialHeading = upcomingStep.initialHeading,
-            let finalHeading = upcomingStep.finalHeading,
-            let coordinates = routeProgress.currentLegProgress.currentStep.coordinates {
-            
-            // The max here is 180. The closer it is to 180, the sharper the turn.
-            if initialHeading.clockwiseDifference(from: finalHeading) > 180 - RouteControllerMaxManipulatedCourseAngle {
-                nearByCoordinates = coordinates
-            }
-        }
-        
-        guard let closest = Polyline(nearByCoordinates).closestCoordinate(to: location.coordinate) else { return nil }
-        guard let calculatedCourseForLocationOnStep = interpolatedCourse(from: location, along: nearByCoordinates) else { return nil }
-        
-        var userCourse = calculatedCourseForLocationOnStep
-        var userCoordinate = closest.coordinate
-        if !shouldSnap(location, toRouteWith: calculatedCourseForLocationOnStep) {
-            userCourse = location.course
-            userCoordinate = location.coordinate
-        }
-        
-        return CLLocation(coordinate: userCoordinate, altitude: location.altitude, horizontalAccuracy: location.horizontalAccuracy, verticalAccuracy: location.verticalAccuracy, course: userCourse, speed: location.speed, timestamp: location.timestamp)
+        return snappedLocation ?? rawLocation
     }
     
-    /**
-     Given a location and a series of coordinates, compute what the course should be for a the location.
-     */
-    func interpolatedCourse(from location: CLLocation, along coordinates: [CLLocationCoordinate2D]) -> CLLocationDirection? {
-        let nearByPolyline = Polyline(coordinates)
-        
-        guard let closest = nearByPolyline.closestCoordinate(to: location.coordinate) else { return nil }
-        
-        let slicedLineBehind = Polyline(coordinates.reversed()).sliced(from: closest.coordinate, to: coordinates.reversed().last)
-        let slicedLineInFront = nearByPolyline.sliced(from: closest.coordinate, to: coordinates.last)
-        let userDistanceBuffer: CLLocationDistance = max(location.speed * RouteControllerDeadReckoningTimeInterval / 2, RouteControllerUserLocationSnappingDistance / 2)
-        
-        guard let pointBehind = slicedLineBehind.coordinateFromStart(distance: userDistanceBuffer) else { return nil }
-        guard let pointBehindClosest = nearByPolyline.closestCoordinate(to: pointBehind) else { return nil }
-        guard let pointAhead = slicedLineInFront.coordinateFromStart(distance: userDistanceBuffer) else { return nil }
-        guard let pointAheadClosest = nearByPolyline.closestCoordinate(to: pointAhead) else { return nil }
-        
-        // Get direction of these points
-        let pointBehindDirection = pointBehindClosest.coordinate.direction(to: closest.coordinate)
-        let pointAheadDirection = closest.coordinate.direction(to: pointAheadClosest.coordinate)
-        let wrappedPointBehind = pointBehindDirection.wrap(min: -180, max: 180)
-        let wrappedPointAhead = pointAheadDirection.wrap(min: -180, max: 180)
-        let wrappedCourse = location.course.wrap(min: -180, max: 180)
-        let relativeAnglepointBehind = (wrappedPointBehind - wrappedCourse).wrap(min: -180, max: 180)
-        let relativeAnglepointAhead = (wrappedPointAhead - wrappedCourse).wrap(min: -180, max: 180)
-        
-        let averageRelativeAngle: Double
-        // User is at the beginning of the route, there is no closest point behind the user.
-        if pointBehindClosest.distance <= 0 && pointAheadClosest.distance > 0 {
-            averageRelativeAngle = relativeAnglepointAhead
-        // User is at the end of the route, there is no closest point in front of the user.
-        } else if pointAheadClosest.distance <= 0 && pointBehindClosest.distance > 0 {
-            averageRelativeAngle = relativeAnglepointBehind
-        } else {
-            averageRelativeAngle = (relativeAnglepointBehind + relativeAnglepointAhead) / 2
-        }
-        
-        return (wrappedCourse + averageRelativeAngle).wrap(min: 0, max: 360)
-    }
+    
     
     /**
      Determines if the a location is qualified enough to allow the user puck to become unsnapped.

--- a/MapboxCoreNavigationTests/LocationTests.swift
+++ b/MapboxCoreNavigationTests/LocationTests.swift
@@ -4,6 +4,15 @@ import CoreLocation
 
 class LocationTests: XCTestCase {
     
+    var setup: (progress: RouteProgress, firstLocation: CLLocation) {
+        let progress = RouteProgress(route: route)
+        let firstCoord = progress.currentLegProgress.nearbyCoordinates.first!
+        let firstLocation = CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
+        
+        return (progress, firstLocation)
+    }
+    
+    
     func testSerializeAndDeserializeLocation() {
         let coordinate = CLLocationCoordinate2D(latitude: 1.1, longitude: 2.2)
         let altitude: CLLocationAccuracy = 3.3
@@ -29,6 +38,45 @@ class LocationTests: XCTestCase {
         let rhs = location.dictionaryRepresentation as NSDictionary
         
         XCTAssert(lhs == rhs)
+    }
+    
+    func testSnappedLocation100MetersAlongRoute() {
+        let progress = setup.progress
+        let firstLocation = setup.firstLocation
+        
+        let initialHeadingOnFirstStep = progress.currentLegProgress.currentStep.finalHeading!
+        let coordinateAlongFirstStep = firstLocation.coordinate.coordinate(at: 100, facing: initialHeadingOnFirstStep)
+        let locationAlongFirstStep = CLLocation(latitude: coordinateAlongFirstStep.latitude, longitude: coordinateAlongFirstStep.longitude)
+        guard let snapped = locationAlongFirstStep.snapped(to: progress.currentLegProgress) else {
+            return XCTFail("Location should of snapped to route")
+        }
+        
+        
+        XCTAssertTrue(locationAlongFirstStep.distance(from: snapped) < 1, "The location is less than 1 meter away from the calculated snapped location")
+ 
+    }
+    
+    func testInterpolatedCourse() {
+        let progress = setup.progress
+        let firstLocation = setup.firstLocation
+        
+        let calculatedCourse = firstLocation.interpolatedCourse(along: progress.currentLegProgress.currentStepProgress.step.coordinates!)!
+        let initialHeadingOnFirstStep = progress.currentLegProgress.currentStepProgress.step.finalHeading!
+        XCTAssertTrue(calculatedCourse - initialHeadingOnFirstStep < 1, "At the beginning of the route, the final heading of the departure step should be very similar to the caclulated course of the first location update.")
+    }
+
+    
+    func testShouldSnap() {
+        let progress = setup.progress
+        let firstLocation = setup.firstLocation
+        
+        let initialHeadingOnFirstStep = progress.currentLegProgress.currentStepProgress.step.finalHeading!
+        
+        XCTAssertTrue(firstLocation.shouldSnap(toRouteWith: initialHeadingOnFirstStep), "Should snap")
+        
+        let differentCourseAndAccurateLocation = CLLocation(coordinate: firstLocation.coordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: 0, speed: 10, timestamp: Date())
+        
+        XCTAssertFalse(differentCourseAndAccurateLocation.shouldSnap(toRouteWith: initialHeadingOnFirstStep), "Should not snap when user course is different, the location is accurate and moving")
     }
     
 }

--- a/MapboxCoreNavigationTests/LocationTests.swift
+++ b/MapboxCoreNavigationTests/LocationTests.swift
@@ -48,7 +48,7 @@ class LocationTests: XCTestCase {
         let coordinateAlongFirstStep = firstLocation.coordinate.coordinate(at: 100, facing: initialHeadingOnFirstStep)
         let locationAlongFirstStep = CLLocation(latitude: coordinateAlongFirstStep.latitude, longitude: coordinateAlongFirstStep.longitude)
         guard let snapped = locationAlongFirstStep.snapped(to: progress.currentLegProgress) else {
-            return XCTFail("Location should of snapped to route")
+            return XCTFail("Location should have snapped to route")
         }
         
         

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -52,36 +52,4 @@ class RouteControllerTests: XCTestCase {
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
     }
-    
-    func testSnappedLocation100MetersAlongRoute() {
-        let navigation = setup.routeController
-        let firstLocation = setup.firstLocation
-        
-        let initialHeadingOnFirstStep = navigation.routeProgress.currentLegProgress.currentStep.finalHeading!
-        let coordinateAlongFirstStep = firstLocation.coordinate.coordinate(at: 100, facing: initialHeadingOnFirstStep)
-        let locationAlongFirstStep = CLLocation(latitude: coordinateAlongFirstStep.latitude, longitude: coordinateAlongFirstStep.longitude)
-        navigation.locationManager(navigation.locationManager, didUpdateLocations: [locationAlongFirstStep])
-        XCTAssertTrue(locationAlongFirstStep.distance(from: navigation.location!) < 1, "The location update is less than 1 meter away from the calculated snapped location")
-    }
-    
-    func testInterpolatedCourse() {
-        let navigation = setup.routeController
-        let firstLocation = setup.firstLocation
-        
-        let calculatedCourse = navigation.interpolatedCourse(from: firstLocation, along: navigation.routeProgress.currentLegProgress.currentStepProgress.step.coordinates!)!
-        let initialHeadingOnFirstStep = navigation.routeProgress.currentLegProgress.currentStepProgress.step.finalHeading!
-        XCTAssertTrue(calculatedCourse - initialHeadingOnFirstStep < 1, "At the beginning of the route, the final heading of the departure step should be very similar to the caclulated course of the first location update.")
-    }
-    
-    func testShouldSnap() {
-        let navigation = setup.routeController
-        let firstLocation = setup.firstLocation
-        let initialHeadingOnFirstStep = navigation.routeProgress.currentLegProgress.currentStepProgress.step.finalHeading!
-        
-        XCTAssertTrue(navigation.shouldSnap(firstLocation, toRouteWith: initialHeadingOnFirstStep), "Should snap")
-        
-        let differentCourseAndAccurateLocation = CLLocation(coordinate: firstLocation.coordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: 0, speed: 10, timestamp: Date())
-        
-        XCTAssertFalse(navigation.shouldSnap(differentCourseAndAccurateLocation, toRouteWith: initialHeadingOnFirstStep), "Should not snap when user course is different, the location is accurate and moving")
-    }
 }


### PR DESCRIPTION
Work in progress. Fixes #1142, by breaking out route snapping into more clearly defined components, and also by exposing the raw location update to the notification consumer.

To-do: 
- [x] Fix build error
- [x] Document change
- [x] Move the tests over, silly!
- [x]  Expand on changes in `CHANGELOG.md`

/cc @mapbox/navigation-ios 