### PR TITLE
Only update the camera once for setOverheadCameraView

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1109,15 +1109,14 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let line = MGLPolyline(coordinates: slicedLine, count: UInt(slicedLine.count))
         
         tracksUserCourse = false
-        let camera = self.camera
-        camera.pitch = 0
-        camera.heading = 0
-        self.camera = camera
         
         // Don't keep zooming in
         guard line.overlayBounds.ne.distance(to: line.overlayBounds.sw) > NavigationMapViewMinimumDistanceForOverheadZooming else { return }
         
-        setVisibleCoordinateBounds(line.overlayBounds, edgePadding: bounds, animated: true)
+        let camera = cameraThatFitsCoordinateBounds(line.overlayBounds, edgePadding: bounds)
+        camera.pitch = 0
+        camera.heading = 0
+        setCamera(camera, animated: true)
     }
 }
 


### PR DESCRIPTION
Previously, this function would first set the pitch and heading to zero, then animate the camera based on the bounds of the line.

This change now does everything in one camera motion.

/cc @mapbox/navigation-ios 