### PR TITLE
Do not force refresh style if we don't have the style type

### DIFF
--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -150,7 +150,13 @@ open class StyleManager: NSObject {
     func forceRefreshAppearanceIfNeeded() {
         guard let location = delegate?.locationFor(styleManager: self) else { return }
         
-        guard currentStyleType != styleType(for: location) else {
+        let styleTypeForLocation = styleType(for: location)
+        
+        // If `styles` does not contain at least one style for the selected location, don't try and apply it.
+        let avilableStyleTypesForLocation = styles.filter { $0.styleType == styleTypeForLocation }
+        guard avilableStyleTypesForLocation.count > 0 else { return }
+        
+        guard currentStyleType != styleTypeForLocation else {
             return
         }
         

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -153,8 +153,8 @@ open class StyleManager: NSObject {
         let styleTypeForLocation = styleType(for: location)
         
         // If `styles` does not contain at least one style for the selected location, don't try and apply it.
-        let avilableStyleTypesForLocation = styles.filter { $0.styleType == styleTypeForLocation }
-        guard avilableStyleTypesForLocation.count > 0 else { return }
+        let availableStyleTypesForLocation = styles.filter { $0.styleType == styleTypeForLocation }
+        guard availableStyleTypesForLocation.count > 0 else { return }
         
         guard currentStyleType != styleTypeForLocation else {
             return

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -91,6 +91,24 @@ class NavigationViewControllerTests: XCTestCase {
         updatedStyleNumberOfTimes = 0
     }
     
+    // If tunnel flags are enabled and we need to switch styles, we should not force refresh the map style because we have only 1 style.
+    func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceWhenOnlyOneStyle() {
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()])
+        navigationViewController.usesNightStyleInsideTunnels = true
+        navigationViewController.routeController.tunnelSimulationEnabled = true
+        let routeController = navigationViewController.routeController!
+        navigationViewController.styleManager.delegate = self
+        
+        let someLocation = dependencies.poi.first!
+        
+        routeController.locationManager(routeController.locationManager, didUpdateLocations: [someLocation])
+        routeController.locationManager(routeController.locationManager, didUpdateLocations: [someLocation])
+        routeController.locationManager(routeController.locationManager, didUpdateLocations: [someLocation])
+        
+        XCTAssertEqual(updatedStyleNumberOfTimes, 0, "The style should not be updated.")
+        updatedStyleNumberOfTimes = 0
+    }
+    
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithTwoStyles() {
         let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()])
         navigationViewController.usesNightStyleInsideTunnels = true


### PR DESCRIPTION
If tunnel flags are enabled, and we detect that the style needs to change for a given location, we should not try and force update the style if we only have one style or if we don't have that style type.

Example case:
1. inits with tunnel flags and a single style, say night for example.
1. Start in a location where it's day time, the opposite of the style we have.
1. We should not emit a force style update because we do not have a style to update to.

/cc @mapbox/navigation-ios 