### PR TITLE
Don't hold onto value from settings observe

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -104,10 +104,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     
     var lastSpokenInstruction: SpokenInstruction?
     var routeProgress: RouteProgress?
-    
-    var volumeToken: NSKeyValueObservation?
-    var muteToken: NSKeyValueObservation?
-    
+
     /**
      Default initializer for `RouteVoiceController`.
      */
@@ -142,11 +139,11 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
         NotificationCenter.default.addObserver(self, selector: #selector(pauseSpeechAndPlayReroutingDing(notification:)), name: .routeControllerWillReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReroute(notification:)), name: .routeControllerDidReroute, object: nil)
         
-        volumeToken = NavigationSettings.shared.observe(\.voiceVolume) { [weak self] (settings, change) in
+        _ = NavigationSettings.shared.observe(\.voiceVolume) { [weak self] (settings, change) in
             self?.audioPlayer?.volume = settings.voiceVolume
         }
         
-        muteToken = NavigationSettings.shared.observe(\.voiceMuted) { [weak self] (settings, change) in
+        _ = NavigationSettings.shared.observe(\.voiceMuted) { [weak self] (settings, change) in
             if settings.voiceMuted {
                 self?.audioPlayer?.stop()
                 self?.speechSynth.stopSpeaking(at: .immediate)


### PR DESCRIPTION
While looking into if we had any memory leaks ([steps I followed](http://blog.mallow-tech.com/2017/12/ways-to-detect-the-memory-leaks-in-swift/)), I found a leak in `RouteVoiceController.resumeNotifications()`.

Unsure why, but holding onto the output from these observe functions seems to be leaking:

![image](https://user-images.githubusercontent.com/1058624/40143091-48ad6020-590f-11e8-92ca-ca7a31380251.png)

/cc @mapbox/navigation-ios 
