### PR TITLE
Fix steps list pulsing

### DIFF
--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -47,14 +47,14 @@ open class StepsViewController: UIViewController {
     func rebuildDataSourceIfNecessary() -> Bool {
         
         let legIndex = routeProgress.legIndex
-        let didProcessCurrentStep = previousLegIndex == legIndex && previousStepIndex == routeProgress.currentLegProgress.stepIndex
+        // Don't include the current step in the list
+        let stepIndex = routeProgress.currentLegProgress.stepIndex + 1
+        let didProcessCurrentStep = previousLegIndex == legIndex && previousStepIndex == stepIndex
         
         guard !didProcessCurrentStep else { return false }
         
         sections.removeAll()
         
-        // Don't include the current step in the list
-        let stepIndex = routeProgress.currentLegProgress.stepIndex + 1
         let legs = routeProgress.route.legs
         
         for (index, leg) in legs.enumerated() {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1386

`didProcessCurrentStep` was always false because we are essentially comparing `routeProgress.currentLegProgress.stepIndex + 1` to `routeProgress.currentLegProgress.stepIndex` on every update. 

/cc @frederoni @vincethecoder @JThramer 