### PR TITLE
Skip playing sound in unit test

### DIFF
--- a/MapboxNavigationTests/MapboxVoiceControllerTests.swift
+++ b/MapboxNavigationTests/MapboxVoiceControllerTests.swift
@@ -45,15 +45,8 @@ class MapboxVoiceControllerTests: XCTestCase {
     func testVoiceDeinit() {
         var voiceController: MockMapboxVoiceController? = MockMapboxVoiceController()
         let deinitExpectation = expectation(description: "Voice Controller should deinitialize")
-        voiceController?.deinitExpectation = deinitExpectation
-        let bundle = Bundle(for: MapboxVoiceControllerTests.self)
-        let filePath = bundle.path(forResource: "turn_left", ofType: "data")
-        let filePathURL = URL(fileURLWithPath: filePath! )
-        let data = try! Data(contentsOf: filePathURL)
-        voiceController?.play(data)
+        voiceController!.deinitExpectation = deinitExpectation
         voiceController = nil
-        XCTAssertNil(voiceController, "voiceController should be nil after nilling it.")
-        
         wait(for: [deinitExpectation], timeout: 3)
     }
 }


### PR DESCRIPTION
Fixes #1450

Playing a sound in the simulator fails intermittently so let's not do that in a unit test.

cc @bsudekum 