### PR TITLE
Fix typo in NavigationViewController’s refined Obj-C init

### DIFF
--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -132,7 +132,7 @@
     MBSimulatedLocationManager *locationManager = [[MBSimulatedLocationManager alloc] initWithRoute:route];
     MBNavigationViewController *controller = [[MBNavigationViewController alloc] initWithRoute:route
                                                                                     directions:[MBDirections sharedDirections]
-                                                                                         style:nil
+                                                                                        styles:nil
                                                                                locationManager:locationManager];
     [self presentViewController:controller animated:YES completion:nil];
     

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -331,7 +331,7 @@ public class NavigationViewController: UIViewController {
 
      See [Mapbox Directions](https://mapbox.github.io/mapbox-navigation-ios/directions/) for further information.
      */
-    @objc(initWithRoute:directions:style:locationManager:)
+    @objc(initWithRoute:directions:styles:locationManager:)
     required public init(for route: Route,
                          directions: Directions = Directions.shared,
                          styles: [Style]? = [DayStyle(), NightStyle()],


### PR DESCRIPTION
`NavigationViewController.init(for:directions:style:locationManager:)` takes multiple styles.

@JThramer @vincethecoder  👀 