### PR TITLE
Avoid mirroring checkmark in right-to-left layout

### DIFF
--- a/MapboxNavigation/Resources/Assets.xcassets/report_checkmark.imageset/Contents.json
+++ b/MapboxNavigation/Resources/Assets.xcassets/report_checkmark.imageset/Contents.json
@@ -2,8 +2,7 @@
   "images" : [
     {
       "idiom" : "universal",
-      "filename" : "report_checkmark.pdf",
-      "language-direction" : "left-to-right"
+      "filename" : "report_checkmark.pdf"
     }
   ],
   "info" : {


### PR DESCRIPTION
Apparently checkmarks [look the same](https://mdn.mozillademos.org/files/10211/persistentdrawer.png) in right-to-left languages as they do in left-to-right languages. There’s the separate issue of a checkmark having negative connotations in some languages, but that’s best handled as part of #1181.