### PR TITLE
Removes many usages of async expectations in favor of semaphores

### DIFF
--- a/MapboxNavigation/ImageDownload.swift
+++ b/MapboxNavigation/ImageDownload.swift
@@ -9,6 +9,7 @@ enum DownloadError: Error {
 protocol ImageDownload: URLSessionDataDelegate {
     init(request: URLRequest, in session: URLSession)
     func addCompletion(_ completion: @escaping ImageDownloadCompletionBlock)
+    var isFinished: Bool { get }
 }
 
 class ImageDownloadOperation: Operation, ImageDownload {

--- a/MapboxNavigation/ImageDownloader.swift
+++ b/MapboxNavigation/ImageDownloader.swift
@@ -4,6 +4,7 @@ typealias ImageDownloadCompletionBlock = (UIImage?, Data?, Error?) -> Void
 
 protocol ReentrantImageDownloader {
     func downloadImage(with url: URL, completion: ImageDownloadCompletionBlock?) -> Void
+    func activeOperationWithURL(_ url: URL) -> ImageDownload?
     func setOperationType(_ operationType: ImageDownload.Type?)
 }
 
@@ -35,8 +36,8 @@ class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegat
     func downloadImage(with url: URL, completion: ImageDownloadCompletionBlock?) {
         let request: URLRequest = urlRequestWithURL(url)
         var operation: ImageDownload
-        if operations[url] != nil {
-            operation = operations[url]!
+        if let activeOperation = activeOperationWithURL(url) {
+            operation = activeOperation
         } else {
             operation = operationType.init(request: request, in: self.urlSession)
             self.operations[url] = operation
@@ -47,6 +48,13 @@ class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegat
         if let completion = completion {
             operation.addCompletion(completion)
         }
+    }
+
+    func activeOperationWithURL(_ url: URL) -> ImageDownload? {
+        if let operation = operations[url], !operation.isFinished {
+            return operation
+        }
+        return nil
     }
 
     private func urlRequestWithURL(_ url: URL) -> URLRequest {

--- a/MapboxNavigationTests/DataCacheTests.swift
+++ b/MapboxNavigationTests/DataCacheTests.swift
@@ -5,18 +5,21 @@ import XCTest
 class DataCacheTests: XCTestCase {
 
     let cache: DataCache = DataCache()
-    let asyncTimeout: TimeInterval = 10.0
+
+    private func clearDisk() {
+        let semaphore = DispatchSemaphore(value: 0)
+        cache.clearDisk {
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
 
     override func setUp() {
         super.setUp()
         self.continueAfterFailure = false
 
         cache.clearMemory()
-        let expectation = self.expectation(description: "Clearing Disk Cache")
-        cache.clearDisk {
-            expectation.fulfill()
-        }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        clearDisk()
     }
 
     let dataKey = "dataKey"
@@ -34,19 +37,19 @@ class DataCacheTests: XCTestCase {
     }
 
     private func storeDataInMemory() {
-        let expectation = self.expectation(description: "Storing data in memory cache")
+        let semaphore = DispatchSemaphore(value: 0)
         cache.store(exampleData!, forKey: dataKey, toDisk: false) {
-            expectation.fulfill()
+            semaphore.signal()
         }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        semaphore.wait()
     }
 
     private func storeDataOnDisk() {
-        let expectation = self.expectation(description: "Storing data in disk cache")
+        let semaphore = DispatchSemaphore(value: 0)
         cache.store(exampleData!, forKey: dataKey, toDisk: true) {
-            expectation.fulfill()
+            semaphore.signal()
         }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        semaphore.wait()
     }
 
     // MARK: Tests
@@ -80,12 +83,7 @@ class DataCacheTests: XCTestCase {
         storeDataOnDisk()
 
         cache.clearMemory()
-
-        let expectation = self.expectation(description: "Clearing Disk Cache")
-        cache.clearDisk {
-            expectation.fulfill()
-        }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        clearDisk()
 
         XCTAssertNil(cache.data(forKey: dataKey))
     }

--- a/MapboxNavigationTests/ImageCacheTests.swift
+++ b/MapboxNavigationTests/ImageCacheTests.swift
@@ -5,36 +5,40 @@ import XCTest
 class ImageCacheTests: XCTestCase {
 
     let cache: ImageCache = ImageCache()
-    let asyncTimeout: TimeInterval = 2.0
+    let asyncTimeout: TimeInterval = 10.0
+
+    private func clearDiskCache() {
+        let semaphore = DispatchSemaphore(value: 0)
+        cache.clearDisk {
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
 
     override func setUp() {
         super.setUp()
         self.continueAfterFailure = false
 
         cache.clearMemory()
-        let expectation = self.expectation(description: "Clearing Disk Cache")
-        cache.clearDisk {
-            expectation.fulfill()
-        }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        clearDiskCache()
     }
 
     let imageKey = "imageKey"
 
     private func storeImageInMemory() {
-        let expectation = self.expectation(description: "Storing image in memory cache")
+        let semaphore = DispatchSemaphore(value: 0)
         cache.store(ShieldImage.i280.image, forKey: imageKey, toDisk: false) {
-            expectation.fulfill()
+            semaphore.signal()
         }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        semaphore.wait()
     }
 
     private func storeImageOnDisk() {
-        let expectation = self.expectation(description: "Storing image in disk cache")
+        let semaphore = DispatchSemaphore(value: 0)
         cache.store(ShieldImage.i280.image, forKey: imageKey, toDisk: true) {
-            expectation.fulfill()
+            semaphore.signal()
         }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        semaphore.wait()
     }
 
     // MARK: Tests
@@ -93,12 +97,7 @@ class ImageCacheTests: XCTestCase {
         storeImageOnDisk()
 
         cache.clearMemory()
-
-        let expectation = self.expectation(description: "Clearing Disk Cache")
-        cache.clearDisk {
-            expectation.fulfill()
-        }
-        self.wait(for: [expectation], timeout: asyncTimeout)
+        clearDiskCache()
 
         XCTAssertNil(cache.image(forKey: imageKey))
     }

--- a/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -15,7 +15,6 @@ class ImageDownloaderTests: XCTestCase {
     }()
 
     let imageURL = URL(string: "https://zombo.com/lulz/selfie.png")!
-    let asyncTimeout: TimeInterval = 15.0
 
     override func setUp() {
         super.setUp()
@@ -38,15 +37,15 @@ class ImageDownloaderTests: XCTestCase {
         var imageReturned: UIImage?
         var dataReturned: Data?
         var errorReturned: Error?
+        let semaphore = DispatchSemaphore(value: 0)
 
-        let async = self.expectation(description: "Image Download")
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             imageReturned = image
             dataReturned = data
             errorReturned = error
-            async.fulfill()
+            semaphore.signal()
         }
-        wait(for: [async], timeout: asyncTimeout)
+        semaphore.wait()
 
         // The ImageDownloader is meant to be used with an external caching mechanism
         let request = ImageLoadingURLProtocolSpy.pastRequestForURL(imageURL)!
@@ -59,45 +58,62 @@ class ImageDownloaderTests: XCTestCase {
     }
 
     func testDownloadingSameImageWhileInProgressAddsCallbacksWithoutAddingAnotherRequest() {
-        let firstDownload = self.expectation(description: "First Image Download")
-        let secondDownload = self.expectation(description: "Second Image Download")
         var firstCallbackCalled = false
         var secondCallbackCalled = false
+        var operation: ImageDownload?
+
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             firstCallbackCalled = true
-            firstDownload.fulfill()
         }
+        operation = downloader.activeOperationWithURL(imageURL)!
+
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             secondCallbackCalled = true
-            secondDownload.fulfill()
         }
-        wait(for: [firstDownload, secondDownload], timeout: asyncTimeout)
 
-        //These flags might seem redundant, but it's good to be explicit sometimes
+        XCTAssertTrue(operation! === downloader.activeOperationWithURL(imageURL)!, "Expected \(String(describing: operation)) to be identical to \(String(describing: downloader.activeOperationWithURL(imageURL)))")
+
+        runUntil(condition: {
+            return downloader.activeOperationWithURL(imageURL) == nil
+        }, pollingInterval: 0.1)
+
+        //These flags might seem redundant, but it's good to be explicit here
         XCTAssertTrue(firstCallbackCalled)
         XCTAssertTrue(secondCallbackCalled)
     }
 
     func testDownloadingImageAgainAfterFirstDownloadCompletes() {
-        let firstDownload = self.expectation(description: "First Image Download")
+        let semaphore = DispatchSemaphore(value: 0)
         var firstCallbackCalled = false
+
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             firstCallbackCalled = true
-            firstDownload.fulfill()
+            semaphore.signal()
         }
-        wait(for: [firstDownload], timeout: asyncTimeout)
+        semaphore.wait()
 
-        let secondDownload = self.expectation(description: "Second Image Download")
+        // we are beholden to the URL loading system here... can't proceed until the URLProtocol has finished winding down its previous URL loading work
+        runUntil(condition: {
+            return downloader.activeOperationWithURL(imageURL) == nil
+        }, pollingInterval: 0.1)
+
         var secondCallbackCalled = false
+
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             secondCallbackCalled = true
-            secondDownload.fulfill()
+            semaphore.signal()
         }
-        wait(for: [secondDownload], timeout: asyncTimeout)
+        semaphore.wait()
 
         //These flags might seem redundant, but it's good to be explicit sometimes
         XCTAssertTrue(firstCallbackCalled)
         XCTAssertTrue(secondCallbackCalled)
     }
 
+    private func runUntil(condition: () -> Bool, pollingInterval: TimeInterval) {
+        if condition() == false {
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: pollingInterval))
+            runUntil(condition: condition, pollingInterval: pollingInterval)
+        }
+    }
 }

--- a/MapboxNavigationTests/InstructionsBannerViewSnapshotTests.swift
+++ b/MapboxNavigationTests/InstructionsBannerViewSnapshotTests.swift
@@ -24,13 +24,13 @@ class InstructionsBannerViewSnapshotTests: FBSnapshotTestCase {
     }
     
     override func tearDown() {
-        super.tearDown()
-        
-        let clearImageCacheExpectation = self.expectation(description: "Clear Image Cache")
+        let semaphore = DispatchSemaphore(value: 0)
         imageRepository.resetImageCache {
-            clearImageCacheExpectation.fulfill()
+            semaphore.signal()
         }
-        self.wait(for: [clearImageCacheExpectation], timeout: asyncTimeout)
+        semaphore.wait()
+
+        super.tearDown()
     }
     
     func testSinglelinePrimary() {

--- a/MapboxNavigationTests/Support/ImageDownloadOperationSpy.swift
+++ b/MapboxNavigationTests/Support/ImageDownloadOperationSpy.swift
@@ -60,6 +60,5 @@ class ImageDownloadOperationSpy: Operation, ImageDownload {
         completionBlocks.forEach { completion in
             completion(image, data, error)
         }
-        RunLoop.current.run(until: Date())
     }
 }


### PR DESCRIPTION
Also introduces a runUntil(condition:, pollingInterval:) helper which should be incrementally better than a raw runLoop advancement

TODO: semaphore wait()'s currently don't have a timeout, which might be bad for CI