### PR TITLE
Insufficient contrast for severe congestion text in night theme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### User Interface
 * Added support for abbreviated top banner instructions. [#1169](https://github.com/mapbox/mapbox-navigation-ios/pull/1169)
 * Reveal the steps list by swiping down on the top banner. [#1150](https://github.com/mapbox/mapbox-navigation-ios/pull/1150)
+* Fixed the poor contrast of the `TimeRemainingLabel.appearance().trafficSevereColor`, when navigation night style (theme) is enabled. [#1228](https://github.com/mapbox/mapbox-navigation-ios/pull/1228)
 
 ## v0.15.0 (March 13, 2018)
 

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -121,7 +121,7 @@ open class DayStyle: Style {
         TimeRemainingLabel.appearance().trafficHeavyColor = #colorLiteral(red:0.91, green:0.20, blue:0.25, alpha:1.0)
         TimeRemainingLabel.appearance().trafficLowColor = #colorLiteral(red: 0.4666666687, green: 0.7647058964, blue: 0.2666666806, alpha: 1)
         TimeRemainingLabel.appearance().trafficModerateColor = #colorLiteral(red:0.95, green:0.65, blue:0.31, alpha:1.0)
-        TimeRemainingLabel.appearance().trafficSevereColor = #colorLiteral(red:0.54, green:0.06, blue:0.22, alpha:1.0)
+        TimeRemainingLabel.appearance().trafficSevereColor = #colorLiteral(red: 0.7705719471, green: 0.1753477752, blue: 0.1177056804, alpha: 1)
         TimeRemainingLabel.appearance().trafficUnknownColor = .defaultPrimaryText
         UserPuckCourseView.appearance().puckColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 1)
         WayNameLabel.appearance().normalFont = UIFont.systemFont(ofSize:20, weight: .medium).adjustedFont


### PR DESCRIPTION
This fixes the poor contrast of the severe congestion `TimeRemainingLabel` color when navigation night style (theme) is enabled. 

Fixes issue https://github.com/mapbox/mapbox-navigation-ios/issues/1192

/cc @mapbox/navigation-ios 


BEFORE (_left_) `-->`   AFTER (_right_)

![dark red color-before](https://user-images.githubusercontent.com/2340650/37487942-88368590-2869-11e8-9a48-80f9df726eab.png)              ![dark red color](https://user-images.githubusercontent.com/2340650/37487819-18d90da8-2869-11e8-9cf9-5ddc0fc4742d.png) 
