### PR TITLE
Updating destination waypoint when route changes

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		3EA93DC5BA00B5DFCBE7BAC3 /* RouteControllerDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */; };
 		6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */; };
 		64847A041F04629D003F3A69 /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64847A031F04629D003F3A69 /* Feedback.swift */; };
+		8D07C5A820B612310093D779 /* EmptyStyle.json in Resources */ = {isa = PBXBuildFile; fileRef = 8D07C5A720B612310093D779 /* EmptyStyle.json */; };
 		8D24A2F62040960C0098CBF8 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D24A2F52040960C0098CBF8 /* UIEdgeInsets.swift */; };
 		8D24A2F820409A890098CBF8 /* CGSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D24A2F720409A890098CBF8 /* CGSize.swift */; };
 		8D24A2FA20449B430098CBF8 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D24A2F920449B430098CBF8 /* Dictionary.swift */; };
@@ -585,6 +586,7 @@
 		3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteControllerDelegateSpy.swift; sourceTree = "<group>"; };
 		6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaypointConfirmationViewController.swift; sourceTree = "<group>"; };
 		64847A031F04629D003F3A69 /* Feedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
+		8D07C5A720B612310093D779 /* EmptyStyle.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = EmptyStyle.json; sourceTree = "<group>"; };
 		8D24A2F52040960C0098CBF8 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		8D24A2F720409A890098CBF8 /* CGSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGSize.swift; sourceTree = "<group>"; };
 		8D24A2F920449B430098CBF8 /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
@@ -1010,6 +1012,7 @@
 			children = (
 				35EB9A6920A1A89500CB1225 /* turn_left.data */,
 				352690481ECC843700E387BD /* Fixture.swift */,
+				8D07C5A720B612310093D779 /* EmptyStyle.json */,
 				355DB5741EFA78070091BFB7 /* GGPark-to-BernalHeights.route */,
 				355DB5761EFA780E0091BFB7 /* UnionSquare-to-GGPark.route */,
 				351030101F54B72000E3B7E7 /* route-for-lane-testing.json */,
@@ -1679,6 +1682,7 @@
 				355DB5751EFA78070091BFB7 /* GGPark-to-BernalHeights.route in Resources */,
 				35EB9A6A20A1AB7C00CB1225 /* turn_left.data in Resources */,
 				3540514D1F73F3BB00ED572D /* route-with-straight-roundabout.json in Resources */,
+				8D07C5A820B612310093D779 /* EmptyStyle.json in Resources */,
 				16B63DCD205C8EEF002D56D4 /* route-with-instructions.json in Resources */,
 				AE5F8771209A082500F58FDB /* route-with-banner-instructions.json in Resources */,
 				35DC9D8F1F4321CC001ECD64 /* route-with-lanes.json in Resources */,

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -290,7 +290,8 @@ class RouteMapViewController: UIViewController {
         
         mapView.addArrow(route: routeController.routeProgress.route, legIndex: routeController.routeProgress.legIndex, stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
         mapView.showRoutes([routeController.routeProgress.route], legIndex: routeController.routeProgress.legIndex)
-        
+        mapView.showWaypoints(routeController.routeProgress.route)
+
         if annotatesSpokenInstructions {
             mapView.showVoiceInstructionsOnMap(route: routeController.routeProgress.route)
         }

--- a/MapboxNavigationTests/Fixtures/EmptyStyle.json
+++ b/MapboxNavigationTests/Fixtures/EmptyStyle.json
@@ -1,0 +1,1 @@
+{"version":8,"sources":{},"layers":[]}

--- a/MapboxNavigationTests/Fixtures/Fixture.swift
+++ b/MapboxNavigationTests/Fixtures/Fixture.swift
@@ -52,6 +52,11 @@ internal class Fixture {
         })
     }
     
+    class var blankStyle: URL {
+        let path = Bundle(for: self).path(forResource: "EmptyStyle", ofType: "json")
+        return URL(fileURLWithPath: path!)
+    }
+    
     class func route(from jsonFile: String, waypoints: [Waypoint]) -> Route {
         let response = JSONFromFileNamed(name: jsonFile)
         let jsonRoute = (response["routes"] as! [AnyObject]).first as! [String : Any]

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -164,7 +164,7 @@ class NavigationViewControllerTests: XCTestCase {
     
     func testDestinationAnnotationUpdatesUponReroute() {
         let styleLoaded = XCTestExpectation(description: "Style Loaded")
-        let navigationViewController = NavigationViewControllerTestable(for: initialRoute, styles: [DayStyle()], styleLoaded: styleLoaded)
+        let navigationViewController = NavigationViewControllerTestable(for: initialRoute, styles: [TestableDayStyle()], styleLoaded: styleLoaded)
         
         //wait for the style to load -- routes won't show without it.
         wait(for: [styleLoaded], timeout: 5)
@@ -256,5 +256,12 @@ class NavigationViewControllerTestable: NavigationViewController {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("This initalizer is not supported in this testing subclass.")
+    }
+}
+
+class TestableDayStyle: DayStyle {
+    required init() {
+        super.init()
+        mapStyleURL = Fixture.blankStyle
     }
 }

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -165,13 +165,12 @@ class NavigationViewControllerTests: XCTestCase {
     func testDestinationAnnotationUpdatesUponReroute() {
         let styleLoaded = XCTestExpectation(description: "Style Loaded")
         let navigationViewController = NavigationViewControllerTestable(for: initialRoute, styles: [DayStyle()], styleLoaded: styleLoaded)
-        let routeController = navigationViewController.routeController!
         
         //wait for the style to load -- routes won't show without it.
         wait(for: [styleLoaded], timeout: 5)
         navigationViewController.route = initialRoute
         
-        let firstDestination = routeController.routeProgress.remainingWaypoints.last!.coordinate
+        let firstDestination = initialRoute.routeOptions.waypoints.last!.coordinate
         guard let annotations = navigationViewController.mapView?.annotations else { return XCTFail("Annotations not found.")}
 
         let destinations = annotations.filter(annotationFilter(matching: firstDestination))
@@ -181,7 +180,7 @@ class NavigationViewControllerTests: XCTestCase {
         navigationViewController.route = newRoute
         
         guard let newAnnotations = navigationViewController.mapView?.annotations else { return XCTFail("New annotations not found.")}
-        let secondDestination = routeController.routeProgress.remainingWaypoints.last!.coordinate
+        let secondDestination = newRoute.routeOptions.waypoints.last!.coordinate
 
         //do we have a destination on the second route?
         let newDestinations = newAnnotations.filter(annotationFilter(matching: secondDestination))

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -5,6 +5,7 @@ import Turf
 @testable import MapboxNavigation
 
 let response = Fixture.JSONFromFileNamed(name: "route-with-instructions")
+let otherResponse = Fixture.JSONFromFileNamed(name: "route-for-lane-testing")
 
 class NavigationViewControllerTests: XCTestCase {
     
@@ -45,6 +46,17 @@ class NavigationViewControllerTests: XCTestCase {
         let route     = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], routeOptions: NavigationRouteOptions(waypoints: [waypoint1, waypoint2]))
         
         route.accessToken = "foo"
+        
+        return route
+    }()
+    
+    lazy var newRoute: Route = {
+        let jsonRoute = (otherResponse["routes"] as! [AnyObject]).first as! [String: Any]
+        let waypoint1 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.901166, longitude: -77.036548))
+        let waypoint2 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.900206, longitude: -77.033792))
+        let route     = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], routeOptions: NavigationRouteOptions(waypoints: [waypoint1, waypoint2]))
+        
+        route.accessToken = "bar"
         
         return route
     }()
