### PR TITLE
Clean up NavigationMapViewDelegate method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,11 @@
 ### Other changes
 
 * `DistanceFormatter`, `ReplayLocationManager`, `SimulatedLocationManager`, `LanesView`, and `ManueverView` are now subclassable. ([#1345](https://github.com/mapbox/mapbox-navigation-ios/pull/1345]))
-* Renamed methods on `NavigationMapViewDelegate` ([#1364](https://github.com/mapbox/mapbox-navigation-ios/pull/1364), [#1338](https://github.com/mapbox/mapbox-navigation-ios/pull/1338), [#1318](https://github.com/mapbox/mapbox-navigation-ios/pull/1318)):    
-    - `NavigationMapViewDelegate.navigationMapView(_:shapeDescribingRoute:)` renamed to `NavigationMapViewDelegate.navigationMapView(_:shapeDescribing:)`.
-    - `NavigationMapViewDelegate.navigationMapView(_:shapeDescribingWaypoints:)` renamed to `NavigationMapViewDelegate.navigationMapView(_:simplifiedShapeDescribingRoute:)`.
-    - `NavigationMapViewDelegate.navigationMapView(_:shapeDescribingWaypoints:)` renamed to `NavigationMapViewDelegate.navigationMapView(_:shapeFor:legIndex:)`.
-    - `NavigationMapViewDelegate.navigationMapView(_:imageForAnnotation:)` renamed to `NavigationMapViewDelegate.navigationMapView(_:imageFor:)`.
-    - `NavigationMapViewDelegate.navigationMapView(_:viewForAnnotation:)` renamed to `NavigationMapViewDelegate.navigationMapView(_:viewFor:)`.
-    - `NavigationViewControllerDelegate.navigationViewControllerDidCancelNavigation(_:)` to `NavigationViewControllerDelegate.navigationViewControllerDidDismiss(_:byCanceling:)`
+* Renamed several  `NavigationMapViewDelegate` methods ([#1364](https://github.com/mapbox/mapbox-navigation-ios/pull/1364), [#1338](https://github.com/mapbox/mapbox-navigation-ios/pull/1338), [#1318](https://github.com/mapbox/mapbox-navigation-ios/pull/1318), [#1378](https://github.com/mapbox/mapbox-navigation-ios/pull/1378)):
+    * `NavigationViewControllerDelegate.navigationViewControllerDidCancelNavigation(_:)` to `NavigationViewControllerDelegate.navigationViewControllerDidDismiss(_:byCanceling:)`
+    * `NavigationMapViewDelegate.navigationMapView(_:shapeDescribing:)` to `NavigationMapViewDelegate.navigationMapView(_:shapeFor:)`.
+    * `NavigationMapViewDelegate.navigationMapView(_:simplifiedShapeDescribing:)` to `NavigationMapViewDelegate.navigationMapView(_:simplifiedShapeFor:)`.
+    * `-[MBNavigationMapViewDelegate navigationMapView:shapeDescribingWaypoints:legIndex:]` to `-[MBNavigationMapViewDelegate navigationMapView:shapeForWaypoints:legIndex:]` in Objective-C.
 
 ## v0.16.2 (April 13, 2018)
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -92,14 +92,16 @@ public protocol NavigationViewControllerDelegate {
      
      If this method is unimplemented, the navigation map view represents the route line using an `MGLPolylineFeature` based on `route`’s `coordinates` property.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape?
+    @objc(navigationMapView:shapeForRoute:)
+    optional func navigationMapView(_ mapView: NavigationMapView, shapeFor route: Route) -> MGLShape?
     
     /**
      Returns an `MGLShape` that represents the path of the route line’s casing.
      
-     If this method is unimplemented, the navigation map view represents the route line’s casing using an `MGLPolylineFeature` identical to the one returned by `navigationMapView(_:shapeDescribing:)`.
+     If this method is unimplemented, the navigation map view represents the route line’s casing using an `MGLPolylineFeature` identical to the one returned by `navigationMapView(_:shapeFor:)`.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape?
+    @objc(navigationMapView:simplifiedShapeForRoute:)
+    optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape?
     
     /*
      Returns an `MGLStyleLayer` that marks the location of each destination along the route when there are multiple destinations. The returned layer is added to the map below the layer returned by `navigationMapView(_:waypointSymbolStyleLayerWithIdentifier:source:)`.
@@ -478,12 +480,12 @@ extension NavigationViewController: RouteMapViewControllerDelegate {
         delegate?.navigationMapView?(mapView, didTap: route)
     }
     
-    @objc public func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeDescribing: route)
+    @objc public func navigationMapView(_ mapView: NavigationMapView, shapeFor route: Route) -> MGLShape? {
+        return delegate?.navigationMapView?(mapView, shapeFor: route)
     }
     
-    @objc public func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeDescribing: route)
+    @objc public func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape? {
+        return delegate?.navigationMapView?(mapView, shapeFor: route)
     }
     
     public func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -671,16 +671,16 @@ extension RouteMapViewController: NavigationViewDelegate {
         return delegate?.navigationMapView?(mapView, shapeFor: waypoints, legIndex: legIndex)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, shapeDescribing route: Route) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeDescribing: route)
+    func navigationMapView(_ mapView: NavigationMapView, shapeFor route: Route) -> MGLShape? {
+        return delegate?.navigationMapView?(mapView, shapeFor: route)
     }
     
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
         delegate?.navigationMapView?(mapView, didSelect: route)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeDescribing route: Route) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, simplifiedShapeDescribing: route)
+    func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape? {
+        return delegate?.navigationMapView?(mapView, simplifiedShapeFor: route)
     }
     
     func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {


### PR DESCRIPTION
Reverted some NavigationMapViewDelegate method names to conform to Objective-C naming conventions and be more consistent.

Relative to master:

Old (Swift) | New (Swift) | Old (Objective-C) | New (Objective-C)
----|----|----|----
`navigationMapView(_:shapeDescribing:)` | `navigationMapView(_:shapeFor:)` | `-navigationMapView:shapeDescribing:` | `-navigationMapView:shapeForRoute:`
`navigationMapView(_:simplifiedShapeDescribing:)` | `navigationMapView(_:simplifiedShapeFor:)` | `-navigationMapView:simplifiedShapeDescribing:` | `-navigationMapView:simplifiedShapeForRoute:`
`navigationMapView(_:shapeFor:legIndex:)` | `navigationMapView(_:shapeFor:legIndex:)` | `-navigationMapView:shapeFor:legIndex:` | `-navigationMapView:shapeForWaypoints:legIndex:`
`navigationMapView(_:imageFor:)` | `navigationMapView(_:imageFor:)` | `-navigationMapView:imageFor:` | `-navigationMapView:imageForAnnotation:`
`navigationMapView(_:viewFor:)` | `navigationMapView(_:viewFor:)` | `-navigationMapView:viewFor:` | `-navigationMapView:viewForAnnotation:`

Relative to v0.17.0-beta.1, the only changes are:

Old (Swift) | New (Swift) | Old (Objective-C) | New (Objective-C)
----|----|----|----
`navigationMapView(_:shapeDescribing:)` | `navigationMapView(_:shapeFor:)` | `-navigationMapView:shapeDescribingRoute:` | `-navigationMapView:shapeForRoute:`
`navigationMapView(_:simplifiedShapeDescribing:)` | `navigationMapView(_:simplifiedShapeFor:)` | `-navigationMapView:simplifiedShapeDescribingRoute:` | `-navigationMapView:simplifiedShapeForRoute:`
`navigationMapView(_:shapeFor:legIndex:)` | `navigationMapView(_:shapeFor:legIndex:)` | `-navigationMapView:shapeDescribingWaypoints:legIndex:` | `-navigationMapView:shapeForWaypoints:legIndex:`

Fixes #1375.

/cc @vincethecoder @bsudekum