### PR TITLE
Revert "Only update the camera once for setOverheadCameraView"

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1109,14 +1109,15 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let line = MGLPolyline(coordinates: slicedLine, count: UInt(slicedLine.count))
         
         tracksUserCourse = false
+        let camera = self.camera
+        camera.pitch = 0
+        camera.heading = 0
+        self.camera = camera
         
         // Don't keep zooming in
         guard line.overlayBounds.ne.distance(to: line.overlayBounds.sw) > NavigationMapViewMinimumDistanceForOverheadZooming else { return }
         
-        let camera = cameraThatFitsCoordinateBounds(line.overlayBounds, edgePadding: bounds)
-        camera.pitch = 0
-        camera.heading = 0
-        setCamera(camera, animated: true)
+        setVisibleCoordinateBounds(line.overlayBounds, edgePadding: bounds, animated: true)
     }
 }
 


### PR DESCRIPTION
Reverts mapbox/mapbox-navigation-ios#1189

Two camera functions are fighting each other here, causes a strange effect in some cases. Need to reassess. 