### PR TITLE
Describe return type fom map/reduce

### DIFF
--- a/MapboxCoreNavigation/MMEEventsManager.swift
+++ b/MapboxCoreNavigation/MMEEventsManager.swift
@@ -335,7 +335,7 @@ extension UIDevice {
             var systemInfo = utsname()
             uname(&systemInfo)
             let machineMirror = Mirror(reflecting: systemInfo.machine)
-            let identifier = machineMirror.children.reduce("") { identifier, element in
+            let identifier: String = machineMirror.children.reduce("") { (identifier: String, element: Mirror.Child) in
                 guard let value = element.value as? Int8, value != 0 else { return identifier }
                 return identifier + String(UnicodeScalar(UInt8(value)))
             }

--- a/MapboxCoreNavigation/MMEEventsManager.swift
+++ b/MapboxCoreNavigation/MMEEventsManager.swift
@@ -335,12 +335,10 @@ extension UIDevice {
             var systemInfo = utsname()
             uname(&systemInfo)
             let machineMirror = Mirror(reflecting: systemInfo.machine)
-            let identifier: String = machineMirror.children.reduce("") { (identifier: String, element: Mirror.Child) in
+            return machineMirror.children.reduce("") { (identifier: String, element: Mirror.Child) in
                 guard let value = element.value as? Int8, value != 0 else { return identifier }
                 return identifier + String(UnicodeScalar(UInt8(value)))
             }
-            
-            return identifier
         }
     }
 }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -520,7 +520,7 @@ extension RouteController {
             _ = enqueueFoundFasterRouteEvent()
         }
 
-        if let lastReroute = outstandingFeedbackEvents.map({$0 as? RerouteEvent }).last {
+        if let lastReroute: RerouteEvent? = outstandingFeedbackEvents.map({$0 as? RerouteEvent }).last {
             lastReroute?.update(newRoute: routeProgress.route)
         }
 
@@ -992,7 +992,7 @@ extension RouteController: CLLocationManagerDelegate {
     func updateIntersectionDistances() {
         if let coordinates = routeProgress.currentLegProgress.currentStep.coordinates, let intersections = routeProgress.currentLegProgress.currentStep.intersections {
             let polyline = Polyline(coordinates)
-            let distances = intersections.map { polyline.distance(from: coordinates.first, to: $0.location) }
+            let distances: [CLLocationDistance] = intersections.map { polyline.distance(from: coordinates.first, to: $0.location) }
             routeProgress.currentLegProgress.currentStepProgress.intersectionDistances = distances
         }
     }

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -38,12 +38,12 @@ class InstructionPresenter {
         guard let source = self.dataSource else { return [] }
         var attributedPairs = self.attributedPairs(for: instruction, dataSource: source, imageRepository: imageRepository, onImageDownload: completeShieldDownload)
         let availableBounds = source.availableBounds()
-        let totalWidth = attributedPairs.attributedStrings.map { $0.size() }.reduce(.zero, +).width
+        let totalWidth: CGFloat = attributedPairs.attributedStrings.map { $0.size() }.reduce(.zero, +).width
         let stringFits = totalWidth <= availableBounds.width
         
         guard !stringFits else { return attributedPairs.attributedStrings }
         
-        let indexedComponents = attributedPairs.components.enumerated().map { IndexedVisualInstructionComponent(component: $1, index: $0) }
+        let indexedComponents: [IndexedVisualInstructionComponent] = attributedPairs.components.enumerated().map { IndexedVisualInstructionComponent(component: $1, index: $0) }
         let filtered = indexedComponents.filter { $0.component.abbreviation != nil }
         let sorted = filtered.sorted { $0.component.abbreviationPriority < $1.component.abbreviationPriority }
         for component in sorted {
@@ -53,7 +53,7 @@ class InstructionPresenter {
             guard let abbreviation = component.component.abbreviation else { continue }
             
             attributedPairs.attributedStrings[component.index] = NSAttributedString(string: joinChar + abbreviation, attributes: attributes(for: source))
-            let newWidth = attributedPairs.attributedStrings.map { $0.size() }.reduce(.zero, +).width
+            let newWidth: CGFloat = attributedPairs.attributedStrings.map { $0.size() }.reduce(.zero, +).width
             
             if newWidth <= availableBounds.width {
                 break

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -479,7 +479,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             return
         }
 
-        let waypoints = Array(route.legs.map { $0.destination }.dropLast())
+        let waypoints: [Waypoint] = Array(route.legs.map { $0.destination }.dropLast())
         
         let source = navigationMapDelegate?.navigationMapView?(self, shapeFor: waypoints, legIndex: legIndex) ?? shape(for: waypoints, legIndex: legIndex)
         if route.routeOptions.waypoints.count > 2 { //are we on a multipoint route?
@@ -782,7 +782,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             
             // The last coord of the preceding step, is shared with the first coord of the next step.
             // We don't need both.
-            var legCoordinates = Array(leg.steps.compactMap {
+            var legCoordinates: [CLLocationCoordinate2D] = Array(leg.steps.compactMap {
                 $0.coordinates?.suffix(from: 1)
                 }.joined())
             
@@ -793,8 +793,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             
             // We're trying to create a sequence that conforms to `((segmentStartCoordinate, segmentEndCoordinate), segmentCongestionLevel)`.
             // This is represents a segment on the route and it's associated congestion level.
-            let segments = zip(legCoordinates, legCoordinates.suffix(from: 1)).map { [$0.0, $0.1] }
-            let congestionSegments = Array(zip(segments, legCongestion))
+            let segments: [[CLLocationCoordinate2D]] = zip(legCoordinates, legCoordinates.suffix(from: 1)).map { [$0.0, $0.1] }
+            let congestionSegments: [([CLLocationCoordinate2D], CongestionLevel)] = Array(zip(segments, legCongestion))
             
             // Merge adjacent segments with the same congestion level
             var mergedCongestionSegments = [CongestionSegment]()
@@ -808,7 +808,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
                 }
             }
             
-            let lines = mergedCongestionSegments.map { (congestionSegment: CongestionSegment) -> MGLPolylineFeature in
+            let lines: [MGLPolylineFeature] = mergedCongestionSegments.map { (congestionSegment: CongestionSegment) -> MGLPolylineFeature in
                 let polyline = MGLPolylineFeature(coordinates: congestionSegment.0, count: UInt(congestionSegment.0.count))
                 polyline.attributes[MBCongestionAttribute] = String(describing: congestionSegment.1)
                 if let legIndex = legIndex {
@@ -829,7 +829,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         var linesPerLeg: [MGLPolylineFeature] = []
         
         for (index, leg) in route.legs.enumerated() {
-            let legCoordinates = Array(leg.steps.compactMap {
+            let legCoordinates: [CLLocationCoordinate2D] = Array(leg.steps.compactMap {
                 $0.coordinates
             }.joined())
             
@@ -949,7 +949,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             return
         }
         
-        let streetsSourceIdentifiers = style.sources.compactMap {
+        let streetsSourceIdentifiers: [String] = style.sources.compactMap {
             $0 as? MGLVectorTileSource
         }.filter {
             $0.isMapboxStreets

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -743,7 +743,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         
         let closestCoordinate = location.coordinate
         let roadLabelLayerIdentifier = "roadLabelLayer"
-        var streetsSources = style.sources.compactMap {
+        var streetsSources: [MGLVectorTileSource] = style.sources.compactMap {
             $0 as? MGLVectorTileSource
             }.filter {
                 $0.isMapboxStreets

--- a/RouteTest/Fixture.swift
+++ b/RouteTest/Fixture.swift
@@ -44,7 +44,7 @@ class Fixture {
         let jsonRoute = (response["routes"] as! [AnyObject]).first as! [String: Any]
         let jsonWaypoints = response["waypoints"] as! [[String: Any]]
         
-        let waypoints = jsonWaypoints.map { (waypointDict) -> Waypoint in
+        let waypoints: [Waypoint] = jsonWaypoints.map { (waypointDict) -> Waypoint in
             let locationDict = waypointDict["location"] as! [CLLocationDegrees]
             let coord = CLLocationCoordinate2D(latitude: locationDict[1], longitude: locationDict[0])
             return Waypoint(coordinate: coord)


### PR DESCRIPTION
As pointed in the WWDC talk "Building Faster in Xcode", relying on the compiler to infer the return type  from a map/filter/compactMap can add up to a slower build time. This PR finds a few places we're creating variables from a map/reduce/compactMap and explicitly names the return type.

Thoughts on adopting this as a best practice going forward? Beyond helping the compiler, it does in fact make it easier to review the code by knowing exactly what is returned. 

/cc @mapbox/navigation-ios 