### PR TITLE
Only use horizontal accuracy for checking isQualified

### DIFF
--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -6,8 +6,7 @@ extension CLLocation {
     
     var isQualified: Bool {
         return
-            0...100 ~= horizontalAccuracy &&
-                0...30 ~= verticalAccuracy
+            0...100 ~= horizontalAccuracy
     }
     
     /// Returns a dictionary representation of the location.


### PR DESCRIPTION
We're not really interested in verticalAccuracy, nor is a good litmus test for whether a location is accuracy. Personally, I've seen many cases where the vertical accuracy would previously be unqualified but the horizontal accuracy would be qualified:

```json
{
            "lng": -122.3928341989904,
            "horizontalAccuracy": 48,
            "course": 253.165305586835,
            "verticalAccuracy": 63.95016860961914,
            "speed": 21.015432357788086,
            "lat": 37.61509585378829,
            "altitude": -13.206028914186902,
            "timestamp": "2018-04-01T23:43:58.999+0000"
        },
        {
            "lng": -122.39305106695443,
            "horizontalAccuracy": 48,
            "course": 253.52910878278655,
            "verticalAccuracy": 52.994686126708984,
            "speed": 21.015432357788086,
            "lat": 37.61503088880565,
            "altitude": -11.841697524188362,
            "timestamp": "2018-04-01T23:43:59.999+0000"
        },
```

This PR removes vertical accuracy from `CLLocation.isQualified` to focus only on `horizontalAccuracy`.

/cc @mapbox/navigation-ios 