### PR TITLE
Add Sequence.swift to MapboxNavigation podspec

### DIFF
--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxNavigation/*", "MapboxCoreNavigation/{Date,Geometry,Sequence,String}.swift"]
+  s.source_files = ["MapboxNavigation/*", "MapboxCoreNavigation/{Date,Sequence,String}.swift"]
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxNavigation/*", "MapboxCoreNavigation/{Date,Geometry,String}.swift"]
+  s.source_files = ["MapboxNavigation/*", "MapboxCoreNavigation/{Date,Geometry,Sequence,String}.swift"]
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
Include Sequence.swift in MapboxNavigation, fixing a compilation error when building a version of MapboxNavigation that is assembled by CocoaPods instead of being built from the checked-in Xcode project.

Fixes #1295.

/cc @frederoni @JThramer @bsudekum