### PR TITLE
Remove progress bar from bottom banner

### DIFF
--- a/MapboxNavigation/BottomBannerView.swift
+++ b/MapboxNavigation/BottomBannerView.swift
@@ -16,7 +16,6 @@ open class BottomBannerView: UIView {
     weak var arrivalTimeLabel: ArrivalTimeLabel!
     weak var cancelButton: CancelButton!
     weak var dividerView: SeparatorView!
-    weak var progressBar: ProgressBar!
     weak var routeController: RouteController!
     weak var delegate: BottomBannerViewDelegate?
     
@@ -76,8 +75,6 @@ open class BottomBannerView: UIView {
     }
     
     func updateETA(routeProgress: RouteProgress) {
-        progressBar.setProgress(routeProgress.currentLegProgress.userHasArrivedAtWaypoint ? 1 : CGFloat(routeProgress.fractionTraveled), animated: true)
-        
         guard let arrivalDate = NSCalendar.current.date(byAdding: .second, value: Int(routeProgress.durationRemaining), to: Date()) else { return }
         arrivalTimeLabel.text = dateFormatter.string(from: arrivalDate)
 

--- a/MapboxNavigation/BottomBannerViewLayout.swift
+++ b/MapboxNavigation/BottomBannerViewLayout.swift
@@ -32,11 +32,6 @@ extension BottomBannerView {
         addSubview(dividerView)
         self.dividerView = dividerView
         
-        let progressBar = ProgressBar()
-        progressBar.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(progressBar)
-        self.progressBar = progressBar
-        
         setupConstraints()
     }
     
@@ -66,11 +61,6 @@ extension BottomBannerView {
         
         c.append(arrivalTimeLabel.trailingAnchor.constraint(equalTo: dividerView.leadingAnchor, constant: -10))
         c.append(arrivalTimeLabel.centerYAnchor.constraint(equalTo: cancelButton.centerYAnchor))
-        
-        c.append(progressBar.leadingAnchor.constraint(equalTo: leadingAnchor))
-        c.append(progressBar.trailingAnchor.constraint(equalTo: trailingAnchor))
-        c.append(progressBar.bottomAnchor.constraint(equalTo: bottomAnchor))
-        c.append(progressBar.heightAnchor.constraint(equalToConstant: 3))
     }
     
     fileprivate func setupVerticalRegularLayout(_ c: inout [NSLayoutConstraint]) {
@@ -94,11 +84,6 @@ extension BottomBannerView {
         
         c.append(arrivalTimeLabel.centerYAnchor.constraint(equalTo: centerYAnchor))
         c.append(arrivalTimeLabel.trailingAnchor.constraint(equalTo: dividerView.leadingAnchor, constant: -10))
-        
-        c.append(progressBar.leadingAnchor.constraint(equalTo: leadingAnchor))
-        c.append(progressBar.trailingAnchor.constraint(equalTo: trailingAnchor))
-        c.append(progressBar.bottomAnchor.constraint(equalTo: bottomAnchor))
-        c.append(progressBar.heightAnchor.constraint(equalToConstant: 3))
     }
     
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
This change removes the progress bar from the bottom banner as it's suboptimal for trips with reroutes.
The `ProgressBar` is also being used as a countdown indicator in the feedback form.

@bsudekum 👀 