### PR TITLE
Dismiss reroute status view if request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 * `RouteController`’s `routeProgress` is now exposed to Objective-C. [#1323](https://github.com/mapbox/mapbox-navigation-ios/pull/1323)
 * Exit indications are now drawn accurately with a correct exit bearing. [#1288](https://github.com/mapbox/mapbox-navigation-ios/pull/1288)
 * Added a delegate method, `NavigationViewControllerDelegate.navigationViewController(_:roadNameAt:)` which allows you to customize the contents of the road name label displayed towards the bottom of the map view. [#1309](https://github.com/mapbox/mapbox-navigation-ios/pull/1309)
-
-### User interface
-
 * If a reroute request fails, the `Rerouting...` status view update is dismissed. [#1357](https://github.com/mapbox/mapbox-navigation-ios/pull/1357)
 
 ## v0.16.2 (April 13, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### User interface
 
-* If a reroute request fails, the `Rerouting...` status view update is dismissed.
+* If a reroute request fails, the `Rerouting...` status view update is dismissed. [#1357](https://github.com/mapbox/mapbox-navigation-ios/pull/1357)
 
 ## v0.16.2 (April 13, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Exit indications are now drawn accurately with a correct exit bearing. [#1288](https://github.com/mapbox/mapbox-navigation-ios/pull/1288)
 * Added a delegate method, `NavigationViewControllerDelegate.navigationViewController(_:roadNameAt:)` which allows you to customize the contents of the road name label displayed towards the bottom of the map view. [#1309](https://github.com/mapbox/mapbox-navigation-ios/pull/1309)
 
+### User interface
+
+* If a reroute request fails, the `Rerouting...` status view update is dismissed.
+
 ## v0.16.2 (April 13, 2018)
 
 * Fixed a compiler error after installing the SDK using CocoaPods. ([#1296](https://github.com/mapbox/mapbox-navigation-ios/pull/1296))

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -756,6 +756,7 @@ extension RouteController: CLLocationManagerDelegate {
                 NotificationCenter.default.post(name: .routeControllerDidFailToReroute, object: self, userInfo: [
                     RouteControllerNotificationUserInfoKey.routingErrorKey: error
                 ])
+                return
             }
 
             guard let route = route else { return }

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -131,7 +131,6 @@ class MapboxCoreNavigationTests: XCTestCase {
         route.accessToken = "foo"
         let navigation = RouteController(along: route, directions: directions)
         let invalidLocation = CLLocation(latitude: 200, longitude: 200)
-        navigation.reroute(from: invalidLocation)
         
         expectation(forNotification: .routeControllerWillReroute, object: navigation) { (notification) -> Bool in
             return true
@@ -140,6 +139,8 @@ class MapboxCoreNavigationTests: XCTestCase {
         expectation(forNotification: .routeControllerDidFailToReroute, object: navigation) { (notification) -> Bool in
             return true
         }
+        
+        navigation.reroute(from: invalidLocation)
         
         waitForExpectations(timeout: 2) { (error) in
             XCTAssertNil(error)

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -126,4 +126,23 @@ class MapboxCoreNavigationTests: XCTestCase {
             XCTAssertNil(error)
         }
     }
+    
+    func testFailToReroute() {
+        route.accessToken = "foo"
+        let navigation = RouteController(along: route, directions: directions)
+        let invalidLocation = CLLocation(latitude: 200, longitude: 200)
+        navigation.reroute(from: invalidLocation)
+        
+        expectation(forNotification: .routeControllerWillReroute, object: navigation) { (notification) -> Bool in
+            return true
+        }
+        
+        expectation(forNotification: .routeControllerDidFailToReroute, object: navigation) { (notification) -> Bool in
+            return true
+        }
+        
+        waitForExpectations(timeout: 2) { (error) in
+            XCTAssertNil(error)
+        }
+    }
 }

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -129,8 +129,8 @@ class MapboxCoreNavigationTests: XCTestCase {
     
     func testFailToReroute() {
         route.accessToken = "foo"
-        let navigation = RouteController(along: route, directions: directions)
-        let invalidLocation = CLLocation(latitude: 200, longitude: 200)
+        let directionsClientSpy = DirectionsSpy(accessToken: "garbage", host: nil)
+        let navigation = RouteController(along: route, directions: directionsClientSpy)
         
         expectation(forNotification: .routeControllerWillReroute, object: navigation) { (notification) -> Bool in
             return true
@@ -140,7 +140,8 @@ class MapboxCoreNavigationTests: XCTestCase {
             return true
         }
         
-        navigation.reroute(from: invalidLocation)
+        navigation.reroute(from: CLLocation(latitude: 0, longitude: 0))
+        directionsClientSpy.fireLastCalculateCompletion(with: nil, routes: nil, error: NSError())
         
         waitForExpectations(timeout: 2) { (error) in
             XCTAssertNil(error)

--- a/MapboxCoreNavigationTests/Support/DirectionsSpy.swift
+++ b/MapboxCoreNavigationTests/Support/DirectionsSpy.swift
@@ -19,7 +19,6 @@ class DirectionsSpy: Directions {
     override func calculateRoutes(matching options: MatchOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> URLSessionDataTask {
         assert(false, "Not ready to handle \(#function)")
         return DummyURLSessionDataTask()
-
     }
     
     public func fireLastCalculateCompletion(with waypoints: [Waypoint]?, routes: [Route]?, error: NSError?) {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -193,6 +193,7 @@ class RouteMapViewController: UIViewController {
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: .routeControllerWillReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: .routeControllerDidReroute, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .routeControllerDidFailToReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: .UIApplicationWillEnterForeground, object: nil)
         NotificationCenter.default.removeObserver(self, name: .UIApplicationDidEnterBackground, object: nil)
         unsubscribeFromKeyboardNotifications()

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -184,6 +184,7 @@ class RouteMapViewController: UIViewController {
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(willReroute(notification:)), name: .routeControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: .routeControllerDidReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(rerouteDidFail(notification:)), name: .routeControllerDidFailToReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground(notification:)), name: .UIApplicationWillEnterForeground, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(removeTimer), name: .UIApplicationDidEnterBackground, object: nil)
         subscribeToKeyboardNotifications()
@@ -313,6 +314,10 @@ class RouteMapViewController: UIViewController {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
         statusView.show(title, showSpinner: true)
+    }
+    
+    @objc func rerouteDidFail(notification: NSNotification) {
+        statusView.hide()
     }
     
     @objc func didReroute(notification: NSNotification) {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1355

This prevents the reroute status view update from being visible indefinitely.

/cc @mapbox/navigation-ios 
