### PR TITLE
Refactor style types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Renamed redundantly named style types `.dayStyle` and `.nightStyle` to `.day` and `.night`. ([#1250](https://github.com/mapbox/mapbox-navigation-ios/pull/1250))
+
 ### User interface
 * While the user travels through a tunnel, `NavigationMapView` temporarily applies a night style (a style whose `styleType` property is set to `StyleType.nightStyle`). ([#1127](https://github.com/mapbox/mapbox-navigation-ios/pull/1127))
 * The user can reveal the list of upcoming steps by swiping downward from the top banner. ([#1150](https://github.com/mapbox/mapbox-navigation-ios/pull/1150))

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -445,7 +445,7 @@ class CustomDayStyle: DayStyle {
     required init() {
         super.init()
         mapStyleURL = URL(string: "mapbox://styles/mapbox/satellite-streets-v9")!
-        styleType = .dayStyle
+        styleType = .day
     }
     
     override func apply() {
@@ -460,7 +460,7 @@ class CustomNightStyle: NightStyle {
     required init() {
         super.init()
         mapStyleURL = URL(string: "mapbox://styles/mapbox/satellite-streets-v9")!
-        styleType = .nightStyle
+        styleType = .night
     }
 
     override func apply() {

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -44,7 +44,7 @@ open class DayStyle: Style {
     public required init() {
         super.init()
         mapStyleURL = URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v2")!
-        styleType = .dayStyle
+        styleType = .day
         statusBarStyle = .default
     }
     
@@ -152,7 +152,7 @@ open class NightStyle: DayStyle {
     public required init() {
         super.init()
         mapStyleURL = URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v2")!
-        styleType = .nightStyle
+        styleType = .night
         statusBarStyle = .lightContent
     }
     

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -413,7 +413,7 @@ public class NavigationViewController: UIViewController {
         if usesNightStyleInsideTunnels, let currentIntersection = routeProgress.currentLegProgress.currentStepProgress.currentIntersection,
             let classes = currentIntersection.outletRoadClasses {
                 if classes.contains(.tunnel) {
-                    styleManager.applyStyle(type:.nightStyle)
+                    styleManager.applyStyle(type: .night)
                 } else {
                     styleManager.timeOfDayChanged()
                 }

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -29,7 +29,7 @@ open class Style: NSObject {
     /**
      Describes the situations in which the style should be used. By default, the style will be used during the daytime.
      */
-    @objc public var styleType: StyleType = .dayStyle
+    @objc public var styleType: StyleType = .day
     
     /**
      Map style to be used for the style.

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -139,10 +139,10 @@ open class StyleManager: NSObject {
         guard let solar = Solar(date: date, coordinate: location.coordinate),
             let sunrise = solar.sunrise,
             let sunset = solar.sunset else {
-                return .dayStyle
+                return .day
         }
         
-        return solar.date.isNighttime(sunrise: sunrise, sunset: sunset) ? .nightStyle : .dayStyle
+        return solar.date.isNighttime(sunrise: sunrise, sunset: sunset) ? .night : .day
     }
     
     func forceRefreshAppearanceIfNeeded() {

--- a/MapboxNavigation/StyleType.swift
+++ b/MapboxNavigation/StyleType.swift
@@ -3,16 +3,16 @@ import Foundation
 @objc(MBStyleType)
 public enum StyleType: Int, CustomStringConvertible {
     
-    case dayStyle
-    case nightStyle
+    case day
+    case night
     
     public init?(description: String) {
         let type: StyleType
         switch description {
-        case "dayStyle":
-            type = .dayStyle
-        case "nightStyle":
-            type = .nightStyle
+        case "day":
+            type = .day
+        case "night":
+            type = .night
         default:
             return nil
         }
@@ -21,10 +21,10 @@ public enum StyleType: Int, CustomStringConvertible {
     
     public var description: String {
         switch self {
-        case .dayStyle:
-            return "dayStyle"
-        case .nightStyle:
-            return "nightStyle"
+        case .day:
+            return "day"
+        case .night:
+            return "night"
         }
     }
 }

--- a/MapboxNavigationTests/StyleManagerTests.swift
+++ b/MapboxNavigationTests/StyleManagerTests.swift
@@ -32,17 +32,17 @@ class StyleManagerTests: XCTestCase {
         let midnight = dateFormatter.date(from: "00:00")!
         
         styleManager.date = beforeSunrise
-        XCTAssert(styleManager.styleType(for: location) == .nightStyle)
+        XCTAssert(styleManager.styleType(for: location) == .night)
         styleManager.date = afterSunrise
-        XCTAssert(styleManager.styleType(for: location) == .dayStyle)
+        XCTAssert(styleManager.styleType(for: location) == .day)
         styleManager.date = noonDate
-        XCTAssert(styleManager.styleType(for: location) == .dayStyle)
+        XCTAssert(styleManager.styleType(for: location) == .day)
         styleManager.date = beforeSunset
-        XCTAssert(styleManager.styleType(for: location) == .dayStyle)
+        XCTAssert(styleManager.styleType(for: location) == .day)
         styleManager.date = afterSunset
-        XCTAssert(styleManager.styleType(for: location) == .nightStyle)
+        XCTAssert(styleManager.styleType(for: location) == .night)
         styleManager.date = midnight
-        XCTAssert(styleManager.styleType(for: location) == .nightStyle)
+        XCTAssert(styleManager.styleType(for: location) == .night)
     }
     
     func testStyleManagerSanFrancisco() {
@@ -61,17 +61,17 @@ class StyleManagerTests: XCTestCase {
         let midnight = dateFormatter.date(from: "00:00 AM")!
         
         styleManager.date = beforeSunrise
-        XCTAssert(styleManager.styleType(for: location) == .nightStyle)
+        XCTAssert(styleManager.styleType(for: location) == .night)
         styleManager.date = afterSunrise
-        XCTAssert(styleManager.styleType(for: location) == .dayStyle)
+        XCTAssert(styleManager.styleType(for: location) == .day)
         styleManager.date = noonDate
-        XCTAssert(styleManager.styleType(for: location) == .dayStyle)
+        XCTAssert(styleManager.styleType(for: location) == .day)
         styleManager.date = beforeSunset
-        XCTAssert(styleManager.styleType(for: location) == .dayStyle)
+        XCTAssert(styleManager.styleType(for: location) == .day)
         styleManager.date = afterSunset
-        XCTAssert(styleManager.styleType(for: location) == .nightStyle)
+        XCTAssert(styleManager.styleType(for: location) == .night)
         styleManager.date = midnight
-        XCTAssert(styleManager.styleType(for: location) == .nightStyle)
+        XCTAssert(styleManager.styleType(for: location) == .night)
     }
 }
 


### PR DESCRIPTION
Fixes #1249 

`StyleType.nightStyle` is redundantly named according to Swift’s naming conventions and should be written as `StyleType.night`. In ObjC, this bridges to `MBStyleTypeNight`.

@bsudekum 