### PR TITLE
Use tunnel manager delegate for changing styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 
 * Added `NavigationMapView.recenterMap()`. A helpful function for recenter the camera if it becomes uncentered.
+* Moved `RouteController.tunnelSimulationEnabled` to `RouteController.tunnelIntersectionManager.tunnelSimulationEnabled`. [#1489](https://github.com/mapbox/mapbox-navigation-ios/pull/1489/)
+* Deprecated `NavigationViewController.usesNightStyleInsideTunnels`. Style switching in now enabled as long as `RouteController.tunnelIntersectionManager.tunnelSimulationEnabled` is true.
 
 ## v0.18.0 (June 5, 2018)
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -198,11 +198,6 @@ open class RouteController: NSObject {
      Will only be enabled if `tunnelSimulationEnabled` is true.
      */
     public var tunnelIntersectionManager: TunnelIntersectionManager = TunnelIntersectionManager()
-    
-    /**
-     The flag that indicates that the simulated navigation through tunnel(s) is enabled.
-     */
-    public var tunnelSimulationEnabled: Bool = true
 
     var didFindFasterRoute = false
 
@@ -581,9 +576,7 @@ extension RouteController: CLLocationManagerDelegate {
                 self.rawLocation = lastLocation
                 
                 // Check for a tunnel intersection at the current step we found the bad location update.
-                if tunnelSimulationEnabled {
-                    tunnelIntersectionManager.checkForTunnelIntersection(at: lastLocation, routeProgress: routeProgress)
-                }
+                tunnelIntersectionManager.checkForTunnelIntersection(at: lastLocation, routeProgress: routeProgress)
                 
                 return
             }
@@ -622,10 +615,9 @@ extension RouteController: CLLocationManagerDelegate {
                 RouteControllerNotificationUserInfoKey.locationKey: self.location!, //guaranteed value
                 RouteControllerNotificationUserInfoKey.rawLocationKey: location //raw
                 ])
+            
             // Check for a tunnel intersection whenever the current route step progresses.
-            if tunnelSimulationEnabled {
-                tunnelIntersectionManager.checkForTunnelIntersection(at: location, routeProgress: routeProgress)
-            }
+            tunnelIntersectionManager.checkForTunnelIntersection(at: location, routeProgress: routeProgress)
         }
 
         updateDistanceToIntersection(from: location)

