### PR TITLE
Add Arabic, European Portuguese localizations

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -20,13 +20,6 @@ file_filter = MapboxCoreNavigation/Resources/<lang>.lproj/Localizable.strings
 source_file = MapboxCoreNavigation/Resources/Base.lproj/Localizable.strings
 source_lang = en
 
-[mapbox-navigation-ios.LocalizableAbbreviations]
-file_filter = MapboxNavigation/Resources/<lang>.lproj/Abbreviations.csv.plist
-source_file = MapboxNavigation/Resources/Base.lproj/Abbreviations.csv.plist
-source_lang = en
-minimum_perc = 100
-type = PLIST
-
 [mapbox-navigation-ios.swiftexample]
 file_filter = Examples/Swift/<lang>.lproj/Main.strings
 source_file = Examples/Swift/en.lproj/Main.strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 * Fixed an issue where the `RouteStepProgress.upcomingIntersection` property was always set to the current step’s first intersection. ([#1127](https://github.com/mapbox/mapbox-navigation-ios/pull/1127))
 * Added support for using the Mapbox Map Matching API. [#1177](https://github.com/mapbox/mapbox-navigation-ios/pull/1177)
 
+### Other changes
+* Added an Arabic localization. ([#1252](https://github.com/mapbox/mapbox-navigation-ios/pull/1251))
+
 ## v0.15.0 (March 13, 2018)
 
 #### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Added support for using the Mapbox Map Matching API. [#1177](https://github.com/mapbox/mapbox-navigation-ios/pull/1177)
 
 ### Other changes
-* Added an Arabic localization. ([#1252](https://github.com/mapbox/mapbox-navigation-ios/pull/1251))
+* Added Arabic and European Portuguese localizations. ([#1252](https://github.com/mapbox/mapbox-navigation-ios/pull/1251))
 
 ## v0.15.0 (March 13, 2018)
 

--- a/Examples/Objective-C/ar.lproj/Main.strings
+++ b/Examples/Objective-C/ar.lproj/Main.strings
@@ -1,0 +1,6 @@
+
+/* Class = "UIButton"; normalTitle = "Start Navigation"; ObjectID = "8Sl-bV-xyU"; */
+"8Sl-bV-xyU.normalTitle" = "ابدأ التنقل";
+
+/* Class = "UILabel"; text = "Long press map to select a route"; ObjectID = "Hk0-SM-2Wl"; */
+"Hk0-SM-2Wl.text" = "انقر على الخريطة مطولا لاختيار طريق";

--- a/Examples/Objective-C/pt-PT.lproj/Main.strings
+++ b/Examples/Objective-C/pt-PT.lproj/Main.strings
@@ -1,0 +1,6 @@
+
+/* Class = "UIButton"; normalTitle = "Start Navigation"; ObjectID = "8Sl-bV-xyU"; */
+"8Sl-bV-xyU.normalTitle" = "Iniciar Navegação";
+
+/* Class = "UILabel"; text = "Long press map to select a route"; ObjectID = "Hk0-SM-2Wl"; */
+"Hk0-SM-2Wl.text" = "Pressão longa no mapa para selecionar um percurso";

--- a/Examples/Swift/ar.lproj/Main.strings
+++ b/Examples/Swift/ar.lproj/Main.strings
@@ -1,0 +1,15 @@
+
+/* Class = "UIButton"; normalTitle = "Continue to next destination"; ObjectID = "1vl-kS-fBt"; */
+"1vl-kS-fBt.normalTitle" = "تابع نحو المقصد التالي";
+
+/* Class = "UILabel"; text = "Long press to select a destination"; ObjectID = "dEY-t6-Ect"; */
+"dEY-t6-Ect.text" = "انقر مطولا لاختيار مقصد";
+
+/* Class = "UIButton"; normalTitle = "Simulate Locations"; ObjectID = "iiq-Gf-SKY"; */
+"iiq-Gf-SKY.normalTitle" = "حاكِ الأماك";
+
+/* Class = "UIButton"; normalTitle = "Start Navigation"; ObjectID = "nMe-Tl-a1N"; */
+"nMe-Tl-a1N.normalTitle" = "ابدأ التنقل";
+
+/* Class = "UINavigationItem"; title = "Mapbox Navigation"; ObjectID = "zxr-0T-HBr"; */
+"zxr-0T-HBr.title" = "Mapbox Navigation";

--- a/Examples/Swift/pt-PT.lproj/Main.strings
+++ b/Examples/Swift/pt-PT.lproj/Main.strings
@@ -1,0 +1,15 @@
+
+/* Class = "UIButton"; normalTitle = "Continue to next destination"; ObjectID = "1vl-kS-fBt"; */
+"1vl-kS-fBt.normalTitle" = "Continue para o destino seguinte";
+
+/* Class = "UILabel"; text = "Long press to select a destination"; ObjectID = "dEY-t6-Ect"; */
+"dEY-t6-Ect.text" = "Pressione longamente para selecionar um destino";
+
+/* Class = "UIButton"; normalTitle = "Simulate Locations"; ObjectID = "iiq-Gf-SKY"; */
+"iiq-Gf-SKY.normalTitle" = "Simular Localizações";
+
+/* Class = "UIButton"; normalTitle = "Start Navigation"; ObjectID = "nMe-Tl-a1N"; */
+"nMe-Tl-a1N.normalTitle" = "Iniciar Navegação";
+
+/* Class = "UINavigationItem"; title = "Mapbox Navigation"; ObjectID = "zxr-0T-HBr"; */
+"zxr-0T-HBr.title" = "Navegação Mapbox";

--- a/MapboxCoreNavigation/Resources/ar.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/ar.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+/* Inform developer an update is available */
+"UPDATE_AVAILABLE" = "عدّة التنقل من Mapbox لإصدارة آي‌أوإس %@ متوفرة الآن.";
+

--- a/MapboxCoreNavigation/Resources/pt-PT.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/pt-PT.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+/* Inform developer an update is available */
+"UPDATE_AVAILABLE" = "O SDK de Navegação Mapbox para iOS versão %@ já está disponível.";
+

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -607,6 +607,12 @@
 		DAE26B1B20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE26B1C20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Navigation.strings; sourceTree = "<group>"; };
 		DAE26B1F2064407D001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAE26B20206441D8001D6E1F /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Main.strings"; sourceTree = "<group>"; };
+		DAE26B21206441D9001D6E1F /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Main.strings"; sourceTree = "<group>"; };
+		DAE26B22206441D9001D6E1F /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Navigation.strings"; sourceTree = "<group>"; };
+		DAE26B23206441F7001D6E1F /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		DAE26B2420644215001D6E1F /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		DAE26B2520644225001D6E1F /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-PT"; path = "Resources/pt-PT.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		DAE7114C1F22E94E009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE7114D1F22E966009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE7114E1F22E977009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Navigation.strings; sourceTree = "<group>"; };
@@ -1339,6 +1345,7 @@
 				da,
 				he,
 				ar,
+				"pt-PT",
 			);
 			mainGroup = C5ADFBBF1DDCC7840011824B;
 			productRefGroup = C5ADFBCA1DDCC7840011824B /* Products */;
@@ -1805,6 +1812,7 @@
 				DA3525712011435E0048DDFC /* da */,
 				DAC049C020171886004C2217 /* he */,
 				DAE26B1A20644047001D6E1F /* ar */,
+				DAE26B20206441D8001D6E1F /* pt-PT */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -1835,6 +1843,7 @@
 				DA352568201096F20048DDFC /* da */,
 				DA1811FD20128B0900C91918 /* he */,
 				DAE26B1B20644047001D6E1F /* ar */,
+				DAE26B21206441D9001D6E1F /* pt-PT */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -1864,6 +1873,7 @@
 				DA352572201143BA0048DDFC /* da */,
 				DA1811FE20128B0900C91918 /* he */,
 				DAE26B1C20644047001D6E1F /* ar */,
+				DAE26B22206441D9001D6E1F /* pt-PT */,
 			);
 			name = Navigation.storyboard;
 			path = Resources;
@@ -1888,6 +1898,7 @@
 				DA18120120128B7B00C91918 /* he */,
 				DAC049BE201715D5004C2217 /* ru */,
 				DAE26B1F2064407D001D6E1F /* ar */,
+				DAE26B23206441F7001D6E1F /* pt-PT */,
 			);
 			name = Localizable.strings;
 			path = Resources;
@@ -1904,6 +1915,7 @@
 				DAF257122017C1E800367EF5 /* sv */,
 				DAD88E00202AC7AA00AAA536 /* uk */,
 				DAD88E02202AC81F00AAA536 /* da */,
+				DAE26B2520644225001D6E1F /* pt-PT */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";
@@ -1927,6 +1939,7 @@
 				DA18120320128E9400C91918 /* fr */,
 				DAC049C1201718AC004C2217 /* he */,
 				DAD88E01202AC80100AAA536 /* uk */,
+				DAE26B2420644215001D6E1F /* pt-PT */,
 			);
 			name = Localizable.strings;
 			path = Resources;

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -603,6 +603,10 @@
 		DADAD827203504C6002E25CA /* MBNavigationSettings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBNavigationSettings.m; sourceTree = "<group>"; };
 		DADAD82C20350849002E25CA /* MBRouteVoiceController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBRouteVoiceController.h; sourceTree = "<group>"; };
 		DADAD82D20350849002E25CA /* MBRouteVoiceController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBRouteVoiceController.m; sourceTree = "<group>"; };
+		DAE26B1A20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Main.strings; sourceTree = "<group>"; };
+		DAE26B1B20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Main.strings; sourceTree = "<group>"; };
+		DAE26B1C20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Navigation.strings; sourceTree = "<group>"; };
+		DAE26B1F2064407D001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DAE7114C1F22E94E009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE7114D1F22E966009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE7114E1F22E977009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Navigation.strings; sourceTree = "<group>"; };
@@ -868,7 +872,6 @@
 				3510300E1F54B67000E3B7E7 /* LaneTests.swift */,
 				3540514E1F73F3F300ED572D /* ManeuverViewTests.swift */,
 				35B711D11E5E7AD2001EDA8D /* MapboxNavigationTests.swift */,
-				16E4F97E205B05FE00531791 /* MapboxVoiceControllerTests.swift */,
 				35F1F5921FD57EFD00F8E502 /* StyleManagerTests.swift */,
 				3527D2B61EC45FBD00C07FC9 /* Fixtures.xcassets */,
 				355DB5731EFA73410091BFB7 /* Fixtures */,
@@ -1335,6 +1338,7 @@
 				bg,
 				da,
 				he,
+				ar,
 			);
 			mainGroup = C5ADFBBF1DDCC7840011824B;
 			productRefGroup = C5ADFBCA1DDCC7840011824B /* Products */;
@@ -1800,6 +1804,7 @@
 				DA5AD03C1FEBA03700FC7D7B /* bg */,
 				DA3525712011435E0048DDFC /* da */,
 				DAC049C020171886004C2217 /* he */,
+				DAE26B1A20644047001D6E1F /* ar */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -1829,6 +1834,7 @@
 				DA5AD03D1FEBA03700FC7D7B /* bg */,
 				DA352568201096F20048DDFC /* da */,
 				DA1811FD20128B0900C91918 /* he */,
+				DAE26B1B20644047001D6E1F /* ar */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -1857,6 +1863,7 @@
 				DA5AD03E1FEBA03700FC7D7B /* bg */,
 				DA352572201143BA0048DDFC /* da */,
 				DA1811FE20128B0900C91918 /* he */,
+				DAE26B1C20644047001D6E1F /* ar */,
 			);
 			name = Navigation.storyboard;
 			path = Resources;
@@ -1880,6 +1887,7 @@
 				DA545AC01FA9A15A0090908E /* nl */,
 				DA18120120128B7B00C91918 /* he */,
 				DAC049BE201715D5004C2217 /* ru */,
+				DAE26B1F2064407D001D6E1F /* ar */,
 			);
 			name = Localizable.strings;
 			path = Resources;

