### PR TITLE
Update tests for MapboxDirections 0.20.0

### DIFF
--- a/MapboxNavigationTests/InstructionsBannerViewSnapshotTests.swift
+++ b/MapboxNavigationTests/InstructionsBannerViewSnapshotTests.swift
@@ -150,9 +150,9 @@ class InstructionsBannerViewSnapshotTests: FBSnapshotTestCase {
         view.distance = 482
         
         let primary = [
-                       VisualInstructionComponent(type: .text, text: "West", imageURL: nil, abbreviation: "W", abbreviationPriority: 0),
-                       VisualInstructionComponent(type: .text, text: "Fremont", imageURL: nil, abbreviation: nil, abbreviationPriority: NSNotFound),
-                       VisualInstructionComponent(type: .text, text: "Avenue", imageURL: nil, abbreviation: "Ave", abbreviationPriority: 1)
+            VisualInstructionComponent(type: .text, text: "West", imageURL: nil, abbreviation: "W", abbreviationPriority: 0),
+            VisualInstructionComponent(type: .text, text: "Fremont", imageURL: nil, abbreviation: nil, abbreviationPriority: NSNotFound),
+            VisualInstructionComponent(type: .text, text: "Avenue", imageURL: nil, abbreviation: "Ave", abbreviationPriority: 1)
         ]
         
         view.set(makeVisualInstruction(.continue, .straightAhead, primaryInstruction: primary, secondaryInstruction: nil))
@@ -232,7 +232,7 @@ class InstructionsBannerViewSnapshotTests: FBSnapshotTestCase {
         view.distanceFormatter.numberFormatter.locale = Locale(identifier: "sv-se")
         view.distance = 1000 * 999
         
-        let primary = [VisualInstructionComponent(type: .text, text: "Lorem Ipsum / Dolor Sit Amet", imageURL: nil, maneuverType: .none, maneuverDirection: .none, abbreviation: nil, abbreviationPriority: NSNotFound)]
+        let primary = [VisualInstructionComponent(type: .text, text: "Lorem Ipsum / Dolor Sit Amet", imageURL: nil, abbreviation: nil, abbreviationPriority: NSNotFound)]
         view.set(makeVisualInstruction(primaryInstruction: primary, secondaryInstruction: nil))
         
         verifyView(view, size: view.bounds.size)
@@ -246,7 +246,7 @@ class InstructionsBannerViewSnapshotTests: FBSnapshotTestCase {
         view.distanceFormatter.numberFormatter.locale = Locale(identifier: "uk-UA")
         view.distance = 1000 * 999
         
-        let primary = [VisualInstructionComponent(type: .text, text: "Lorem Ipsum / Dolor Sit Amet", imageURL: nil, maneuverType: .none, maneuverDirection: .none, abbreviation: nil, abbreviationPriority: NSNotFound)]
+        let primary = [VisualInstructionComponent(type: .text, text: "Lorem Ipsum / Dolor Sit Amet", imageURL: nil,  abbreviation: nil, abbreviationPriority: NSNotFound)]
         view.set(makeVisualInstruction(primaryInstruction: primary, secondaryInstruction: nil))
         
         verifyView(view, size: view.bounds.size)


### PR DESCRIPTION
Fixes #1312 

Not sure how this happened. It's almost as if CI had both MapboxDirections 0.19.0 and 0.20.0 in the cache. 🤔 

A `VisualInstructionComponent` no longer takes a maneuverDirection and maneuverType. These properties belongs to the `VisualInstruction`.

@1ec5 @JThramer 👀 