### PR TITLE
Exit View Sizing Fix

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -874,12 +874,12 @@ extension RouteMapViewController: StepsViewControllerDelegate {
         let instructionsView = StepInstructionsView(frame: navigationView.instructionsBannerView.frame)
         instructionsView.backgroundColor = StepInstructionsView.appearance().backgroundColor
         instructionsView.delegate = self
-        instructionsView.set(instructions)
         instructionsView.distance = distance
         
         navigationView.instructionsBannerContentView.backgroundColor = instructionsView.backgroundColor
         
         view.addSubview(instructionsView)
+        instructionsView.set(instructions)
         previewInstructionsView = instructionsView
     }
     


### PR DESCRIPTION
Fixes #1467. Problem was in the `RouteMapViewController` where setting `InstructionsView` instructions before adding the view to the hierarchy could cause issues with the appearance engine in some cases.

/cc @mapbox/navigation-ios