### PR TITLE
Rename dismissal delegate method; removed documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master
 
 * Upgraded to the [Mapbox Maps SDK for iOS v4.0.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v4.0.0). If you have customized the route map’s appearance, you may need to migrate your code to use expressions instead of style functions. ([#1076](https://github.com/mapbox/mapbox-navigation-ios/pull/1076))
-* `NavigationViewControllerDelegate.navigationViewControllerDidCancelNavigation(_:)` has been superseded by `NavigationViewControllerDelegate.navigationViewControllerDidEndNavigation(_:cancelled:)`. [#1318](https://github.com/mapbox/mapbox-navigation-ios/pull/1318)
+* Renamed `NavigationViewControllerDelegate.navigationViewControllerDidCancelNavigation(_:)` to `NavigationViewControllerDelegate.navigationViewControllerDidDismiss(_:byCanceling:)`. [#1318](https://github.com/mapbox/mapbox-navigation-ios/pull/1318)
 * `RouteController`’s `routeProgress` is now exposed to Objective-C. [#1323](https://github.com/mapbox/mapbox-navigation-ios/pull/1323)
 * Exit indications are now drawn accurately with a correct exit bearing. [#1288](https://github.com/mapbox/mapbox-navigation-ios/pull/1288)
 * Added a delegate method, `NavigationViewControllerDelegate.navigationViewController(_:roadNameAt:)` which allows you to customize the contents of the road name label displayed towards the bottom of the map view. [#1309](https://github.com/mapbox/mapbox-navigation-ios/pull/1309)

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -431,7 +431,7 @@ extension ViewController: NavigationViewControllerDelegate {
     
     // Called when the user hits the exit button.
     // If implemented, you are responsible for also dismissing the UI.
-    func navigationViewControllerDidEndNavigation(_ navigationViewController: NavigationViewController, cancelled: Bool) {
+    func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
         navigationViewController.dismiss(animated: true, completion: nil)
     }
 }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -445,7 +445,7 @@ open class RouteController: NSObject {
     }
 
     /**
-     Discard a recorded feedback event, for example if you have a custom feedback UI and the user cancelled feedback.
+     Discard a recorded feedback event, for example if you have a custom feedback UI and the user canceled feedback.
      */
     @objc public func cancelFeedback(feedbackId: String) {
         if let index = outstandingFeedbackEvents.index(where: {$0.id.uuidString == feedbackId}) {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -9,9 +9,12 @@ import Mapbox
 @objc(MBNavigationViewControllerDelegate)
 public protocol NavigationViewControllerDelegate {
     /**
-     Called when the user exits a route and dismisses the navigation view controller by tapping the Cancel button.
+     Called when the navigation view controller is dismissed, such as when the user ends a trip.
+     
+     - parameter navigationViewController: The navigation view controller that was dismissed.
+     - parameter canceled: True if the user dismissed the navigation view controller by tapping the Cancel button; false if the navigation view controller dismissed by some other means.
      */
-    @objc optional func navigationViewControllerDidEndNavigation(_ navigationViewController: NavigationViewController, cancelled: Bool)
+    @objc optional func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool)
     
     /**
      Called when the user arrives at the destination waypoint for a route leg.
@@ -518,8 +521,8 @@ extension NavigationViewController: RouteMapViewControllerDelegate {
         delegate?.navigationViewControllerDidCancelFeedback?(self)
     }
     
-    func mapViewControllerDidEndNavigation(_ mapViewController: RouteMapViewController, cancelled: Bool) {
-        if delegate?.navigationViewControllerDidEndNavigation?(self, cancelled: cancelled) != nil {
+    func mapViewControllerDidDismiss(_ mapViewController: RouteMapViewController, byCanceling canceled: Bool) {
+        if delegate?.navigationViewControllerDidDismiss?(self, byCanceling: canceled) != nil {
             // The receiver should handle dismissal of the NavigationViewController
         } else {
             dismiss(animated: true, completion: nil)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -459,7 +459,7 @@ func defaultFeedbackHandlers(source: FeedbackSource = .user) -> (send: FeedbackV
         endOfRoute.dismissHandler = { [weak self] (stars, comment) in
             guard let rating = self?.rating(for: stars) else { return }
             self?.routeController.setEndOfRoute(rating: rating, comment: comment)
-            self?.delegate?.mapViewControllerDidEndNavigation(self!, cancelled: false)
+            self?.delegate?.mapViewControllerDidDismiss(self!, byCanceling: false)
         }
     }
     
@@ -557,7 +557,7 @@ extension RouteMapViewController {
 extension RouteMapViewController: NavigationViewDelegate {
     // MARK: NavigationViewDelegate
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton) {
-        delegate?.mapViewControllerDidEndNavigation(self, cancelled: true)
+        delegate?.mapViewControllerDidDismiss(self, byCanceling: true)
     }
     
     // MARK: MGLMapViewDelegate
@@ -922,7 +922,7 @@ protocol RouteMapViewControllerDelegate: NavigationMapViewDelegate, MGLMapViewDe
 
     func mapViewControllerDidOpenFeedback(_ mapViewController: RouteMapViewController)
     func mapViewControllerDidCancelFeedback(_ mapViewController: RouteMapViewController)
-    func mapViewControllerDidEndNavigation(_ mapViewController: RouteMapViewController, cancelled: Bool)
+    func mapViewControllerDidDismiss(_ mapViewController: RouteMapViewController, byCanceling canceled: Bool)
     func mapViewController(_ mapViewController: RouteMapViewController, didSend feedbackId: String, feedbackType: FeedbackType)
     func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool
     

--- a/README.md
+++ b/README.md
@@ -130,28 +130,9 @@ then initialize `NavigationViewController` with your style or styles:
 NavigationViewController(for: route, styles: [CustomStyle()])
 ```
 
-### `NavigationViewControllerDelegate` methods
+### Starting from scratch
 
-* `navigationViewController:didArriveAtDestination:`: Fired when the user arrives at their destination. You are responsible for dismissing the UI.
-* `navigationViewControllerDidCancelNavigation`: Fired when the user taps `Cancel`. You are responsible for dismissing the UI.
-* `navigationViewController:shouldRerouteFromLocation:`: Fired when SDK detects that a user has gone off route. You can return `false` here to either prevent a reroute from occuring or if you want to rerequest an alternative route manually.
-* `navigationViewController:willRerouteFromLocation:`: Fired just before the SDK requests a new route.
-* `navigationViewController:didRerouteAlongRoute:`: Fired as soon as the SDK receives a new route.
-* `navigationViewController:didFailToRerouteWithError:`: Fired when SDK receives an error instead of a new route.
-
-### `RouteController`
-
-`RouteController` is given a route. Internally `RouteController` matches the user's current location to the route while looking at 3 principle pieces:
-
-1. Is the user on or off the route?
-1. How far along the step is the user?
-1. Does the user need to be alerted about an upcoming maneuver?
-
-The library compares the user from the route and decides upon each one of these parameters and acts accordingly. The developer is told what is happening behind the scenes via notifications.
-
-### Building your own custom navigation UI
-
-Looking for a more advanced use case? See our installation guide of [MapboxCoreNavigation](./custom-navigation.md).
+If your application needs something totally custom, such as a voice-only experience or an unconventional user interface, consult the [Core Navigation installation guide](./custom-navigation.md).
 
 ## Contributing
 

--- a/RouteTest/AppDelegate.swift
+++ b/RouteTest/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, NavigationViewControllerD
         return true
     }
     
-    func navigationViewControllerDidEndNavigation(_ navigationViewController: NavigationViewController, cancelled: Bool) {
+    func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
         startNavigation()
     }
     


### PR DESCRIPTION
Renamed `NavigationViewControllerDelegate.navigationViewControllerDidEndNavigation(_:cancelled:)` to `navigationViewControllerDidDismiss(_:byCanceling:)`, which reads more like one of the standard UIKit view controller delegate methods. Also prefer the American spelling of cancel* over the British spelling.

Removed the delegate method section of the readme. That documentation was not only redundant to NavigationViewControllerDelegate’s documentation comments, but it also used inaccurate or outdated names.

/ref #1318
/cc @frederoni @vincethecoder