### PR TITLE
Do not change EORVC constraints if view is nil

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -915,7 +915,7 @@ extension RouteMapViewController {
         NotificationCenter.default.removeObserver(self, name: .UIKeyboardWillHide, object: nil)
     }
     @objc fileprivate func keyboardWillShow(notification: NSNotification) {
-        guard let _ = navigationView.endOfRouteView else { return }
+        guard navigationView.endOfRouteView != nil else { return }
         guard let userInfo = notification.userInfo else { return }
         let curve = UIViewAnimationCurve(rawValue: userInfo[UIKeyboardAnimationCurveUserInfoKey] as! Int)
         let options = (duration: userInfo[UIKeyboardAnimationDurationUserInfoKey] as! Double,
@@ -933,7 +933,7 @@ extension RouteMapViewController {
     }
     
     @objc fileprivate func keyboardWillHide(notification: NSNotification) {
-        guard let _ = navigationView.endOfRouteView else { return }
+        guard navigationView.endOfRouteView != nil else { return }
         guard let userInfo = notification.userInfo else { return }
         let curve = UIViewAnimationCurve(rawValue: userInfo[UIKeyboardAnimationCurveUserInfoKey] as! Int)
         let options = (duration: userInfo[UIKeyboardAnimationDurationUserInfoKey] as! Double,

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -915,6 +915,7 @@ extension RouteMapViewController {
         NotificationCenter.default.removeObserver(self, name: .UIKeyboardWillHide, object: nil)
     }
     @objc fileprivate func keyboardWillShow(notification: NSNotification) {
+        guard let _ = navigationView.endOfRouteView else { return }
         guard let userInfo = notification.userInfo else { return }
         let curve = UIViewAnimationCurve(rawValue: userInfo[UIKeyboardAnimationCurveUserInfoKey] as! Int)
         let options = (duration: userInfo[UIKeyboardAnimationDurationUserInfoKey] as! Double,
@@ -932,13 +933,14 @@ extension RouteMapViewController {
     }
     
     @objc fileprivate func keyboardWillHide(notification: NSNotification) {
+        guard let _ = navigationView.endOfRouteView else { return }
         guard let userInfo = notification.userInfo else { return }
         let curve = UIViewAnimationCurve(rawValue: userInfo[UIKeyboardAnimationCurveUserInfoKey] as! Int)
         let options = (duration: userInfo[UIKeyboardAnimationDurationUserInfoKey] as! Double,
                        curve: UIViewAnimationOptions(curve: curve!))
         
         navigationView.endOfRouteShowConstraint?.constant = 0
-
+        
         UIView.animate(withDuration: options.duration, delay: 0, options: options.curve, animations: view.layoutIfNeeded, completion: nil)
     }
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1259

This keyboard logic is specific to the end of route view controller, specifically when the user touches the info field. If the view is nil (and thus not shown), there is no need to run this logic.

/cc @JThramer 