### PR TITLE
Adjust ImageDownloader tests

### DIFF
--- a/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -68,7 +68,7 @@ class ImageDownloaderTests: XCTestCase {
         }
         var firstCallbackCalled = false
         var secondCallbackCalled = false
-        var operation: ImageDownload?
+        var operation: ImageDownload
 
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             firstCallbackCalled = true
@@ -79,16 +79,19 @@ class ImageDownloaderTests: XCTestCase {
             secondCallbackCalled = true
         }
 
-        XCTAssertTrue(operation! === downloader.activeOperationWithURL(imageURL)!,
+        XCTAssertTrue(operation === downloader.activeOperationWithURL(imageURL)!,
                       "Expected \(String(describing: operation)) to be identical to \(String(describing: downloader.activeOperationWithURL(imageURL)))")
 
         var spinCount = 0
         runUntil(condition: {
             spinCount += 1
-            return firstCallbackCalled && secondCallbackCalled && downloader.activeOperationWithURL(imageURL) == nil
+            return operation.isFinished
         }, pollingInterval: 0.1, until: XCTestCase.NavigationTests.timeout)
 
         print("Succeeded after evaluating condition \(spinCount) times.")
+
+        XCTAssertTrue(firstCallbackCalled)
+        XCTAssertTrue(secondCallbackCalled)
     }
 
     func testDownloadingImageAgainAfterFirstDownloadCompletes() {
@@ -102,13 +105,15 @@ class ImageDownloaderTests: XCTestCase {
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             callbackCalled = true
         }
+        var operation = downloader.activeOperationWithURL(imageURL)!
 
         runUntil(condition: {
             spinCount += 1
-            return callbackCalled && downloader.activeOperationWithURL(imageURL) == nil
+            return operation.isFinished
         }, pollingInterval: 0.1, until: XCTestCase.NavigationTests.timeout)
 
         print("Succeeded after evaluating first condition \(spinCount) times.")
+        XCTAssertTrue(callbackCalled)
 
         callbackCalled = false
         spinCount = 0
@@ -116,13 +121,15 @@ class ImageDownloaderTests: XCTestCase {
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             callbackCalled = true
         }
+        operation = downloader.activeOperationWithURL(imageURL)!
 
         runUntil(condition: {
             spinCount += 1
-            return callbackCalled && downloader.activeOperationWithURL(imageURL) == nil
+            return operation.isFinished
         }, pollingInterval: 0.1, until: XCTestCase.NavigationTests.timeout)
 
         print("Succeeded after evaluating second condition \(spinCount) times.")
+        XCTAssertTrue(callbackCalled)
     }
 
     private func runUntil(condition: () -> Bool, pollingInterval: TimeInterval, until timeout: DispatchTime) {

--- a/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -85,7 +85,7 @@ class ImageDownloaderTests: XCTestCase {
         var spinCount = 0
         runUntil(condition: {
             spinCount += 1
-            return firstCallbackCalled && secondCallbackCalled && ImageLoadingURLProtocolSpy.hasActiveRequestForURL(imageURL) == false && downloader.activeOperationWithURL(imageURL) == nil
+            return firstCallbackCalled && secondCallbackCalled && downloader.activeOperationWithURL(imageURL) == nil
         }, pollingInterval: 0.1, until: XCTestCase.NavigationTests.timeout)
 
         print("Succeeded after evaluating condition \(spinCount) times.")
@@ -105,7 +105,7 @@ class ImageDownloaderTests: XCTestCase {
 
         runUntil(condition: {
             spinCount += 1
-            return callbackCalled && ImageLoadingURLProtocolSpy.hasActiveRequestForURL(imageURL) == false && downloader.activeOperationWithURL(imageURL) == nil
+            return callbackCalled && downloader.activeOperationWithURL(imageURL) == nil
         }, pollingInterval: 0.1, until: XCTestCase.NavigationTests.timeout)
 
         print("Succeeded after evaluating first condition \(spinCount) times.")
@@ -119,7 +119,7 @@ class ImageDownloaderTests: XCTestCase {
 
         runUntil(condition: {
             spinCount += 1
-            return callbackCalled && ImageLoadingURLProtocolSpy.hasActiveRequestForURL(imageURL) == false && downloader.activeOperationWithURL(imageURL) == nil
+            return callbackCalled && downloader.activeOperationWithURL(imageURL) == nil
         }, pollingInterval: 0.1, until: XCTestCase.NavigationTests.timeout)
 
         print("Succeeded after evaluating second condition \(spinCount) times.")

--- a/MapboxNavigationTests/Support/ImageLoadingURLProtocolSpy.swift
+++ b/MapboxNavigationTests/Support/ImageLoadingURLProtocolSpy.swift
@@ -39,6 +39,11 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
             return
         }
 
+        defer {
+            ImageLoadingURLProtocolSpy.pastRequests[url] = ImageLoadingURLProtocolSpy.activeRequests[url]
+            ImageLoadingURLProtocolSpy.activeRequests[url] = nil
+        }
+
         // We only want there to be one active request per resource at any given time (with callbacks appended if requested multiple times)
         if ImageLoadingURLProtocolSpy.hasActiveRequestForURL(url) {
             XCTFail("There should only be one request in flight at a time per resource")
@@ -54,8 +59,6 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
     }
 
     override func stopLoading() {
-        ImageLoadingURLProtocolSpy.pastRequests[request.url!] = ImageLoadingURLProtocolSpy.activeRequests[request.url!]
-        ImageLoadingURLProtocolSpy.activeRequests[request.url!] = nil
     }
 
     /**


### PR DESCRIPTION
URL loading is deferred until after the current run loop iteration. The two reentrancy tests are adjusted to use the download operation's `isFinished` flag as a continuation criteria, and assertions are done in a more appropriate place for better failure localization.