### PR TITLE
Reroute proactively, not opportunistically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Master
 
-#### User Interface
+#### User interface
 * Added support for abbreviated top banner instructions. [#1169](https://github.com/mapbox/mapbox-navigation-ios/pull/1169)
 * Reveal the steps list by swiping down on the top banner. [#1150](https://github.com/mapbox/mapbox-navigation-ios/pull/1150)
+
+#### Core Navigation
+* Renamed the `RouteController.reroutesOpportunistically` property to `RouteController.reroutesProactively`, `RouteControllerOpportunisticReroutingInterval` global variable to `RouteControllerProactiveReroutingInterval`, and the `RouteControllerNotificationUserInfoKey.isOpportunisticKey` value to `RouteControllerNotificationUserInfoKey.isProactiveKey`. ([#1230](https://github.com/mapbox/mapbox-navigation-ios/pull/1230))
 
 ## v0.15.0 (March 13, 2018)
 

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -78,7 +78,7 @@ public var RouteControllerNumberOfSecondsForRerouteFeedback: TimeInterval = 10
 /**
  The number of seconds between attempts to automatically calculate a more optimal route while traveling.
  */
-public var RouteControllerOpportunisticReroutingInterval: TimeInterval = 120
+public var RouteControllerProactiveReroutingInterval: TimeInterval = 120
 
 let FasterRouteFoundEvent = "navigation.fasterRoute"
 

--- a/MapboxCoreNavigation/MBRouteController.h
+++ b/MapboxCoreNavigation/MBRouteController.h
@@ -21,7 +21,7 @@ extern const NSNotificationName MBRouteControllerWillRerouteNotification;
 /**
  Posted when `MBRouteController` obtains a new route in response to the user diverging from a previous route.
  
- The user info dictionary contains the keys `MBRouteControllerLocationKey` and `MBRouteControllerIsOpportunisticKey`.
+ The user info dictionary contains the keys `MBRouteControllerLocationKey` and `MBRouteControllerIsProactiveKey`.
  
  :nodoc:
  */
@@ -73,6 +73,6 @@ extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocati
 extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey;
 
 /**
- A key in the user info dictionary of a `Notification.Name.RouteControllerDidReroute` notification. The corresponding value is an `NSNumber` instance containing a Boolean value indicating whether `RouteController` opportunistically rerouted the user onto a faster route.
+ A key in the user info dictionary of a `Notification.Name.RouteControllerDidReroute` notification. The corresponding value is an `NSNumber` instance containing a Boolean value indicating whether `RouteController` proactively rerouted the user onto a faster route.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerIsOpportunisticKey;
+extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerIsProactiveKey;

--- a/MapboxCoreNavigation/MBRouteController.m
+++ b/MapboxCoreNavigation/MBRouteController.m
@@ -10,6 +10,6 @@ const MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProgressKey
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey                   = @"location";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocationKey                = @"rawLocation";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey               = @"error";
-const MBRouteControllerNotificationUserInfoKey MBRouteControllerIsOpportunisticKey            = @"RouteControllerDidFindFasterRoute";
+const MBRouteControllerNotificationUserInfoKey MBRouteControllerIsProactiveKey                = @"RouteControllerDidFindFasterRoute";
 
 NSString *const MBErrorDomain = @"ErrorDomain";

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -324,7 +324,7 @@ class RouteMapViewController: UIViewController {
             }
         }
         
-        if notification.userInfo![RouteControllerNotificationUserInfoKey.isOpportunisticKey] as! Bool {
+        if notification.userInfo![RouteControllerNotificationUserInfoKey.isProactiveKey] as! Bool {
             let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
             showStatus(title: title, withSpinner: true, for: 3)
         }

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -151,7 +151,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     
     @objc func didReroute(notification: NSNotification) {
         // Play reroute sound when a faster route is found
-        if notification.userInfo?[RouteControllerNotificationUserInfoKey.isOpportunisticKey] as! Bool {
+        if notification.userInfo?[RouteControllerNotificationUserInfoKey.isProactiveKey] as! Bool {
             pauseSpeechAndPlayReroutingDing(notification: notification)
         }
     }


### PR DESCRIPTION
“Opportunistic” can have a negative connotation. The automatic rerouting feature is just trying to be helpful, proactively. So the following symbols have been renamed:

* `RouteController.reroutesOpportunistically` to `RouteController.reroutesProactively`
* `RouteControllerOpportunisticReroutingInterval` to `RouteControllerProactiveReroutingInterval`
* `RouteControllerNotificationUserInfoKey.isOpportunisticKey` to `RouteControllerNotificationUserInfoKey.isProactiveKey`

/cc @bsudekum