### PR TITLE
Update user course view when in overview mode

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -349,6 +349,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             let newCamera = MGLMapCamera(lookingAtCenter: location.coordinate, fromDistance: altitude, pitch: 45, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear) : nil
             setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: padding, completionHandler: nil)
+        } else {
+            UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
+                self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)
+            }, completion: nil)
         }
         
         if let userCourseView = userCourseView as? UserCourseView {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -401,14 +401,6 @@ class RouteMapViewController: UIViewController {
         if annotatesSpokenInstructions {
             mapView.showVoiceInstructionsOnMap(route: routeController.routeProgress.route)
         }
-
-        guard isInOverviewMode else {
-            return
-        }
-
-        if let coordinates = routeController.routeProgress.route.coordinates, let userLocation = routeController.locationManager.location?.coordinate {
-            mapView.setOverheadCameraView(from: userLocation, along: coordinates, for: overheadInsets)
-        }
     }
     
 func defaultFeedbackHandlers(source: FeedbackSource = .user) -> (send: FeedbackViewController.SendFeedbackHandler, dismiss: () -> Void) {


### PR DESCRIPTION
This change fixes course view tracking when in overview mode and stops fitting the camera to the remaining route on each location update. Please disregard the low framerate which is just to keep the gif at a reasonable size.


| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/764476/37404601-a003f90a-2792-11e8-8038-3bb983abeb9a.gif" width=200>  | <img src="https://user-images.githubusercontent.com/764476/37404597-9e5053ba-2792-11e8-9c8c-01aa52d1155a.gif" width=200> |

@mapbox/navigation-ios 👀 