--- a/MapboxNavigation/Resources/ar.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/ar.lproj/Navigation.strings
@@ -1,0 +1,13 @@
+
+/* Class = "UIButton"; normalTitle = "Report Problem"; ObjectID = "I8f-iR-MZm"; */
+"I8f-iR-MZm.normalTitle" = "أبلِغ عن مشكلة";
+
+/* Class = "UILabel"; text = "Rate your trip"; ObjectID = "W5U-cV-cDO"; */
+"W5U-cV-cDO.text" = "قيّم رحلتك";
+
+/* Class = "UILabel"; text = "Thank you for your report!"; ObjectID = "upm-fg-ffn"; */
+"upm-fg-ffn.text" = "شكرا لك على هذا التقرير!";
+
+/* Class = "UILabel"; text = "Report Problem"; ObjectID = "xTH-eK-F5H"; */
+"xTH-eK-F5H.text" = "أبلِغ عن مشكلة";
+

--- a/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
@@ -1,0 +1,77 @@
+/* Dismiss button title on the steps view */
+"DISMISS_STEPS_TITLE" = "Fechar";
+
+/* End Navigation Button Text */
+"END_NAVIGATION" = "Terminar Navegação";
+
+/* Title used for arrival */
+"END_OF_ROUTE_ARRIVED" = "Chegou";
+
+/* Comment Placeholder Text */
+"END_OF_ROUTE_TITLE" = "Como podemos melhorar?";
+
+/* Error message when the SDK is unable to read a spoken instruction. */
+"FAILED_INSTRUCTION" = "Incapaz de ler instrução em voz alta.";
+
+/* Indicates a faster route was found */
+"FASTER_ROUTE_FOUND" = "Encontrado Percurso Mais Rápido";
+
+/* Feedback type for Bad Route */
+"FEEDBACK_BAD_ROUTE" = "Percurso \nRuim";
+
+/* Feedback type for Confusing Instruction */
+"FEEDBACK_CONFUSING_INSTRUCTION" = "Instrução\nConfusa";
+
+/* Feedback type for Other Map Issue Issue */
+"FEEDBACK_GENERAL_ISSUE" = "Outro\nProblema no Mapa";
+
+/* Feedback type for Missing Exit */
+"FEEDBACK_MISSING_EXIT" = "Saída\nem Falta";
+
+/* Feedback type for Missing Road */
+"FEEDBACK_MISSING_ROAD" = "Estrada\nem Falta";
+
+/* Feedback type for a maneuver that is Not Allowed */
+"FEEDBACK_NOT_ALLOWED" = "Não\nPermitido";
+
+/* Feedback type for Report Traffic */
+"FEEDBACK_REPORT_TRAFFIC" = "Relatar\nTrânsito";
+
+/* Feedback type for Road Closed */
+"FEEDBACK_ROAD_CLOSURE" = "Estrada\nFechada";
+
+/* Format for displaying the first two major ways */
+"LEG_MAJOR_WAYS_FORMAT" = "%1$@ e %2$@";
+
+/* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
+"LESS_THAN" = "<%@";
+
+/* Accessibility value of label indicating the absence of a rating */
+"NO_RATING" = "Sem classificação definida.";
+
+/* Rating Reset To Zero Accessability Hint */
+"RATING_ACCESSIBILITY_RESET" = "Toque para redifinir classificação para zero.";
+
+/* Format for accessibility label of button for setting a rating; 1 = number of stars */
+"RATING_ACCESSIBILITY_SET" = "Definir classificação de %ld-estrela(s)";
+
+/* Format for accessibility value of label indicating the existing rating; 1 = number of stars */
+"RATING_STARS_FORMAT" = "Definida(s) %ld estrela(s).";
+
+/* Title on button that appears when a reroute occurs */
+"REROUTE_REPORT_TITLE" = "Relatar Problema";
+
+/* Indicates that rerouting is in progress */
+"REROUTING" = "Redirecionando...";
+
+/* Button title for resume tracking */
+"RESUME" = "Continuar";
+
+/* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
+"USER_IN_SIMULATION_MODE" = "Simulando Navegação em %d×";
+
+/* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
+"WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";
+
+/* Format for displaying start and endpoint for leg; 1 = source ; 2 = destination */
+"WAYPOINT_SOURCE_DESTINATION_FORMAT" = "%1$@ e %2$@";

