### PR TITLE
Improve arrival location and end of route screen animation

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -217,7 +217,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
             guard let routes = potentialRoutes else { return }
             return success(routes)
         }
-
+        
         _ = Directions.shared.calculate(options, completionHandler: handler)
     }
 

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -217,7 +217,7 @@ class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDel
             guard let routes = potentialRoutes else { return }
             return success(routes)
         }
-        
+
         _ = Directions.shared.calculate(options, completionHandler: handler)
     }
 

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -82,11 +82,6 @@ public var RouteControllerProactiveReroutingInterval: TimeInterval = 120
 
 let FasterRouteFoundEvent = "navigation.fasterRoute"
 
-/**
- The number of seconds remaining on the final step of a leg before the user is considered "arrived".
- */
-public var RouteControllerDurationRemainingWaypointArrival: TimeInterval = 3
-
 //MARK: - Route Snapping (CLLocation)
 /**
  Accepted deviation excluding horizontal accuracy before the user is considered to be off route.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -661,7 +661,7 @@ extension RouteController: CLLocationManagerDelegate {
         let currentDestination = routeProgress.currentLeg.destination
         guard let remainingVoiceInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions else { return }
 
-        if routeProgress.currentLegProgress.remainingSteps.count == 1 && remainingVoiceInstructions.count == 0 && currentDestination != previousArrivalWaypoint {
+        if routeProgress.currentLegProgress.remainingSteps.count <= 1 && remainingVoiceInstructions.count == 0 && currentDestination != previousArrivalWaypoint {
             previousArrivalWaypoint = currentDestination
 
             routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -659,9 +659,9 @@ extension RouteController: CLLocationManagerDelegate {
 
     func updateRouteLegProgress(for location: CLLocation) {
         let currentDestination = routeProgress.currentLeg.destination
-        let legDurationRemaining = routeProgress.currentLegProgress.durationRemaining
+        guard let remainingVoiceInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions else { return }
 
-        if legDurationRemaining < RouteControllerDurationRemainingWaypointArrival, currentDestination != previousArrivalWaypoint {
+        if routeProgress.currentLegProgress.remainingSteps.count == 1 && remainingVoiceInstructions.count == 0 && currentDestination != previousArrivalWaypoint {
             previousArrivalWaypoint = currentDestination
 
             routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -344,11 +344,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             let padding = UIEdgeInsets(top: point.y, left: point.x, bottom: bounds.height - point.y, right: bounds.width - point.x)
             let newCamera = MGLMapCamera(lookingAtCenter: location.coordinate, fromDistance: altitude, pitch: 45, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear) : nil
-            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: padding, completionHandler: {
-                UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
-                    self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)
-                }, completion: nil)
-            })
+            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: padding, completionHandler: nil)
         } else {
             UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
                 self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -516,7 +516,7 @@ func defaultFeedbackHandlers(source: FeedbackSource = .user) -> (send: FeedbackV
         navigationView.mapView.tracksUserCourse = false
         UIView.animate(withDuration: duration, delay: 0.0, options: [.curveLinear], animations: animate, completion: completion)
         
-        guard let height = self.navigationView.endOfRouteHeightConstraint?.constant else { return }
+        guard let height = navigationView.endOfRouteHeightConstraint?.constant else { return }
         let insets = UIEdgeInsets(top: navigationView.instructionsBannerView.bounds.height, left: 20, bottom: height + 20, right: 20)
         
         if let coordinates = routeController.routeProgress.route.coordinates, let userLocation = routeController.locationManager.location?.coordinate {


### PR DESCRIPTION
This fixes a few issues:

* Animations when showing the end of route view controller: https://github.com/mapbox/mapbox-navigation-ios/issues/975
* The location at which the arrival screen is shown

Previously, we had a hardcoded duration at which the arrival screen was shown. Now this is being handled by the server.

<img src="https://user-images.githubusercontent.com/1058624/39888477-bf6f206a-5449-11e8-90f0-21feda5a3c27.gif" width=200px />

/cc @mapbox/navigation-ios 
