### PR TITLE
RouteController - Retain Cycles & Zombie Refs

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -378,6 +378,7 @@ open class RouteController: NSObject {
     @objc public func suspendLocationUpdates() {
         locationManager.stopUpdatingLocation()
         locationManager.stopUpdatingHeading()
+        locationManager.delegate = nil
     }
 
     /**

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -286,8 +286,8 @@ open class RouteController: NSObject {
     private func setupTunnelIntersectionManager() {
         tunnelIntersectionManager = TunnelIntersectionManager()
         tunnelIntersectionManager?.delegate = self
-        tunnelIntersectionManagerCompletionHandler = { enabled, _ in
-            self.tunnelIntersectionManager?.isAnimationEnabled = enabled
+        tunnelIntersectionManagerCompletionHandler = { [weak self] enabled, _ in
+            self?.tunnelIntersectionManager?.isAnimationEnabled = enabled
         }
     }
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -368,6 +368,7 @@ open class RouteController: NSObject {
      Will continue monitoring until `suspendLocationUpdates()` is called.
      */
     @objc public func resume() {
+        locationManager.delegate = self
         locationManager.startUpdatingLocation()
         locationManager.startUpdatingHeading()
     }

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -248,19 +248,31 @@ class RouteControllerTests: XCTestCase {
         var routeController: RouteControllerSpy? = RouteControllerSpy(along: initialRoute, directions: directionsClientSpy, locationManager: locationManager, eventsManager: eventsManagerSpy)
         let expectation = XCTestExpectation(description: "Deinit")
         routeController?.deinitCalled = expectation.fulfill
-        
-        
-        DispatchQueue.global(qos: .background).async {
-            routeController = nil
-        }
+        routeController = nil
+
         
         wait(for: [expectation], timeout: 5)
     }
+
+    func testRouteControllerNilsOutLocationDelegateOnDeinit() {
+        let locationManager = NavigationLocationManager()
+        var routeController: RouteControllerSpy? = RouteControllerSpy(along: initialRoute, directions: directionsClientSpy, locationManager: locationManager, eventsManager: eventsManagerSpy)
+        let expectation = XCTestExpectation(description: "Deinit")
+        routeController?.deinitCalled = expectation.fulfill
+        routeController = nil
+
+        wait(for: [expectation], timeout: 5)
+
+        XCTAssertNil(locationManager.delegate, "Location Manager Delegate should be nil")
+
+    }
 }
+
 
 class RouteControllerSpy: RouteController {
     var deinitCalled: (() -> Void)?
-    deinit {
-        deinitCalled?()
+    override func suspendLocationUpdates() {
+        super.suspendLocationUpdates()
+        deinitCalled?() //suspendLocationUpdates is the first thing called on deinit
     }
 }

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -242,5 +242,25 @@ class RouteControllerTests: XCTestCase {
         XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedEventName))
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedEventName))
     }
+    
+    func testRouteControllerDoesNotHaveRetainCycle() {
+        let locationManager = NavigationLocationManager()
+        var routeController: RouteControllerSpy? = RouteControllerSpy(along: initialRoute, directions: directionsClientSpy, locationManager: locationManager, eventsManager: eventsManagerSpy)
+        let expectation = XCTestExpectation(description: "Deinit")
+        routeController?.deinitCalled = expectation.fulfill
+        
+        
+        DispatchQueue.global(qos: .background).async {
+            routeController = nil
+        }
+        
+        wait(for: [expectation], timeout: 5)
+    }
+}
 
+class RouteControllerSpy: RouteController {
+    var deinitCalled: (() -> Void)?
+    deinit {
+        deinitCalled?()
+    }
 }


### PR DESCRIPTION
![My favorite game!](https://i.imgur.com/fDyEHwP.gif)

Fixes #1408. Two issues are root cause here:

- A strong reference capture in a `RouteController` completion closure that causes a retain cycle,
- A unsafe_unretained reference persisting in the `NavigationLocationManager` that causes a crash.

/cc @mapbox/navigation-ios 