### PR TITLE
Update style color palette for v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* New guidance navigation styles are provided through `MGLStyle`. ([#1366](https://github.com/mapbox/mapbox-navigation-ios/pull/1366))
+
 ### Packaging
 
 * Upgraded to the [Mapbox Maps SDK for iOS v4.0.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v4.0.0). If you have customized the route map’s appearance, you may need to migrate your code to use expressions instead of style functions. ([#1076](https://github.com/mapbox/mapbox-navigation-ios/pull/1076))

--- a/Examples/Objective-C/Base.lproj/Main.storyboard
+++ b/Examples/Objective-C/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -48,7 +49,7 @@
                                     <constraint firstItem="Hk0-SM-2Wl" firstAttribute="centerX" secondItem="A3N-JT-loC" secondAttribute="centerX" id="O4U-Pg-RJR"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-preview-day-v2"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-preview-day-v3"/>
                                     <userDefinedRuntimeAttribute type="number" keyPath="latitude">
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>

--- a/Examples/Swift/Base.lproj/Main.storyboard
+++ b/Examples/Swift/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aCx-td-5El">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aCx-td-5El">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -140,7 +140,7 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="68P-Cf-VxO">
-                                <rect key="frame" x="158" y="587" width="60" height="60"/>
+                                <rect key="frame" x="157.5" y="587" width="60" height="60"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="60" id="LOt-aV-LJs"/>
@@ -194,7 +194,7 @@
                             <constraint firstItem="AwW-Zh-nH6" firstAttribute="top" secondItem="bFk-po-evo" secondAttribute="bottom" id="nhP-ne-sUG"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-preview-day-v2"/>
+                            <userDefinedRuntimeAttribute type="string" keyPath="styleURL__" value="mapbox://styles/mapbox/navigation-preview-day-v3"/>
                         </userDefinedRuntimeAttributes>
                     </view>
                     <connections>
@@ -220,7 +220,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1vl-kS-fBt">
-                                <rect key="frame" x="91" y="318" width="193" height="30"/>
+                                <rect key="frame" x="91" y="318.5" width="193" height="30"/>
                                 <state key="normal" title="Continue to next destination"/>
                                 <connections>
                                     <action selector="continueButtonPressed:" destination="JoY-h8-mcz" eventType="touchUpInside" id="ytK-Vg-d0S"/>

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		353280A11FA72871005175F3 /* InstructionLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353280A01FA72871005175F3 /* InstructionLabel.swift */; };
 		353610CE1FAB6A8F00FB1746 /* BottomBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353610CD1FAB6A8F00FB1746 /* BottomBannerView.swift */; };
 		353AA5601FCEF583009F0384 /* StyleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353AA55F1FCEF583009F0384 /* StyleManager.swift */; };
+		353E3C8F20A3501C00FD1789 /* MGLStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E3C8E20A3501C00FD1789 /* MGLStyle.swift */; };
 		353E68FC1EF0B7F8007B2AE5 /* NavigationLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E68FB1EF0B7F8007B2AE5 /* NavigationLocationManager.swift */; };
 		353E68FE1EF0B985007B2AE5 /* BundleAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E68FD1EF0B985007B2AE5 /* BundleAdditions.swift */; };
 		353E69041EF0C4E5007B2AE5 /* SimulatedLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353E69031EF0C4E5007B2AE5 /* SimulatedLocationManager.swift */; };
@@ -482,6 +483,7 @@
 		353610CD1FAB6A8F00FB1746 /* BottomBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomBannerView.swift; sourceTree = "<group>"; };
 		35375EC01F31FA86004CE727 /* NavigationSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationSettings.swift; sourceTree = "<group>"; };
 		353AA55F1FCEF583009F0384 /* StyleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleManager.swift; sourceTree = "<group>"; };
+		353E3C8E20A3501C00FD1789 /* MGLStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLStyle.swift; sourceTree = "<group>"; };
 		353E68FB1EF0B7F8007B2AE5 /* NavigationLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationManager.swift; sourceTree = "<group>"; };
 		353E68FD1EF0B985007B2AE5 /* BundleAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleAdditions.swift; sourceTree = "<group>"; };
 		353E69031EF0C4E5007B2AE5 /* SimulatedLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedLocationManager.swift; sourceTree = "<group>"; };
@@ -1112,6 +1114,7 @@
 				C5A7EC5B1FD610A80008B9BA /* VisualInstructionComponent.swift */,
 				8D391CE11FD71E78006BB91F /* Waypoint.swift */,
 				35ECAF2C2092275100DC3BC3 /* UIImage.swift */,
