### PR TITLE
Remove OS_ACTIVITY_MODE from Objective-C example scheme

### DIFF
--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-Objective-C.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-Objective-C.xcscheme
@@ -71,13 +71,6 @@
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
Rolled back part of #188 that set the `OS_ACTIVITY_MODE` flag when running the example application. This flag was only needed in older Xcode versions to suppress console spew, but it also suppresses legitimate logging from the SDK and its dependencies.

This flag has already been removed from the Swift example application’s scheme as of #1063.

/cc @bsudekum @JThramer