### PR TITLE
Adjust ImageDownloaderTests to use a new instance each time

### DIFF
--- a/MapboxNavigation/ImageDownloader.swift
+++ b/MapboxNavigation/ImageDownloader.swift
@@ -23,7 +23,6 @@ class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegat
 
     override init() {
         self.queue = OperationQueue()
-        self.queue.maxConcurrentOperationCount = 6
         self.queue.name = Bundle.mapboxNavigation.bundleIdentifier! + ".ImageDownloader"
     }
 

--- a/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -35,12 +35,16 @@ class ImageDownloaderTests: XCTestCase {
     }
 
     func testDownloadingAnImage() {
+        guard let downloader = downloader else {
+            XCTFail()
+            return
+        }
         var imageReturned: UIImage?
         var dataReturned: Data?
         var errorReturned: Error?
         let semaphore = DispatchSemaphore(value: 0)
 
-        downloader?.downloadImage(with: imageURL) { (image, data, error) in
+        downloader.downloadImage(with: imageURL) { (image, data, error) in
             imageReturned = image
             dataReturned = data
             errorReturned = error

--- a/MapboxNavigationTests/ImageRepositoryTests.swift
+++ b/MapboxNavigationTests/ImageRepositoryTests.swift
@@ -27,6 +27,12 @@ class ImageRepositoryTests: XCTestCase {
         XCTAssert(semaphoreResult == .success, "Semaphore timed out")
     }
 
+    override func tearDown() {
+        URLProtocol.unregisterClass(ImageLoadingURLProtocolSpy.self)
+
+        super.tearDown()
+    }
+
     func test_imageWithURL_downloadsImageWhenNotCached() {
         let imageName = "1.png"
         let fakeURL = URL(string: "http://an.image.url/\(imageName)")!
@@ -67,10 +73,5 @@ class ImageRepositoryTests: XCTestCase {
         
         XCTAssertNil(ImageLoadingURLProtocolSpy.pastRequestForURL(fakeURL))
         XCTAssertNotNil(imageReturned)
-    }
-
-    override func tearDown() {
-        URLProtocol.unregisterClass(ImageLoadingURLProtocolSpy.self)
-        super.tearDown()
     }
 }

--- a/MapboxNavigationTests/InstructionsBannerViewIntegrationTests.swift
+++ b/MapboxNavigationTests/InstructionsBannerViewIntegrationTests.swift
@@ -62,9 +62,9 @@ class InstructionsBannerViewIntegrationTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
-
         imageRepository.imageDownloader.setOperationType(nil)
+
+        super.tearDown()
     }
 
     func testDelimiterIsShownWhenShieldsNotLoaded() {

--- a/MapboxNavigationTests/MapboxNavigationTests.swift
+++ b/MapboxNavigationTests/MapboxNavigationTests.swift
@@ -20,11 +20,6 @@ class MapboxNavigationTests: FBSnapshotTestCase {
         isDeviceAgnostic = true
     }
 
-    override func tearDown() {
-        super.tearDown()
-
-    }
-
     func storyboard() -> UIStoryboard {
         return UIStoryboard(name: "Navigation", bundle: .mapboxNavigation)
     }

--- a/MapboxNavigationTests/MapboxVoiceControllerTests.swift
+++ b/MapboxNavigationTests/MapboxVoiceControllerTests.swift
@@ -41,8 +41,4 @@ class MapboxVoiceControllerTests: XCTestCase {
 
         XCTAssertTrue(controller!.hasCachedSpokenInstructionForKey(cacheKey))
     }
-
-    func testControllerPrefersCachedData() {
-    }
-
 }


### PR DESCRIPTION
Removing this statefulness (the `lazy var`) should make sense here; we're registering & unregistering the `URLProtocol` subclass in a loop while the URL loading system may be doing other work. I'm hopeful this will help with the test instabilities noted in #1327 and elsewhere.

I also noticed that the `ImageDownloader`'s `OperationQueue`'s `maxConcurrentOperationCount` was set semi-arbitrarily, so I removed it. This defaults the configuration to `NSOperationQueueDefaultMaxConcurrentOperationCount`. We could also consider setting it to `2`.