### PR TITLE
Force-Unwrap anchor crash fix

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.7.5"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.7.6"
 github "ceeK/Solar" "2.1.0"
 github "facebook/ios-snapshot-test-case" "2.1.4"
 github "mapbox/MapboxDirections.swift" "v0.18.0"

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -664,7 +664,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         }
         
         //otherwise, ask the delegate or return .zero
-        return self.delegate?.navigationMapViewUserAnchorPoint?(mapView) ?? .zero
+        return delegate?.navigationMapViewUserAnchorPoint?(mapView) ?? .zero
     }
     
     /**

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -658,9 +658,13 @@ extension RouteMapViewController: NavigationViewDelegate {
     }
     
     func navigationMapViewUserAnchorPoint(_ mapView: NavigationMapView) -> CGPoint {
-        let endOfRouteTime = (navigationView.endOfRouteView != nil && navigationView.endOfRouteShowConstraint!.isActive == true)
-        guard !endOfRouteTime else { return CGPoint(x: mapView.bounds.midX, y: (mapView.bounds.height * 0.4)) }
-        return delegate?.navigationMapViewUserAnchorPoint?(mapView) ?? .zero
+        //If the end of route component is showing, then put the anchor point slightly above the middle of the map
+        if navigationView.endOfRouteView != nil, let show = navigationView.endOfRouteShowConstraint, show.isActive {
+            return CGPoint(x: mapView.bounds.midX, y: (mapView.bounds.height * 0.4))
+        }
+        
+        //otherwise, ask the delegate or return .zero
+        return self.delegate?.navigationMapViewUserAnchorPoint?(mapView) ?? .zero
     }
     
     /**


### PR DESCRIPTION
![Hello darkness my old friend...](https://i.imgur.com/Sp5b3RC.gif)

* Fixing issue where an unsafe force-unwrap could cause a crash under certain circumstances.

Fixes #1221.

/cc @mapbox/navigation-ios 