### PR TITLE
Inform delegate when canceling through eorvc

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -459,7 +459,7 @@ func defaultFeedbackHandlers(source: FeedbackSource = .user) -> (send: FeedbackV
         endOfRoute.dismissHandler = { [weak self] (stars, comment) in
             guard let rating = self?.rating(for: stars) else { return }
             self?.routeController.setEndOfRoute(rating: rating, comment: comment)
-            self?.dismiss(animated: true, completion: nil)
+            self?.delegate?.mapViewControllerDidCancelNavigation(self!)
         }
     }
     


### PR DESCRIPTION
Dismissing a view controller only works if it was presented with a UINavigationViewController. By informing the delegate when the navigation is ended, we dismiss by default but also let the developer pop or replace the view controller by implementing `NavigationViewController.mapViewControllerDidCancelNavigation(_:)`.

@JThramer 