--- a/MapboxCoreNavigation/TunnelIntersectionManager.swift
+++ b/MapboxCoreNavigation/TunnelIntersectionManager.swift
@@ -8,18 +8,18 @@ import CoreLocation
 public protocol TunnelIntersectionManagerDelegate: class {
     
     /**
-     Called immediately when the location manager detects a tunnel on a route.
+     Called immediately when the location manager detects a user will enter a tunnel.
      
-     - parameter manager: The location manager that currently sends the location updates.
+     - parameter manager: The `TunnelIntersectionManager` that currently sends the location updates.
      - parameter location: The user’s current location where the tunnel was detected.
      */
     @objc(tunnelIntersectionManager:willEnableAnimationAtLocation:)
     optional func tunnelIntersectionManager(_ manager: TunnelIntersectionManager, willEnableAnimationAt location: CLLocation)
     
     /**
-     Called immediately when the location manager detects the user's current location is no longer within a tunnel.
+     Called immediately when the location manager detects the user will exit a tunnel.
      
-     - parameter manager: The location manager that currently sends the location updates.
+     - parameter manager: The `TunnelIntersectionManager` that currently sends the location updates.
      - parameter location: The user’s current location where the tunnel was detected.
      */
     @objc(tunnelIntersectionManager:willDisableAnimationAtLocation:)

--- a/MapboxCoreNavigation/TunnelIntersectionManager.swift
+++ b/MapboxCoreNavigation/TunnelIntersectionManager.swift
@@ -68,7 +68,10 @@ open class TunnelIntersectionManager: NSObject {
         guard let currentIntersection = routeProgress.currentLegProgress.currentStepProgress.currentIntersection else {
             return false
         }
-        
+       
+        // `currentIntersection` is basically the intersection that you have last passed through.
+        // While the upcoming intersection is the one you will be approaching next.
+        // The user is essentially always between the current and upcoming intersection.
         if let classes = currentIntersection.outletRoadClasses, classes.contains(.tunnel) {
             return true
         }

--- a/MapboxCoreNavigation/TunnelIntersectionManager.swift
+++ b/MapboxCoreNavigation/TunnelIntersectionManager.swift
@@ -47,9 +47,16 @@ open class TunnelIntersectionManager: NSObject {
     /**
      The flag that indicates whether simulated location manager is initialized.
      */
-    @objc public var isAnimationEnabled: Bool = false
+    @objc private var isAnimationEnabled: Bool = false
+    
+    /**
+     Flag indicating whether the user is animated through tunnels.
+     */
+    @objc public var tunnelSimulationEnabled: Bool = true
     
     func checkForTunnelIntersection(at location: CLLocation, routeProgress: RouteProgress) {
+        guard tunnelSimulationEnabled else { return }
+        
         let tunnelDetected = userWithinTunnelEntranceRadius(at: location, routeProgress: routeProgress)
         
         if tunnelDetected {

--- a/MapboxCoreNavigation/TunnelIntersectionManager.swift
+++ b/MapboxCoreNavigation/TunnelIntersectionManager.swift
@@ -47,7 +47,7 @@ open class TunnelIntersectionManager: NSObject {
     /**
      The flag that indicates whether simulated location manager is initialized.
      */
-    @objc private var isAnimationEnabled: Bool = false
+    @objc var isAnimationEnabled: Bool = false
     
     /**
      Flag indicating whether the user is animated through tunnels.

--- a/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
+++ b/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
@@ -23,7 +23,6 @@ class TunnelIntersectionManagerTests: XCTestCase {
         let navigation = RouteController(along: tunnelRoute, directions: directions)
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         let tunnelIntersectionManager = TunnelIntersectionManager()
-        navigation.tunnelSimulationEnabled = true
         
         return (tunnelIntersectionManager: tunnelIntersectionManager,
                           routeController: navigation,

--- a/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
+++ b/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
@@ -44,7 +44,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
         let tunnelIntersectionManager = routeController.tunnelIntersectionManager
         
         // Set tunnel intersection manager's delegate
-        tunnelIntersectionManager?.delegate = routeController
+        tunnelIntersectionManager.delegate = routeController
         
         // Advance to step with a tunnel intersection
         routeController.advanceStepIndex(to: 1)
@@ -66,7 +66,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
         
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [tunnelEntranceLocation])
         
-        var userIsAtTunnelEntranceRadius = tunnelIntersectionManager?.userWithinTunnelEntranceRadius(at: currentLocation, routeProgress: routeController.routeProgress) ?? false
+        var userIsAtTunnelEntranceRadius = tunnelIntersectionManager.userWithinTunnelEntranceRadius(at: currentLocation, routeProgress: routeController.routeProgress)
         XCTAssertTrue(userIsAtTunnelEntranceRadius, "Location must be within the tunnel entrance radius")
         
         let outsideTunnelEntranceRadius = intersectionLocation.coordinate(at: 200, facing: intersectionLocation.direction(to: tunnelSetup.firstLocation.coordinate))
@@ -79,7 +79,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
                          intersection: tunnelIntersection,
                              distance: 10)
         
-        userIsAtTunnelEntranceRadius = tunnelIntersectionManager?.userWithinTunnelEntranceRadius(at: currentLocation, routeProgress: routeController.routeProgress) ?? false
+        userIsAtTunnelEntranceRadius = tunnelIntersectionManager.userWithinTunnelEntranceRadius(at: currentLocation, routeProgress: routeController.routeProgress)
         XCTAssertFalse(userIsAtTunnelEntranceRadius, "Location must not be within the tunnel entrance radius")
     }
     
@@ -87,7 +87,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
         let routeController = tunnelSetup.routeController
         
         routeController.tunnelIntersectionManager = tunnelSetup.tunnelIntersectionManager
-        routeController.tunnelIntersectionManager?.delegate = routeController
+        routeController.tunnelIntersectionManager.delegate = routeController
         
         // Step with a tunnel intersection
         routeController.advanceStepIndex(to: 1)
@@ -99,7 +99,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
         let tunnelEntranceLocation = CLLocation(latitude: tunnelIntersection.location.latitude, longitude: tunnelIntersection.location.longitude)
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [tunnelEntranceLocation])
         
-        var didDetectTunnel = routeController.tunnelIntersectionManager?.didDetectTunnel(at: routeController.location!, for: routeController.locationManager, routeProgress: routeController.routeProgress) ?? false
+        var didDetectTunnel = routeController.tunnelIntersectionManager.userWithinTunnelEntranceRadius(at: routeController.location!, routeProgress: routeController.routeProgress)
         
         XCTAssertTrue(didDetectTunnel, "A tunnel should be detected at that location")
         
@@ -109,7 +109,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
         fakeLocation = location(at: tunnelSetup.firstLocation.coordinate, for: routeController, intersection: routeController.routeProgress.currentLegProgress.currentStep.intersections![0])
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [fakeLocation])
         
-        didDetectTunnel = routeController.tunnelIntersectionManager?.didDetectTunnel(at: routeController.location!, for: routeController.locationManager, routeProgress: routeController.routeProgress) ?? false
+        didDetectTunnel = routeController.tunnelIntersectionManager.userWithinTunnelEntranceRadius(at: routeController.location!, routeProgress: routeController.routeProgress)
         
         XCTAssertFalse(didDetectTunnel, "A tunnel should not exist at that location")
     }
@@ -118,7 +118,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
         let routeController = tunnelSetup.routeController
         
         routeController.tunnelIntersectionManager = tunnelSetup.tunnelIntersectionManager
-        routeController.tunnelIntersectionManager?.delegate = routeController
+        routeController.tunnelIntersectionManager.delegate = routeController
         
         // Step with a tunnel intersection
         routeController.advanceStepIndex(to: 1)
@@ -140,15 +140,15 @@ class TunnelIntersectionManagerTests: XCTestCase {
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [tunnelLocation])
         
         // Enable the tunnel animation, which should enable the simulated location manager
-        routeController.tunnelIntersectionManager?.delegate?.tunnelIntersectionManager?(routeController.locationManager, willEnableAnimationAt: routeController.location!)
-        XCTAssertTrue(routeController.tunnelIntersectionManager?.isAnimationEnabled ?? false, "Animation through tunnel should be enabled.")
+        routeController.tunnelIntersectionManager.delegate?.tunnelIntersectionManager?(routeController.tunnelIntersectionManager, willEnableAnimationAt: routeController.location!)
+        XCTAssertTrue(routeController.tunnelIntersectionManager.isAnimationEnabled, "Animation through tunnel should be enabled.")
     }
     
     func testTunnelSimulatedNavigationDisabled() {
         let routeController = tunnelSetup.routeController
         
         routeController.tunnelIntersectionManager = tunnelSetup.tunnelIntersectionManager
-        routeController.tunnelIntersectionManager?.delegate = routeController
+        routeController.tunnelIntersectionManager.delegate = routeController
         
         // Step after a tunnel intersection
         routeController.advanceStepIndex(to: 2)
@@ -166,20 +166,19 @@ class TunnelIntersectionManagerTests: XCTestCase {
         
         // Disable the tunnel animation, which should disable the simulated location manager
         // Assuming the tunnel animation was previously enabled
-        routeController.tunnelIntersectionManager?.isAnimationEnabled = true
+        routeController.tunnelIntersectionManager.isAnimationEnabled = true
         
         let tunnelExitLocation = location(at: routeController.location!.coordinate, horizontalAccuracy: 20)
 
-        XCTAssertEqual(routeController.tunnelIntersectionManager?.delegate as? NSObject, routeController)
-        routeController.tunnelIntersectionManager(routeController.locationManager, willDisableAnimationAt: tunnelExitLocation)
+        XCTAssertEqual(routeController.tunnelIntersectionManager.delegate as? NSObject, routeController)
+        routeController.tunnelIntersectionManager(routeController.tunnelIntersectionManager, willDisableAnimationAt: tunnelExitLocation)
         XCTAssertNotNil(routeController.tunnelIntersectionManager)
-        if let tunnelIntersectionManager = routeController.tunnelIntersectionManager {
-            XCTAssertTrue(tunnelIntersectionManager.isAnimationEnabled, "Animation through tunnel should remain enabled after 1 location update.")
-            routeController.tunnelIntersectionManager(routeController.locationManager, willDisableAnimationAt: tunnelExitLocation)
-            XCTAssertTrue(tunnelIntersectionManager.isAnimationEnabled, "Animation through tunnel should remain enabled after 2 location updates.")
-            routeController.tunnelIntersectionManager(routeController.locationManager, willDisableAnimationAt: tunnelExitLocation)
-            XCTAssertFalse(tunnelIntersectionManager.isAnimationEnabled, "Animation through tunnel should be disabled after 3 location updates.")
-        }
+        let tunnelIntersectionManager = routeController.tunnelIntersectionManager
+        XCTAssertTrue(tunnelIntersectionManager.isAnimationEnabled, "Animation through tunnel should remain enabled after 1 location update.")
+        routeController.tunnelIntersectionManager(routeController.tunnelIntersectionManager, willDisableAnimationAt: tunnelExitLocation)
+        XCTAssertTrue(tunnelIntersectionManager.isAnimationEnabled, "Animation through tunnel should remain enabled after 2 location updates.")
+        routeController.tunnelIntersectionManager(routeController.tunnelIntersectionManager, willDisableAnimationAt: tunnelExitLocation)
+        XCTAssertFalse(tunnelIntersectionManager.isAnimationEnabled, "Animation through tunnel should be disabled after 3 location updates.")
     }
     
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -349,6 +349,7 @@ open class NavigationViewController: UIViewController {
         self.routeController = RouteController(along: route, directions: directions, locationManager: locationManager ?? NavigationLocationManager())
         self.routeController.usesDefaultUserInterface = true
         self.routeController.delegate = self
+        self.routeController.tunnelIntersectionManager?.delegate = self
         
         self.directions = directions
         self.route = route
@@ -427,14 +428,6 @@ open class NavigationViewController: UIViewController {
         let secondsRemaining = routeProgress.currentLegProgress.currentStepProgress.durationRemaining
 
         mapViewController?.notifyDidChange(routeProgress: routeProgress, location: location, secondsRemaining: secondsRemaining)
-        
-        if usesNightStyleInsideTunnels, let tunnelIntersectionManager = routeController.tunnelIntersectionManager {
-            if tunnelIntersectionManager.isAnimationEnabled {
-                styleManager.applyStyle(type: .night)
-            } else  {
-                styleManager.timeOfDayChanged()
-            }
-        }
     }
     
     @objc func didPassInstructionPoint(notification: NSNotification) {
@@ -602,6 +595,18 @@ extension NavigationViewController: RouteControllerDelegate {
             self.mapViewController?.showEndOfRoute { _ in }
         }
         return advancesToNextLeg
+    }
+}
+
+extension NavigationViewController: TunnelIntersectionManagerDelegate {
+    public func tunnelIntersectionManager(_ manager: CLLocationManager, willEnableAnimationAt location: CLLocation) {
+        guard usesNightStyleInsideTunnels else { return }
+        styleManager.applyStyle(type: .night)
+    }
+    
+    public func tunnelIntersectionManager(_ manager: CLLocationManager, willDisableAnimationAt location: CLLocation) {
+        guard usesNightStyleInsideTunnels else { return }
+        styleManager.timeOfDayChanged()
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -322,11 +322,6 @@ open class NavigationViewController: UIViewController {
      */
     @objc public var annotatesSpokenInstructions = false
     
-    /**
-     A Boolean value that indicates whether the dark style should apply when a route controller enters a tunnel.
-     */
-    @objc public var usesNightStyleInsideTunnels: Bool = true
-    
     var styleManager: StyleManager!
     
     required public init?(coder aDecoder: NSCoder) {
@@ -600,13 +595,11 @@ extension NavigationViewController: RouteControllerDelegate {
 
 extension NavigationViewController: TunnelIntersectionManagerDelegate {
     public func tunnelIntersectionManager(_ manager: TunnelIntersectionManager, willEnableAnimationAt location: CLLocation) {
-        guard usesNightStyleInsideTunnels else { return }
         routeController.tunnelIntersectionManager(manager, willEnableAnimationAt: location)
         styleManager.applyStyle(type: .night)
     }
     
     public func tunnelIntersectionManager(_ manager: TunnelIntersectionManager, willDisableAnimationAt location: CLLocation) {
-        guard usesNightStyleInsideTunnels else { return }
         routeController.tunnelIntersectionManager(manager, willDisableAnimationAt: location)
         styleManager.timeOfDayChanged()
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -349,7 +349,7 @@ open class NavigationViewController: UIViewController {
         self.routeController = RouteController(along: route, directions: directions, locationManager: locationManager ?? NavigationLocationManager())
         self.routeController.usesDefaultUserInterface = true
         self.routeController.delegate = self
-        self.routeController.tunnelIntersectionManager?.delegate = self
+        self.routeController.tunnelIntersectionManager.delegate = self
         
         self.directions = directions
         self.route = route
@@ -599,13 +599,15 @@ extension NavigationViewController: RouteControllerDelegate {
 }
 
 extension NavigationViewController: TunnelIntersectionManagerDelegate {
-    public func tunnelIntersectionManager(_ manager: CLLocationManager, willEnableAnimationAt location: CLLocation) {
+    public func tunnelIntersectionManager(_ manager: TunnelIntersectionManager, willEnableAnimationAt location: CLLocation) {
         guard usesNightStyleInsideTunnels else { return }
+        routeController.tunnelIntersectionManager(manager, willEnableAnimationAt: location)
         styleManager.applyStyle(type: .night)
     }
     
-    public func tunnelIntersectionManager(_ manager: CLLocationManager, willDisableAnimationAt location: CLLocation) {
+    public func tunnelIntersectionManager(_ manager: TunnelIntersectionManager, willDisableAnimationAt location: CLLocation) {
         guard usesNightStyleInsideTunnels else { return }
+        routeController.tunnelIntersectionManager(manager, willDisableAnimationAt: location)
         styleManager.timeOfDayChanged()
     }
 }

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -88,8 +88,6 @@ class NavigationViewControllerTests: XCTestCase {
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithOneStyle() {
         let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle()])
-        navigationViewController.usesNightStyleInsideTunnels = true
-        navigationViewController.routeController.tunnelSimulationEnabled = true
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -106,8 +104,6 @@ class NavigationViewControllerTests: XCTestCase {
     // If tunnel flags are enabled and we need to switch styles, we should not force refresh the map style because we have only 1 style.
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceWhenOnlyOneStyle() {
         let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()])
-        navigationViewController.usesNightStyleInsideTunnels = true
-        navigationViewController.routeController.tunnelSimulationEnabled = true
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -123,8 +119,6 @@ class NavigationViewControllerTests: XCTestCase {
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithTwoStyles() {
         let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()])
-        navigationViewController.usesNightStyleInsideTunnels = true
-        navigationViewController.routeController.tunnelSimulationEnabled = true
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         


### PR DESCRIPTION
As pointed out in https://github.com/mapbox/mapbox-navigation-ios/issues/1486, calling `styleManager.timeOfDayChanged()` is expensive because we have to re-init `Solar` on every call to check. 

Now with this change, we're only changing the style from/to day/night when the tunnel manager tells us we have entered/exited a tunnel.

/cc @mapbox/navigation-ios 