### PR TITLE
Fixes a couple warnings in a forward-compatible way

### DIFF
--- a/MapboxCoreNavigation/MMEEventsManager.swift
+++ b/MapboxCoreNavigation/MMEEventsManager.swift
@@ -195,7 +195,7 @@ struct EventDetails {
 }
 
 extension MMEEventsManager {
-    open static var unrated: Int { return -1 }
+    public static var unrated: Int { return -1 }
     
     func addDefaultEvents(routeController: RouteController) -> [String: Any] {
         return EventDetails(routeController: routeController, session: routeController.sessionState).eventDictionary

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -179,7 +179,7 @@ class InstructionPresenter {
     }
 
     private func attributes(for dataSource: InstructionPresenterDataSource) -> [NSAttributedStringKey: Any] {
-        return [.font: dataSource.font, .foregroundColor: dataSource.textColor]
+        return [.font: dataSource.font as Any, .foregroundColor: dataSource.textColor as Any]
     }
 
     private func attributedString(withFont font: UIFont, shieldImage: UIImage) -> NSAttributedString {


### PR DESCRIPTION
Smoothing the transition to Xcode 10; these changes are safe to merge