### PR TITLE
Fix setOverheadCameraView for short routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `NavigationMapViewDelegate.navigationMapView(_:shapeFor:)` Now expects an array of `Route`. The first route will be rendered as the main route, all subsequent routes will be rendered as alternate routes.
 * Added support for generic route shields. Image-backed route shields also now display as generic (instead of plain text) while the SDK loads the image. [#1190](https://github.com/mapbox/mapbox-navigation-ios/issues/1190), [#1417](https://github.com/mapbox/mapbox-navigation-ios/pull/1417)
 * Animating the user through tunnels and automatically switching the map style when entering a tunnel is now on by default. [#1449](https://github.com/mapbox/mapbox-navigation-ios/pull/1449)
+* Fixed an issue when going into overhead mode with a short route. [#1456](https://github.com/mapbox/mapbox-navigation-ios/pull/1456/)
 
 ## v0.17.0 (May 14, 2018)
 

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1030,13 +1030,24 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let line = MGLPolyline(coordinates: slicedLine, count: UInt(slicedLine.count))
         
         tracksUserCourse = false
+        
+        // If the user has a short distance left on the route, prevent the camera from zooming all the way.
+        // `MGLMapView.setVisibleCoordinateBounds(:edgePadding:animated:)` will go beyond what is convient for the driver.
+        guard line.overlayBounds.ne.distance(to: line.overlayBounds.sw) > NavigationMapViewMinimumDistanceForOverheadZooming else {
+            let camera = self.camera
+            camera.pitch = 0
+            camera.heading = 0
+            camera.centerCoordinate = userLocation
+            camera.altitude = NavigationMapView.defaultAltitude
+            setCamera(camera, animated: true)
+            return
+        }
+        
+        // Sadly, `MGLMapView.setVisibleCoordinateBounds(:edgePadding:animated:)` uses the current pitch and direction of the mapview. Ideally, we'd be able to pass in zero.
         let camera = self.camera
         camera.pitch = 0
         camera.heading = 0
         self.camera = camera
-        
-        // Don't keep zooming in
-        guard line.overlayBounds.ne.distance(to: line.overlayBounds.sw) > NavigationMapViewMinimumDistanceForOverheadZooming else { return }
         
         setVisibleCoordinateBounds(line.overlayBounds, edgePadding: bounds, animated: true)
     }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1032,7 +1032,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         tracksUserCourse = false
         
         // If the user has a short distance left on the route, prevent the camera from zooming all the way.
-        // `MGLMapView.setVisibleCoordinateBounds(:edgePadding:animated:)` will go beyond what is convient for the driver.
+        // `MGLMapView.setVisibleCoordinateBounds(:edgePadding:animated:)` will go beyond what is convenient for the driver.
         guard line.overlayBounds.ne.distance(to: line.overlayBounds.sw) > NavigationMapViewMinimumDistanceForOverheadZooming else {
             let camera = self.camera
             camera.pitch = 0


### PR DESCRIPTION
Addresses the bug in https://github.com/mapbox/mapbox-navigation-ios/issues/1455

Previously, if the user only had a few meters left on the route, we'd flip up the camera, then break early and never actually set the correct center coordinate.

Now, if we detect there is not much left on the route, we simple flip the camera and set the center coordinates to the user.

/cc @mapbox/navigation-ios 