### PR TITLE
Using absolute paths for scripts run

### DIFF
--- a/scripts/convert_string_files.sh
+++ b/scripts/convert_string_files.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-source ./file_conversion.sh
-DIRECTORIES=( "../MapboxNavigation" "../MapboxCoreNavigation" "../Examples" )
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "${DIR}/file_conversion.sh"
+DIRECTORIES=( "${DIR}/../MapboxNavigation" "${DIR}/../MapboxCoreNavigation" "${DIR}/../Examples" )
 
 for dir in ${DIRECTORIES[@]}
 do

--- a/scripts/extract_localizable.sh
+++ b/scripts/extract_localizable.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-NAVIGATION=../MapboxNavigation
-CORE=../MapboxCoreNavigation
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+NAVIGATION="${DIR}/../MapboxNavigation"
+CORE="${DIR}/../MapboxCoreNavigation"
 
 LANGUAGES=( "Base" )
 
@@ -21,7 +23,7 @@ do
     ibtool ${NAVIGATION}/Resources/${lang}.lproj/Navigation.storyboard --generate-strings-file ${NAVIGATION}/Resources/${lang}.lproj/Navigation.strings
 
     # Remove strings that should not be translated
-    source ./file_conversion.sh
+    source "${DIR}/file_conversion.sh"
     convertIfNeeded "${NAVIGATION}/Resources/${lang}.lproj/Navigation.strings"
     sed -i '' -e '/DO NOT TRANSLATE/{N;N;d;}' "${NAVIGATION}/Resources/${lang}.lproj/Navigation.strings"
 


### PR DESCRIPTION
Now you can executing `extract_localizable.sh` and `convert_string_files.sh` at any directories rather than the directory where it is 😉