### PR TITLE
Remove report problem button after rerouting

### DIFF
--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -43,7 +43,6 @@ open class NavigationView: UIView {
         static let feedbackTopConstraintPadding: CGFloat = 10.0
         static let buttonSize: CGSize = 50.0
         static let buttonSpacing: CGFloat = 8.0
-        static let rerouteReportTitle = NSLocalizedString("REROUTE_REPORT_TITLE", bundle: .mapboxNavigation, value: "Report Problem", comment: "Title on button that appears when a reroute occurs")
     }
     
     lazy var bannerShowConstraints: [NSLayoutConstraint] = [
@@ -60,8 +59,6 @@ open class NavigationView: UIView {
     lazy var endOfRouteHideConstraint: NSLayoutConstraint? = self.endOfRouteView?.topAnchor.constraint(equalTo: self.bottomAnchor)
     
     lazy var endOfRouteHeightConstraint: NSLayoutConstraint? = self.endOfRouteView?.heightAnchor.constraint(equalToConstant: Constants.endOfRouteHeight)
-    
-    lazy var rerouteFeedbackTopConstraint: NSLayoutConstraint = self.rerouteReportButton.topAnchor.constraint(equalTo: self.informationStackView.bottomAnchor, constant: Constants.feedbackTopConstraintPadding)
     
     private enum Images {
         static let overview = UIImage(named: "overview", in: .mapboxNavigation, compatibleWith: nil)!.withRenderingMode(.alwaysTemplate)
@@ -120,13 +117,6 @@ open class NavigationView: UIView {
         view.clipsToBounds = true
         view.layer.borderWidth = 1.0 / UIScreen.main.scale
         return view
-    }()
-    
-    lazy var rerouteReportButton: ReportButton = {
-        let button: ReportButton = .forAutoLayout()
-        button.setTitle(Constants.rerouteReportTitle, for: .normal)
-        button.isHidden = true
-        return button
     }()
     
     lazy var bottomBannerContentView: BottomBannerContentView = .forAutoLayout()
@@ -212,7 +202,6 @@ open class NavigationView: UIView {
             floatingStackView,
             resumeButton,
             wayNameView,
-            rerouteReportButton,
             bottomBannerContentView,
             instructionsBannerContentView
         ]

--- a/MapboxNavigation/NavigationViewLayout.swift
+++ b/MapboxNavigation/NavigationViewLayout.swift
@@ -27,9 +27,6 @@ extension NavigationView {
         resumeButton.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: 10).isActive = true
         resumeButton.bottomAnchor.constraint(equalTo: bottomBannerView.topAnchor, constant: -10).isActive = true
         
-        rerouteReportButton.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
-        rerouteReportButton.topAnchor.constraint(equalTo: informationStackView.bottomAnchor, constant: 10).isActive = true
-        
         bottomBannerContentView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
         bottomBannerContentView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
         bottomBannerContentView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -42,7 +42,6 @@ class RouteMapViewController: UIViewController {
         static let overview: Selector = #selector(RouteMapViewController.toggleOverview(_:))
         static let mute: Selector = #selector(RouteMapViewController.toggleMute(_:))
         static let feedback: Selector = #selector(RouteMapViewController.feedback(_:))
-        static let rerouteFeedback: Selector = #selector(RouteMapViewController.rerouteFeedback(_:))
         static let recenter: Selector = #selector(RouteMapViewController.recenter(_:))
     }
 
@@ -138,7 +137,6 @@ class RouteMapViewController: UIViewController {
         navigationView.overviewButton.addTarget(self, action: Actions.overview, for: .touchUpInside)
         navigationView.muteButton.addTarget(self, action: Actions.mute, for: .touchUpInside)
         navigationView.reportButton.addTarget(self, action: Actions.feedback, for: .touchUpInside)
-        navigationView.rerouteReportButton.addTarget(self, action: Actions.rerouteFeedback, for: .touchUpInside)
         navigationView.resumeButton.addTarget(self, action: Actions.recenter, for: .touchUpInside)
         resumeNotifications()
         notifyUserAboutLowVolume()
@@ -245,12 +243,6 @@ class RouteMapViewController: UIViewController {
         NavigationSettings.shared.voiceMuted = muted
     }
     
-    @objc func rerouteFeedback(_ sender: Any) {
-        showFeedback(source: .reroute)
-        navigationView.rerouteReportButton.slideUp(constraint: navigationView.rerouteFeedbackTopConstraint)
-        delegate?.mapViewControllerDidOpenFeedback(self)
-    }
-    
     @objc func feedback(_ sender: Any) {
         showFeedback()
         delegate?.mapViewControllerDidOpenFeedback(self)
@@ -342,12 +334,6 @@ class RouteMapViewController: UIViewController {
         
         if !(routeController.locationManager is SimulatedLocationManager) {
             statusView.hide(delay: 2, animated: true)
-            
-            if !navigationView.reportButton.isHidden {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: {
-                    self.navigationView.rerouteReportButton.slideDown(constraint: self.navigationView.rerouteFeedbackTopConstraint, interval: 5)
-                })
-            }
         }
         
         if notification.userInfo![RouteControllerNotificationUserInfoKey.isProactiveKey] as! Bool {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1438

I have the feeling the "Report Problem" button that is shown after rerouting is more confusing, loud and distracting for drivers than helpful. It takes the same amount of clicks to give feedback after rerouting anyways. 

This PR simply removes the button. The string remains because it's used in the actual feedback UI.

<img src="https://user-images.githubusercontent.com/1058624/40678568-b6cf4f34-6335-11e8-8dbf-1fbb17a01a22.png" width="200px" /> 

/cc @mapbox/navigation-ios @leonyuu