### PR TITLE
Clean up delegate method names; use UUIDs for feedback IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Added the `NavigationViewControllerDelegate.navigationViewController(_:roadNameAt:)` method for customizing the contents of the road name label that appears towards the bottom of the map view. ([#1309](https://github.com/mapbox/mapbox-navigation-ios/pull/1309))
 * If the SDK tries but fails to reroute the user, the “Rerouting…” status view no longer stays visible permanently. ([#1357](https://github.com/mapbox/mapbox-navigation-ios/pull/1357))
 * Completed waypoints now remain on the map but are slightly translucent. ([#1364](https://github.com/mapbox/mapbox-navigation-ios/pull/1364))
+* Fixed an issue preventing `NavigationViewController.navigationMapView(_:simplifiedShapeDescribing:)` (now `NavigationViewController.navigationMapView(_:simplifiedShapeFor:)`) from being called. ([#1413](https://github.com/mapbox/mapbox-navigation-ios/pull/1413))
 
 ### Spoken instructions
 
@@ -28,11 +29,27 @@
 ### Other changes
 
 * `DistanceFormatter`, `ReplayLocationManager`, `SimulatedLocationManager`, `LanesView`, and `ManueverView` are now subclassable. ([#1345](https://github.com/mapbox/mapbox-navigation-ios/pull/1345]))
-* Renamed several  `NavigationMapViewDelegate` methods ([#1364](https://github.com/mapbox/mapbox-navigation-ios/pull/1364), [#1338](https://github.com/mapbox/mapbox-navigation-ios/pull/1338), [#1318](https://github.com/mapbox/mapbox-navigation-ios/pull/1318), [#1378](https://github.com/mapbox/mapbox-navigation-ios/pull/1378)):
+* Renamed many `NavigationViewController` and `NavigationMapViewDelegate` methods ([#1364](https://github.com/mapbox/mapbox-navigation-ios/pull/1364), [#1338](https://github.com/mapbox/mapbox-navigation-ios/pull/1338), [#1318](https://github.com/mapbox/mapbox-navigation-ios/pull/1318), [#1378](https://github.com/mapbox/mapbox-navigation-ios/pull/1378), [#1413](https://github.com/mapbox/mapbox-navigation-ios/pull/1413)):
     * `NavigationViewControllerDelegate.navigationViewControllerDidCancelNavigation(_:)` to `NavigationViewControllerDelegate.navigationViewControllerDidDismiss(_:byCanceling:)`
+    * `-[MBNavigationViewControllerDelegate navigationViewController:didArriveAt:]` to `-[MBNavigationViewControllerDelegate navigationViewController:didArriveAtWaypoint:]` in Objective-C
+    * `NavigationViewControllerDelegate.navigationMapView(_:routeStyleLayerWithIdentifier:source:)` to `NavigationViewControllerDelegate.navigationViewController(_:routeStyleLayerWithIdentifier:source:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:routeCasingStyleLayerWithIdentifier:source:)` to `NavigationViewControllerDelegate.navigationViewController(_:routeCasingStyleLayerWithIdentifier:source:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:shapeFor:)` to `NavigationViewControllerDelegate.navigationViewController(_:shapeFor:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:simplifiedShapeFor:)` to `NavigationViewControllerDelegate.navigationViewController(_:simplifiedShapeFor:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:waypointStyleLayerWithIdentifier:source:)` to `NavigationViewControllerDelegate.navigationViewController(_:waypointStyleLayerWithIdentifier:source:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:waypointSymbolStyleLayerWithIdentifier:source:)` to `NavigationViewControllerDelegate.navigationViewController(_:waypointSymbolStyleLayerWithIdentifier:source:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:shapeFor:legIndex:)` to `NavigationViewControllerDelegate.navigationViewController(_:shapeFor:legIndex:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:didTap:)` to `NavigationViewControllerDelegate.navigationViewController(_:didSelect:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:imageFor:)` to `NavigationViewControllerDelegate.navigationViewController(_:imageFor:)`
+    * `NavigationViewControllerDelegate.navigationMapView(_:viewFor:)` to `NavigationViewControllerDelegate.navigationViewController(_:viewFor:)`
+    * `NavigationViewControllerDelegate.navigationViewController(_:didSend:feedbackType:)` to `NavigationViewControllerDelegate.navigationViewController(_:didSendFeedbackAssigned:feedbackType:)`
+    * `-[MBNavigationViewControllerDelegate navigationViewController:shouldDiscard:]` to `-[MBNavigationViewControllerDelegate navigationViewController:shouldDiscardLocation:]` in Objective-C
+    * `-[MBNavigationViewControllerDelegate navigationViewController:roadNameAt:]` to `-[MBNavigationViewControllerDelegate navigationViewController:roadNameAtLocation:]`
     * `NavigationMapViewDelegate.navigationMapView(_:shapeDescribing:)` to `NavigationMapViewDelegate.navigationMapView(_:shapeFor:)`.
     * `NavigationMapViewDelegate.navigationMapView(_:simplifiedShapeDescribing:)` to `NavigationMapViewDelegate.navigationMapView(_:simplifiedShapeFor:)`.
-    * `-[MBNavigationMapViewDelegate navigationMapView:shapeDescribingWaypoints:legIndex:]` to `-[MBNavigationMapViewDelegate navigationMapView:shapeForWaypoints:legIndex:]` in Objective-C.
+    * `-[MBNavigationMapViewDelegate navigationMapView:shapeDescribingWaypoints:legIndex:]` to `-[MBNavigationMapViewDelegate navigationMapView:shapeForWaypoints:legIndex:]` in Objective-C
+* `RouteController.recordFeedback(type:description:)` now returns a `UUID` instead of a string. Some `RouteController` methods have been renamed to accept `UUID`s as arguments instead of strings. ([#1413](https://github.com/mapbox/mapbox-navigation-ios/pull/1413))
+* Renamed `TunnelIntersectionManagerDelegate.tunnelIntersectionManager(_:willEnableAnimationAt:callback:)` to `TunnelIntersectionManagerDelegate.tunnelIntersectionManager(_:willEnableAnimationAt:completionHandler:)` and `TunnelIntersectionManagerDelegate.tunnelIntersectionManager(_:willDisableAnimationAt:callback:)` to `TunnelIntersectionManagerDelegate.tunnelIntersectionManager(_:willDisableAnimationAt:completionHandler:)`. ([#1413](https://github.com/mapbox/mapbox-navigation-ios/pull/1413))
 
 ## v0.16.2 (April 13, 2018)
 

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -16,7 +16,7 @@ enum ExampleMode {
     case multipleWaypoints
 }
 
-class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate, VoiceControllerDelegate {
+class ViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate {
 
     // MARK: - Class Constants
     static let mapInsets = UIEdgeInsets(top: 25, left: 25, bottom: 25, right: 25)
@@ -350,16 +350,16 @@ extension ViewController: NavigationMapViewDelegate {
         guard let routeOptions = currentRoute?.routeOptions else { return }
         let modifiedOptions = routeOptions.without(waypoint: waypoint)
 
-        let destroyWaypoint: (UIAlertAction) -> Void = {_ in self.requestRoute(with:modifiedOptions, success: self.defaultSuccess, failure: self.defaultFailure) }
-
-        presentWaypointRemovalActionSheet(callback: destroyWaypoint)
+        presentWaypointRemovalActionSheet { _ in
+            self.requestRoute(with:modifiedOptions, success: self.defaultSuccess, failure: self.defaultFailure)
+        }
     }
 
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
         currentRoute = route
     }
 
-    private func presentWaypointRemovalActionSheet(callback approve: @escaping ((UIAlertAction) -> Void)) {
+    private func presentWaypointRemovalActionSheet(completionHandler approve: @escaping ((UIAlertAction) -> Void)) {
         let title = NSLocalizedString("Remove Waypoint?", comment: "Waypoint Removal Action Sheet Title")
         let message = NSLocalizedString("Would you like to remove this waypoint?", comment: "Waypoint Removal Action Sheet Message")
         let removeTitle = NSLocalizedString("Remove Waypoint", comment: "Waypoint Removal Action Item Title")
@@ -372,9 +372,11 @@ extension ViewController: NavigationMapViewDelegate {
 
         self.present(actionSheet, animated: true, completion: nil)
     }
+}
 
-    // To use these delegate methods, set the `VoiceControllerDelegate` on your `VoiceController`.
-    //
+// MARK: VoiceControllerDelegate methods
+// To use these delegate methods, set the `VoiceControllerDelegate` on your `VoiceController`.
+extension ViewController: VoiceControllerDelegate {
     // Called when there is an error with speaking a voice instruction.
     func voiceController(_ voiceController: RouteVoiceController, spokenInstructionsDidFailWith error: Error) {
         print(error.localizedDescription)

--- a/MapboxCoreNavigation/TunnelIntersectionManager.swift
+++ b/MapboxCoreNavigation/TunnelIntersectionManager.swift
@@ -2,7 +2,10 @@ import Foundation
 import CoreLocation
 
 /**
-  A closure (block) to be called when a user enters or exits a tunnel.
+ A closure called when a user enters or exits a tunnel.
+ 
+ - parameter animationEnabled: Whether animation was enabled.
+ - parameter manager: The active navigation location manager.
  */
 public typealias RouteControllerSimulationCompletionBlock = ((_ animationEnabled: Bool, _ manager: NavigationLocationManager)-> Void)
 
@@ -18,20 +21,20 @@ public protocol TunnelIntersectionManagerDelegate: class {
      
      - parameter manager: The location manager that currently sends the location updates.
      - parameter location: The user’s current location where the tunnel was detected.
-     - parameter callback: The callback which indicates the animated enabled status and the active location manager.
+     - parameter completionHandler: Called when the animation finishes.
      */
-    @objc(tunnelIntersectionManager:willEnableAnimationAtLocation:callback:)
-    optional func tunnelIntersectionManager(_ manager: CLLocationManager, willEnableAnimationAt location: CLLocation, callback: RouteControllerSimulationCompletionBlock?)
+    @objc(tunnelIntersectionManager:willEnableAnimationAtLocation:completionHandler:)
+    optional func tunnelIntersectionManager(_ manager: CLLocationManager, willEnableAnimationAt location: CLLocation, completionHandler: RouteControllerSimulationCompletionBlock?)
     
     /**
      Called immediately when the location manager detects the user's current location is no longer within a tunnel.
      
      - parameter manager: The location manager that currently sends the location updates.
      - parameter location: The user’s current location where the tunnel was detected.
-     - parameter callback: The callback which indicates the animated enabled status and the active location manager.
+     - parameter completionHandler: Called when the animation finishes.
      */
-    @objc(tunnelIntersectionManager:willDisableAnimationAtLocation:callback:)
-    optional func tunnelIntersectionManager(_ manager: CLLocationManager, willDisableAnimationAt location: CLLocation, callback: RouteControllerSimulationCompletionBlock?)
+    @objc(tunnelIntersectionManager:willDisableAnimationAtLocation:completionHandler:)
+    optional func tunnelIntersectionManager(_ manager: CLLocationManager, willDisableAnimationAt location: CLLocation, completionHandler: RouteControllerSimulationCompletionBlock?)
 }
 
 @objc(MBTunnelIntersectionManager)
@@ -61,9 +64,7 @@ open class TunnelIntersectionManager: NSObject {
      Given a user's current location, location manager and route progress,
      returns a Boolean whether a tunnel has been detected on the current route step progress.
      */
-    @objc public func didDetectTunnel(at location: CLLocation,
-                                      for manager: CLLocationManager,
-                                    routeProgress: RouteProgress) -> Bool {
+    @objc public func didDetectTunnel(at location: CLLocation, for manager: CLLocationManager, routeProgress: RouteProgress) -> Bool {
         
         guard let currentIntersection = routeProgress.currentLegProgress.currentStepProgress.currentIntersection else {
             return false
@@ -99,7 +100,7 @@ open class TunnelIntersectionManager: NSObject {
     @objc public func enableTunnelAnimation(for manager: CLLocationManager,
                                         routeController: RouteController,
                                           routeProgress: RouteProgress,
-                                               callback: RouteControllerSimulationCompletionBlock?) {
+                                               completionHandler: RouteControllerSimulationCompletionBlock?) {
         guard !isAnimationEnabled else { return }
         
         isAnimationEnabled = true
@@ -109,13 +110,13 @@ open class TunnelIntersectionManager: NSObject {
         self.animatedLocationManager?.routeProgress = routeProgress
         self.animatedLocationManager?.startUpdatingHeading()
         
-        callback?(isAnimationEnabled, self.animatedLocationManager!)
+        completionHandler?(isAnimationEnabled, self.animatedLocationManager!)
     }
     
     @objc public func suspendTunnelAnimation(for manager: CLLocationManager,
                                              at location: CLLocation,
                                          routeController: RouteController,
-                                                callback: RouteControllerSimulationCompletionBlock?) {
+                                                completionHandler: RouteControllerSimulationCompletionBlock?) {
         
         guard isAnimationEnabled else { return }
         
@@ -136,6 +137,6 @@ open class TunnelIntersectionManager: NSObject {
         
         routeController.rawLocation = location
         
-        callback?(isAnimationEnabled, routeController.locationManager)
+        completionHandler?(isAnimationEnabled, routeController.locationManager)
     }
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -26,7 +26,8 @@ public protocol NavigationViewControllerDelegate {
      - parameter waypoint: The waypoint that the user has arrived at.
      - returns: True to automatically advance to the next leg, or false to remain on the now completed leg.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
+    @objc(navigationViewController:didArriveAtWaypoint:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
 
     /**
      Returns whether the navigation view controller should be allowed to calculate a new route.
@@ -76,74 +77,78 @@ public protocol NavigationViewControllerDelegate {
     /**
      Returns an `MGLStyleLayer` that determines the appearance of the route line.
      
-     If this method is unimplemented, the navigation map view draws the route line using an `MGLLineStyleLayer`.
+     If this method is unimplemented, the navigation view controller’s map view draws the route line using an `MGLLineStyleLayer`.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
     /**
      Returns an `MGLStyleLayer` that determines the appearance of the route line’s casing.
      
-     If this method is unimplemented, the navigation map view draws the route line’s casing using an `MGLLineStyleLayer` whose width is greater than that of the style layer returned by `navigationMapView(_:routeStyleLayerWithIdentifier:source:)`.
+     If this method is unimplemented, the navigation view controller’s map view draws the route line’s casing using an `MGLLineStyleLayer` whose width is greater than that of the style layer returned by `navigationViewController(_:routeStyleLayerWithIdentifier:source:)`.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
     /**
      Returns an `MGLShape` that represents the path of the route line.
      
-     If this method is unimplemented, the navigation map view represents the route line using an `MGLPolylineFeature` based on `route`’s `coordinates` property.
+     If this method is unimplemented, the navigation view controller’s map view represents the route line using an `MGLPolylineFeature` based on `route`’s `coordinates` property.
      */
-    @objc(navigationMapView:shapeForRoute:)
-    optional func navigationMapView(_ mapView: NavigationMapView, shapeFor route: Route) -> MGLShape?
+    @objc(navigationViewController:shapeForRoute:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor route: Route) -> MGLShape?
     
     /**
      Returns an `MGLShape` that represents the path of the route line’s casing.
      
-     If this method is unimplemented, the navigation map view represents the route line’s casing using an `MGLPolylineFeature` identical to the one returned by `navigationMapView(_:shapeFor:)`.
+     If this method is unimplemented, the navigation view controller’s map view represents the route line’s casing using an `MGLPolylineFeature` identical to the one returned by `navigationViewController(_:shapeFor:)`.
      */
-    @objc(navigationMapView:simplifiedShapeForRoute:)
-    optional func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape?
+    @objc(navigationViewController:simplifiedShapeForRoute:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, simplifiedShapeFor route: Route) -> MGLShape?
     
     /*
-     Returns an `MGLStyleLayer` that marks the location of each destination along the route when there are multiple destinations. The returned layer is added to the map below the layer returned by `navigationMapView(_:waypointSymbolStyleLayerWithIdentifier:source:)`.
+     Returns an `MGLStyleLayer` that marks the location of each destination along the route when there are multiple destinations. The returned layer is added to the map below the layer returned by `navigationViewController(_:waypointSymbolStyleLayerWithIdentifier:source:)`.
      
-     If this method is unimplemented, the navigation map view marks each destination waypoint with a circle.
+     If this method is unimplemented, the navigation view controller’s map view marks each destination waypoint with a circle.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
     /*
-     Returns an `MGLStyleLayer` that places an identifying symbol on each destination along the route when there are multiple destinations. The returned layer is added to the map above the layer returned by `navigationMapView(_:waypointStyleLayerWithIdentifier:source:)`.
+     Returns an `MGLStyleLayer` that places an identifying symbol on each destination along the route when there are multiple destinations. The returned layer is added to the map above the layer returned by `navigationViewController(_:waypointStyleLayerWithIdentifier:source:)`.
      
-     If this method is unimplemented, the navigation map view labels each destination waypoint with a number, starting with 1 at the first destination, 2 at the second destination, and so on.
+     If this method is unimplemented, the navigation view controller’s map view labels each destination waypoint with a number, starting with 1 at the first destination, 2 at the second destination, and so on.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
     /**
      Returns an `MGLShape` that represents the destination waypoints along the route (that is, excluding the origin).
      
-     If this method is unimplemented, the navigation map view represents the route waypoints using `navigationMapView(_:shapeFor:legIndex:)`.
+     If this method is unimplemented, the navigation map view represents the route waypoints using `navigationViewController(_:shapeFor:legIndex:)`.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape?
+    @objc(navigationViewController:shapeForWaypoints:legIndex:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape?
     
     /**
-     Called when the user taps on the route.
-     - parameter mapView: The map view of the NavigationViewController
-     - parameter route: The route (on the map) that was tapped.
+     Called when the user taps to select a route on the navigation view controller’s map view.
+     - parameter navigationViewController: The navigation view controller presenting the route that the user selected.
+     - parameter route: The route on the map that the user selected.
      */
-    @objc optional func navigationMapView(_ mapView: NavigationMapView, didTap route: Route)
+    @objc(navigationViewController:didSelectRoute:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, didSelect route: Route)
     
     /**
      Return an `MGLAnnotationImage` that represents the destination marker.
      
-     If this method is unimplemented, the navigation map view will represent the destination annotation with the default marker.
+     If this method is unimplemented, the navigation view controller’s map view will represent the destination annotation with the default marker.
      */
-    @objc optional func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
+    @objc(navigationViewController:imageForAnnotation:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
     
     /**
      Returns a view object to mark the given point annotation object on the map.
      
-     The user location annotation view can also be customized via this method. When annotation is an instance of `MGLUserLocation`, return an instance of `MGLUserLocationAnnotationView` (or a subclass thereof). Note that, when `NavigationMapView.tracksUserCourse` is set to `true`, the map view uses a distinct user course view; to customize it, set the `NavigationMapView.userCourseView` property of the map view returned by this view controller’s `mapView` property.
+     The user location annotation view can also be customized via this method. When annotation is an instance of `MGLUserLocation`, return an instance of `MGLUserLocationAnnotationView` (or a subclass thereof). Note that when `NavigationMapView.tracksUserCourse` is set to `true`, the navigation view controller’s map view uses a distinct user course view; to customize it, set the `NavigationMapView.userCourseView` property of the map view stored by the `NavigationViewController.mapView` property.
      */
-    @objc optional func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
+    @objc(navigationViewController:viewForAnnotation:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
     
     /**
      Called when the user opens the feedback form.
@@ -159,10 +164,11 @@ public protocol NavigationViewControllerDelegate {
      Called when the user sends feedback.
      
      - parameter viewController: The navigation view controller that reported the feedback.
-     - parameter feedbackId: A UUID string used to identify the feedback event.
+     - parameter uuid: The feedback event’s unique identifier.
      - parameter feedbackType: The type of feedback event that was sent.
      */
-    @objc optional func navigationViewController(_ viewController: NavigationViewController, didSend feedbackId: String, feedbackType: FeedbackType)
+    @objc(navigationViewController:didSendFeedbackAssignedUUID:feedbackType:)
+    optional func navigationViewController(_ viewController: NavigationViewController, didSendFeedbackAssigned uuid: UUID, feedbackType: FeedbackType)
     
     /**
      Returns the center point of the user course view in screen coordinates relative to the map view.
@@ -176,9 +182,10 @@ public protocol NavigationViewControllerDelegate {
      
      - parameter navigationViewController: The navigation view controller that discarded the location.
      - parameter location: The location that will be discarded.
-     - return: If `true`, the location is discarded and the `NavigationViewController` will not consider it. If `false`, the location will not be thrown out.
+     - returns: If `true`, the location is discarded and the `NavigationViewController` will not consider it. If `false`, the location will not be thrown out.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool
+    @objc(navigationViewController:shouldDiscardLocation:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool
     
     /**
      Called to allow the delegate to customize the contents of the road name label that is displayed towards the bottom of the map view.
@@ -187,9 +194,10 @@ public protocol NavigationViewControllerDelegate {
      
      - parameter navigationViewController: The navigation view controller that will display the road name.
      - parameter location: The user’s current location.
-     - return: The road name to display in the label, or nil to hide the label.
+     - returns: The road name to display in the label, or nil to hide the label.
      */
-    @objc optional func navigationViewController(_ navigationViewController: NavigationViewController, roadNameAt location: CLLocation) -> String?
+    @objc(navigationViewController:roadNameAtLocation:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, roadNameAt location: CLLocation) -> String?
 }
 
 /**
@@ -469,43 +477,43 @@ open class NavigationViewController: UIViewController {
 //MARK: - RouteMapViewControllerDelegate
 extension NavigationViewController: RouteMapViewControllerDelegate {
     public func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationMapView?(mapView, routeCasingStyleLayerWithIdentifier: identifier, source: source)
+        return delegate?.navigationViewController?(self, routeCasingStyleLayerWithIdentifier: identifier, source: source)
     }
     
     public func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationMapView?(mapView, routeStyleLayerWithIdentifier: identifier, source: source)
+        return delegate?.navigationViewController?(self, routeStyleLayerWithIdentifier: identifier, source: source)
     }
     
-    func navigationMapView(_ mapView: NavigationMapView, didTap route: Route) {
-        delegate?.navigationMapView?(mapView, didTap: route)
+    public func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
+        delegate?.navigationViewController?(self, didSelect: route)
     }
     
     @objc public func navigationMapView(_ mapView: NavigationMapView, shapeFor route: Route) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeFor: route)
+        return delegate?.navigationViewController?(self, shapeFor: route)
     }
     
     @objc public func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeFor: route)
+        return delegate?.navigationViewController?(self, simplifiedShapeFor: route)
     }
     
     public func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationMapView?(mapView, waypointStyleLayerWithIdentifier: identifier, source: source)
+        return delegate?.navigationViewController?(self, waypointStyleLayerWithIdentifier: identifier, source: source)
     }
     
     public func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationMapView?(mapView, waypointSymbolStyleLayerWithIdentifier: identifier, source: source)
+        return delegate?.navigationViewController?(self, waypointSymbolStyleLayerWithIdentifier: identifier, source: source)
     }
     
     @objc public func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape? {
-        return delegate?.navigationMapView?(mapView, shapeFor: waypoints, legIndex: legIndex)
+        return delegate?.navigationViewController?(self, shapeFor: waypoints, legIndex: legIndex)
     }
     
     @objc public func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
-        return delegate?.navigationMapView?(mapView, imageFor: annotation)
+        return delegate?.navigationViewController?(self, imageFor: annotation)
     }
     
     @objc public func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
-        return delegate?.navigationMapView?(mapView, viewFor: annotation)
+        return delegate?.navigationViewController?(self, viewFor: annotation)
     }
     
     func mapViewControllerDidOpenFeedback(_ mapViewController: RouteMapViewController) {
@@ -524,8 +532,8 @@ extension NavigationViewController: RouteMapViewControllerDelegate {
         }
     }
     
-    func mapViewController(_ mapViewController: RouteMapViewController, didSend feedbackId: String, feedbackType: FeedbackType) {
-        delegate?.navigationViewController?(self, didSend: feedbackId, feedbackType: feedbackType)
+    func mapViewController(_ mapViewController: RouteMapViewController, didSendFeedbackAssigned uuid: UUID, feedbackType: FeedbackType) {
+        delegate?.navigationViewController?(self, didSendFeedbackAssigned: uuid, feedbackType: feedbackType)
     }
     
     public func navigationMapViewUserAnchorPoint(_ mapView: NavigationMapView) -> CGPoint {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -260,7 +260,7 @@ class RouteMapViewController: UIViewController {
         guard let parent = parent else { return }
     
         let controller = feedbackViewController
-        let defaults = defaultFeedbackHandlers() //this is done every time to refresh the feedbackId
+        let defaults = defaultFeedbackHandlers() //this is done every time to refresh the feedback UUID
         controller.sendFeedbackHandler = defaults.send
         controller.dismissFeedbackHandler = defaults.dismiss
         
@@ -434,30 +434,30 @@ class RouteMapViewController: UIViewController {
     }
     
 func defaultFeedbackHandlers(source: FeedbackSource = .user) -> (send: FeedbackViewController.SendFeedbackHandler, dismiss: () -> Void) {
-        let identifier = routeController.recordFeedback()
-        let send = defaultSendFeedbackHandler(feedbackId: identifier)
-        let dismiss = defaultDismissFeedbackHandler(feedbackId: identifier)
+        let uuid = routeController.recordFeedback()
+        let send = defaultSendFeedbackHandler(uuid: uuid)
+        let dismiss = defaultDismissFeedbackHandler(uuid: uuid)
         
         return (send, dismiss)
     }
     
-    func defaultSendFeedbackHandler(source: FeedbackSource = .user, feedbackId identifier: String) -> FeedbackViewController.SendFeedbackHandler {
+    func defaultSendFeedbackHandler(source: FeedbackSource = .user, uuid: UUID) -> FeedbackViewController.SendFeedbackHandler {
         return { [weak self] (item) in
             guard let strongSelf = self, let parent = strongSelf.parent else { return }
         
-            strongSelf.delegate?.mapViewController(strongSelf, didSend: identifier, feedbackType: item.feedbackType)
-            strongSelf.routeController.updateFeedback(feedbackId: identifier, type: item.feedbackType, source: source, description: nil)
+            strongSelf.delegate?.mapViewController(strongSelf, didSendFeedbackAssigned: uuid, feedbackType: item.feedbackType)
+            strongSelf.routeController.updateFeedback(uuid: uuid, type: item.feedbackType, source: source, description: nil)
             strongSelf.dismiss(animated: true) {
                 DialogViewController().present(on: parent)
             }
         }
     }
     
-    func defaultDismissFeedbackHandler(feedbackId identifier: String) -> (() -> Void) {
+    func defaultDismissFeedbackHandler(uuid: UUID) -> (() -> Void) {
         return { [weak self ] in
             guard let strongSelf = self else { return }
             strongSelf.delegate?.mapViewControllerDidCancelFeedback(strongSelf)
-            strongSelf.routeController.cancelFeedback(feedbackId: identifier)
+            strongSelf.routeController.cancelFeedback(uuid: uuid)
             strongSelf.dismiss(animated: true, completion: nil)
         }
     }
@@ -962,7 +962,7 @@ fileprivate extension UIViewAnimationOptions {
     func mapViewControllerDidOpenFeedback(_ mapViewController: RouteMapViewController)
     func mapViewControllerDidCancelFeedback(_ mapViewController: RouteMapViewController)
     func mapViewControllerDidDismiss(_ mapViewController: RouteMapViewController, byCanceling canceled: Bool)
-    func mapViewController(_ mapViewController: RouteMapViewController, didSend feedbackId: String, feedbackType: FeedbackType)
+    func mapViewController(_ mapViewController: RouteMapViewController, didSendFeedbackAssigned uuid: UUID, feedbackType: FeedbackType)
     func mapViewControllerShouldAnnotateSpokenInstructions(_ routeMapViewController: RouteMapViewController) -> Bool
     
     /**

--- a/docs/examples/Advanced.md
+++ b/docs/examples/Advanced.md
@@ -9,7 +9,7 @@ import MapboxDirections
 import Mapbox
 
 
-class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate, VoiceControllerDelegate, NavigationMapViewDelegate, NavigationViewControllerDelegate {
+class AdvancedViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate, NavigationMapViewDelegate, NavigationViewControllerDelegate {
     
     var mapView: NavigationMapView?
     var currentRoute: Route? {

--- a/docs/examples/Custom Destination Marker.md
+++ b/docs/examples/Custom Destination Marker.md
@@ -8,7 +8,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class CustomDestinationMarkerController: UIViewController, NavigationViewControllerDelegate {
+class CustomDestinationMarkerController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -35,9 +35,11 @@ class CustomDestinationMarkerController: UIViewController, NavigationViewControl
             self.present(navigationController, animated: true, completion: nil)
         }
     }
-    
-    func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
-        var annotationImage = mapView.dequeueReusableAnnotationImage(withIdentifier: "marker")
+}
+
+extension CustomDestinationMarkerController: NavigationViewControllerDelegate {
+    func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
+        var annotationImage = navigationViewController.mapView!.dequeueReusableAnnotationImage(withIdentifier: "marker")
         
         if annotationImage == nil {
             // Leaning Tower of Pisa by Stefan Spieler from the Noun Project.

--- a/docs/examples/Custom Server.md
+++ b/docs/examples/Custom Server.md
@@ -8,7 +8,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class CustomServerViewController: UIViewController, NavigationViewControllerDelegate {
+class CustomServerViewController: UIViewController {
     
     let routeOptions = NavigationRouteOptions(coordinates: [
         CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648),
@@ -39,7 +39,9 @@ class CustomServerViewController: UIViewController, NavigationViewControllerDele
             self.present(self.navigationViewController!, animated: true, completion: nil)
         }
     }
-    
+}
+
+extension CustomServerViewController: NavigationViewControllerDelegate {
     // Never reroute internally. Instead,
     // 1. Fetch a route from your server
     // 2. Map Match the coordinates from your server

--- a/docs/examples/Embedded Navigation.md
+++ b/docs/examples/Embedded Navigation.md
@@ -7,7 +7,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class EmbeddedExampleViewController: UIViewController, NavigationViewControllerDelegate  {
+class EmbeddedExampleViewController: UIViewController {
  
     @IBOutlet weak var reroutedLabel: UILabel!
     @IBOutlet weak var enableReroutes: UISwitch!
@@ -75,9 +75,9 @@ class EmbeddedExampleViewController: UIViewController, NavigationViewControllerD
             ])
         self.didMove(toParentViewController: self)
     }
+}
 
-    //MARK: - NavigationViewControllerDelegate
-    
+extension EmbeddedExampleViewController: NavigationViewControllerDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldRerouteFrom location: CLLocation) -> Bool {
         return enableReroutes.isOn
     }

--- a/docs/examples/Waypoint Arrival Screen.md
+++ b/docs/examples/Waypoint Arrival Screen.md
@@ -8,7 +8,7 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-class WaypointArrivalScreenViewController: UIViewController, NavigationViewControllerDelegate {
+class WaypointArrivalScreenViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,7 +38,9 @@ class WaypointArrivalScreenViewController: UIViewController, NavigationViewContr
             self.present(navigationController, animated: true, completion: nil)
         }
     }
-    
+}
+
+extension WaypointArrivalScreenViewController: NavigationViewControllerDelegate {
     // Show an alert when arriving at the waypoint and wait until the user to start next leg.
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool {
         let alert = UIAlertController(title: "Arrived at \(String(describing: waypoint.name))", message: "Would you like to continue?", preferredStyle: .alert)


### PR DESCRIPTION
This one is a doozy. Hot on the heels of #1378, most public NavigationViewControllerDelegate methods and some RouteControllerDelegate and TunnelIntersectionManagerDelegate methods have been renamed to conform to Cocoa naming conventions in both Swift and Objective-C. The biggest change is that all the NavigationViewControllerDelegate methods now begin with `navigationViewController` instead of sometimes beginning with `navigationMapView`. If an implementation needs access to the map view, it can use `navigationViewController.mapView`.

NavigationViewControllerDelegate changes:

v0.16._x_ | This PR
----|----
`navigationMapView(_:routeStyleLayerWithIdentifier:source:)` | `navigationViewController(_:routeStyleLayerWithIdentifier:source:)`
`navigationMapView(_:routeCasingStyleLayerWithIdentifier:source:)` | `navigationViewController(_:routeCasingStyleLayerWithIdentifier:source:)`
`navigationMapView(_:shapeFor:)` | `navigationViewController(_:shapeFor:)`
`navigationMapView(_:simplifiedShapeFor:)` | `navigationViewController(_:simplifiedShapeFor:)`
`navigationMapView(_:waypointStyleLayerWithIdentifier:source:)` | `navigationViewController(_:waypointStyleLayerWithIdentifier:source:)`
`navigationMapView(_:waypointSymbolStyleLayerWithIdentifier:source:)` | `navigationViewController(_:waypointSymbolStyleLayerWithIdentifier:source:)`
`navigationMapView(_:shapeFor:legIndex:)` | `navigationViewController(_:shapeFor:legIndex:)`
`navigationMapView(_:didTap:)` | `navigationViewController(_:didSelect:)`
`navigationMapView(_:imageFor:)` | `navigationViewController(_:imageFor:)`
`navigationMapView(_:viewFor:)` | `navigationViewController(_:viewFor:)`
`navigationViewController(_:didSend:feedbackType:)` | `navigationViewController(_:didSendFeedbackAssigned:feedbackType:)`

NavigationViewControllerDelegate changes in Objective-C only:

v0.16._x_ | This PR
----|----
`-navigationViewController:didArriveAt:` | `-navigationViewController:didArriveAtWaypoint:`
`-navigationViewController:shouldDiscard:` | `-navigationViewController:shouldDiscardLocation:`
`-navigationViewController:roadNameAt:` | `-navigationViewController:roadNameAtLocation:`

TunnelIntersectionManagerDelegate changes:

master | This PR
----|----
`tunnelIntersectionManager(_:willEnableAnimationAt:callback:)` | `tunnelIntersectionManager(_:willEnableAnimationAt:completionHandler:)`
`tunnelIntersectionManager(_:willDisableAnimationAt:callback:)` | `tunnelIntersectionManager(_:willDisableAnimationAt:completionHandler:)`

Along for the ride, MapboxNavigation now represents feedback IDs as `UUID`s instead of `String`s, just like in Core Navigation, resulting in the following changes to RouteController:

v0.16._x_ | This PR
----|----
`recordFeedback(type:description:)` returns `String` | `recordFeedback(type:description:)` returns `UUID`
`updateFeedback(feedbackId:type:source:description:)` | `updateFeedback(uuid:type:source:description:)`
`cancelFeedback(feedbackId:)` | `cancelFeedback(uuid:)`

Finally, this PR fixes an issue (present in the current release) where `NavigationViewController.navigationMapView(_:shapeDescribing:)` (now `navigationMapView(_:shapeFor:)`) was getting called instead of `navigationMapView(_:simplifiedShapeDescribing:)` (now `navigationMapView(_:simplifiedShapeFor:)`).

Fixes #1376.

/cc @bsudekum @JThramer @vincethecoder