### PR TITLE
Allow exit view for all maneuver types

### DIFF
--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -88,8 +88,7 @@ class InstructionPresenter {
             guard component.type != .exit else { continue }
             
             //If we have a exit, in the first two components, lets handle that first.
-            let isExit = [.takeOffRamp, .reachFork, .merge].contains(instruction.maneuverType)
-            if isExit, component.type == .exitCode, 0...1 ~= index,
+            if component.type == .exitCode, 0...1 ~= index,
                 let exitString = attributedString(forExitComponent: component, maneuverDirection: instruction.maneuverDirection, dataSource: dataSource) {
                 build(component, [exitString])
             }


### PR DESCRIPTION
This change allows the exit view to show on all maneuver types, not just `.takeOffRamp, .reachFork, .merge`. Otherwise, for all other types, we would get the text `Exit foobar...`.

/cc @JThramer @1ec5 