### PR TITLE
Fix syntax error in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Changes to the Mapbox Navigation SDK for iOS
+# Changes to the Mapbox Navigation SDK for iOS
 
 ## v0.16.0 (March 26, 2018)
 


### PR DESCRIPTION
FYI, the documentation publishing script relies on the current release’s section being the first second-level header in the document:

https://github.com/mapbox/mapbox-navigation-ios/blob/17ab0869b6f55b5ad4a4ae757de314bc2002c574/scripts/document.sh#L46-L47

As a result of #1148, [the v0.16.0 documentation](https://www.mapbox.com/mapbox-navigation-ios/navigation/0.16.0/) has empty release notes.

/cc @mapbox/navigation-ios