--- a/MapboxNavigation/Resources/pt-PT.lproj/Localizable.stringsdict
+++ b/MapboxNavigation/Resources/pt-PT.lproj/Localizable.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>RATING_ACCESSIBILITY_SET</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>Definir classificação %ld-estrela</string>
+			<key>other</key>
+			<string>Definir classificação %ld-estrelas</string>
+		</dict>
+	</dict>
+	<key>RATING_STARS_FORMAT</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>Definida %ld estrela.</string>
+			<key>other</key>
+			<string>Definidas %ld estrelas.</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/MapboxNavigation/Resources/pt-PT.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/pt-PT.lproj/Navigation.strings
@@ -1,0 +1,13 @@
+
+/* Class = "UIButton"; normalTitle = "Report Problem"; ObjectID = "I8f-iR-MZm"; */
+"I8f-iR-MZm.normalTitle" = "Relatar Problema";
+
+/* Class = "UILabel"; text = "Rate your trip"; ObjectID = "W5U-cV-cDO"; */
+"W5U-cV-cDO.text" = "Classifique a sua viajem";
+
+/* Class = "UILabel"; text = "Thank you for your report!"; ObjectID = "upm-fg-ffn"; */
+"upm-fg-ffn.text" = "Obrigado pelo seu relatório!";
+
+/* Class = "UILabel"; text = "Report Problem"; ObjectID = "xTH-eK-F5H"; */
+"xTH-eK-F5H.text" = "Relatar Problema";
+

