### PR TITLE
Backfill events tests & decouple events from RouteController

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -528,7 +528,7 @@ extension RouteController: CLLocationManagerDelegate {
     }
 
     @objc public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        
+        print("locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation])")
         let filteredLocations = locations.filter {
             sessionState.pastLocations.push($0)
             return $0.isQualified
@@ -951,22 +951,27 @@ struct SessionState {
 extension RouteController {
     // MARK: Sending events
     func sendDepartEvent() {
+        print("\(#function)")
         eventsManager.enqueueEvent(withName: MMEEventTypeNavigationDepart, attributes: eventsManager.navigationDepartEvent(routeController: self))
         eventsManager.flush()
     }
 
     func sendArriveEvent() {
+        print("\(#function)")
         eventsManager.enqueueEvent(withName: MMEEventTypeNavigationArrive, attributes: eventsManager.navigationArriveEvent(routeController: self))
         eventsManager.flush()
     }
 
     open func sendCancelEvent(rating: Int? = nil, comment: String? = nil) {
+        print("\(#function)")
         let attributes = eventsManager.navigationCancelEvent(routeController: self, rating: rating, comment: comment)
         eventsManager.enqueueEvent(withName: MMEEventTypeNavigationCancel, attributes: attributes)
         eventsManager.flush()
     }
 
     func sendFeedbackEvent(event: CoreFeedbackEvent) {
+        print("\(#function)")
+
         // remove from outstanding event queue
         if let index = outstandingFeedbackEvents.index(of: event) {
             outstandingFeedbackEvents.remove(at: index)
@@ -982,6 +987,7 @@ extension RouteController {
     // MARK: Enqueue feedback
 
     func enqueueFeedbackEvent(type: FeedbackType, description: String?) -> String {
+        print("\(#function)")
         let eventDictionary = eventsManager.navigationFeedbackEvent(routeController: self, type: type, description: description)
         let event = FeedbackEvent(timestamp: Date(), eventDictionary: eventDictionary)
 
@@ -991,6 +997,7 @@ extension RouteController {
     }
 
     func enqueueRerouteEvent() -> String {
+        print("\(#function)")
         let timestamp = Date()
         let eventDictionary = eventsManager.navigationRerouteEvent(routeController: self)
 
@@ -999,12 +1006,14 @@ extension RouteController {
 
         let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
 
+        print("Appending event internally")
         outstandingFeedbackEvents.append(event)
 
         return event.id.uuidString
     }
     
     func enqueueFoundFasterRouteEvent() -> String {
+        print("\(#function)")
         let timestamp = Date()
         let eventDictionary = eventsManager.navigationRerouteEvent(routeController: self, eventType: FasterRouteFoundEvent)
         
@@ -1018,6 +1027,7 @@ extension RouteController {
     }
 
     func checkAndSendOutstandingFeedbackEvents(forceAll: Bool) {
+        print("\(#function)")
         let now = Date()
         let eventsToPush = forceAll ? outstandingFeedbackEvents : outstandingFeedbackEvents.filter {
             now.timeIntervalSince($0.timestamp) > SecondsBeforeCollectionAfterFeedbackEvent

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -528,7 +528,6 @@ extension RouteController: CLLocationManagerDelegate {
     }
 
     @objc public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        print("locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation])")
         let filteredLocations = locations.filter {
             sessionState.pastLocations.push($0)
             return $0.isQualified
@@ -999,7 +998,6 @@ extension RouteController {
 
         let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
 
-        print("Appending event internally")
         outstandingFeedbackEvents.append(event)
 
         return event.id.uuidString
@@ -1014,6 +1012,7 @@ extension RouteController {
         let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
 
         outstandingFeedbackEvents.append(event)
+//        eventsManager.enqueueEvent(withName: MMEEventTypeNavigationReroute, attributes: event.eventDictionary)
 
         return event.id.uuidString
     }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -250,18 +250,17 @@ open class RouteController: NSObject {
         self.locationManager.activityType = route.routeOptions.activityType
         self.eventsManager = eventsManager
         UIDevice.current.isBatteryMonitoringEnabled = true
+
         super.init()
 
         self.locationManager.delegate = self
-        self.resumeNotifications()
-        self.resetSession()
-
-        DispatchQueue.main.async {
-            self.startEvents(route: route)
-        }
+        resumeNotifications()
+        resetSession()
 
         checkForUpdates()
         checkForLocationUsageDescription()
+
+        startEvents(route: route)
     }
 
     deinit {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -49,7 +49,7 @@ extension Notification.Name {
 }
 
 /**
- The `RouteControllerDelegate` class provides methods for responding to significant occasions during the user’s traversal of a route monitored by a `RouteController`.
+ The `RouteControllerDelegate` protocol provides methods for responding to significant events during the user’s traversal of a route monitored by a `RouteController`.
  */
 @objc(MBRouteControllerDelegate)
 public protocol RouteControllerDelegate: class {
@@ -111,9 +111,9 @@ public protocol RouteControllerDelegate: class {
     optional func routeController(_ routeController: RouteController, didFailToRerouteWith error: Error)
 
     /**
-     Called when the route controller’s location manager receive a location update.
+     Called when the route controller’s location manager receives a location update.
 
-     These locations can be modified due to replay or simulation but they can
+     These locations may be modified due to replay or simulation and can
      also derive from regular location updates from a `CLLocationManager`.
 
      - parameter routeController: The route controller that received the new locations.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -701,6 +701,7 @@ extension RouteController: CLLocationManagerDelegate {
                 // If the upcoming maneuver in the new route is the same as the current upcoming maneuver, don't announce it
                 strongSelf.routeProgress = RouteProgress(route: route, legIndex: 0, spokenInstructionIndex: strongSelf.routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex)
                 strongSelf.delegate?.routeController?(strongSelf, didRerouteAlong: route)
+                //TODO: this seems wrong
                 strongSelf.didReroute(notification: NSNotification(name: .routeControllerDidReroute, object: nil, userInfo: [
                     RouteControllerNotificationUserInfoKey.isProactiveKey: true
                 ]))

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -624,6 +624,8 @@ extension RouteController: CLLocationManagerDelegate {
             previousArrivalWaypoint = currentDestination
 
             routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
+
+            // TODO: we should be more explicit about the default behavior here (nil vs. returning false)
             let advancesToNextLeg = delegate?.routeController?(self, didArriveAt: currentDestination) ?? true
 
             if !routeProgress.isFinalLeg && advancesToNextLeg {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -251,7 +251,6 @@ open class RouteController: NSObject {
         self.directions = directions
         self.routeProgress = RouteProgress(route: route)
         self.locationManager = locationManager
-        // TODO: shouldn't this be done inside didSet
         self.locationManager.activityType = route.routeOptions.activityType
         self.eventsManager = eventsManager
         UIDevice.current.isBatteryMonitoringEnabled = true
@@ -593,7 +592,6 @@ extension RouteController: CLLocationManagerDelegate {
         updateRouteStepProgress(for: location)
         updateRouteLegProgress(for: location)
 
-        // TODO: refactor this!!
         guard userIsOnRoute(location) || !(delegate?.routeController?(self, shouldRerouteFrom: location) ?? true) else {
             reroute(from: location)
             return
@@ -625,7 +623,6 @@ extension RouteController: CLLocationManagerDelegate {
 
             routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
 
-            // TODO: we should be more explicit about the default behavior here (nil vs. returning false)
             let advancesToNextLeg = delegate?.routeController?(self, didArriveAt: currentDestination) ?? true
 
             if !routeProgress.isFinalLeg && advancesToNextLeg {
@@ -722,7 +719,6 @@ extension RouteController: CLLocationManagerDelegate {
                 // If the upcoming maneuver in the new route is the same as the current upcoming maneuver, don't announce it
                 strongSelf.routeProgress = RouteProgress(route: route, legIndex: 0, spokenInstructionIndex: strongSelf.routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex)
                 strongSelf.delegate?.routeController?(strongSelf, didRerouteAlong: route)
-                //TODO: this seems wrong // when we call from here, we want to mutate the re-route event
                 strongSelf.didReroute(notification: NSNotification(name: .routeControllerDidReroute, object: nil, userInfo: [
                     RouteControllerNotificationUserInfoKey.isProactiveKey: true]))
                 strongSelf.didFindFasterRoute = false
@@ -997,10 +993,10 @@ extension RouteController {
             if let index = outstandingFeedbackEvents.index(of: event) {
                 outstandingFeedbackEvents.remove(at: index)
             }
-
+            
             let eventName = event.eventDictionary["event"] as! String
             let eventDictionary = eventsManager.navigationFeedbackEventWithLocationsAdded(event: event, routeController: self)
-
+            
             eventsManager.enqueueEvent(withName: eventName, attributes: eventDictionary)
         }
         eventsManager.flush()

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -246,6 +246,7 @@ open class RouteController: NSObject {
         self.directions = directions
         self.routeProgress = RouteProgress(route: route)
         self.locationManager = locationManager
+        // TODO: shouldn't this be done inside didSet
         self.locationManager.activityType = route.routeOptions.activityType
         self.eventsManager = eventsManager
         UIDevice.current.isBatteryMonitoringEnabled = true
@@ -260,11 +261,7 @@ open class RouteController: NSObject {
         }
 
         checkForUpdates()
-
-        guard let _ = Bundle.main.bundleIdentifier else { return }
-        if Bundle.main.locationAlwaysUsageDescription == nil && Bundle.main.locationWhenInUseUsageDescription == nil && Bundle.main.locationAlwaysAndWhenInUseUsageDescription == nil {
-            preconditionFailure("This application’s Info.plist file must include a NSLocationWhenInUseUsageDescription. See https://developer.apple.com/documentation/corelocation for more information.")
-        }
+        checkForLocationUsageDescription()
     }
 
     deinit {
@@ -766,7 +763,7 @@ extension RouteController: CLLocationManagerDelegate {
         }
     }
 
-    func checkForUpdates() {
+    private func checkForUpdates() {
         #if TARGET_IPHONE_SIMULATOR
             guard let version = Bundle(for: RouteController.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") else { return }
             let latestVersion = String(describing: version)
@@ -782,6 +779,15 @@ extension RouteController: CLLocationManagerDelegate {
                 }
             }).resume()
         #endif
+    }
+
+    private func checkForLocationUsageDescription() {
+        guard let _ = Bundle.main.bundleIdentifier else {
+            return
+        }
+        if Bundle.main.locationAlwaysUsageDescription == nil && Bundle.main.locationWhenInUseUsageDescription == nil && Bundle.main.locationAlwaysAndWhenInUseUsageDescription == nil {
+            preconditionFailure("This application’s Info.plist file must include a NSLocationWhenInUseUsageDescription. See https://developer.apple.com/documentation/corelocation for more information.")
+        }
     }
 
     func getDirections(from location: CLLocation, completion: @escaping (_ route: Route?, _ error: Error?)->Void) {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -1036,7 +1036,6 @@ extension RouteController {
         let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
 
         outstandingFeedbackEvents.append(event)
-//        eventsManager.enqueueEvent(withName: MMEEventTypeNavigationReroute, attributes: event.eventDictionary)
 
         return event.id.uuidString
     }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -144,6 +144,7 @@ public protocol RouteControllerDelegate: class {
  */
 @objc(MBRouteController)
 open class RouteController: NSObject {
+    // TODO: This needs to be injected as a default initializer param so that we can substitute a spy under test.
     let events = MMEEventsManager.shared()
 
     /**
@@ -555,7 +556,9 @@ extension RouteController: CLLocationManagerDelegate {
             potentialLocation = lastLocation
         }
         
-        guard let location = potentialLocation else { return }
+        guard let location = potentialLocation else {
+            return
+        }
         
         self.rawLocation = location
 
@@ -588,7 +591,8 @@ extension RouteController: CLLocationManagerDelegate {
         updateDistanceToIntersection(from: location)
         updateRouteStepProgress(for: location)
         updateRouteLegProgress(for: location)
-        
+
+        // TODO: refactor this!!
         guard userIsOnRoute(location) || !(delegate?.routeController?(self, shouldRerouteFrom: location) ?? true) else {
             reroute(from: location)
             return

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -87,7 +87,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         
         let secondLocation = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 38, longitude: -124),
                                         altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: 0, speed: 0,
-                                        timestamp: Date(timeIntervalSinceNow: 5))
+                                        timestamp: Date(timeIntervalSinceNow: 1))
         
         let locationManager = ReplayLocationManager(locations: [firstLocation, secondLocation])
         let navigation = RouteController(along: route, directions: directions, locationManager: locationManager)

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -114,24 +114,35 @@ class RouteControllerTests: XCTestCase {
         XCTAssertEqual(navigation.location!.course, mbTestHeading, "Course should be using bearing")
     }
 
+    // MARK: When told to re-route from location -- `reroute(from:)`
+    func testReroutingFromALocation() {
+        XCTFail("Start here...")
+//        let controller = setup.routeController
+//        controller.reroute(from: someLocation)
+//
+//        // TODO: it tells the delegate
+//        XCTAssertTrue(delegate.recentMessages.includes("routeController(_, willRerouteFrom:)"))
+//
+//        // TODO: it logs the event
+//        XCTAssertTrue(eventsManagerSpy.recentEvents.includes("whatever we need to include"))
+//
+//        // TODO: it posts a "will reroute" notification (figure out whether to keep this after clarifying the event tracking)
+//        XCTAssertTrue(notificationObserver.recentNotifications.includes(.routeControllerWillReroute))
+    }
+
     // MARK: Failing to get directions from location
     // TODO: it tells the delegate
     // TODO: it logs the event
     // TODO: it posts a notification with the error (do we keep this after clarifying the event tracking
 
-    // MARK: When told to re-route from location
-    // TODO: it tells the delegate
-    // TODO: it logs the event
-    // TODO: it posts a "will reroute" notification (do we keep this after clarifying the event tracking
-
     // MARK: When a RouteProgress is set / when progress changes
-    // TODO: it posts a re-route notification?!? Note that it does not tell the delegate. check how this is used.
+    // TODO: it posts a re-route notification... Note that it does not tell the delegate. check how this is used.
 
     // MARK: Checking for a faster route
     // getDirections, if a bunch of checks are met (refactoring oppty), schenanigans
     // TODO: it sets routeProgress & all that
     // TODO: it tells the delegate
-    // TODO: possible bug, it calls didReroute with a mock Notification, does not post
+    // TODO: major refactoring opportunity, it calls didReroute with a mock Notification, does not post
 
 
 

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -162,6 +162,8 @@ class RouteControllerTests: XCTestCase {
         let routeController = dependencies.routeController
         let testLocation = dependencies.firstLocation
 
+        routeController.delaysEventFlushing = false
+
         let willRerouteNotificationExpectation = expectation(forNotification: .routeControllerWillReroute, object: routeController) { (notification) -> Bool in
             let fromLocation = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as? CLLocation
             return fromLocation == testLocation
@@ -222,7 +224,4 @@ class RouteControllerTests: XCTestCase {
     // TODO: test & refactor the mutation of the re-route events
     // TODO: what about SessionState?
 
-    // MARK: When route progress changes (triggered in locationManager(didUpdateLocations:))
-    // TODO: it posts a routeControllerProgressDidChange notification
-    
 }

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -164,6 +164,9 @@ class RouteControllerTests: XCTestCase {
     // TODO: it tells the delegate
     // TODO: major refactoring opportunity, it calls didReroute with a mock Notification, does not post
 
+    // MARK: more tests
+    // TODO: test feedback event mutation workflow
+    // TODO: test & refactor the mutation of the re-route events
 
 
 }

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import MapboxDirections
 import Turf
+import MapboxMobileEvents
 @testable import MapboxCoreNavigation
 
 fileprivate let mbTestHeading: CLLocationDirection = 50
@@ -129,18 +130,22 @@ class RouteControllerTests: XCTestCase {
         controller.reroute(from: someLocation)
 
         // It logs the event
-        XCTAssertTrue(eventsManagerSpy.recentEvents.contains("whatever we need to include"))
+        let expectedName: String = MMEEventTypeNavigationReroute
+        XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedName))
+        XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedName))
 
 //        // TODO: it tells the delegate
 //        XCTAssertTrue(delegate.recentMessages.includes("routeController(_, willRerouteFrom:)"))
 //
 //        // TODO: it posts a "will reroute" notification (figure out whether to keep this after clarifying the event tracking)
 //        XCTAssertTrue(notificationObserver.recentNotifications.includes(.routeControllerWillReroute))
+
+        // TODO: what about SessionState?
     }
 
     // MARK: Failing to get directions from location
     // TODO: it tells the delegate
-    // TODO: it logs the event
+    // TODO: it logs the telemetry event
     // TODO: it posts a notification with the error (do we keep this after clarifying the event tracking
 
     // MARK: When a RouteProgress is set / when progress changes

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -234,7 +234,7 @@ class RouteControllerTests: XCTestCase {
         // MARK: It tells the delegate that the user did arrive
         XCTAssertTrue(delegate.recentMessages.contains("routeController(_:didArriveAt:)"))
 
-        // FIXME: event isn't logged unless the routecontroller receives another location update. if this doesn't happen, no event. which means we might not be accounting for all of our arrivals.
+        // FIXME: event isn't logged unless the routecontroller receives yet another location update.
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [currentLocation])
 
         // MARK: It enqueues and flushes an arrival event
@@ -242,20 +242,5 @@ class RouteControllerTests: XCTestCase {
         XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedEventName))
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedEventName))
     }
-
-    // MARK: Next steps
-    // TODO: Feedback event
-    // TODO: More detailed testing of rerouting scenarios
-
-    // MARK: Failing to get directions from location
-    // TODO: it tells the delegate
-    // TODO: it logs the telemetry event
-    // TODO: it posts a notification with the error (do we keep this after clarifying the event tracking
-
-    // MARK: Checking for a faster route
-    // getDirections, if a bunch of checks are met (refactoring oppty), schenanigans
-    // TODO: it sets routeProgress & all that
-    // TODO: it tells the delegate
-    // TODO: major refactoring opportunity, it calls didReroute with a mock Notification, does not post
 
 }

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -126,10 +126,14 @@ class RouteControllerTests: XCTestCase {
     func testReroutingFromALocationSendsEvents() {
         let controller = setup.routeController
 
-        let someLocation = CLLocation(latitude: 123, longitude: 456)
+        let someLocation = setup.firstLocation
         controller.reroute(from: someLocation)
 
         // It logs the event
+        // when the next location update is received
+        controller.locationManager(controller.locationManager, didUpdateLocations: [someLocation])
+
+        // It logs (flushes) the event
         let expectedName: String = MMEEventTypeNavigationReroute
         XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedName))
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedName))

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -6,68 +6,68 @@ import Turf
 fileprivate let mbTestHeading: CLLocationDirection = 50
 
 class RouteControllerTests: XCTestCase {
-    
+
     var setup: (routeController: RouteController, firstLocation: CLLocation) {
         route.accessToken = "foo"
         let navigation = RouteController(along: route, directions: directions)
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         return (routeController: navigation, firstLocation: CLLocation(coordinate: firstCoord, altitude: 5, horizontalAccuracy: 10, verticalAccuracy: 5, course: 20, speed: 4, timestamp: Date()))
     }
-    
+
     func testUserIsOnRoute() {
         let navigation = setup.routeController
         let firstLocation = setup.firstLocation
-        
+
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertTrue(navigation.userIsOnRoute(firstLocation), "User should be on route")
     }
-    
+
     func testUserIsOffRoute() {
         let navigation = setup.routeController
         let firstLocation = setup.firstLocation
-        
+
         let coordinateOffRoute = firstLocation.coordinate.coordinate(at: 100, facing: 90)
         let locationOffRoute = CLLocation(latitude: coordinateOffRoute.latitude, longitude: coordinateOffRoute.longitude)
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [locationOffRoute])
         XCTAssertFalse(navigation.userIsOnRoute(locationOffRoute), "User should be off route")
     }
-    
+
     func testAdvancingToFutureStepAndNotRerouting() {
         let navigation = setup.routeController
         let firstLocation = setup.firstLocation
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertTrue(navigation.userIsOnRoute(firstLocation), "User should be on route")
         XCTAssertEqual(navigation.routeProgress.currentLegProgress.stepIndex, 0, "User is on first step")
-        
+
         let futureCoordinate = navigation.routeProgress.currentLegProgress.leg.steps[2].coordinates![10]
         let futureLocation = CLLocation(latitude: futureCoordinate.latitude, longitude: futureCoordinate.longitude)
-        
+
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [futureLocation])
         XCTAssertTrue(navigation.userIsOnRoute(futureLocation), "User should be on route")
-        
+
         XCTAssertEqual(navigation.routeProgress.currentLegProgress.stepIndex, 2, "User should be on route and we should increment all the way to the 4th step")
     }
-    
+
     func testSnappedLocation() {
         let navigation = setup.routeController
         let firstLocation = setup.firstLocation
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
     }
-    
+
     func testSnappedLocationForUnqualifiedLocation() {
         let navigation = setup.routeController
         let firstLocation = setup.firstLocation
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
-        
+
         let futureCoord = Polyline(navigation.routeProgress.currentLegProgress.nearbyCoordinates).coordinateFromStart(distance: 100)!
         let futureInaccurateLocation = CLLocation(coordinate: futureCoord, altitude: 0, horizontalAccuracy: 1, verticalAccuracy: 200, course: 0, speed: 5, timestamp: Date())
-        
+
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [futureInaccurateLocation])
         XCTAssertEqual(navigation.location!.coordinate, futureInaccurateLocation.coordinate, "Inaccurate location is still snapped")
     }
-  
+
     func testUserPuckShouldFaceBackwards() {
         // This route is a simple straight line: http://geojson.io/#id=gist:anonymous/64cfb27881afba26e3969d06bacc707c&map=17/37.77717/-122.46484
         let response = Fixture.JSONFromFileNamed(name: "straight-line")
@@ -76,41 +76,63 @@ class RouteControllerTests: XCTestCase {
         let waypoint2 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.7727, longitude: -122.433378))
         let directions = Directions(accessToken: "pk.feedCafeDeadBeefBadeBede")
         let route = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], routeOptions: NavigationRouteOptions(waypoints: [waypoint1, waypoint2]))
-        
+
         route.accessToken = "foo"
         let navigation = RouteController(along: route, directions: directions)
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         let firstLocation = CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
         let coordNearStart = Polyline(navigation.routeProgress.currentLegProgress.nearbyCoordinates).coordinateFromStart(distance: 10)!
-        
+
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
-        
+
         // We're now 10 meters away from the last coord, looking at the start.
         // Basically, simulating moving backwards.
         let directionToStart = coordNearStart.direction(to: firstCoord)
         let facingTowardsStartLocation = CLLocation(coordinate: coordNearStart, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: directionToStart, speed: 0, timestamp: Date())
-        
+
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [facingTowardsStartLocation])
-        
+
         // The course should not be the interpolated course, rather the raw course.
         XCTAssertEqual(directionToStart, navigation.location!.course, "The course should be the raw course and not an interpolated course")
         XCTAssertFalse(facingTowardsStartLocation.shouldSnap(toRouteWith: facingTowardsStartLocation.interpolatedCourse(along: navigation.routeProgress.currentLegProgress.nearbyCoordinates)!, distanceToFirstCoordinateOnLeg: facingTowardsStartLocation.distance(from: firstLocation)), "Should not snap")
     }
-    
+
     func testLocationShouldUseHeading() {
         let navigation = setup.routeController
         let firstLocation = setup.firstLocation
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
-        
+
         XCTAssertEqual(navigation.location!.course, firstLocation.course, "Course should be using course")
-        
+
         let invalidCourseLocation = CLLocation(coordinate: firstLocation.coordinate, altitude: firstLocation.altitude, horizontalAccuracy: firstLocation.horizontalAccuracy, verticalAccuracy: firstLocation.verticalAccuracy, course: -1, speed: firstLocation.speed, timestamp: firstLocation.timestamp)
-        
+
         let heading = CLHeading(heading: mbTestHeading, accuracy: 1)!
-        
+
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [invalidCourseLocation])
         navigation.locationManager(navigation.locationManager, didUpdateHeading: heading)
-        
+
         XCTAssertEqual(navigation.location!.course, mbTestHeading, "Course should be using bearing")
     }
+
+    // MARK: Failing to get directions from location
+    // TODO: it tells the delegate
+    // TODO: it logs the event
+    // TODO: it posts a notification with the error (do we keep this after clarifying the event tracking
+
+    // MARK: When told to re-route from location
+    // TODO: it tells the delegate
+    // TODO: it logs the event
+    // TODO: it posts a "will reroute" notification (do we keep this after clarifying the event tracking
+
+    // MARK: When a RouteProgress is set / when progress changes
+    // TODO: it posts a re-route notification?!? Note that it does not tell the delegate. check how this is used.
+
+    // MARK: Checking for a faster route
+    // getDirections, if a bunch of checks are met (refactoring oppty), schenanigans
+    // TODO: it sets routeProgress & all that
+    // TODO: it tells the delegate
+    // TODO: possible bug, it calls didReroute with a mock Notification, does not post
+
+
+
 }

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -10,7 +10,7 @@ class RouteControllerTests: XCTestCase {
 
     struct Constants {
         static let jsonRoute = (response["routes"] as! [AnyObject]).first as! [String : Any]
-        static let accessToken = "access-token"
+        static let accessToken = "nonsense"
     }
 
     let eventsManagerSpy = EventsManagerSpy()

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -11,9 +11,7 @@ class RouteControllerTests: XCTestCase {
     let eventsManagerSpy = EventsManagerSpy()
 
     lazy var setup: (routeController: RouteController, firstLocation: CLLocation) = {
-        print("line #: \(#line); function: \(#function)")
-        route.accessToken = "foo"
-        let navigation = RouteController(along: route, directions: directions, locationManager: NavigationLocationManager(), eventsManager: eventsManagerSpy)
+        let navigation = RouteController(along: initialRoute, directions: directionsClientSpy, locationManager: NavigationLocationManager(), eventsManager: eventsManagerSpy)
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         return (routeController: navigation, firstLocation: CLLocation(coordinate: firstCoord, altitude: 5, horizontalAccuracy: 10, verticalAccuracy: 5, course: 20, speed: 4, timestamp: Date()))
     }()

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -10,12 +10,13 @@ class RouteControllerTests: XCTestCase {
 
     let eventsManagerSpy = EventsManagerSpy()
 
-    var setup: (routeController: RouteController, firstLocation: CLLocation) {
+    lazy var setup: (routeController: RouteController, firstLocation: CLLocation) = {
+        print("line #: \(#line); function: \(#function)")
         route.accessToken = "foo"
         let navigation = RouteController(along: route, directions: directions, locationManager: NavigationLocationManager(), eventsManager: eventsManagerSpy)
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         return (routeController: navigation, firstLocation: CLLocation(coordinate: firstCoord, altitude: 5, horizontalAccuracy: 10, verticalAccuracy: 5, course: 20, speed: 4, timestamp: Date()))
-    }
+    }()
 
     override func setUp() {
         super.setUp()
@@ -125,8 +126,8 @@ class RouteControllerTests: XCTestCase {
     // MARK: When told to re-route from location -- `reroute(from:)`
     func testReroutingFromALocationSendsEvents() {
         let controller = setup.routeController
-
         let someLocation = setup.firstLocation
+
         print("Kicking off reroute...")
         controller.reroute(from: someLocation)
 

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -180,6 +180,8 @@ class RouteControllerTests: XCTestCase {
         let expectedEventName = MMEEventTypeNavigationReroute
         XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedEventName))
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedEventName))
+        XCTAssertEqual(eventsManagerSpy.enqueuedEventCount(with: expectedEventName), 1)
+        XCTAssertEqual(eventsManagerSpy.flushedEventCount(with: expectedEventName), 1)
 
         // TODO: it tells the delegate
 //        XCTAssertTrue(delegate.recentMessages.includes("routeController(_, willRerouteFrom:)"))

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -145,15 +145,14 @@ class RouteControllerTests: XCTestCase {
 
     // MARK: When told to re-route from location -- `reroute(from:)`
     func testReroutingFromALocationSendsEvents() {
-        let controller = setup.routeController
+        let routeController = setup.routeController
+
         let testLocation = setup.firstLocation
-        let updatedRoute = alternateRoute
+        routeController.reroute(from: testLocation)
+        directionsClientSpy.fireLastCalculateCompletion(with: nil, routes: [alternateRoute], error: nil)
+        routeController.locationManager(routeController.locationManager, didUpdateLocations: [testLocation])
+
         let expectedEventName = MMEEventTypeNavigationReroute
-
-        controller.reroute(from: testLocation)
-        directionsClientSpy.fireLastCalculateCompletion(with: nil, routes: [updatedRoute], error: nil)
-        controller.locationManager(controller.locationManager, didUpdateLocations: [testLocation])
-
         XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedEventName))
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedEventName))
 

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -127,11 +127,13 @@ class RouteControllerTests: XCTestCase {
         let controller = setup.routeController
 
         let someLocation = setup.firstLocation
+        print("Kicking off reroute...")
         controller.reroute(from: someLocation)
 
-        // It logs the event
         // when the next location update is received
+        print("Simulating location update")
         controller.locationManager(controller.locationManager, didUpdateLocations: [someLocation])
+
 
         // It logs (flushes) the event
         let expectedName: String = MMEEventTypeNavigationReroute

--- a/MapboxCoreNavigationTests/Support/DirectionsSpy.swift
+++ b/MapboxCoreNavigationTests/Support/DirectionsSpy.swift
@@ -1,0 +1,36 @@
+import Foundation
+import MapboxDirections
+
+class DirectionsSpy: Directions {
+    
+    var lastCalculateOptionsCompletion: RouteCompletionHandler?
+    
+    override func calculate(_ options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> URLSessionDataTask {
+        assert(false, "Not ready to handle \(#function)")
+        return DummyURLSessionDataTask()
+    }
+    
+    override func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> URLSessionDataTask {
+        lastCalculateOptionsCompletion = completionHandler
+        return DummyURLSessionDataTask()
+    }
+    
+    override func calculateRoutes(matching options: MatchOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> URLSessionDataTask {
+        assert(false, "Not ready to handle \(#function)")
+        return DummyURLSessionDataTask()
+
+    }
+    
+    public func fireLastCalculateCompletion(with waypoints: [Waypoint]?, routes: [Route]?, error: NSError?) {
+        guard let lastCalculateOptionsCompletion = lastCalculateOptionsCompletion else {
+            assert(false, "Can't fire a completion handler which doesn't exist!")
+            return
+        }
+
+        lastCalculateOptionsCompletion(waypoints, routes, error)
+    }
+    
+    public func reset() {
+        lastCalculateOptionsCompletion = nil
+    }
+}

--- a/MapboxCoreNavigationTests/Support/DummyURLSessionDataTask.swift
+++ b/MapboxCoreNavigationTests/Support/DummyURLSessionDataTask.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+class DummyURLSessionDataTask: URLSessionDataTask {
+    override func resume() {
+        //
+    }
+}

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -3,5 +3,9 @@ import MapboxMobileEvents
 
 class EventsManagerSpy: MMEEventsManager {
 
+    var recentEvents: NSArray = NSMutableArray()
 
+    func reset() {
+        recentEvents = NSMutableArray()
+    }
 }

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -1,11 +1,48 @@
 import Foundation
 import MapboxMobileEvents
 
+typealias MockTelemetryEvent = (name: String, attributes: [String: Any])
+
 class EventsManagerSpy: MMEEventsManager {
 
-    var recentEvents: NSArray = NSMutableArray()
+    private var enqueuedEvents = [MockTelemetryEvent]()
+    private var flushedEvents = [MockTelemetryEvent]()
 
     func reset() {
-        recentEvents = NSMutableArray()
+        enqueuedEvents.removeAll()
+        flushedEvents.removeAll()
+    }
+
+    override func enqueueEvent(withName name: String) {
+        self.enqueueEvent(withName: name, attributes: [:])
+    }
+
+    override func enqueueEvent(withName name: String, attributes: [String: Any] = [:]) {
+        let event: MockTelemetryEvent = MockTelemetryEvent(name: name, attributes: attributes)
+        enqueuedEvents.append(event)
+    }
+
+    override func flush() {
+        enqueuedEvents.forEach { (event: MockTelemetryEvent) in
+            flushedEvents.append(event)
+        }
+    }
+
+    public func hasFlushedEvent(with name: String) -> Bool {
+        return flushedEvents.contains { (event: MockTelemetryEvent) in
+            if event.name == name {
+                return true
+            }
+            return false
+        }
+    }
+
+    public func hasEnqueuedEvent(with name: String) -> Bool {
+        return enqueuedEvents.contains { (event: MockTelemetryEvent) in
+            if event.name == name {
+                return true
+            }
+            return false
+        }
     }
 }

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -18,18 +18,22 @@ class EventsManagerSpy: MMEEventsManager {
     }
 
     override func enqueueEvent(withName name: String, attributes: [String: Any] = [:]) {
+        print("enqueueEvent...")
         let event: MockTelemetryEvent = MockTelemetryEvent(name: name, attributes: attributes)
         enqueuedEvents.append(event)
     }
 
     override func flush() {
+        print("flush")
         enqueuedEvents.forEach { (event: MockTelemetryEvent) in
             flushedEvents.append(event)
         }
     }
 
     public func hasFlushedEvent(with name: String) -> Bool {
+        print("hasFlushedEvent(with:)")
         for event in flushedEvents {
+//            print("event: \(event.name)")
             if event.name == name {
                 return true
             }
@@ -38,7 +42,9 @@ class EventsManagerSpy: MMEEventsManager {
     }
 
     public func hasEnqueuedEvent(with name: String) -> Bool {
+        print("hasEnqueuedEvent(with:)")
         for event in enqueuedEvents {
+//            print("event: \(event.name)")
             if event.name == name {
                 return true
             }

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -8,7 +8,7 @@ class EventsManagerSpy: MMEEventsManager {
     private var enqueuedEvents = [MockTelemetryEvent]()
     private var flushedEvents = [MockTelemetryEvent]()
 
-    func reset() {
+    public func reset() {
         enqueuedEvents.removeAll()
         flushedEvents.removeAll()
     }
@@ -38,5 +38,17 @@ class EventsManagerSpy: MMEEventsManager {
         return enqueuedEvents.contains(where: { (event) -> Bool in
             return event.attributes["event"] as! String == name
         })
+    }
+
+    public func enqueuedEventCount(with name: String) -> Int {
+        return enqueuedEvents.filter { (event) in
+            return event.attributes["event"] as! String == name
+        }.count
+    }
+
+    public func flushedEventCount(with name: String) -> Int {
+        return flushedEvents.filter { (event) in
+            return event.attributes["event"] as! String == name
+        }.count
     }
 }

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -29,20 +29,20 @@ class EventsManagerSpy: MMEEventsManager {
     }
 
     public func hasFlushedEvent(with name: String) -> Bool {
-        return flushedEvents.contains { (event: MockTelemetryEvent) in
+        for event in flushedEvents {
             if event.name == name {
                 return true
             }
-            return false
         }
+        return false
     }
 
     public func hasEnqueuedEvent(with name: String) -> Bool {
-        return enqueuedEvents.contains { (event: MockTelemetryEvent) in
+        for event in enqueuedEvents {
             if event.name == name {
                 return true
             }
-            return false
         }
+        return false
     }
 }

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -1,0 +1,7 @@
+import Foundation
+import MapboxMobileEvents
+
+class EventsManagerSpy: MMEEventsManager {
+
+
+}

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -18,37 +18,25 @@ class EventsManagerSpy: MMEEventsManager {
     }
 
     override func enqueueEvent(withName name: String, attributes: [String: Any] = [:]) {
-        print("enqueueEvent...")
         let event: MockTelemetryEvent = MockTelemetryEvent(name: name, attributes: attributes)
         enqueuedEvents.append(event)
     }
 
     override func flush() {
-        print("flush")
         enqueuedEvents.forEach { (event: MockTelemetryEvent) in
             flushedEvents.append(event)
         }
     }
 
     public func hasFlushedEvent(with name: String) -> Bool {
-        print("hasFlushedEvent(with:)")
-        for event in flushedEvents {
-//            print("event: \(event.name)")
-            if event.name == name {
-                return true
-            }
-        }
-        return false
+        return flushedEvents.contains(where: { (event) -> Bool in
+            return event.attributes["event"] as! String == name
+        })
     }
 
     public func hasEnqueuedEvent(with name: String) -> Bool {
-        print("hasEnqueuedEvent(with:)")
-        for event in enqueuedEvents {
-//            print("event: \(event.name)")
-            if event.name == name {
-                return true
-            }
-        }
-        return false
+        return enqueuedEvents.contains(where: { (event) -> Bool in
+            return event.attributes["event"] as! String == name
+        })
     }
 }

--- a/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerSpy.swift
@@ -22,6 +22,10 @@ class EventsManagerSpy: MMEEventsManager {
         enqueuedEvents.append(event)
     }
 
+    override func sendTurnstileEvent() {
+        flushedEvents.append((name: "???", attributes: ["event" : MMEEventTypeAppUserTurnstile, "eventsManager" : String(describing: self)]))
+    }
+
     override func flush() {
         enqueuedEvents.forEach { (event: MockTelemetryEvent) in
             flushedEvents.append(event)

--- a/MapboxCoreNavigationTests/Support/RouteControllerDelegateSpy.swift
+++ b/MapboxCoreNavigationTests/Support/RouteControllerDelegateSpy.swift
@@ -3,10 +3,10 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 class RouteControllerDelegateSpy: RouteControllerDelegate {
-    public var recentMessages: [String] = []
+    private(set) var recentMessages: [String] = []
 
     public func reset() {
-        recentMessages = []
+        recentMessages.removeAll()
     }
 
     internal func routeController(_ routeController: RouteController, shouldRerouteFrom location: CLLocation) -> Bool {

--- a/MapboxCoreNavigationTests/Support/RouteControllerDelegateSpy.swift
+++ b/MapboxCoreNavigationTests/Support/RouteControllerDelegateSpy.swift
@@ -1,0 +1,42 @@
+import Foundation
+import MapboxCoreNavigation
+import MapboxDirections
+
+class RouteControllerDelegateSpy: RouteControllerDelegate {
+    public var recentMessages: [String] = []
+
+    public func reset() {
+        recentMessages = []
+    }
+
+    internal func routeController(_ routeController: RouteController, shouldRerouteFrom location: CLLocation) -> Bool {
+        recentMessages.append(#function)
+        return true
+    }
+
+    internal func routeController(_ routeController: RouteController, willRerouteFrom location: CLLocation) {
+        recentMessages.append(#function)
+    }
+
+    internal func routeController(_ routeController: RouteController, shouldDiscard location: CLLocation) -> Bool {
+        recentMessages.append(#function)
+        return true
+    }
+
+    internal func routeController(_ routeController: RouteController, didRerouteAlong route: Route) {
+        recentMessages.append(#function)
+    }
+
+    internal func routeController(_ routeController: RouteController, didFailToRerouteWith error: Error) {
+        recentMessages.append(#function)
+    }
+
+    internal func routeController(_ routeController: RouteController, didUpdate locations: [CLLocation]) {
+        recentMessages.append(#function)
+    }
+
+    internal func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) -> Bool {
+        recentMessages.append(#function)
+        return true
+    }
+}

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
 		160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D827A2059973C00D278D6 /* DataCacheTests.swift */; };
+		16120A4D20645D6E007EA21D /* EventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* EventsManagerSpy.swift */; };
 		166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166224442025699600EA4824 /* ImageRepositoryTests.swift */; };
 		1662244720256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662244620256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift */; };
 		1662244B2029059C00EA4824 /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662244A2029059C00EA4824 /* ImageCacheTests.swift */; };
@@ -402,6 +403,7 @@
 /* Begin PBXFileReference section */
 		160D8278205996DA00D278D6 /* DataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
 		160D827A2059973C00D278D6 /* DataCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCacheTests.swift; sourceTree = "<group>"; };
+		16120A4C20645D6E007EA21D /* EventsManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerSpy.swift; sourceTree = "<group>"; };
 		166224442025699600EA4824 /* ImageRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryTests.swift; sourceTree = "<group>"; };
 		1662244620256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadingURLProtocolSpy.swift; sourceTree = "<group>"; };
 		1662244A2029059C00EA4824 /* ImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
@@ -808,6 +810,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		16120A4B20645D2C007EA21D /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				16120A4C20645D6E007EA21D /* EventsManagerSpy.swift */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
 		16E3625A2012656C00DF0592 /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -1190,6 +1200,7 @@
 		C5ADFBD61DDCC7840011824B /* MapboxCoreNavigationTests */ = {
 			isa = PBXGroup;
 			children = (
+				16120A4B20645D2C007EA21D /* Support */,
 				C52D09CF1DEF5E5F00BE3C5C /* Fixtures */,
 				C52D09D21DEF636C00BE3C5C /* Fixture.swift */,
 				C5ADFBD71DDCC7840011824B /* MapboxCoreNavigationTests.swift */,
@@ -1923,6 +1934,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */,
+				16120A4D20645D6E007EA21D /* EventsManagerSpy.swift in Sources */,
 				359A8AED1FA78D3000BDB486 /* DistanceFormatterTests.swift in Sources */,
 				C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */,
 				359574AA1F28CCBB00838209 /* LocationTests.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
 		160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D827A2059973C00D278D6 /* DataCacheTests.swift */; };
 		16120A4D20645D6E007EA21D /* EventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* EventsManagerSpy.swift */; };
+		16435E03206EE32F00AF48B6 /* DirectionsSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */; };
+		16435E05206EE37800AF48B6 /* DummyURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */; };
+		16435E06206EE37800AF48B6 /* DummyURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */; };
 		166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166224442025699600EA4824 /* ImageRepositoryTests.swift */; };
 		1662244720256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662244620256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift */; };
 		1662244B2029059C00EA4824 /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662244A2029059C00EA4824 /* ImageCacheTests.swift */; };
@@ -404,6 +407,8 @@
 		160D8278205996DA00D278D6 /* DataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
 		160D827A2059973C00D278D6 /* DataCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCacheTests.swift; sourceTree = "<group>"; };
 		16120A4C20645D6E007EA21D /* EventsManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerSpy.swift; sourceTree = "<group>"; };
+		16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectionsSpy.swift; sourceTree = "<group>"; };
+		16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyURLSessionDataTask.swift; sourceTree = "<group>"; };
 		166224442025699600EA4824 /* ImageRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryTests.swift; sourceTree = "<group>"; };
 		1662244620256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadingURLProtocolSpy.swift; sourceTree = "<group>"; };
 		1662244A2029059C00EA4824 /* ImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
@@ -813,6 +818,8 @@
 		16120A4B20645D2C007EA21D /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */,
+				16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */,
 				16120A4C20645D6E007EA21D /* EventsManagerSpy.swift */,
 			);
 			path = Support;
@@ -1884,6 +1891,7 @@
 				16E4F97F205B05FE00531791 /* MapboxVoiceControllerTests.swift in Sources */,
 				35A262B92050A5CD00AEFF6D /* InstructionsBannerViewSnapshotTests.swift in Sources */,
 				35F1F5931FD57EFD00F8E502 /* StyleManagerTests.swift in Sources */,
+				16435E06206EE37800AF48B6 /* DummyURLSessionDataTask.swift in Sources */,
 				16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */,
 				8D54F14A206ECF720038736D /* InstructionPresenterTests.swift in Sources */,
 				166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */,
@@ -1933,6 +1941,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				16435E05206EE37800AF48B6 /* DummyURLSessionDataTask.swift in Sources */,
 				C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */,
 				16120A4D20645D6E007EA21D /* EventsManagerSpy.swift in Sources */,
 				359A8AED1FA78D3000BDB486 /* DistanceFormatterTests.swift in Sources */,
@@ -1940,6 +1949,7 @@
 				359574AA1F28CCBB00838209 /* LocationTests.swift in Sources */,
 				C582BA2C2073E77E00647DAA /* StringTests.swift in Sources */,
 				C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */,
+				16435E03206EE32F00AF48B6 /* DirectionsSpy.swift in Sources */,
 				C5ABB50E20408D2C00AFA92C /* RouteControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		3EA9371104016CD402547F1A /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA938479CF48D7AD1B6369B /* ImageCache.swift */; };
 		3EA937B1F4DF73EB004BA6BE /* InstructionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93230997B8D59E3B76C8C /* InstructionPresenter.swift */; };
 		3EA93A1FEFDDB709DE84BED9 /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA938BE5468824787100228 /* ImageRepository.swift */; };
+		3EA93DC5BA00B5DFCBE7BAC3 /* RouteControllerDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */; };
 		6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */; };
 		64847A041F04629D003F3A69 /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64847A031F04629D003F3A69 /* Feedback.swift */; };
 		8D24A2F62040960C0098CBF8 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D24A2F52040960C0098CBF8 /* UIEdgeInsets.swift */; };
