### PR TITLE
Add failing test for tunnel + style refreshes

### DIFF
--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -115,7 +115,7 @@ open class StyleManager: NSObject {
     func applyStyle() {
         guard let location = delegate?.locationFor(styleManager: self) else {
             // We can't calculate sunset or sunrise w/o a location so just apply the first style
-            if let style = styles.first {
+            if let style = styles.first, currentStyleType != style.styleType {
                 currentStyleType = style.styleType
                 style.apply()
                 delegate?.styleManager?(self, didApply: style)
@@ -125,7 +125,7 @@ open class StyleManager: NSObject {
         
         // Single style usage
         guard styles.count > 1 else {
-            if let style = styles.first {
+            if let style = styles.first, currentStyleType != style.styleType {
                 currentStyleType = style.styleType
                 style.apply()
                 delegate?.styleManager?(self, didApply: style)

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -116,6 +116,7 @@ open class StyleManager: NSObject {
         guard let location = delegate?.locationFor(styleManager: self) else {
             // We can't calculate sunset or sunrise w/o a location so just apply the first style
             if let style = styles.first {
+                currentStyleType = style.styleType
                 style.apply()
                 delegate?.styleManager?(self, didApply: style)
             }
@@ -125,6 +126,7 @@ open class StyleManager: NSObject {
         // Single style usage
         guard styles.count > 1 else {
             if let style = styles.first {
+                currentStyleType = style.styleType
                 style.apply()
                 delegate?.styleManager?(self, didApply: style)
             }


### PR DESCRIPTION
In the case where a developer has all tunnel flags turned on, we're force refreshing the map style on every update which causes the map style to flash on and off:

https://github.com/mapbox/mapbox-navigation-ios/blob/026fddd1bc07080f33d0cf3f5e7df3b41a04781a/MapboxNavigation/NavigationViewController.swift#L431-L437

- [x] add failing test
- [x] actually fix the code

/cc @mapbox/navigation-ios 