### PR TITLE
Prevent double voice instruction before rerouting

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -102,3 +102,8 @@ public var RouteSnappingMaxManipulatedCourseAngle: CLLocationDirection = 25
  Minimum Accuracy (maximum deviation, in meters) that the route snapping engine will accept before it stops snapping.
  */
 public var RouteSnappingMinimumHorizontalAccuracy: CLLocationAccuracy = 20.0
+
+/**
+ Multiplier applied to the distance which is used to caclulate if the user is on a future step.
+ */
+public var RouteControllerAdvanceToFutureStepDistanceMultiplier: Double = 0.75

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -102,8 +102,3 @@ public var RouteSnappingMaxManipulatedCourseAngle: CLLocationDirection = 25
  Minimum Accuracy (maximum deviation, in meters) that the route snapping engine will accept before it stops snapping.
  */
 public var RouteSnappingMinimumHorizontalAccuracy: CLLocationAccuracy = 20.0
-
-/**
- Multiplier applied to the distance which is used to caclulate if the user is on a future step.
- */
-public var RouteControllerAdvanceToFutureStepDistanceMultiplier: Double = 0.75

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -640,12 +640,11 @@ extension RouteController: CLLocationManagerDelegate {
         }
         
         // Check and see if the user is near a future step.
-        guard let nearestStep = routeProgress.currentLegProgress.closestStep(to: location.coordinate),
-            nearestStep.index != routeProgress.currentLegProgress.stepIndex else {
+        guard let nearestStep = routeProgress.currentLegProgress.closestStep(to: location.coordinate) else {
             return false
         }
         
-        if nearestStep.distance < radius {
+        if nearestStep.distance < radius * RouteControllerAdvanceToFutureStepDistanceMultiplier {
             advanceStepIndex(to: nearestStep.index)
             return true
         }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -644,7 +644,7 @@ extension RouteController: CLLocationManagerDelegate {
             return false
         }
         
-        if nearestStep.distance < radius * RouteControllerAdvanceToFutureStepDistanceMultiplier {
+        if nearestStep.distance < RouteControllerUserLocationSnappingDistance {
             advanceStepIndex(to: nearestStep.index)
             return true
         }


### PR DESCRIPTION
Followup to: https://github.com/mapbox/mapbox-navigation-ios/pull/1121

We look to see if the user is on future steps before rerouting. In cases where the user is actually closer to a future step but also actively rerouting, we should just reroute. This PR prevents false positives when rerouting by using `RouteControllerUserLocationSnappingDistance`. This way, we only advance you to a future step if we are very very confident that you are actually on one.

![image](https://user-images.githubusercontent.com/1058624/37223290-e5f03a8a-2384-11e8-810f-17d7a450ae50.png)

In the case above, we were getting a voice instruction on the step that is headed to the right because it so happens the user is 23.5m of this step before rerouting (rerouting threshold in this case is 25m).

/cc @mapbox/navigation-ios 