### PR TITLE
ImageDownloader creates and mutates downloads within a barrier block

### DIFF
--- a/MapboxNavigation/ImageDownload.swift
+++ b/MapboxNavigation/ImageDownload.swift
@@ -57,7 +57,7 @@ class ImageDownloadOperation: Operation, ImageDownload {
     }
 
     func addCompletion(_ completion: @escaping ImageDownloadCompletionBlock) {
-        barrierQueue.async {
+        barrierQueue.async(flags: .barrier) {
             self.completionBlocks.append(completion)
         }
     }


### PR DESCRIPTION
ImageDownload also uses a barrier when appending completions.
These two changes should address the instability in ImageDownloaderTests

[#1453]
