### PR TITLE
Enable tunnel style switching and animation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added the ability to render more than 1 alternate route. [#1372](https://github.com/mapbox/mapbox-navigation-ios/pull/1372/)
 * `NavigationMapViewDelegate.navigationMapView(_:shapeFor:)` Now expects an array of `Route`. The first route will be rendered as the main route, all subsequent routes will be rendered as alternate routes.
 * Added support for generic route shields. Image-backed route shields also now display as generic (instead of plain text) while the SDK loads the image. [#1190](https://github.com/mapbox/mapbox-navigation-ios/issues/1190), [#1417](https://github.com/mapbox/mapbox-navigation-ios/pull/1417)
+* Animating the user through tunnels and automatically switching the map style when entering a tunnel is now on by default.
 
 ## v0.17.0 (May 14, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added the ability to render more than 1 alternate route. [#1372](https://github.com/mapbox/mapbox-navigation-ios/pull/1372/)
 * `NavigationMapViewDelegate.navigationMapView(_:shapeFor:)` Now expects an array of `Route`. The first route will be rendered as the main route, all subsequent routes will be rendered as alternate routes.
 * Added support for generic route shields. Image-backed route shields also now display as generic (instead of plain text) while the SDK loads the image. [#1190](https://github.com/mapbox/mapbox-navigation-ios/issues/1190), [#1417](https://github.com/mapbox/mapbox-navigation-ios/pull/1417)
-* Animating the user through tunnels and automatically switching the map style when entering a tunnel is now on by default.
+* Animating the user through tunnels and automatically switching the map style when entering a tunnel is now on by default. [#1449](https://github.com/mapbox/mapbox-navigation-ios/pull/1449)
 
 ## v0.17.0 (May 14, 2018)
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -190,7 +190,7 @@ open class RouteController: NSObject {
     /**
      The flag that indicates that the simulated navigation through tunnel(s) is enabled.
      */
-    public var tunnelSimulationEnabled: Bool = false
+    public var tunnelSimulationEnabled: Bool = true
 
     var didFindFasterRoute = false
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -325,7 +325,7 @@ open class NavigationViewController: UIViewController {
     /**
      A Boolean value that indicates whether the dark style should apply when a route controller enters a tunnel.
      */
-    @objc public var usesNightStyleInsideTunnels: Bool = false
+    @objc public var usesNightStyleInsideTunnels: Bool = true
     
     var styleManager: StyleManager!
     


### PR DESCRIPTION
Now that we have tested tunnel style switching and animations for the past couple of months, I think it's about time we enable this feature by default since it is a very helpful feature.

/cc @mapbox/navigation-ios 