### PR TITLE
Update maneuver arrow after completing step

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -423,7 +423,6 @@ public class NavigationViewController: UIViewController {
     @objc func didPassInstructionPoint(notification: NSNotification) {
         let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
         
-        mapViewController?.updateMapOverlays(for: routeProgress)
         mapViewController?.updateCameraAltitude(for: routeProgress)
         
         clearStaleNotifications()

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -273,6 +273,7 @@ class RouteMapViewController: UIViewController {
 
     func notifyDidReroute(route: Route) {
         updateETA()
+        currentStepIndexMapped = 0
         
         instructionsBannerView.update(for: routeController.routeProgress.currentLegProgress)
         lanesView.update(for: routeController.routeProgress.currentLegProgress)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -95,6 +95,7 @@ class RouteMapViewController: UIViewController {
         }
     }
     var currentLegIndexMapped = 0
+    var currentStepIndexMapped = 0
     
     /**
      A Boolean value that determines whether the map annotates the locations at which instructions are spoken for debugging purposes.
@@ -172,6 +173,7 @@ class RouteMapViewController: UIViewController {
         annotatesSpokenInstructions = delegate?.mapViewControllerShouldAnnotateSpokenInstructions(self) ?? false
         showRouteIfNeeded()
         currentLegIndexMapped = routeController.routeProgress.legIndex
+        currentStepIndexMapped = routeController.routeProgress.currentLegProgress.stepIndex
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -396,6 +398,11 @@ class RouteMapViewController: UIViewController {
             mapView.showRoutes([routeProgress.route], legIndex: routeProgress.legIndex)
             
             currentLegIndexMapped = routeProgress.legIndex
+        }
+        
+        if currentStepIndexMapped != routeProgress.currentLegProgress.stepIndex {
+            updateMapOverlays(for: routeProgress)
+            currentStepIndexMapped = routeProgress.currentLegProgress.stepIndex
         }
         
         if annotatesSpokenInstructions {


### PR DESCRIPTION
Previously, we were only updating the maneuver arrow when a voice instruction was given. Since https://github.com/mapbox/mapbox-navigation-ios/pull/1263, we no longer give a voice instruction directly when completing a step. Now we wait until a voice instruction should be given, not necessarily if spokenVoiceInstructionIndex == 0.

When the step distance is equal to the first `distanceAlongGeometry` value, the maneuver arrow would hang around on the previous step.

This now ensures the maneuver arrow is always updated when completing a step.

/cc @mapbox/navigation-ios 