### PR TITLE
Improve re-centering user puck

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -178,6 +178,12 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             if let location = userLocationForCourseTracking {
                 updateCourseTracking(location: location, animated: true)
             }
+            
+            if let location = userLocationForCourseTracking, tracksUserCourse {
+                UIView.animate(withDuration: 1, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
+                    self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)
+                }, completion: nil)
+            }
         }
     }
 


### PR DESCRIPTION
fixes `#1` in https://github.com/mapbox/mapbox-navigation-ios/issues/1199

![new3](https://user-images.githubusercontent.com/1058624/37053013-e57c6738-212f-11e8-83b2-c9c7d17566dc.gif)


There is still however a quick snap after rerouting which is not as a big as issue as `#2` in https://github.com/mapbox/mapbox-navigation-ios/issues/1199

/cc @frederoni @JThramer 