### PR TITLE
Stop building for i386

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -2606,6 +2606,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2663,6 +2664,7 @@
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
_Continuation of https://github.com/mapbox/mapbox-navigation-ios/pull/1394_

The i386 slice has been removed from the Maps SDK but Carthage sometimes tries to build MapboxNavigation with i386 included, depending on the destination. This change sets the available architectures to 64 bit only.

Grabbed this from https://github.com/Carthage/Carthage/issues/1771#issuecomment-284756853 and applied it to the entire project, not just the navigation frameworks.

/cc @mapbox/navigation-ios @friedbunny 