### PR TITLE
Use current step for snapping course

### DIFF
--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -90,7 +90,7 @@ extension CLLocation {
      Calculates the proper coordinates to use when calculating a snapped location.
      */
     func coordinates(for legProgress: RouteLegProgress) -> [CLLocationCoordinate2D] {
-        var coordinates = legProgress.nearbyCoordinates
+        let nearbyCoordinates = legProgress.nearbyCoordinates
         let stepCoordinates = legProgress.currentStep.coordinates!
         
         // If the upcoming maneuver a sharp turn, only look at the current step for snapping.
@@ -101,15 +101,20 @@ extension CLLocation {
             
             // The max here is 180. The closer it is to 180, the sharper the turn.
             if initialHeading.clockwiseDifference(from: finalHeading) > 180 - RouteSnappingMaxManipulatedCourseAngle {
-                coordinates = stepCoordinates
+                return stepCoordinates
+            }
+            
+            
+            if finalHeading.difference(from: course) > RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion {
+                return stepCoordinates
             }
         }
         
-        if speed < RouteControllerMaximumSpeedForUsingCurrentStep {
-            coordinates = stepCoordinates
+        if speed <= RouteControllerMaximumSpeedForUsingCurrentStep {
+            return stepCoordinates
         }
         
-        return coordinates
+        return nearbyCoordinates
     }
     
     

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -94,7 +94,7 @@ class RouteControllerTests: XCTestCase {
         XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
     }
     
-    func testSnappedAtEndOfStepLocation() {
+    func testSnappedAtEndOfStepLocationWhenMovingSlowly() {
         let navigation = dependencies.routeController
         let firstLocation = dependencies.firstLocation
         
@@ -110,6 +110,26 @@ class RouteControllerTests: XCTestCase {
         let firstLocationOnNextStepWithSpeed = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, course: 10, speed: 5, timestamp: Date())
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithSpeed])
         XCTAssertEqual(navigation.location!.coordinate, firstCoordinateOnUpcomingStep, "User is snapped to upcoming step when moving")
+    }
+    
+    func testSnappedAtEndOfStepLocationWhenCourseIsSimilar() {
+        let navigation = dependencies.routeController
+        let firstLocation = dependencies.firstLocation
+        
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
+        XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
+        
+        let firstCoordinateOnUpcomingStep = navigation.routeProgress.currentLegProgress.upComingStep!.coordinates!.first!
+        
+        let finalHeading = navigation.routeProgress.currentLegProgress.upComingStep!.finalHeading!
+        let firstLocationOnNextStepWithDifferentCourse = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 30, verticalAccuracy: 10, course: -finalHeading, speed: 5, timestamp: Date())
+        
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithDifferentCourse])
+        XCTAssertEqual(navigation.location!.coordinate, navigation.routeProgress.currentLegProgress.currentStep.coordinates!.last!, "When user's course is dissimilar from the finalHeading, they should not snap to upcoming step")
+        
+        let firstLocationOnNextStepWithCorrectCourse = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 30, verticalAccuracy: 10, course: finalHeading, speed: 5, timestamp: Date())
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithCorrectCourse])
+        XCTAssertEqual(navigation.location!.coordinate, firstCoordinateOnUpcomingStep, "User is snapped to upcoming step when their course is similar to the final heading")
     }
 
     func testSnappedLocationForUnqualifiedLocation() {


### PR DESCRIPTION
Building on https://github.com/mapbox/mapbox-navigation-ios/pull/1425, https://github.com/mapbox/mapbox-navigation-ios/pull/1425 was a good addition, but does not seem to catch all cases. There still seems to be situations where the user puck can end up snapping the course in between steps.

This change will snap the puck to the current step coordinates when the user's course is dissimilar from the heading on their upcoming step.

The one place where this could fall apart is when moving very fast through a sharp/windy maneuver. One that comes to mind is a looping on ramp onto a motorway- your course may not be similar to the final heading until the very last second. Still need to test this a bit.

/cc @1ec5 