### PR TITLE
Modify access level for various classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* `DistanceFormatter`, `ReplayLocationManager`, `SimulatedLocationManager`, `LanesView`, and `ManueverView` are now subclassable. ([#1345](https://github.com/mapbox/mapbox-navigation-ios/pull/1345]))
 * Upgraded to the [Mapbox Maps SDK for iOS v4.0.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v4.0.0). If you have customized the route map’s appearance, you may need to migrate your code to use expressions instead of style functions. ([#1076](https://github.com/mapbox/mapbox-navigation-ios/pull/1076))
 * `NavigationViewControllerDelegate.navigationViewControllerDidCancelNavigation(_:)` has been superseded by `NavigationViewControllerDelegate.navigationViewControllerDidEndNavigation(_:cancelled:)`. [#1318](https://github.com/mapbox/mapbox-navigation-ios/pull/1318)
 * `RouteController`’s `routeProgress` is now exposed to Objective-C. [#1323](https://github.com/mapbox/mapbox-navigation-ios/pull/1323)

--- a/MapboxCoreNavigation/DistanceFormatter.swift
+++ b/MapboxCoreNavigation/DistanceFormatter.swift
@@ -98,7 +98,7 @@ extension NSAttributedStringKey {
 
 /// Provides appropriately formatted, localized descriptions of linear distances.
 @objc(MBDistanceFormatter)
-public class DistanceFormatter: LengthFormatter {
+open class DistanceFormatter: LengthFormatter {
     /// True to favor brevity over precision.
     var approx: Bool
     
@@ -146,7 +146,7 @@ public class DistanceFormatter: LengthFormatter {
         super.init(coder: decoder)
     }
     
-    public override func encode(with aCoder: NSCoder) {
+    open override func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
         aCoder.encode(approx, forKey: "approximate")
     }
@@ -175,7 +175,7 @@ public class DistanceFormatter: LengthFormatter {
         return formattedDistance(distance)
     }
     
-    @objc public override func string(fromMeters numberInMeters: Double) -> String {
+    @objc open override func string(fromMeters numberInMeters: Double) -> String {
         return self.string(from: numberInMeters)
     }
     
@@ -192,7 +192,7 @@ public class DistanceFormatter: LengthFormatter {
      
      `NSAttributedStringKey.quantity` is applied to the numeric quantity.
      */
-    @objc public override func attributedString(for obj: Any, withDefaultAttributes attrs: [NSAttributedStringKey : Any]? = nil) -> NSAttributedString? {
+    @objc open override func attributedString(for obj: Any, withDefaultAttributes attrs: [NSAttributedStringKey : Any]? = nil) -> NSAttributedString? {
         guard let distance = obj as? CLLocationDistance else {
             return nil
         }

--- a/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -7,7 +7,7 @@ import CoreLocation
  adjusted by interval between locations.
  */
 @objc(MBReplayLocationManager)
-public class ReplayLocationManager: NavigationLocationManager {
+open class ReplayLocationManager: NavigationLocationManager {
     
     /**
      `speedMultiplier` adjusts the speed of the replay.
@@ -27,7 +27,7 @@ public class ReplayLocationManager: NavigationLocationManager {
         }
     }
     
-    @objc override public var location: CLLocation? {
+    @objc override open var location: CLLocation? {
         get {
             return lastKnownLocation
         }

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -28,7 +28,7 @@ fileprivate class SimulatedLocation: CLLocation {
  The route will be replaced upon a `RouteControllerDidReroute` notification.
  */
 @objc(MBSimulatedLocationManager)
-public class SimulatedLocationManager: NavigationLocationManager {
+open class SimulatedLocationManager: NavigationLocationManager {
     fileprivate var currentDistance: CLLocationDistance = 0
     fileprivate var currentLocation = CLLocation()
     fileprivate var currentSpeed: CLLocationSpeed = 30
@@ -41,7 +41,7 @@ public class SimulatedLocationManager: NavigationLocationManager {
      */
     @objc public var speedMultiplier: Double = 1
     
-    @objc override public var location: CLLocation? {
+    @objc override open var location: CLLocation? {
         get {
             return currentLocation
         }
@@ -98,11 +98,11 @@ public class SimulatedLocationManager: NavigationLocationManager {
         NotificationCenter.default.removeObserver(self, name: .routeControllerProgressDidChange, object: nil)
     }
     
-    override public func startUpdatingLocation() {
+    override open func startUpdatingLocation() {
         DispatchQueue.main.async(execute: tick)
     }
     
-    override public func stopUpdatingLocation() {
+    override open func stopUpdatingLocation() {
         DispatchQueue.main.async {
             NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.tick), object: nil)
         }

--- a/MapboxNavigation/LanesView.swift
+++ b/MapboxNavigation/LanesView.swift
@@ -5,7 +5,7 @@ import MapboxDirections
 /// :nodoc:
 @IBDesignable
 @objc(MBLanesView)
-public class LanesView: UIView {
+open class LanesView: UIView {
     weak var stackView: UIStackView!
     weak var separatorView: SeparatorView!
     
@@ -19,7 +19,7 @@ public class LanesView: UIView {
         commonInit()
     }
     
-    public override func prepareForInterfaceBuilder() {
+    open override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
 
         for _ in 0...4 {

--- a/MapboxNavigation/ManeuverView.swift
+++ b/MapboxNavigation/ManeuverView.swift
@@ -6,7 +6,7 @@ import Turf
 /// :nodoc:
 @IBDesignable
 @objc(MBManeuverView)
-public class ManeuverView: UIView {
+open class ManeuverView: UIView {
 
     @objc public dynamic var primaryColor: UIColor = .defaultTurnArrowPrimary {
         didSet {
@@ -45,7 +45,7 @@ public class ManeuverView: UIView {
         }
     }
 
-    override public func draw(_ rect: CGRect) {
+    override open func draw(_ rect: CGRect) {
         super.draw(rect)
 
         transform = CGAffineTransform.identity

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -193,7 +193,7 @@ public protocol NavigationViewControllerDelegate {
  It provides step by step instructions, an overview of all steps for the given route and support for basic styling.
  */
 @objc(MBNavigationViewController)
-public class NavigationViewController: UIViewController {
+open class NavigationViewController: UIViewController {
     
     /** 
      A `Route` object constructed by [MapboxDirections](https://mapbox.github.io/mapbox-navigation-ios/directions/).
@@ -372,13 +372,13 @@ public class NavigationViewController: UIViewController {
         suspendNotifications()
     }
     
-    override public func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         resumeNotifications()
         view.clipsToBounds = true
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
+    open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         //initialize voice controller if it hasn't been overridden
@@ -394,7 +394,7 @@ public class NavigationViewController: UIViewController {
         }
     }
     
-    public override func viewWillDisappear(_ animated: Bool) {
+    open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         UIApplication.shared.isIdleTimerDisabled = false


### PR DESCRIPTION
Fixes #1344 - Allow subclassing NavigationViewController

This PR also modifies the access level in order to allow subclassing of the following classes:
- DistanceFormatter
- ~NavigationSettings~
- ReplayLocationManager
- SimulatedLocationManager
- LanesView
- ManeuverView

@captainbarbosa @1ec5 👀 