+				353E3C8E20A3501C00FD1789 /* MGLStyle.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1834,6 +1837,7 @@
 				359D1B281FFE70D30052FA42 /* NavigationView.swift in Sources */,
 				8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */,
 				8D24A2F62040960C0098CBF8 /* UIEdgeInsets.swift in Sources */,
+				353E3C8F20A3501C00FD1789 /* MGLStyle.swift in Sources */,
 				DADAD82F20350849002E25CA /* MBRouteVoiceController.m in Sources */,
 				C57491DF1FACC42F006F97BC /* CGPoint.swift in Sources */,
 				8D53136B20653FA20044891E /* ExitView.swift in Sources */,

--- a/MapboxNavigation/BottomBannerView.swift
+++ b/MapboxNavigation/BottomBannerView.swift
@@ -15,7 +15,10 @@ open class BottomBannerView: UIView {
     weak var distanceRemainingLabel: DistanceRemainingLabel!
     weak var arrivalTimeLabel: ArrivalTimeLabel!
     weak var cancelButton: CancelButton!
-    weak var dividerView: SeparatorView!
+    // Vertical divider between cancel button and the labels
+    weak var verticalDividerView: SeparatorView!
+    // Horizontal divider to a some distinction between the map view and the bottom banner
+    weak var horizontalDividerView: SeparatorView!
     weak var routeController: RouteController!
     weak var delegate: BottomBannerViewDelegate?
     

--- a/MapboxNavigation/BottomBannerView.swift
+++ b/MapboxNavigation/BottomBannerView.swift
@@ -17,7 +17,7 @@ open class BottomBannerView: UIView {
     weak var cancelButton: CancelButton!
     // Vertical divider between cancel button and the labels
     weak var verticalDividerView: SeparatorView!
-    // Horizontal divider to a some distinction between the map view and the bottom banner
+    // Horizontal divider between the map view and the bottom banner
     weak var horizontalDividerView: SeparatorView!
     weak var routeController: RouteController!
     weak var delegate: BottomBannerViewDelegate?

--- a/MapboxNavigation/BottomBannerViewLayout.swift
+++ b/MapboxNavigation/BottomBannerViewLayout.swift
@@ -64,7 +64,7 @@ extension BottomBannerView {
         c.append(verticalDividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
         c.append(verticalDividerView.trailingAnchor.constraint(equalTo: cancelButton.leadingAnchor))
         
-        c.append(horizontalDividerView.heightAnchor.constraint(equalToConstant: 1))
+        c.append(horizontalDividerView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale))
         c.append(horizontalDividerView.topAnchor.constraint(equalTo: topAnchor))
         c.append(horizontalDividerView.leadingAnchor.constraint(equalTo: leadingAnchor))
         c.append(horizontalDividerView.trailingAnchor.constraint(equalTo: trailingAnchor))
@@ -92,7 +92,7 @@ extension BottomBannerView {
         c.append(verticalDividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
         c.append(verticalDividerView.trailingAnchor.constraint(equalTo: cancelButton.leadingAnchor))
         
-        c.append(horizontalDividerView.heightAnchor.constraint(equalToConstant: 1))
+        c.append(horizontalDividerView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale))
         c.append(horizontalDividerView.topAnchor.constraint(equalTo: topAnchor))
         c.append(horizontalDividerView.leadingAnchor.constraint(equalTo: leadingAnchor))
         c.append(horizontalDividerView.trailingAnchor.constraint(equalTo: trailingAnchor))

--- a/MapboxNavigation/BottomBannerViewLayout.swift
+++ b/MapboxNavigation/BottomBannerViewLayout.swift
@@ -27,10 +27,15 @@ extension BottomBannerView {
         addSubview(cancelButton)
         self.cancelButton = cancelButton
         
-        let dividerView = SeparatorView()
-        dividerView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(dividerView)
-        self.dividerView = dividerView
+        let verticalDivider = SeparatorView()
+        verticalDivider.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(verticalDivider)
+        self.verticalDividerView = verticalDivider
+        
+        let horizontalDividerView = SeparatorView()
+        horizontalDividerView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(horizontalDividerView)
+        self.horizontalDividerView = horizontalDividerView
         
         setupConstraints()
     }
@@ -54,12 +59,17 @@ extension BottomBannerView {
         c.append(distanceRemainingLabel.leadingAnchor.constraint(equalTo: timeRemainingLabel.trailingAnchor, constant: 10))
         c.append(distanceRemainingLabel.lastBaselineAnchor.constraint(equalTo: timeRemainingLabel.lastBaselineAnchor))
         
-        c.append(dividerView.widthAnchor.constraint(equalToConstant: 1))
-        c.append(dividerView.heightAnchor.constraint(equalToConstant: 40))
-        c.append(dividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
-        c.append(dividerView.trailingAnchor.constraint(equalTo: cancelButton.leadingAnchor))
+        c.append(verticalDividerView.widthAnchor.constraint(equalToConstant: 1))
+        c.append(verticalDividerView.heightAnchor.constraint(equalToConstant: 40))
+        c.append(verticalDividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
+        c.append(verticalDividerView.trailingAnchor.constraint(equalTo: cancelButton.leadingAnchor))
         
-        c.append(arrivalTimeLabel.trailingAnchor.constraint(equalTo: dividerView.leadingAnchor, constant: -10))
+        c.append(horizontalDividerView.heightAnchor.constraint(equalToConstant: 1))
+        c.append(horizontalDividerView.topAnchor.constraint(equalTo: topAnchor))
+        c.append(horizontalDividerView.leadingAnchor.constraint(equalTo: leadingAnchor))
+        c.append(horizontalDividerView.trailingAnchor.constraint(equalTo: trailingAnchor))
+        
+        c.append(arrivalTimeLabel.trailingAnchor.constraint(equalTo: verticalDividerView.leadingAnchor, constant: -10))
         c.append(arrivalTimeLabel.centerYAnchor.constraint(equalTo: cancelButton.centerYAnchor))
     }
     
@@ -77,13 +87,18 @@ extension BottomBannerView {
         c.append(cancelButton.trailingAnchor.constraint(equalTo: trailingAnchor))
         c.append(cancelButton.bottomAnchor.constraint(equalTo: bottomAnchor))
         
-        c.append(dividerView.widthAnchor.constraint(equalToConstant: 1))
-        c.append(dividerView.heightAnchor.constraint(equalToConstant: 40))
-        c.append(dividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
-        c.append(dividerView.trailingAnchor.constraint(equalTo: cancelButton.leadingAnchor))
+        c.append(verticalDividerView.widthAnchor.constraint(equalToConstant: 1))
+        c.append(verticalDividerView.heightAnchor.constraint(equalToConstant: 40))
+        c.append(verticalDividerView.centerYAnchor.constraint(equalTo: centerYAnchor))
+        c.append(verticalDividerView.trailingAnchor.constraint(equalTo: cancelButton.leadingAnchor))
+        
+        c.append(horizontalDividerView.heightAnchor.constraint(equalToConstant: 1))
+        c.append(horizontalDividerView.topAnchor.constraint(equalTo: topAnchor))
+        c.append(horizontalDividerView.leadingAnchor.constraint(equalTo: leadingAnchor))
+        c.append(horizontalDividerView.trailingAnchor.constraint(equalTo: trailingAnchor))
         
         c.append(arrivalTimeLabel.centerYAnchor.constraint(equalTo: centerYAnchor))
-        c.append(arrivalTimeLabel.trailingAnchor.constraint(equalTo: dividerView.leadingAnchor, constant: -10))
+        c.append(arrivalTimeLabel.trailingAnchor.constraint(equalTo: verticalDividerView.leadingAnchor, constant: -10))
     }
     
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -3,8 +3,9 @@ import Mapbox
 
 extension UIColor {
     class var defaultRouteCasing: UIColor { get { return .defaultTintStroke } }
-    class var defaultRouteLayer: UIColor { get { return #colorLiteral(red:0.00, green:0.70, blue:0.99, alpha:1.0) } }
-    class var defaultAlternateLine: UIColor { get { return .gray } }
+    class var defaultRouteLayer: UIColor { get { return #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 1) } }
+    class var defaultAlternateLine: UIColor { get { return #colorLiteral(red: 0.6, green: 0.6, blue: 0.6, alpha: 1) } }
+    class var defaultAlternateLineCasing: UIColor { get { return #colorLiteral(red: 0.5019607843, green: 0.4980392157, blue: 0.5019607843, alpha: 1) } }
     class var defaultManeuverArrowStroke: UIColor { get { return .defaultRouteLayer } }
     class var defaultManeuverArrow: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
     
@@ -16,16 +17,16 @@ extension UIColor {
     
     class var trafficUnknown: UIColor { get { return defaultRouteLayer } }
     class var trafficLow: UIColor { get { return defaultRouteLayer } }
-    class var trafficModerate: UIColor { get { return #colorLiteral(red:0.95, green:0.65, blue:0.31, alpha:1.0) } }
-    class var trafficHeavy: UIColor { get { return #colorLiteral(red:0.91, green:0.20, blue:0.25, alpha:1.0) } }
-    class var trafficSevere: UIColor { get { return #colorLiteral(red:0.54, green:0.06, blue:0.22, alpha:1.0) } }
+    class var trafficModerate: UIColor { get { return #colorLiteral(red: 0.9529411765, green: 0.6509803922, blue: 0.3098039216, alpha: 1) } }
+    class var trafficHeavy: UIColor { get { return #colorLiteral(red: 0.9137254902, green: 0.2, blue: 0.2509803922, alpha: 1) } }
+    class var trafficSevere: UIColor { get { return #colorLiteral(red: 0.5411764706, green: 0.05882352941, blue: 0.2196078431, alpha: 1) } }
     class var trafficAlternateLow: UIColor { get { return #colorLiteral(red: 0.4666666687, green: 0.7647058964, blue: 0.2666666806, alpha: 1) } }
 }
 
 extension UIColor {
     // General styling
-    fileprivate class var defaultTint: UIColor { get { return #colorLiteral(red: 0.1411764771, green: 0.3960784376, blue: 0.5647059083, alpha: 1) } }
-    fileprivate class var defaultTintStroke: UIColor { get { return #colorLiteral(red:0.18, green:0.49, blue:0.78, alpha:1.0) } }
+    fileprivate class var defaultTint: UIColor { get { return #colorLiteral(red: 0.1843137255, green: 0.4784313725, blue: 0.7764705882, alpha: 1) } }
+    fileprivate class var defaultTintStroke: UIColor { get { return #colorLiteral(red: 0.1843137255, green: 0.4784313725, blue: 0.7764705882, alpha: 1) } }
     fileprivate class var defaultPrimaryText: UIColor { get { return #colorLiteral(red: 45.0/255.0, green: 45.0/255.0, blue: 45.0/255.0, alpha: 1) } }
     fileprivate class var defaultSecondaryText: UIColor { get { return #colorLiteral(red: 0.4509803922, green: 0.4509803922, blue: 0.4509803922, alpha: 1) } }
 }

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Mapbox
 
+extension MGLStyle {
+    // Returns the URL to the current version of the Mapbox Navigation Guidance Day style.
+    public class var navigationGuidanceDayStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v2")! } }
+    // Returns the URL to the current version of the Mapbox Navigation Guidance Night style.
+    public class var navigationGuidanceNightStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v2")! } }
+}
+
 extension UIColor {
     class var defaultRouteCasing: UIColor { get { return .defaultTintStroke } }
     class var defaultRouteLayer: UIColor { get { return #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 1) } }
@@ -45,7 +52,7 @@ open class DayStyle: Style {
     
     public required init() {
         super.init()
-        mapStyleURL = URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v2")!
+        mapStyleURL = MGLStyle.navigationGuidanceDayStyleURL
         styleType = .day
         statusBarStyle = .default
     }
@@ -160,7 +167,7 @@ open class NightStyle: DayStyle {
     
     public required init() {
         super.init()
-        mapStyleURL = URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v2")!
+        mapStyleURL = MGLStyle.navigationGuidanceNightStyleURL
         styleType = .night
         statusBarStyle = .lightContent
     }

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -136,7 +136,7 @@ open class DayStyle: Style {
         SecondaryLabel.appearance().normalFont = UIFont.systemFont(ofSize: 26, weight: .medium).adjustedFont
         SecondaryLabel.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).normalTextColor = #colorLiteral(red: 0.2156862745, green: 0.2156862745, blue: 0.2156862745, alpha: 1)
         SecondaryLabel.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).normalTextColor = #colorLiteral(red: 0.2156862745, green: 0.2156862745, blue: 0.2156862745, alpha: 1)
-        SeparatorView.appearance().backgroundColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.1)
+        SeparatorView.appearance().backgroundColor = #colorLiteral(red: 0.737254902, green: 0.7960784314, blue: 0.8705882353, alpha: 1)
         StatusView.appearance().backgroundColor = UIColor.black.withAlphaComponent(2.0/3.0)
         StepInstructionsView.appearance().backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
         StepListIndicatorView.appearance().gradientColors = [#colorLiteral(red: 0.431372549, green: 0.431372549, blue: 0.431372549, alpha: 1), #colorLiteral(red: 0.6274509804, green: 0.6274509804, blue: 0.6274509804, alpha: 1), #colorLiteral(red: 0.431372549, green: 0.431372549, blue: 0.431372549, alpha: 1)]

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -3,9 +3,9 @@ import Mapbox
 
 extension MGLStyle {
     // Returns the URL to the current version of the Mapbox Navigation Guidance Day style.
-    public class var navigationGuidanceDayStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v2")! } }
+    public class var navigationGuidanceDayStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v3")! } }
     // Returns the URL to the current version of the Mapbox Navigation Guidance Night style.
-    public class var navigationGuidanceNightStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v2")! } }
+    public class var navigationGuidanceNightStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v3")! } }
 }
 
 extension UIColor {

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -1,12 +1,6 @@
 import Foundation
 import Mapbox
 
-extension MGLStyle {
-    // Returns the URL to the current version of the Mapbox Navigation Guidance Day style.
-    public class var navigationGuidanceDayStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v3")! } }
-    // Returns the URL to the current version of the Mapbox Navigation Guidance Night style.
-    public class var navigationGuidanceNightStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v3")! } }
-}
 
 extension UIColor {
     class var defaultRouteCasing: UIColor { get { return .defaultTintStroke } }

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -224,6 +224,7 @@ open class NightStyle: DayStyle {
         ResumeButton.appearance().tintColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         SecondaryLabel.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).normalTextColor = #colorLiteral(red: 0.7349056005, green: 0.7675836682, blue: 0.8063536286, alpha: 1)
         SecondaryLabel.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).normalTextColor = #colorLiteral(red: 0.7349056005, green: 0.7675836682, blue: 0.8063536286, alpha: 1)
+        SeparatorView.appearance().backgroundColor = #colorLiteral(red: 0.3764705882, green: 0.4901960784, blue: 0.6117647059, alpha: 0.796599912)
         StepInstructionsView.appearance().backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
         StepTableViewCell.appearance().backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
         StepsBackgroundView.appearance().backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)

--- a/MapboxNavigation/InstructionsBannerViewLayout.swift
+++ b/MapboxNavigation/InstructionsBannerViewLayout.swift
@@ -117,7 +117,7 @@ extension BaseInstructionsBannerView {
         _separatorView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
         
         // Visible separator docked to the bottom
-        separatorView.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        separatorView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale).isActive = true
         separatorView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
         separatorView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
         separatorView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true

--- a/MapboxNavigation/MGLStyle.swift
+++ b/MapboxNavigation/MGLStyle.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Mapbox
+
+extension MGLStyle {
+    // Returns the URL to the current version of the Mapbox Navigation Guidance Day style.
+    @objc
+    public class var navigationGuidanceDayStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v2")! } }
+    // Returns the URL to the current version of the Mapbox Navigation Guidance Night style.
+    @objc
+    public class var navigationGuidanceNightStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v2")! } }
+    
+    @objc
+    public func navigationGuidanceDayStyle(version: Int) -> URL {
+        return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v\(version)")!
+    }
+
+    @objc
+    public func navigationGuidanceNightStyle(version: Int) -> URL {
+        return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v\(version)")!
+    }
+}

--- a/MapboxNavigation/MGLStyle.swift
+++ b/MapboxNavigation/MGLStyle.swift
@@ -5,17 +5,20 @@ extension MGLStyle {
     // Returns the URL to the current version of the Mapbox Navigation Guidance Day style.
     @objc
     public class var navigationGuidanceDayStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v2")! } }
+    
     // Returns the URL to the current version of the Mapbox Navigation Guidance Night style.
     @objc
     public class var navigationGuidanceNightStyleURL: URL { get { return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v2")! } }
     
     @objc
-    public func navigationGuidanceDayStyle(version: Int) -> URL {
+    // Returns the URL to the given version of the navigation guidance style. Available version are 1, 2, and 3.
+    public class func navigationGuidanceDayStyleURL(version: Int) -> URL {
         return URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v\(version)")!
     }
 
     @objc
-    public func navigationGuidanceNightStyle(version: Int) -> URL {
+    // Returns the URL to the given version of the navigation guidance style. Available version are 2, and 3.
+    public class func navigationGuidanceNightStyleURL(version: Int) -> URL {
         return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v\(version)")!
     }
 }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -510,6 +510,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         if let lineCasingSource = style.source(withIdentifier: sourceCasingIdentifier) {
             style.removeSource(lineCasingSource)
         }
+        
         removeAlternates()
     }
     
@@ -520,6 +521,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
         if let altLayer = style.layer(withIdentifier: alternateLayerIdentifier) {
             style.removeLayer(altLayer)
+        }
+        
+        if let altCasingLayer = style.layer(withIdentifier: alternateCasingLayerIdentifier) {
+            style.removeLayer(altCasingLayer)
         }
         
         if let altSource = style.source(withIdentifier: alternateSourceIdentifier) {

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -104,7 +104,6 @@ open class NavigationView: UIView {
     lazy var muteButton = FloatingButton.rounded(image: Images.volumeUp, selectedImage: Images.volumeOff)
     lazy var reportButton = FloatingButton.rounded(image: Images.feedback)
     
-    lazy var separatorView: SeparatorView = .forAutoLayout()
     lazy var lanesView: LanesView = .forAutoLayout(hidden: true)
     lazy var nextBannerView: NextBannerView = .forAutoLayout(hidden: true)
     lazy var statusView: StatusView = {
@@ -211,7 +210,6 @@ open class NavigationView: UIView {
             mapView,
             informationStackView,
             floatingStackView,
-            separatorView,
             resumeButton,
             wayNameView,
             rerouteReportButton,

--- a/MapboxNavigation/NavigationViewLayout.swift
+++ b/MapboxNavigation/NavigationViewLayout.swift
@@ -16,10 +16,6 @@ extension NavigationView {
         instructionsBannerView.heightAnchor.constraint(equalToConstant: 96).isActive = true
         
         NSLayoutConstraint.activate(bannerShowConstraints)
-        separatorView.topAnchor.constraint(equalTo: instructionsBannerView.bottomAnchor).isActive = true
-        separatorView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        separatorView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-        separatorView.heightAnchor.constraint(equalToConstant: 2).isActive = true
 
         informationStackView.topAnchor.constraint(equalTo: instructionsBannerView.bottomAnchor).isActive = true
         informationStackView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true

--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -13,6 +13,7 @@ open class NextBannerView: UIView {
     
     weak var maneuverView: ManeuverView!
     weak var instructionLabel: NextInstructionLabel!
+    weak var bottomSeparatorView: SeparatorView!
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -48,6 +49,11 @@ open class NextBannerView: UIView {
             let availableWidth = self.bounds.width - BaseInstructionsBannerView.maneuverViewSize.width - BaseInstructionsBannerView.padding * 3
             return CGRect(x: 0, y: 0, width: availableWidth, height: self.instructionLabel.font.lineHeight)
         }
+        
+        let bottomSeparatorView = SeparatorView()
+        bottomSeparatorView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(bottomSeparatorView)
+        self.bottomSeparatorView = bottomSeparatorView
     }
     
     override open func prepareForInterfaceBuilder() {
@@ -72,6 +78,11 @@ open class NextBannerView: UIView {
         instructionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 70).isActive = true
         instructionLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
         instructionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16).isActive = true
+        
+        bottomSeparatorView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        bottomSeparatorView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        bottomSeparatorView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        bottomSeparatorView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale).isActive = true
     }
     
     func shouldShowNextBanner(for routeProgress: RouteProgress) -> Bool {

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,6 +19,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="unQ-4I-UPo" customClass="MBSeparatorView">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="JsN-yF-tXj"/>
+                                </constraints>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4jh-bR-wXL" userLabel="Arrival Labels Container">
                                 <rect key="frame" x="0.0" y="16" width="375" height="60"/>
                                 <subviews>
@@ -147,6 +153,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstAttribute="trailing" secondItem="unQ-4I-UPo" secondAttribute="trailing" id="1BB-nP-SYc"/>
                             <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="evE-dd-pMr" secondAttribute="trailing" id="3Da-jA-RLx"/>
                             <constraint firstItem="TEs-GQ-xWN" firstAttribute="top" secondItem="evE-dd-pMr" secondAttribute="bottom" constant="65" id="6IH-iM-ln5"/>
                             <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="P8U-kf-mkb" secondAttribute="top" constant="10" id="GFJ-yQ-Cye"/>
@@ -155,7 +162,9 @@
                             <constraint firstItem="ekW-06-trL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="TeT-ls-Ns4"/>
                             <constraint firstItem="ekW-06-trL" firstAttribute="trailing" secondItem="P8U-kf-mkb" secondAttribute="trailing" id="UUM-FL-FrV"/>
                             <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="TEs-GQ-xWN" secondAttribute="trailing" id="Vg9-Xi-JtV"/>
+                            <constraint firstItem="unQ-4I-UPo" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="WJ9-OZ-x1y"/>
                             <constraint firstAttribute="bottom" secondItem="ekW-06-trL" secondAttribute="bottom" id="f1v-ju-qen"/>
+                            <constraint firstItem="unQ-4I-UPo" firstAttribute="top" secondItem="P8U-kf-mkb" secondAttribute="top" id="gVo-YH-zU7"/>
                             <constraint firstItem="evE-dd-pMr" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="k0v-jB-TbO"/>
                             <constraint firstItem="TEs-GQ-xWN" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="lxR-dT-lxi"/>
                             <constraint firstItem="4jh-bR-wXL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="muP-uc-2iF"/>

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -152,7 +152,7 @@ open class StepsViewController: UIViewController {
         separatorBottomView.topAnchor.constraint(equalTo: dismissButton.topAnchor).isActive = true
         separatorBottomView.leadingAnchor.constraint(equalTo: dismissButton.leadingAnchor).isActive = true
         separatorBottomView.trailingAnchor.constraint(equalTo: dismissButton.trailingAnchor).isActive = true
-        separatorBottomView.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        separatorBottomView.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale).isActive = true
         
         tableView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
         tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -18,6 +18,7 @@ open class StepsViewController: UIViewController {
     weak var tableView: UITableView!
     weak var backgroundView: UIView!
     weak var bottomView: UIView!
+    weak var separatorBottomView: SeparatorView!
     weak var dismissButton: DismissButton!
     weak var delegate: StepsViewControllerDelegate?
     
@@ -132,6 +133,11 @@ open class StepsViewController: UIViewController {
         bottomView.backgroundColor = DismissButton.appearance().backgroundColor
         view.addSubview(bottomView)
         self.bottomView = bottomView
+        
+        let separatorBottomView = SeparatorView()
+        separatorBottomView.translatesAutoresizingMaskIntoConstraints = false
+        dismissButton.addSubview(separatorBottomView)
+        self.separatorBottomView = separatorBottomView
 
         dismissButton.heightAnchor.constraint(equalToConstant: 54).isActive = true
         dismissButton.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
@@ -142,6 +148,11 @@ open class StepsViewController: UIViewController {
         bottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         bottomView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
         bottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        
+        separatorBottomView.topAnchor.constraint(equalTo: dismissButton.topAnchor).isActive = true
+        separatorBottomView.leadingAnchor.constraint(equalTo: dismissButton.leadingAnchor).isActive = true
+        separatorBottomView.trailingAnchor.constraint(equalTo: dismissButton.trailingAnchor).isActive = true
+        separatorBottomView.heightAnchor.constraint(equalToConstant: 1).isActive = true
         
         tableView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
         tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -34,7 +34,7 @@ open class Style: NSObject {
     /**
      Map style to be used for the style.
      */
-    @objc open var mapStyleURL: URL = URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v3")!
+    @objc open var mapStyleURL: URL = MGLStyle.navigationGuidanceDayStyleURL
     
     /**
      Applies the style for all changed properties.

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -34,7 +34,7 @@ open class Style: NSObject {
     /**
      Map style to be used for the style.
      */
-    @objc open var mapStyleURL: URL = URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v2")!
+    @objc open var mapStyleURL: URL = URL(string: "mapbox://styles/mapbox/navigation-guidance-day-v3")!
     
     /**
      Applies the style for all changed properties.


### PR DESCRIPTION
Partially closes #1347 

This PR updates the color palette for v3 guidance day/night styles.
v2 guidance map styles will still be used by default but convenient methods for any version has been added in the form of (`MGLStyle.navigationGuidance{Day/Night}StyleURL(version:)`.

@1ec5 @bsudekum 👀 