### PR TITLE
Prevent automatic snapping to road network

### DIFF
--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -44,9 +44,6 @@ open class NavigationLocationManager: CLLocationManager {
         // Other navigation prevents Apple from snapping to the road network
         activityType = .otherNavigation
         
-        // Necessary when `.otherNavigation` is enabled.
-        pausesLocationUpdatesAutomatically = false
-        
         if #available(iOS 9.0, *) {
             if Bundle.main.backgroundModes.contains("location") {
                 allowsBackgroundLocationUpdates = true

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -41,7 +41,11 @@ open class NavigationLocationManager: CLLocationManager {
         
         requestWhenInUseAuthorization()
         
+        // Other navigation prevents Apple from snapping to the road network
         activityType = .otherNavigation
+        
+        // Necessary when `.otherNavigation` is enabled.
+        pausesLocationUpdatesAutomatically = false
         
         if #available(iOS 9.0, *) {
             if Bundle.main.backgroundModes.contains("location") {

--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -41,6 +41,8 @@ open class NavigationLocationManager: CLLocationManager {
         
         requestWhenInUseAuthorization()
         
+        activityType = .otherNavigation
+        
         if #available(iOS 9.0, *) {
             if Bundle.main.backgroundModes.contains("location") {
                 allowsBackgroundLocationUpdates = true

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -328,7 +328,13 @@ public class NavigationViewController: UIViewController {
         
         super.init(nibName: nil, bundle: nil)
         
-        self.routeController = RouteController(along: route, directions: directions, locationManager: locationManager ?? NavigationLocationManager())
+        // `NavigationLocationManager.pausesLocationUpdatesAutomatically` needs to be applied inconjuction with `NavigationLocationManager.activityType = .otherNavigation`.
+        // However, it cannot be set in `NavigationLocationManager` because it cannot be used with UI-less apps (I.E. MapboxCoreNavigation tests or anyone just using MapboxCoreNavigation in the background).
+        // Ref: https://github.com/mapbox/mapbox-navigation-ios/pull/1266#issuecomment-377262740
+        let manager = locationManager ?? NavigationLocationManager()
+        manager.pausesLocationUpdatesAutomatically = false
+        
+        self.routeController = RouteController(along: route, directions: directions, locationManager: manager)
         self.routeController.usesDefaultUserInterface = true
         self.routeController.delegate = self
         


### PR DESCRIPTION
The location manager has the ability to snap to the road network when it deems it necessary. This presents a lot of problems like this drive I had below:

![image](https://user-images.githubusercontent.com/1058624/38063796-ed714d14-32af-11e8-852f-96195f294c2a.png)
> I took a right onto van ness here

From reading through some links in https://stackoverflow.com/a/46849708/1522419, the only real way we can disable this snapping feature is by setting the activity type to `.otherNavigation `.

/cc @mapbox/navigation-ios 
