### PR TITLE
Don't speak over each other

### DIFF
--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -169,8 +169,8 @@ open class MapboxVoiceController: RouteVoiceController {
      Plays an audio file.
      */
     @objc open func play(_ data: Data) {
-        
-        guard !super.speechSynth.isSpeaking else { return }
+
+        super.speechSynth.stopSpeaking(at: .immediate)
         
         DispatchQueue.global(qos: .userInitiated).async {
             do {

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -78,8 +78,6 @@ open class MapboxVoiceController: RouteVoiceController {
         
         assert(routeProgress != nil, "routeProgress should not be nil.")
         
-        
-        
         guard let _ = routeProgress!.route.speechLocale else {
             speakWithDefaultSpeechSynthesizer(instruction, error: nil)
             return
@@ -171,6 +169,9 @@ open class MapboxVoiceController: RouteVoiceController {
      Plays an audio file.
      */
     @objc open func play(_ data: Data) {
+        
+        guard !super.speechSynth.isSpeaking else { return }
+        
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 self.audioPlayer = try AVAudioPlayer(data: data)
@@ -186,6 +187,7 @@ open class MapboxVoiceController: RouteVoiceController {
                 let played = self.audioPlayer?.play() ?? false
                 
                 guard played else {
+                    try super.unDuckAudio()
                     self.speakWithDefaultSpeechSynthesizer(self.lastSpokenInstruction!, error: NSError(code: .spokenInstructionFailed, localizedFailureReason: self.localizedErrorMessage, spokenInstructionCode: .audioPlayerFailedToPlay))
                     return
                 }


### PR DESCRIPTION
We have a few reports of the the RouteVoiceController and the MapboxVoiceController are speaking over each other in a few cases:

1. Turned on my car in a parking lot, bluetooth connected, was playing from Audible
2. Entered my address, got a route telling me to go around the block (Original route above)
3. Realized I didn't need to go around because I could drive out of the parking lot directly onto SE 23rd Ave, which triggered a reroute (Rerouted route above)
4. The reroute paused the Audible playback
5. "Turn left onto Southeast Morrison Street" was spoken simultaneously by Polly _and_ the fallback robot phone voice
6. When the announcement was done, Audible did not start playing again

It's difficult to reproduce but these are changes that I see as pretty valid changes. 

/cc @mapbox/navigation-ios @lyzidiamond 