### PR TITLE
Allow developers to control whether battery monitoring is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Added `NavigationMapView.recenterMap()`. A helpful function for recenter the camera if it becomes uncentered.
+* Added `RouteController.isBatteryMonitoringEnabled` which allows developers control whether battery monitoring is enabled when RouteController is inited. [#1476](https://github.com/mapbox/mapbox-navigation-ios/pull/1476)
 
 ## v0.18.0 (June 5, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master
 
 * Added `NavigationMapView.recenterMap()`. A helpful function for recenter the camera if it becomes uncentered.
-* Added `RouteController.isBatteryMonitoringEnabled` which allows developers control whether battery monitoring is enabled when RouteController is inited. [#1476](https://github.com/mapbox/mapbox-navigation-ios/pull/1476)
+* Added `RouteControllerDelegate.routeControllerWillDisableBatteryMonitoring(_:)` which allows developers control whether battery monitoring is disabled when `RouteController.deinit()` is called.
 
 ## v0.18.0 (June 5, 2018)
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -154,7 +154,7 @@ public protocol RouteControllerDelegate: class {
      Implementing this method will allow developers to change whether battery monitoring is disabled when `RouteController` is deinited.
      
      - parameter routeController: The route controller that will change the state of battery monitoring.
-     - returns: A bool representing the value you would like `UIDevice.isBatteryMonitoringEnabled` set to.
+     - returns: A bool indicating whether to disable battery monitoring when the RouteController is deinited.
      */
     @objc(routeControllerShouldDisableBatteryMonitoring:)
     optional func routeControllerShouldDisableBatteryMonitoring(_ routeController: RouteController) -> Bool

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -203,6 +203,13 @@ open class RouteController: NSObject {
      The flag that indicates that the simulated navigation through tunnel(s) is enabled.
      */
     public var tunnelSimulationEnabled: Bool = true
+    
+    /**
+     By default, `RouteContoller` will enable `UIDevice.isBatteryMonitoringEnabled`.
+     
+     If your app requires custom battery monitor, disable this property.
+     */
+    public var isBatteryMonitoringEnabled = true
 
     var didFindFasterRoute = false
 
@@ -277,9 +284,12 @@ open class RouteController: NSObject {
         self.locationManager = locationManager
         self.locationManager.activityType = route.routeOptions.activityType
         self.eventsManager = eventsManager
-        UIDevice.current.isBatteryMonitoringEnabled = true
 
         super.init()
+        
+        if isBatteryMonitoringEnabled {
+            UIDevice.current.isBatteryMonitoringEnabled = true
+        }
 
         self.locationManager.delegate = self
         resumeNotifications()
@@ -303,7 +313,10 @@ open class RouteController: NSObject {
         sendCancelEvent(rating: endOfRouteStarRating, comment: endOfRouteComment)
         sendOutstandingFeedbackEvents(forceAll: true)
         suspendNotifications()
-        UIDevice.current.isBatteryMonitoringEnabled = false
+        
+        if isBatteryMonitoringEnabled {
+            UIDevice.current.isBatteryMonitoringEnabled = false
+        }
     }
 
     func startEvents(accessToken: String?) {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -316,9 +316,12 @@ open class RouteController: NSObject {
         sendOutstandingFeedbackEvents(forceAll: true)
         suspendNotifications()
         
-        if let delegate = delegate?.routeControllerShouldDisableBatteryMonitoring?(self) {
-            UIDevice.current.isBatteryMonitoringEnabled = !delegate
-        } else {
+        guard let shouldDisable = delegate?.routeControllerShouldDisableBatteryMonitoring?(self) else {
+            UIDevice.current.isBatteryMonitoringEnabled = false
+            return
+        }
+        
+        if shouldDisable {
             UIDevice.current.isBatteryMonitoringEnabled = false
         }
     }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -292,9 +292,6 @@ open class RouteController: NSObject {
         self.eventsManager = eventsManager
 
         super.init()
-        
-        let monitorBatteryValue = delegate?.routeController?(self, willChangeBatteryMonitoringState: true) ?? true
-        UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
 
         self.locationManager.delegate = self
         resumeNotifications()
@@ -395,6 +392,9 @@ open class RouteController: NSObject {
         locationManager.delegate = self
         locationManager.startUpdatingLocation()
         locationManager.startUpdatingHeading()
+        
+        let monitorBatteryValue = delegate?.routeController?(self, willChangeBatteryMonitoringState: true) ?? true
+        UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
     }
 
     /**

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -149,16 +149,15 @@ public protocol RouteControllerDelegate: class {
     
     
     /**
-     Called when the route controller will change how battery monitoring is handled.
+     Called when the route controller will disable battery monitoring.
      
-     You can implement this method to override the value that is used for setting `UIDevice.isBatteryMonitoringEnabled`. This method is called when the `RouteController` is initialized and deinitialized.
+     Implementing this method will allow developers to change whether battery monitoring is disabled when `RouteController` is deinited.
      
      - parameter routeController: The route controller that will change the state of battery monitoring.
-     - parameter to: A bool representing the new upcoming value of `UIDevice.isBatteryMonitoringEnabled`.
      - returns: A bool representing the value you would like `UIDevice.isBatteryMonitoringEnabled` set to.
      */
-    @objc(routeController:willChangeBatteryMonitoringStateTo:)
-    optional func routeController(_ routeController: RouteController, willChangeBatteryMonitoringState to: Bool) -> Bool
+    @objc(routeControllerWillDisableBatteryMonitoring:)
+    optional func routeControllerWillDisableBatteryMonitoring(_ routeController: RouteController) -> Bool
 }
 
 /**
@@ -290,6 +289,7 @@ open class RouteController: NSObject {
         self.locationManager = locationManager
         self.locationManager.activityType = route.routeOptions.activityType
         self.eventsManager = eventsManager
+        UIDevice.current.isBatteryMonitoringEnabled = true
 
         super.init()
 
@@ -316,7 +316,7 @@ open class RouteController: NSObject {
         sendOutstandingFeedbackEvents(forceAll: true)
         suspendNotifications()
         
-        let monitorBatteryValue = delegate?.routeController?(self, willChangeBatteryMonitoringState: false) ?? false
+        let monitorBatteryValue = delegate?.routeControllerWillDisableBatteryMonitoring?(self) ?? false
         UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
     }
 
@@ -392,9 +392,6 @@ open class RouteController: NSObject {
         locationManager.delegate = self
         locationManager.startUpdatingLocation()
         locationManager.startUpdatingHeading()
-        
-        let monitorBatteryValue = delegate?.routeController?(self, willChangeBatteryMonitoringState: true) ?? true
-        UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
     }
 
     /**

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -207,7 +207,7 @@ open class RouteController: NSObject {
     /**
      By default, `RouteContoller` will enable `UIDevice.isBatteryMonitoringEnabled`.
      
-     If your app requires custom battery monitor, disable this property.
+     If your app requires custom battery monitoring, disable this property.
      */
     public var isBatteryMonitoringEnabled = true
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -316,8 +316,11 @@ open class RouteController: NSObject {
         sendOutstandingFeedbackEvents(forceAll: true)
         suspendNotifications()
         
-        let monitorBatteryValue = delegate?.routeControllerShouldDisableBatteryMonitoring?(self) ?? false
-        UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
+        if let delegate = delegate?.routeControllerShouldDisableBatteryMonitoring?(self) {
+            UIDevice.current.isBatteryMonitoringEnabled = !delegate
+        } else {
+            UIDevice.current.isBatteryMonitoringEnabled = false
+        }
     }
 
     func startEvents(accessToken: String?) {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -146,6 +146,19 @@ public protocol RouteControllerDelegate: class {
      */
     @objc(routeController:shouldPreventReroutesWhenArrivingAtWaypoint:)
     optional func routeController(_ routeController: RouteController, shouldPreventReroutesWhenArrivingAt waypoint: Waypoint) -> Bool
+    
+    
+    /**
+     Called when the route controller will change how battery monitoring is handled.
+     
+     You can implement this method to override the value that is used for setting `UIDevice.isBatteryMonitoringEnabled`. This method is called when the `RouteController` is initialized and deinitialized.
+     
+     - parameter routeController: The route controller that will change the state of battery monitoring.
+     - parameter to: A bool representing the new upcoming value of `UIDevice.isBatteryMonitoringEnabled`.
+     - returns: A bool representing the value you would like `UIDevice.isBatteryMonitoringEnabled` set to.
+     */
+    @objc(routeController:willChangeBatteryMonitoringStateTo:)
+    optional func routeController(_ routeController: RouteController, willChangeBatteryMonitoringState to: Bool) -> Bool
 }
 
 /**
@@ -203,13 +216,6 @@ open class RouteController: NSObject {
      The flag that indicates that the simulated navigation through tunnel(s) is enabled.
      */
     public var tunnelSimulationEnabled: Bool = true
-    
-    /**
-     By default, `RouteContoller` will enable `UIDevice.isBatteryMonitoringEnabled`.
-     
-     If your app requires custom battery monitoring, disable this property.
-     */
-    public var isBatteryMonitoringEnabled = true
 
     var didFindFasterRoute = false
 
@@ -287,9 +293,8 @@ open class RouteController: NSObject {
 
         super.init()
         
-        if isBatteryMonitoringEnabled {
-            UIDevice.current.isBatteryMonitoringEnabled = true
-        }
+        let monitorBatteryValue = delegate?.routeController?(self, willChangeBatteryMonitoringState: true) ?? true
+        UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
 
         self.locationManager.delegate = self
         resumeNotifications()
@@ -314,9 +319,8 @@ open class RouteController: NSObject {
         sendOutstandingFeedbackEvents(forceAll: true)
         suspendNotifications()
         
-        if isBatteryMonitoringEnabled {
-            UIDevice.current.isBatteryMonitoringEnabled = false
-        }
+        let monitorBatteryValue = delegate?.routeController?(self, willChangeBatteryMonitoringState: false) ?? false
+        UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
     }
 
     func startEvents(accessToken: String?) {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -156,8 +156,8 @@ public protocol RouteControllerDelegate: class {
      - parameter routeController: The route controller that will change the state of battery monitoring.
      - returns: A bool representing the value you would like `UIDevice.isBatteryMonitoringEnabled` set to.
      */
-    @objc(routeControllerWillDisableBatteryMonitoring:)
-    optional func routeControllerWillDisableBatteryMonitoring(_ routeController: RouteController) -> Bool
+    @objc(routeControllerShouldDisableBatteryMonitoring:)
+    optional func routeControllerShouldDisableBatteryMonitoring(_ routeController: RouteController) -> Bool
 }
 
 /**
@@ -316,7 +316,7 @@ open class RouteController: NSObject {
         sendOutstandingFeedbackEvents(forceAll: true)
         suspendNotifications()
         
-        let monitorBatteryValue = delegate?.routeControllerWillDisableBatteryMonitoring?(self) ?? false
+        let monitorBatteryValue = delegate?.routeControllerShouldDisableBatteryMonitoring?(self) ?? false
         UIDevice.current.isBatteryMonitoringEnabled = monitorBatteryValue
     }
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -1396,7 +1396,6 @@
 				358D14601E5E3B7700ADE590 /* Frameworks */,
 				358D14611E5E3B7700ADE590 /* Resources */,
 				354A01C41E66265100D765C2 /* Embed Frameworks */,
-				35E9B0AC1F9E0C2300BF84AB /* Copy Carthage Dependencies */,
 				DA408F661FB3CA3C004D9661 /* Apply Mapbox Access Token */,
 			);
 			buildRules = (
@@ -1766,34 +1765,6 @@
 			);
 			name = "Carthage copy frameworks";
 			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		35E9B0AC1F9E0C2300BF84AB /* Copy Carthage Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Mapbox.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/MapboxDirections.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Polyline.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Turf.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Solar.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/MapboxMobileEvents.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/MapboxSpeech.framework",
-			);
-			name = "Copy Carthage Dependencies";
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Mapbox.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/MapboxDirections.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Polyline.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Turf.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Solar.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/MapboxMobileEvents.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/MapboxSpeech.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Addresses part 1 of https://github.com/mapbox/mapbox-navigation-ios/issues/1474

If an app sets `UIDevice.isBatteryMonitoringEnabled` on their own, we should not reset this property when initing/deiniting. 

This new prop makes it so developers can control whether this `UIDevice.isBatteryMonitoringEnabled` is enabled internally.

/cc @mapbox/navigation-ios @simonseyer 