### PR TITLE
Keep completed waypoints on map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * `RouteController`’s `routeProgress` is now exposed to Objective-C. [#1323](https://github.com/mapbox/mapbox-navigation-ios/pull/1323)
 * Exit indications are now drawn accurately with a correct exit bearing. [#1288](https://github.com/mapbox/mapbox-navigation-ios/pull/1288)
 * Added a delegate method, `NavigationViewControllerDelegate.navigationViewController(_:roadNameAt:)` which allows you to customize the contents of the road name label displayed towards the bottom of the map view. [#1309](https://github.com/mapbox/mapbox-navigation-ios/pull/1309)
+* Completed waypoints now remain on the map but are slightly translucent. [#1364](https://github.com/mapbox/mapbox-navigation-ios/pull/1364)
+* `navigationMapView(_:shapeFor:)` has been renamed to `navigationMapView(_:shapeFor:legIndex:)`. [#1364](https://github.com/mapbox/mapbox-navigation-ios/pull/1364)
 
 ## v0.16.2 (April 13, 2018)
 

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -922,7 +922,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let symbol = MGLSymbolStyleLayer(identifier: identifier, source: source)
         
         symbol.text = NSExpression(format: "CAST(name, 'NSString')")
-        symbol.textOpacity = NSExpression(forConditional: NSPredicate(format: "waypointCompleted == false"), trueExpression: NSExpression(forConstantValue: 0.5), falseExpression: NSExpression(forConstantValue: 1))
+        symbol.textOpacity = NSExpression(forConditional: NSPredicate(format: "waypointCompleted == true"), trueExpression: NSExpression(forConstantValue: 0.5), falseExpression: NSExpression(forConstantValue: 1))
         symbol.textFontSize = NSExpression(forConstantValue: 10)
         symbol.textHaloWidth = NSExpression(forConstantValue: 0.25)
         symbol.textHaloColor = NSExpression(forConstantValue: UIColor.black)

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -118,9 +118,9 @@ public protocol NavigationViewControllerDelegate {
     /**
      Returns an `MGLShape` that represents the destination waypoints along the route (that is, excluding the origin).
      
-     If this method is unimplemented, the navigation map view represents the route waypoints using `navigationMapView(_:shapeFor:)`.
+     If this method is unimplemented, the navigation map view represents the route waypoints using `navigationMapView(_:shapeFor:legIndex:)`.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint]) -> MGLShape?
+    @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape?
     
     /**
      Called when the user taps on the route.
@@ -501,8 +501,8 @@ extension NavigationViewController: RouteMapViewControllerDelegate {
         return delegate?.navigationMapView?(mapView, waypointSymbolStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    public func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint]) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeFor: waypoints)
+    public func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape? {
+        return delegate?.navigationMapView?(mapView, shapeFor: waypoints, legIndex: legIndex)
     }
     
     public func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -641,8 +641,8 @@ extension RouteMapViewController: NavigationViewDelegate {
         return delegate?.navigationMapView?(mapView, waypointSymbolStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint]) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeFor: waypoints)
+    func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape? {
+        return delegate?.navigationMapView?(mapView, shapeFor: waypoints, legIndex: legIndex)
     }
 
     func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {


### PR DESCRIPTION
_Addresses a few issues in https://github.com/mapbox/mapbox-navigation-ios/issues/1306_

Previously, when arriving at a waypoint, we would redraw the waypoints on the map and remove the completed the waypoint. This caused the upcoming waypoint to always be 1. 

Now, completed waypoints are kept on the map but made more translucent.

![simulator screen shot - iphone x - 2018-05-01 at 11 15 08](https://user-images.githubusercontent.com/1058624/39486557-7687b124-4d31-11e8-898f-ff56fc371add.png)
![simulator screen shot - iphone x - 2018-05-01 at 11 21 17](https://user-images.githubusercontent.com/1058624/39486669-cc41396e-4d31-11e8-9d0a-33e6853ccf1e.png)


> Completed waypoint 1

/cc @mapbox/navigation-ios @srikanthsrnvs