### PR TITLE
Remove log

### DIFF
--- a/MapboxNavigation/Cache.swift
+++ b/MapboxNavigation/Cache.swift
@@ -91,7 +91,6 @@ internal class FileCache {
         do {
             return try Data.init(contentsOf: cacheURLWithKey(key))
         } catch {
-            NSLog("No viable data in disk cache for URL: %@", key)
             return nil
         }
     }


### PR DESCRIPTION
This log was getting printed quite often. I think we can silently continue if the audio is not found on disk. 

/cc @mapbox/navigation-ios 