### PR TITLE
Only update banner if something has changed.

### DIFF
--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -78,6 +78,9 @@ open class BaseInstructionsBannerView: UIControl {
     
     func set(_ instruction: VisualInstructionBanner?) {
         let secondaryInstruction = instruction?.secondaryInstruction
+        
+        guard instruction?.primaryInstruction != primaryLabel.instruction, secondaryLabel.instruction != secondaryInstruction, maneuverView.visualInstruction != instruction else { return }
+        
         primaryLabel.numberOfLines = secondaryInstruction == nil ? 2 : 1
         
         if secondaryInstruction == nil {
@@ -86,9 +89,7 @@ open class BaseInstructionsBannerView: UIControl {
             baselineAlignInstructions()
         }
         
-        if instruction?.primaryInstruction != primaryLabel.instruction {
-            primaryLabel.instruction = instruction?.primaryInstruction
-        }
+        primaryLabel.instruction = instruction?.primaryInstruction
         secondaryLabel.instruction = secondaryInstruction
         maneuverView.visualInstruction = instruction
     }

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -86,7 +86,9 @@ open class BaseInstructionsBannerView: UIControl {
             baselineAlignInstructions()
         }
         
-        primaryLabel.instruction = instruction?.primaryInstruction
+        if instruction?.primaryInstruction != primaryLabel.instruction {
+            primaryLabel.instruction = instruction?.primaryInstruction
+        }
         secondaryLabel.instruction = secondaryInstruction
         maneuverView.visualInstruction = instruction
     }


### PR DESCRIPTION
Setting `primaryLabel.instruction` has a relatively expensive didset:

https://github.com/mapbox/mapbox-navigation-ios/blob/36be30079c2c1cba0301e8a17f027c82075b56f3/MapboxNavigation/InstructionLabel.swift#L16-L34

This PR change the set function on InstructionBannerView to only update the text if something has changed.

I'm open to changing this to inspect to see if the individual pieces have changed instead, something like 

```swift
if primaryLabel.instruction != instruction?.primaryInstruction {
  primaryLabel.instruction = instruction?.primaryInstruction
}
```

This would occur for each component. 

/cc @mapbox/navigation-ios 