### PR TITLE
Fix SIGABRT in DataCache and add test

### DIFF
--- a/MapboxNavigation/DataCache.swift
+++ b/MapboxNavigation/DataCache.swift
@@ -11,8 +11,8 @@ public class DataCache: NSObject, BimodalDataCache {
 
         super.init()
 
-        NotificationCenter.default.addObserver(forName: .UIApplicationDidReceiveMemoryWarning, object: nil, queue: nil) { [unowned self] (notif) in
-            self.clearMemory()
+        NotificationCenter.default.addObserver(forName: .UIApplicationDidReceiveMemoryWarning, object: nil, queue: nil) { [weak self] (notif) in
+            self?.clearMemory()
         }
     }
 

--- a/MapboxNavigationTests/DataCacheTests.swift
+++ b/MapboxNavigationTests/DataCacheTests.swift
@@ -93,6 +93,9 @@ class DataCacheTests: XCTestCase {
     func testClearingMemoryCacheOnMemoryWarning() {
         storeDataInMemory()
 
+        var tempDataCache: DataCache? = DataCache()
+        tempDataCache?.clearMemory()
+        tempDataCache = nil
         NotificationCenter.default.post(name: .UIApplicationDidReceiveMemoryWarning, object: nil)
 
         XCTAssertNil(cache.data(forKey: dataKey))


### PR DESCRIPTION
Fixes a crash in the DataCache. Unowned should be used if the instance has the same lifetime or longer which seems to be correct in this case. It's almost as if the removal of the observer is not really removing it or it's being delayed one cycle?

@akitchen 👀 

<details>

```md
Crashed: com.apple.main-thread
0  libsystem_kernel.dylib         0x18330c2e8 __pthread_kill + 8
1  libsystem_pthread.dylib        0x183425748 pthread_kill$VARIANT$armv81 + 360
2  libsystem_c.dylib              0x18327afbc abort + 140
3  libswiftCore.dylib             0x103ac0f08 swift_reportError + 256
4  libswiftCore.dylib             0x103ac1010 swift_deletedMethodError + 104
5  libswiftCore.dylib             0x103aeec30 swift_unknownUnownedLoadStrong + 74
6  MapboxNavigation               0x1034ac828 closure #1 in DataCache.init() (DataCache.swift:15)
7  MapboxNavigation               0x1034ac8e0 thunk for @callee_owned (@in Notification) -> () (DataCache.swift)
8  Foundation                     0x1840edec4 -[__NSObserver _doit:] + 312
9  CoreFoundation                 0x18378913c __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 20
10 CoreFoundation                 0x1837886dc _CFXRegistrationPost + 420
11 CoreFoundation                 0x183788440 ___CFXNotificationPost_block_invoke + 60
12 CoreFoundation                 0x183805e24 -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1408
13 CoreFoundation                 0x1836bed60 _CFXNotificationPost + 380
14 Foundation                     0x1840eb348 -[NSNotificationCenter postNotificationName:object:userInfo:] + 68
15 UIKit                          0x18d024698 -[UIApplication _performMemoryWarning] + 152
16 UIKit                          0x18d024888 -[UIApplication _receivedMemoryNotification] + 140
17 libdispatch.dylib              0x183176a14 _dispatch_client_callout + 16
18 libdispatch.dylib              0x1831b3640 _dispatch_continuation_pop$VARIANT$armv81 + 420
19 libdispatch.dylib              0x1831bc858 _dispatch_source_invoke$VARIANT$armv81 + 528
20 libdispatch.dylib              0x1831b7b64 _dispatch_main_queue_callback_4CF$VARIANT$armv81 + 684
21 CoreFoundation                 0x18379f344 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
22 CoreFoundation                 0x18379cf20 __CFRunLoopRun + 2012
23 CoreFoundation                 0x1836bcc58 CFRunLoopRunSpecific + 436
24 GraphicsServices               0x185568f84 GSEventRunModal + 100
25 UIKit                          0x18ce155c4 UIApplicationMain + 236
26 redacted                         0x102d04128 main (:18)
27 libdyld.dylib                  0x1831dc56c start + 4
```

</details>