### PR TITLE
Fix initial abbreviation of steps

### DIFF
--- a/MapboxNavigation/InstructionLabel.swift
+++ b/MapboxNavigation/InstructionLabel.swift
@@ -7,6 +7,8 @@ import MapboxDirections
 open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
     typealias AvailableBoundsHandler = () -> (CGRect)
     var availableBounds: AvailableBoundsHandler!
+    // This optional view can be used for calculating the available width when using e.g. a UITableView or a UICollectionView where the frame is unknown before the cells are displayed. The bounds of `InstructionLabel` will be used if this view is unset.
+    weak var viewForAvailableBoundsCalculation: UIView?
     var shieldHeight: CGFloat = 30
     var imageRepository: ImageRepository = .shared
     var imageDownloadCompletion: (() -> Void)?

--- a/MapboxNavigation/InstructionsBannerViewLayout.swift
+++ b/MapboxNavigation/InstructionsBannerViewLayout.swift
@@ -141,13 +141,13 @@ extension BaseInstructionsBannerView {
         // Abbreviate if the instructions do not fit on one line
         primaryLabel.availableBounds = { [unowned self] in
             // Available width H:|-padding-maneuverView-padding-availableWidth-padding-|
-            let availableWidth = self.bounds.width - BaseInstructionsBannerView.maneuverViewSize.width - BaseInstructionsBannerView.padding * 3
+            let availableWidth = self.primaryLabel.viewForAvailableBoundsCalculation?.bounds.width ?? self.bounds.width - BaseInstructionsBannerView.maneuverViewSize.width - BaseInstructionsBannerView.padding * 3
             return CGRect(x: 0, y: 0, width: availableWidth, height: self.primaryLabel.font.lineHeight)
         }
         
         secondaryLabel.availableBounds = { [unowned self] in
             // Available width H:|-padding-maneuverView-padding-availableWidth-padding-|
-            let availableWidth = self.bounds.width - BaseInstructionsBannerView.maneuverViewSize.width - BaseInstructionsBannerView.padding * 3
+            let availableWidth = self.secondaryLabel.viewForAvailableBoundsCalculation?.bounds.width ?? self.bounds.width - BaseInstructionsBannerView.maneuverViewSize.width - BaseInstructionsBannerView.padding * 3
             return CGRect(x: 0, y: 0, width: availableWidth, height: self.secondaryLabel.font.lineHeight)
         }
     }

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -212,7 +212,6 @@ extension StepsViewController: UITableViewDataSource {
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: cellId, for: indexPath) as! StepTableViewCell
-        updateCell(cell, at: indexPath)
         return cell
     }
     
@@ -222,7 +221,14 @@ extension StepsViewController: UITableViewDataSource {
         return instruction
     }
     
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        updateCell(cell as! StepTableViewCell, at: indexPath)
+    }
+    
     func updateCell(_ cell: StepTableViewCell, at indexPath: IndexPath) {
+        cell.instructionsView.primaryLabel.viewForAvailableBoundsCalculation = cell
+        cell.instructionsView.secondaryLabel.viewForAvailableBoundsCalculation = cell
+        
         let step = sections[indexPath.section][indexPath.row]
        
         let usePreviousLeg = indexPath.section != 0 && indexPath.row == 0


### PR DESCRIPTION
Fixes #1390 - Abbreviate less by using a correct non-zero frame for calculating available bounds initially.

As @bsudekum assumed, the issue was previously mitigated by the frequent updates.


![abbr](https://user-images.githubusercontent.com/764476/39707327-672a6bbc-5214-11e8-85b2-931f3688fd47.gif)
