### PR TITLE
Fix UserCourseView sliding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Deprecated `NavigationViewController.usesNightStyleInsideTunnels`. Style switching is enabled as a side effect of `TunnelIntersectionManager.tunnelSimulationEnabled`, which is set to `true` by default. ([#1489](https://github.com/mapbox/mapbox-navigation-ios/pull/1489))
 * Added `RouteControllerDelegate.routeControllerWillDisableBatteryMonitoring(_:)` which allows developers control whether battery monitoring is disabled when `RouteController.deinit()` is called.
 * Fixed an issue where setting `NavigationLocationManager.desiredAccuracy` had no effect. [#1481](https://github.com/mapbox/mapbox-navigation-ios/pull/1481)
-* Fixed an issue where the user puck slid around after the user pressed the Overview button. [#1506](https://github.com/mapbox/mapbox-navigation-ios/pull/1506)
+* Fixed an issue where the user location view slid around after the user pressed the Overview button. [#1506](https://github.com/mapbox/mapbox-navigation-ios/pull/1506)
 
 ## v0.18.0 (June 5, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Deprecated `NavigationViewController.usesNightStyleInsideTunnels`. Style switching is enabled as a side effect of `TunnelIntersectionManager.tunnelSimulationEnabled`, which is set to `true` by default. ([#1489](https://github.com/mapbox/mapbox-navigation-ios/pull/1489))
 * Added `RouteControllerDelegate.routeControllerWillDisableBatteryMonitoring(_:)` which allows developers control whether battery monitoring is disabled when `RouteController.deinit()` is called.
 * Fixed an issue where setting `NavigationLocationManager.desiredAccuracy` had no effect. [#1481](https://github.com/mapbox/mapbox-navigation-ios/pull/1481)
+* Fixed an issue where the user puck slid around after the user pressed the Overview button. [#1506](https://github.com/mapbox/mapbox-navigation-ios/pull/1506)
 
 ## v0.18.0 (June 5, 2018)
 

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1047,8 +1047,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         camera.pitch = 0
         self.camera = camera
         
-        let camerForLine = cameraThatFitsShape(line, direction: 0, edgePadding: bounds)
-        setCamera(camerForLine, animated: true)
+        let cameraForLine = cameraThatFitsShape(line, direction: 0, edgePadding: bounds)
+        setCamera(cameraForLine, animated: true)
     }
     
     /**

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -343,7 +343,9 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear) : nil
             setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: padding, completionHandler: nil)
         } else {
-            self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)
+            UIView.animate(withDuration: 0, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
+                self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)
+            })
         }
         
         if let userCourseView = userCourseView as? UserCourseView {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -330,7 +330,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     }
     
     @objc public func updateCourseTracking(location: CLLocation?, animated: Bool) {
-        let duration: TimeInterval = animated ? 1 : 0
+        // While animating to overhead mode, don't animate the puck.
+        let duration: TimeInterval = animated && !isAnimatingToOverheadMode ? 1 : 0
         animatesUserLocation = animated
         userLocationForCourseTracking = location
         guard let location = location, CLLocationCoordinate2DIsValid(location.coordinate) else {
@@ -344,8 +345,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear) : nil
             setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: padding, completionHandler: nil)
         } else {
-            // While animating to overhead mode, don't animate the puck.
-            UIView.animate(withDuration: isAnimatingToOverheadMode ? 0 : duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
+            UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear, .beginFromCurrentState], animations: {
                 self.userCourseView?.center = self.convert(location.coordinate, toPointTo: self)
             })
         }
@@ -1040,8 +1040,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             camera.heading = 0
             camera.centerCoordinate = userLocation
             camera.altitude = NavigationMapView.defaultAltitude
-            setCamera(camera, withDuration: 1, animationTimingFunction: nil) {
-                self.isAnimatingToOverheadMode = false
+            setCamera(camera, withDuration: 1, animationTimingFunction: nil) { [weak self] in
+                self?.isAnimatingToOverheadMode = false
             }
             return
         }
@@ -1053,8 +1053,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         self.camera = camera
         
         let cameraForLine = cameraThatFitsShape(line, direction: 0, edgePadding: bounds)
-        setCamera(cameraForLine, withDuration: 1, animationTimingFunction: nil) {
-            self.isAnimatingToOverheadMode = false
+        setCamera(cameraForLine, withDuration: 1, animationTimingFunction: nil) { [weak self] in
+            self?.isAnimatingToOverheadMode = false
         }
     }
     


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1505

Fixes and adds a few optimizations around going into overhead mode. The sliding issue mainly is due to the fact we were animating to the position of the puck which is not necessary when going into overhead mode.

/cc @1ec5 @frederoni 