### PR TITLE
Fix Xcode 10 build error

### DIFF
--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxNavigation/*", "MapboxCoreNavigation/{Date,Sequence,String}.swift"]
+  s.source_files = ["MapboxNavigation", "MapboxCoreNavigation/{Date,Sequence,String}.swift"]
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxNavigation", "MapboxCoreNavigation/{Date,Sequence,String}.swift"]
+  s.source_files = ["MapboxNavigation/**/*.{h,m,swift}", "MapboxCoreNavigation/{Date,Sequence,String}.swift"]
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
Without this change, Xcode 10 fails with the error:

```

Showing Recent Messages
:-1: Multiple commands produce '/Users/bobby/Library/Developer/Xcode/DerivedData/Voyage-bxmobzxqvtumspcofllpykcoymjs/Build/Products/Debug-iphonesimulator/MapboxNavigation/MapboxNavigation.framework/Info.plist':
1) Target 'MapboxNavigation' has copy command from '/Users/bobby/Documents/mapbox/mapbox-navigation-ios/MapboxNavigation/Info.plist' to '/Users/bobby/Library/Developer/Xcode/DerivedData/Voyage-bxmobzxqvtumspcofllpykcoymjs/Build/Products/Debug-iphonesimulator/MapboxNavigation/MapboxNavigation.framework/Info.plist'
2) Target 'MapboxNavigation' has process command with input '/Users/bobby/Documents/mapbox/voyage-ios/Pods/Target Support Files/MapboxNavigation/Info.plist'
```

Cocoapods seems to be including erroneous files like this Plist file. To get around this, we need to explicitly outline the source files.

/cc @mapbox/navigation-ios 