### PR TITLE
Use autoreleased observers

### DIFF
--- a/MapboxNavigation/DataCache.swift
+++ b/MapboxNavigation/DataCache.swift
@@ -10,15 +10,10 @@ public class DataCache: NSObject, BimodalDataCache {
         memoryCache.name = "In-Memory Data Cache"
 
         super.init()
-
-        NotificationCenter.default.addObserver(forName: .UIApplicationDidReceiveMemoryWarning, object: nil, queue: nil) { [weak self] (notif) in
-            self?.clearMemory()
-        }
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(DataCache.clearMemory), name: .UIApplicationDidReceiveMemoryWarning, object: nil)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
 
     // MARK: Data cache
 

--- a/MapboxNavigation/ImageCache.swift
+++ b/MapboxNavigation/ImageCache.swift
@@ -10,13 +10,7 @@ internal class ImageCache: BimodalImageCache {
 
         fileCache = FileCache()
 
-        NotificationCenter.default.addObserver(forName: .UIApplicationDidReceiveMemoryWarning, object: nil, queue: nil) { [unowned self] (notif) in
-            self.clearMemory()
-        }
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
+        NotificationCenter.default.addObserver(self, selector: #selector(DataCache.clearMemory), name: .UIApplicationDidReceiveMemoryWarning, object: nil)
     }
 
     // MARK: Image cache

--- a/MapboxNavigationTests/DataCacheTests.swift
+++ b/MapboxNavigationTests/DataCacheTests.swift
@@ -93,11 +93,16 @@ class DataCacheTests: XCTestCase {
     func testClearingMemoryCacheOnMemoryWarning() {
         storeDataInMemory()
 
-        var tempDataCache: DataCache? = DataCache()
-        tempDataCache?.clearMemory()
-        tempDataCache = nil
         NotificationCenter.default.post(name: .UIApplicationDidReceiveMemoryWarning, object: nil)
 
         XCTAssertNil(cache.data(forKey: dataKey))
+    }
+
+    func testNotificationObserverDoesNotCrash() {
+        var tempCache: DataCache? = DataCache()
+        tempCache?.clearMemory()
+        tempCache = nil
+
+        NotificationCenter.default.post(name: .UIApplicationDidReceiveMemoryWarning, object: nil)
     }
 }

--- a/MapboxNavigationTests/ImageCacheTests.swift
+++ b/MapboxNavigationTests/ImageCacheTests.swift
@@ -105,10 +105,6 @@ class ImageCacheTests: XCTestCase {
 
     func testClearingMemoryCacheOnMemoryWarning() {
         storeImageInMemory()
-
-        var tempDataCache: ImageCache? = ImageCache()
-        tempDataCache?.clearMemory()
-        tempDataCache = nil
         
         NotificationCenter.default.post(name: .UIApplicationDidReceiveMemoryWarning, object: nil)
 
@@ -127,5 +123,13 @@ class ImageCacheTests: XCTestCase {
 
         let retrievedImage = cache.image(forKey: "JPEG Test")!
         XCTAssertTrue(retrievedImage.isKind(of: UIImage.self))
+    }
+
+    func testNotificationObserverDoesNotCrash() {
+        var tempCache: ImageCache? = ImageCache()
+        tempCache?.clearMemory()
+        tempCache = nil
+
+        NotificationCenter.default.post(name: .UIApplicationDidReceiveMemoryWarning, object: nil)
     }
 }

--- a/MapboxNavigationTests/ImageCacheTests.swift
+++ b/MapboxNavigationTests/ImageCacheTests.swift
@@ -106,6 +106,10 @@ class ImageCacheTests: XCTestCase {
     func testClearingMemoryCacheOnMemoryWarning() {
         storeImageInMemory()
 
+        var tempDataCache: ImageCache? = ImageCache()
+        tempDataCache?.clearMemory()
+        tempDataCache = nil
+        
         NotificationCenter.default.post(name: .UIApplicationDidReceiveMemoryWarning, object: nil)
 
         XCTAssertNil(cache.image(forKey: imageKey))


### PR DESCRIPTION
`NSNotificationCenter.addObserver(_:selector:name:object:)` removes the observer automatically for apps targeting iOS 9.0 and higher.

@akitchen 👀 