### PR TITLE
Pin MapboxDirections.swift dependency 

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.7
-github "mapbox/MapboxDirections.swift" ~> 0.17
+github "mapbox/MapboxDirections.swift" ~> 0.17.0
 github "mapbox/turf-swift" ~> 0.0.3
 github "mapbox/mapbox-events-ios" ~> 0.3
 github "ceeK/Solar" ~> 2.1.0

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxDirections.swift", "~> 0.17"
+  s.dependency "MapboxDirections.swift", "~> 0.17.0"
   s.dependency "MapboxMobileEvents", "~> 0.3"
   s.dependency "Turf", "~> 0.0.4"
 

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxNavigation"
 
-  s.dependency "MapboxDirections.swift", "~> 0.17"
+  s.dependency "MapboxDirections.swift", "~> 0.17.0"
   s.dependency "Mapbox-iOS-SDK", "~> 3.6"
   s.dependency "MapboxMobileEvents", "~> 0.3"
   s.dependency "Solar", "~> 2.1"


### PR DESCRIPTION
We have [a](https://github.com/mapbox/MapboxDirections.swift/pull/244) [few](https://github.com/mapbox/MapboxDirections.swift/pull/243) [breaking](https://github.com/mapbox/MapboxDirections.swift/pull/236) changes coming down the line in MapboxDirections.swift. If we put out a release of MapboxDirections.swift without updating and releasing this library, people who install this library will get compile errors.

By pinning, we can guarantee releases of MapboxDirections.swift will not interfere with developers here.

/cc @mapbox/navigation-ios 