--- a/docs/guides/Localization and Internationalization.md
+++ b/docs/guides/Localization and Internationalization.md
@@ -48,7 +48,7 @@ The upcoming road or ramp destination is named according to the local or nationa
 | Hebrew     | ✅              | ✅                             | —                     | ✅
 | Hungarian  | ✅              | —                             | —                     | ✅
 | Italian    | ✅              | ✅                             | ✅                     | ✅
-| Portuguese | ✅              | ✅                             | ✅                     | ✅
+| Portuguese | ✅             | ✅                             | ✅                     | ✅
 | Polish     | —              | ✅                             | ✅                     | ✅
 | Romanian   | —              | ✅                             | ✅                     | ✅
 | Russian    | ✅              | ✅                             | ✅                     | ✅

--- a/docs/guides/Localization and Internationalization.md
+++ b/docs/guides/Localization and Internationalization.md
@@ -37,6 +37,7 @@ The upcoming road or ramp destination is named according to the local or nationa
 
 | Language   | User interface | [Spoken instructions][osrmti] | Mapbox Voice API | [`AVSpeechSynthesizer`][iossynth]<br>(iOS 11)
 |------------|:--------------:|:-----------------------------:|:---------------------:|:--------------------------------:
+| Arabic    | ✅              | —                             | —                     | ✅
 | Catalan    | ✅              | —                             | —                     | —
 | Chinese    | ✅ Simplified   | ✅                             | —                     | ✅
 | Danish     | ✅              | ✅                             | ✅                     | ✅


### PR DESCRIPTION
Added a partial Arabic localization and a complete European Portuguese localization from Transifex. Thanks to @safaalfulaij for the Arabic translations and @Rui-Santos for the European Portuguese translations!

<img src="https://user-images.githubusercontent.com/1231218/37797563-66b72b2c-2dd7-11e8-8f61-9276fc868adc.png" width="300" alt="Arabic"> <img src="https://user-images.githubusercontent.com/1231218/37797796-118745be-2dd8-11e8-9c0d-b1de78bc7d36.png" width="300" alt="European Portuguese">

In order to pull these localizations from Transifex, some remnants of the old `localizableabbreviations` resource needed to be removed from the `tx` configuration. (This resource went away as part of #1050.)

/cc @vincethecoder @frederoni