### PR TITLE
Key exit view cache with more information

### DIFF
--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -63,7 +63,8 @@ class ExitView: StylableView {
     
     override var hashValue: Int {
         get {
-             return [foregroundColor?.cgColor.hashValue ?? 0, backgroundColor?.cgColor.hashValue ?? 0, exitText?.hashValue ?? 0, pointSize.hashValue, side.hashValue].reduce(0, +)
+            let criticalProperties: [AnyHashable?] = [foregroundColor, backgroundColor, exitText, pointSize, side]
+            return criticalProperties.compactMap { $0?.hashValue }.reduce(0, ^)
         }
     }
     

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -53,10 +53,17 @@ class ExitView: StylableView {
             invalidateIntrinsicContentSize()
         }
     }
+    
     var pointSize: CGFloat {
         didSet {
             exitNumberLabel.font = exitNumberLabel.font.withSize(pointSize * ExitView.labelFontSizeScaleFactor)
             rebuildConstraints()
+        }
+    }
+    
+    override var hashValue: Int {
+        get {
+             return [foregroundColor?.cgColor.hashValue ?? 0, backgroundColor?.cgColor.hashValue ?? 0, exitText?.hashValue ?? 0, pointSize.hashValue, side.hashValue].reduce(0, +)
         }
     }
     

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -64,7 +64,7 @@ class ExitView: StylableView {
     override var hashValue: Int {
         get {
             let criticalProperties: [AnyHashable?] = [foregroundColor, backgroundColor, exitText, pointSize, side]
-            return criticalProperties.compactMap { $0?.hashValue }.reduce(0, ^)
+            return criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)})
         }
     }
     

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -186,11 +186,7 @@ class InstructionPresenter {
         
         let view = ExitView(pointSize: dataSource.font.pointSize, side: side, text: text)
         let attachment = ExitAttachment()
-        guard var cacheKey = component.cacheKey() else { return nil }
-        
-        if let foregroundColor = view.foregroundColor {
-            cacheKey = "\(cacheKey)-\(String(foregroundColor.cgColor.hashValue))"
-        }
+        guard let cacheKey = component.cacheKey() else { return nil }
         
         if let image = imageRepository.cachedImageForKey(cacheKey) {
             attachment.image = image

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -186,7 +186,12 @@ class InstructionPresenter {
         
         let view = ExitView(pointSize: dataSource.font.pointSize, side: side, text: text)
         let attachment = ExitAttachment()
-        guard let cacheKey = component.cacheKey() else { return nil }
+        guard var cacheKey = component.cacheKey() else { return nil }
+        
+        
+        if let foregroundColor = view.foregroundColor {
+            cacheKey = "\(cacheKey)-\(String(foregroundColor.cgColor.hashValue))"
+        }
         
         if let image = imageRepository.cachedImageForKey(cacheKey) {
             attachment.image = image

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -188,7 +188,6 @@ class InstructionPresenter {
         let attachment = ExitAttachment()
         guard var cacheKey = component.cacheKey() else { return nil }
         
-        
         if let foregroundColor = view.foregroundColor {
             cacheKey = "\(cacheKey)-\(String(foregroundColor.cgColor.hashValue))"
         }

--- a/MapboxNavigation/VisualInstructionComponent.swift
+++ b/MapboxNavigation/VisualInstructionComponent.swift
@@ -9,7 +9,7 @@ extension VisualInstructionComponent {
         switch type {
         case .exit, .exitCode:
             guard let exitCode = self.text else { return nil}
-            return "exit-" + exitCode + "-\(VisualInstructionComponent.scale)"
+            return "exit-" + exitCode + "-\(VisualInstructionComponent.scale)-\(hashValue)"
         case .image, .text:
             guard let imageURL = imageURL else { return nil }
             return "\(imageURL.absoluteString)-\(VisualInstructionComponent.scale)"


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-navigation-ios/issues/1392

We need to use a more descriptive cache key for exit views since a single exit view can be displayed with many different colors.

Ideally, we'd cache based on the `Style` the exit view is used within, but unfortunately we do not have this information available to us in this section of the code.

/cc @JThramer 