### PR TITLE
Hide wayNameView initially

### DIFF
--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -117,10 +117,9 @@ open class NavigationView: UIView {
     lazy var resumeButton: ResumeButton = .forAutoLayout()
     
     lazy var wayNameView: WayNameView = {
-        let view: WayNameView = .forAutoLayout()
+        let view: WayNameView = .forAutoLayout(hidden: true)
         view.clipsToBounds = true
         view.layer.borderWidth = 1.0 / UIScreen.main.scale
-        view.isHidden = true
         return view
     }()
     

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -120,6 +120,7 @@ open class NavigationView: UIView {
         let view: WayNameView = .forAutoLayout()
         view.clipsToBounds = true
         view.layer.borderWidth = 1.0 / UIScreen.main.scale
+        view.isHidden = true
         return view
     }()
     


### PR DESCRIPTION
Fixes the little blue bubble in: https://github.com/mapbox/mapbox-navigation-ios/issues/1198#issuecomment-370612614

Having a hard time reproducing this often, but I think this is a good move nonetheless. 

/cc @JThramer 