### PR TITLE
Increase RouteSnappingMaxManipulatedCourseAngle threshold

### DIFF
--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -96,7 +96,7 @@ public var RouteControllerUserLocationSnappingDistance: CLLocationDistance = 15
 /**
  Maximum angle the user puck will be rotated when snapping the user's course to the route line.
  */
-public var RouteSnappingMaxManipulatedCourseAngle: CLLocationDirection = 25
+public var RouteSnappingMaxManipulatedCourseAngle: CLLocationDirection = 36
 
 /**
  Minimum Accuracy (maximum deviation, in meters) that the route snapping engine will accept before it stops snapping.


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/939

I did some tests this weekend and logged each time the puck becomes unsnapped while on a route. Basically, on any 90 degree turn, the puck always becomes unsnapped momentarily. To counteract this, I increased `RouteSnappingMaxManipulatedCourseAngle` to 36 in https://github.com/mapbox/mapbox-navigation-ios/commit/5b84e08a1547adb2e886ab74c19ea668a7dd565e. This was a value I found that worked well from many tests I did.


/cc @mapbox/navigation-ios 