### PR TITLE
Moves access to active download operations to a dispatch queue.

### DIFF
--- a/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -73,14 +73,14 @@ class ImageDownloaderTests: XCTestCase {
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             firstCallbackCalled = true
         }
-        operation = downloader.activeOperationWithURL(imageURL)!
+        operation = downloader.activeOperation(with: imageURL)!
 
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             secondCallbackCalled = true
         }
 
-        XCTAssertTrue(operation === downloader.activeOperationWithURL(imageURL)!,
-                      "Expected \(String(describing: operation)) to be identical to \(String(describing: downloader.activeOperationWithURL(imageURL)))")
+        XCTAssertTrue(operation === downloader.activeOperation(with: imageURL)!,
+                      "Expected \(String(describing: operation)) to be identical to \(String(describing: downloader.activeOperation(with: imageURL)))")
 
         var spinCount = 0
         runUntil(condition: {
@@ -105,7 +105,7 @@ class ImageDownloaderTests: XCTestCase {
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             callbackCalled = true
         }
-        var operation = downloader.activeOperationWithURL(imageURL)!
+        var operation = downloader.activeOperation(with: imageURL)!
 
         runUntil(condition: {
             spinCount += 1
@@ -121,7 +121,7 @@ class ImageDownloaderTests: XCTestCase {
         downloader.downloadImage(with: imageURL) { (image, data, error) in
             callbackCalled = true
         }
-        operation = downloader.activeOperationWithURL(imageURL)!
+        operation = downloader.activeOperation(with: imageURL)!
 
         runUntil(condition: {
             spinCount += 1

--- a/MapboxNavigationTests/XCTestCase.swift
+++ b/MapboxNavigationTests/XCTestCase.swift
@@ -6,5 +6,7 @@ extension XCTestCase {
         static var timeout: DispatchTime {
             return DispatchTime.now() + DispatchTimeInterval.seconds(10)
         }
+
+        static let pollingInterval: TimeInterval = 0.05
     }
 }


### PR DESCRIPTION
Reads are done synchronously while writes are performed with a barrier.

The occasionally flaky test was pointing out the lack of thread-safety
here, as `downloadImage(with:)` and URL loading callbacks happen on
different queues.