### PR TITLE
Use current step coords for snapped course

### DIFF
--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -88,7 +88,7 @@ extension CLLocation {
         }
         
         guard let closest = Polyline(nearByCoordinates).closestCoordinate(to: coordinate) else { return nil }
-        guard let calculatedCourseForLocationOnStep = interpolatedCourse(along: nearByCoordinates) else { return nil }
+        guard let calculatedCourseForLocationOnStep = interpolatedCourse(along: legProgress.currentStep.coordinates!) else { return nil }
         
         let userCourse = calculatedCourseForLocationOnStep
         let userCoordinate = closest.coordinate


### PR DESCRIPTION
_Builds on https://github.com/mapbox/mapbox-navigation-ios/issues/939_

This prevents the user puck from pointing somewhere between the current and upcoming step when stopped at a stop sign/red light.

The change here changes the calculated course to only use the current step coordinates instead of the current and upcoming step when calculating the snapped course.

This needs some serious testing, disregard for now.

/cc @1ec5 