### PR TITLE
Removes code which registers & unregisters the URLProtocol

### DIFF
--- a/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -18,17 +18,15 @@ class ImageDownloaderTests: XCTestCase {
         super.setUp()
         self.continueAfterFailure = false
 
-        URLProtocol.registerClass(ImageLoadingURLProtocolSpy.self)
         ImageLoadingURLProtocolSpy.reset()
 
-        let originalImageData = UIImagePNGRepresentation(ShieldImage.i280.image)!
-        ImageLoadingURLProtocolSpy.registerData(originalImageData, forURL: imageURL)
+        let imageData = UIImagePNGRepresentation(ShieldImage.i280.image)!
+        ImageLoadingURLProtocolSpy.registerData(imageData, forURL: imageURL)
 
         downloader = ImageDownloader(sessionConfiguration: sessionConfig)
     }
 
     override func tearDown() {
-        URLProtocol.unregisterClass(ImageLoadingURLProtocolSpy.self)
         downloader = nil
 
         super.tearDown()


### PR DESCRIPTION
This code isn't necessary, in fact it can be harmful since URL loading hangs on
our test requests when the URLProtocol isn't registered in time. 

Reasonably sure this is the root cause of the semaphore timeouts we've been running into.