### PR TITLE
Updates semaphore timeout to a read-only computed property

### DIFF
--- a/MapboxNavigationTests/XCTestCase.swift
+++ b/MapboxNavigationTests/XCTestCase.swift
@@ -3,6 +3,8 @@ import XCTest
 
 extension XCTestCase {
     enum NavigationTests {
-        static let timeout: DispatchTime = DispatchTime.distantFuture
+        static var timeout: DispatchTime {
+            return DispatchTime.now() + DispatchTimeInterval.seconds(10)
+        }
     }
 }

--- a/MapboxNavigationTests/XCTestCase.swift
+++ b/MapboxNavigationTests/XCTestCase.swift
@@ -3,6 +3,6 @@ import XCTest
 
 extension XCTestCase {
     enum NavigationTests {
-        static let timeout: DispatchTime = DispatchTime.now() + DispatchTimeInterval.seconds(10)
+        static let timeout: DispatchTime = DispatchTime.distantFuture
     }
 }


### PR DESCRIPTION
Fixes #1327 and other unexpected timeout failures.

This is being done as a read-only computed property to minimize the need for other changes. Not sure if converting to a function might be more appropriate / less unexpected. Opinions welcome.