### PR TITLE
Making NavigationViewController.voiceController a lazy var

### DIFF
--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -99,11 +99,13 @@ public class SimulatedLocationManager: NavigationLocationManager {
     }
     
     override public func startUpdatingLocation() {
-        tick()
+        DispatchQueue.main.async(execute: tick)
     }
     
     override public func stopUpdatingLocation() {
-        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(tick), object: nil)
+        DispatchQueue.main.async {
+            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.tick), object: nil)
+        }
     }
     
     @objc fileprivate func tick() {

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -49,7 +49,9 @@ public class SimulatedLocationManager: NavigationLocationManager {
     
     var route: Route? {
         didSet {
+            stopUpdatingLocation()
             reset()
+            startUpdatingLocation()
         }
     }
     
@@ -76,9 +78,6 @@ public class SimulatedLocationManager: NavigationLocationManager {
             
             currentDistance = 0
             currentSpeed = 30
-            DispatchQueue.main.async {
-                self.startUpdatingLocation()
-            }
         }
     }
     

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -233,7 +233,7 @@ public class NavigationViewController: UIViewController {
      
      See `RouteVoiceController` for more information.
      */
-    @objc public var voiceController: RouteVoiceController? = MapboxVoiceController()
+    @objc public lazy var voiceController: RouteVoiceController? = MapboxVoiceController()
     
     /**
      Provides all routing logic for the user.
@@ -366,6 +366,9 @@ public class NavigationViewController: UIViewController {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        //initialize voice controller if it hasn't been overridden
+        _ = voiceController
         
         UIApplication.shared.isIdleTimerDisabled = true
         routeController.resume()


### PR DESCRIPTION
#![Lazy robot.](https://i.imgur.com/SAakSXg.gif)

Addresses #1203 partially and is a parallel attempt alongside #1204.

* Changing the `voiceController` over to a `lazy` loaded property, that's referenced initially (and the only time) at `viewWillAppear:`

This gives a developer the opportunity to initialize the `NavigationViewController` and set a custom (or no) `VoiceController` anytime between initialization and `viewWillAppear:` time.

To-Do: 
- [x] Fix issue where initial instruction is not spoken.


/cc @mapbox/navigation-ios @Sealos 