### PR TITLE
Add voiceController to the initialization of NavigationViewController

### DIFF
--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -130,10 +130,13 @@
 
 - (void)startNavigation:(MBRoute *)route {
     MBSimulatedLocationManager *locationManager = [[MBSimulatedLocationManager alloc] initWithRoute:route];
+    MBRouteVoiceController *voiceController = [[MBRouteVoiceController alloc] init];
+
     MBNavigationViewController *controller = [[MBNavigationViewController alloc] initWithRoute:route
                                                                                     directions:[MBDirections sharedDirections]
                                                                                          style:nil
-                                                                               locationManager:locationManager];
+                                                                               locationManager:locationManager
+                                                                               voiceController:voiceController];
     [self presentViewController:controller animated:YES completion:nil];
     
     // Suspend notifications and let `MBNavigationViewController` handle all progress and voice updates.

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -233,7 +233,7 @@ public class NavigationViewController: UIViewController {
      
      See `RouteVoiceController` for more information.
      */
-    @objc public var voiceController: RouteVoiceController? = RouteVoiceController()
+    @objc public lazy var voiceController: RouteVoiceController? = MapboxVoiceController()
     
     /**
      Provides all routing logic for the user.

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -233,7 +233,7 @@ public class NavigationViewController: UIViewController {
      
      See `RouteVoiceController` for more information.
      */
-    @objc public var voiceController: RouteVoiceController? = MapboxVoiceController()
+    @objc public var voiceController: RouteVoiceController? = RouteVoiceController()
     
     /**
      Provides all routing logic for the user.
@@ -320,13 +320,16 @@ public class NavigationViewController: UIViewController {
     required public init(for route: Route,
                          directions: Directions = Directions.shared,
                          styles: [Style]? = [DayStyle(), NightStyle()],
-                         locationManager: NavigationLocationManager? = NavigationLocationManager()) {
+                         locationManager: NavigationLocationManager? = NavigationLocationManager(),
+                         voiceController: RouteVoiceController? = MapboxVoiceController()) {
         
         super.init(nibName: nil, bundle: nil)
         
         self.routeController = RouteController(along: route, directions: directions, locationManager: locationManager ?? NavigationLocationManager())
         self.routeController.usesDefaultUserInterface = true
         self.routeController.delegate = self
+     
+        self.voiceController = voiceController
         
         self.directions = directions
         self.route = route

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -316,7 +316,7 @@ public class NavigationViewController: UIViewController {
 
      See [Mapbox Directions](https://mapbox.github.io/mapbox-navigation-ios/directions/) for further information.
      */
-    @objc(initWithRoute:directions:style:locationManager:)
+    @objc(initWithRoute:directions:style:locationManager:voiceController:)
     required public init(for route: Route,
                          directions: Directions = Directions.shared,
                          styles: [Style]? = [DayStyle(), NightStyle()],


### PR DESCRIPTION
When only using the MapboxDirections API without setting a global API token, Mapbox Voice crashes in an attempt to use the shared token (Which is not set).

As a workaround, we can initialize the NavigationViewController with a pre-declared controller: MapboxVoiceController(accessToken: <>).