@@ -144,10 +156,45 @@ class NavigationViewControllerTests: XCTestCase {
         let fultonStreetLocation = dependencies.poi[2]
         
         navigationViewController.mapViewController!.labelRoadNameCompletionHandler = { (defaultRaodNameAssigned) in
-            XCTAssertTrue(defaultRaodNameAssigned, "Unfortunstely label road name was not successfully set")
+            XCTAssertTrue(defaultRaodNameAssigned, "label road name was not successfully set")
         }
         
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [fultonStreetLocation])
+    }
+    
+    func testDestinationAnnotationUpdatesUponReroute() {
+        let styleLoaded = XCTestExpectation(description: "Style Loaded")
+        let navigationViewController = NavigationViewControllerTestable(for: initialRoute, styles: [DayStyle()], styleLoaded: styleLoaded)
+        let routeController = navigationViewController.routeController!
+        
+        //wait for the style to load -- routes won't show without it.
+        wait(for: [styleLoaded], timeout: 5)
+        navigationViewController.route = initialRoute
+        
+        let firstDestination = routeController.routeProgress.remainingWaypoints.last!.coordinate
+        guard let annotations = navigationViewController.mapView?.annotations else { return XCTFail("Annotations not found.")}
+
+        let destinations = annotations.filter(annotationFilter(matching: firstDestination))
+        XCTAssert(!destinations.isEmpty, "Destination annotation does not exist on map")
+    
+        //lets set the second route
+        navigationViewController.route = newRoute
+        
+        guard let newAnnotations = navigationViewController.mapView?.annotations else { return XCTFail("New annotations not found.")}
+        let secondDestination = routeController.routeProgress.remainingWaypoints.last!.coordinate
+
+        //do we have a destination on the second route?
+        let newDestinations = newAnnotations.filter(annotationFilter(matching: secondDestination))
+        XCTAssert(!newDestinations.isEmpty, "New destination annotation does not exist on map")
+        
+    }
+    
+    private func annotationFilter(matching coordinate: CLLocationCoordinate2D) -> ((MGLAnnotation) -> Bool) {
+        let filter = { (annotation: MGLAnnotation) -> Bool in
+            guard let pointAnno = annotation as? MGLPointAnnotation else { return false }
+            return pointAnno.coordinate == coordinate
+        }
+        return filter
     }
 }
 
@@ -186,4 +233,29 @@ extension NavigationViewControllerTests {
                                        speed: 15,
                                    timestamp: Date())
             }
+}
+
+class NavigationViewControllerTestable: NavigationViewController {
+    var styleLoadedExpectation: XCTestExpectation
+    
+    required init(for route: Route,
+                  directions: Directions = Directions.shared,
+                  styles: [Style]? = [DayStyle(), NightStyle()],
+                  locationManager: NavigationLocationManager? = NavigationLocationManager(),
+                  styleLoaded: XCTestExpectation) {
+        styleLoadedExpectation = styleLoaded
+        super.init(for: route, directions: directions,styles: styles, locationManager: locationManager)
+    }
+    
+    required init(for route: Route, directions: Directions, styles: [Style]?, locationManager: NavigationLocationManager?) {
+        fatalError("This initalizer is not supported in this testing subclass.")
+    }
+    
+    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+        styleLoadedExpectation.fulfill()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("This initalizer is not supported in this testing subclass.")
+    }
 }


### PR DESCRIPTION
Fixes #1326. Issue was caused by a missing `showWaypoints(route:)` call.

It's worth calling out that the order-of-operations for the route that the NVC gets initialized with is _really_ obscure and brittle. For instance, unless I manually do `navigationViewController.route = initialRoute` _after_ I wait for the styles to load, I cannot find any annotations on the map, which doesn't seem like reasonable behavior. I thought it out of scope for this issue, but I'll cut a ticket for this as I close this PR out.

/cc @mapbox/navigation-ios 
