### PR TITLE
Don't fallback to default speech synthesizer if prepareToPlay fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Fixed a crash that was caused by check the edit distance of an empty string. [#1281](https://github.com/mapbox/mapbox-navigation-ios/pull/1281/)
 * Removes warnings when using Swift 4.1. [#1271](https://github.com/mapbox/mapbox-navigation-ios/pull/1271)
 
+### Spoken Instruction
+
+* Fixed an issue that would preemptively fallback to the default speech synthesizer. [#1284](https://github.com/mapbox/mapbox-navigation-ios/pull/1284)
+
 ## v0.16.0 (March 26, 2018)
 
 ### User interface

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -191,13 +191,7 @@ open class MapboxVoiceController: RouteVoiceController {
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 self.audioPlayer = try AVAudioPlayer(data: data)
-                let prepared = self.audioPlayer?.prepareToPlay() ?? false
-                
-                guard prepared else {
-                    self.speakWithDefaultSpeechSynthesizer(self.lastSpokenInstruction!, error: NSError(code: .spokenInstructionFailed, localizedFailureReason: self.localizedErrorMessage, spokenInstructionCode: .audioPlayerFailedToPlay))
-                    return
-                }
-                
+                self.audioPlayer?.prepareToPlay()
                 self.audioPlayer?.delegate = self
                 try super.duckAudio()
                 let played = self.audioPlayer?.play() ?? false


### PR DESCRIPTION
We should not be falling back to the default speech synthesizer if the audioPlayer does not [prepareToPlay](https://developer.apple.com/documentation/avfoundation/avaudioplayer/1386886-preparetoplay) properly.

Even if `prepareToPlay` fails, the audio can still play as `prepareToPlay` is just there to preload audio.

I was able to hit this code repeatedly by removing alls checks and playing an audio instruction on every update. When rerouting, we would interrupt the current audio, stopping the audioPlayer and rendering it "unprepared".

/cc @mapbox/navigation-ios 