### PR TITLE
Fixed user puck stuck while in simulation mode.

### DIFF
--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -148,7 +148,8 @@ open class SimulatedLocationManager: NavigationLocationManager {
         // Simulate speed based on expected segment travel time
         if let expectedSegmentTravelTimes = routeProgress?.currentLeg.expectedSegmentTravelTimes,
             let coordinates = routeProgress?.route.coordinates,
-            let closestCoordinateOnRoute = Polyline(routeProgress!.route.coordinates!).closestCoordinate(to: newCoordinate), let nextCoordinateOnRoute = coordinates.after(element: coordinates[closestCoordinateOnRoute.index]),
+            let closestCoordinateOnRoute = Polyline(routeProgress!.route.coordinates!).closestCoordinate(to: newCoordinate),
+            let nextCoordinateOnRoute = coordinates.after(element: coordinates[closestCoordinateOnRoute.index]),
             let time = expectedSegmentTravelTimes.optional[closestCoordinateOnRoute.index] {
             let distance = coordinates[closestCoordinateOnRoute.index].distance(to: nextCoordinateOnRoute)
             currentSpeed =  max(distance / time, 2)

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -49,7 +49,6 @@ open class SimulatedLocationManager: NavigationLocationManager {
     
     var route: Route? {
         didSet {
-            stopUpdatingLocation()
             reset()
         }
     }

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -197,7 +197,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
         return endIndex
     }
     
-    private func calculateCurrentSpeed(distance: CLLocationDistance, coordinatesNearby: [CLLocationCoordinate2D]? = nil, closestLocation: SimulatedLocation? = nil) -> CLLocationSpeed {
+    private func calculateCurrentSpeed(distance: CLLocationDistance, coordinatesNearby: [CLLocationCoordinate2D]? = nil, closestLocation: SimulatedLocation) -> CLLocationSpeed {
 
         // More than 10 nearby coordinates indicates that we are in a roundabout or similar complex shape.
         if let coordinatesNearby = coordinatesNearby, coordinatesNearby.count >= 10 {
@@ -208,13 +208,10 @@ open class SimulatedLocationManager: NavigationLocationManager {
             return maximumSpeed
         }
         // Base speed on previous or upcoming turn penalty
-        else if let closestLocation = closestLocation {
+        else {
             let reversedTurnPenalty = maximumTurnPenalty - closestLocation.turnPenalty
             return reversedTurnPenalty.scale(minimumIn: minimumTurnPenalty, maximumIn: maximumTurnPenalty, minimumOut: minimumSpeed, maximumOut: maximumSpeed)
         }
-        
-        // default speed
-        return 0.0
     }
 }
 

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -183,10 +183,6 @@ open class SimulatedLocationManager: NavigationLocationManager {
     
     private func closestCoordinateIndex(from startIndex: Int, coordinates: [CLLocationCoordinate2D]) -> Int {
         let endIndex = coordinates.endIndex - 1
-
-        guard startIndex < endIndex else {
-            return endIndex
-        }
         
         // In case current coordinate and successive coordinate have identical latitude and longitude,
         // Advance to the next coordinate with an unidentical coordinate to the current coordinate.


### PR DESCRIPTION
Retrieves a unique successive coordinate after the current coordinate.

Here is the console log from inspecting the `routeProgress?.route.coordinates` at that deadlock location:

```
(lldb) po closestCoordinateOnRoute.index
4

(lldb) po coordinates[closestCoordinateOnRoute.index]
▿ CLLocationCoordinate2D
  - latitude : 37.790279999999996
  - longitude : -122.40714999999999

(lldb) po coordinates[5]
▿ CLLocationCoordinate2D
  - latitude : 37.790279999999996
  - longitude : -122.40714999999999

(lldb) po coordinates[6]
▿ CLLocationCoordinate2D
  - latitude : 37.789969999999997
  - longitude : -122.40708999999998
```

Fixes #1383 

/cc @mapbox/navigation-ios 