### PR TITLE
Document public tunnel methods

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -179,6 +179,18 @@ open class RouteController: NSObject {
      When set to `false`, flushing of telemetry events is not delayed. Is set to `true` by default.
      */
     @objc public var delaysEventFlushing = true
+    
+    /**
+     A `TunnelIntersectionManager` used for animating the use user puck when and if a user enters a tunnel.
+     
+     Will only be enabled if `tunnelSimulationEnabled` is true.
+     */
+    public var tunnelIntersectionManager: TunnelIntersectionManager?
+    
+    /**
+     The flag that indicates that the simulated navigation through tunnel(s) is enabled.
+     */
+    public var tunnelSimulationEnabled: Bool = false
 
     var didFindFasterRoute = false
 
@@ -238,14 +250,7 @@ open class RouteController: NSObject {
 
     var userSnapToStepDistanceFromManeuver: CLLocationDistance?
     
-    public var tunnelIntersectionManager: TunnelIntersectionManager?
-    
     var tunnelIntersectionManagerCompletionHandler: RouteControllerSimulationCompletionBlock?
-    
-    /**
-     The flag that indicates that the simulated navigation through tunnel(s) is enabled.
-     */
-    public var tunnelSimulationEnabled: Bool = false
     
     /**
      Intializes a new `RouteController`.

--- a/MapboxCoreNavigation/TunnelIntersectionManager.swift
+++ b/MapboxCoreNavigation/TunnelIntersectionManager.swift
@@ -1,6 +1,9 @@
 import Foundation
 import CoreLocation
 
+/**
+  A closure (block) to be called when a user enters or exits a tunnel.
+ */
 public typealias RouteControllerSimulationCompletionBlock = ((_ animationEnabled: Bool, _ manager: NavigationLocationManager)-> Void)
 
 @objc(MBTunnelIntersectionManagerDelegate)

--- a/MapboxCoreNavigation/TunnelIntersectionManager.swift
+++ b/MapboxCoreNavigation/TunnelIntersectionManager.swift
@@ -6,6 +6,10 @@ import CoreLocation
  */
 public typealias RouteControllerSimulationCompletionBlock = ((_ animationEnabled: Bool, _ manager: NavigationLocationManager)-> Void)
 
+
+/**
+ The `TunnelIntersectionManagerDelegate` protocol provides methods for responding to events where a user enters or exits a tunnel.
+ */
 @objc(MBTunnelIntersectionManagerDelegate)
 public protocol TunnelIntersectionManagerDelegate: class {
     


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1403

This documents a few public tunnel properties and methods.

/cc @1ec5 @vincethecoder 