### PR TITLE
Do not show steps indicator if delegate is not implemented

### DIFF
--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -28,7 +28,11 @@ open class BaseInstructionsBannerView: UIControl {
     weak var _separatorView: UIView!
     weak var separatorView: SeparatorView!
     weak var stepListIndicatorView: StepListIndicatorView!
-    weak var delegate: InstructionsBannerViewDelegate?
+    weak var delegate: InstructionsBannerViewDelegate? {
+        didSet {
+            stepListIndicatorView.isHidden = false
+        }
+    }
     
     var centerYConstraints = [NSLayoutConstraint]()
     var baselineConstraints = [NSLayoutConstraint]()
@@ -62,6 +66,7 @@ open class BaseInstructionsBannerView: UIControl {
         setupLayout()
         centerYAlignInstructions()
         setupAvailableBounds()
+        stepListIndicatorView.isHidden = true
     }
     
     @objc func draggedInstructionsBanner(_ sender: Any) {
@@ -79,7 +84,6 @@ open class BaseInstructionsBannerView: UIControl {
     }
     
     func set(_ instruction: VisualInstructionBanner?) {
-        stepListIndicatorView.isHidden = delegate == nil
         let secondaryInstruction = instruction?.secondaryInstruction
         primaryLabel.numberOfLines = secondaryInstruction == nil ? 2 : 1
         

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -62,18 +62,21 @@ open class BaseInstructionsBannerView: UIControl {
         setupLayout()
         centerYAlignInstructions()
         setupAvailableBounds()
+        stepListIndicatorView.isHidden = delegate != nil
     }
     
     @objc func draggedInstructionsBanner(_ sender: Any) {
-        if let gestureRecognizer = sender as? UIPanGestureRecognizer, gestureRecognizer.state == .ended {
+        if let gestureRecognizer = sender as? UIPanGestureRecognizer, gestureRecognizer.state == .ended, let delegate = delegate {
             stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
-            delegate?.didDragInstructionsBanner?(self)
+            delegate.didDragInstructionsBanner?(self)
         }
     }
     
     @objc func tappedInstructionsBanner(_ sender: Any) {
-        stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
-        delegate?.didTapInstructionsBanner?(self)
+        if let delegate = delegate {
+            stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
+            delegate.didTapInstructionsBanner?(self)
+        }
     }
     
     func set(_ instruction: VisualInstructionBanner?) {

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -62,7 +62,6 @@ open class BaseInstructionsBannerView: UIControl {
         setupLayout()
         centerYAlignInstructions()
         setupAvailableBounds()
-        stepListIndicatorView.isHidden = delegate != nil
     }
     
     @objc func draggedInstructionsBanner(_ sender: Any) {
@@ -80,6 +79,7 @@ open class BaseInstructionsBannerView: UIControl {
     }
     
     func set(_ instruction: VisualInstructionBanner?) {
+        stepListIndicatorView.isHidden = delegate == nil
         let secondaryInstruction = instruction?.secondaryInstruction
         primaryLabel.numberOfLines = secondaryInstruction == nil ? 2 : 1
         


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1473

If the developer has not implemented the ability to show the steps list view, we should not show the steps list indicator.

/cc @mapbox/navigation-ios 