@@ -556,6 +557,7 @@
 		3EA938479CF48D7AD1B6369B /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		3EA938BE5468824787100228 /* ImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		3EA93A10227A7DAF1861D9F5 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
+		3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteControllerDelegateSpy.swift; sourceTree = "<group>"; };
 		6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaypointConfirmationViewController.swift; sourceTree = "<group>"; };
 		64847A031F04629D003F3A69 /* Feedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
 		8D24A2F52040960C0098CBF8 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
@@ -821,6 +823,7 @@
 				16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */,
 				16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */,
 				16120A4C20645D6E007EA21D /* EventsManagerSpy.swift */,
+				3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1951,6 +1954,7 @@
 				C52D09D31DEF636C00BE3C5C /* Fixture.swift in Sources */,
 				16435E03206EE32F00AF48B6 /* DirectionsSpy.swift in Sources */,
 				C5ABB50E20408D2C00AFA92C /* RouteControllerTests.swift in Sources */,
+				3EA93DC5BA00B5DFCBE7BAC3 /* RouteControllerDelegateSpy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MapboxNavigation.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MapboxNavigation.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -61,7 +60,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/MapboxNavigationTests/LaneTests.swift
+++ b/MapboxNavigationTests/LaneTests.swift
@@ -17,13 +17,14 @@ class LaneTests: FBSnapshotTestCase {
     
     override func setUp() {
         super.setUp()
-        let routeController = RouteController(along: route, directions: directions)
-        steps = routeController.routeProgress.currentLeg.steps
-        routeProgress = routeController.routeProgress
-        
-        route.accessToken = bogusToken
         recordMode = false
         isDeviceAgnostic = true
+
+        route.accessToken = bogusToken
+        let routeController = RouteController(along: route, directions: directions)
+
+        steps = routeController.routeProgress.currentLeg.steps
+        routeProgress = routeController.routeProgress
     }
     
     func assertLanes(step: RouteStep) {

--- a/MapboxNavigationTests/Support/SpeechAPISpy.swift
+++ b/MapboxNavigationTests/Support/SpeechAPISpy.swift
@@ -1,12 +1,6 @@
 import Foundation
 import MapboxSpeech
 
-class DummyURLSessionDataTask: URLSessionDataTask {
-    override func resume() {
-        //
-    }
-}
-
 /**
  * This class can be used as a substitute for SpeechSynthesizer under test, in order to verify whether expected calls were made.
  */


### PR DESCRIPTION
This is still WIP in terms of resolving #1200 , however the plan is to:

 - [ ] Backfill tests for key scenarios that generate telemetry events (& NSNotifications & delegate messages)
   - [x] turnstile event upon initialization
   - [x] successful reroute (scenario 1)
   - [ ] successful reroute (scenario 2)
   - [x] arrival event generation
   - [ ] feedback event data collection workflow
 - [ ] Perform a few key refactorings 
   - [ ] remove excess events knowledge and bookkeeping from RouteController
   - [ ] introduce a RouteContollerEventDelegate to manage event generation and pass delegate messages

I would like to do this in a way which can be merged to master early and often in the spirit of True Continuous Integration™ and in order to avoid semantic disconnects with other work streams.

I'll be tidying up / squashing down the commit log a bit, but the tests we have so far are high value and can/should be merged to master more or less immediately with a 👍 from the team.

/cc @vincethecoder who helped bootstrap this work