### PR TITLE
Allow locationFor(styleManager:) to optionally return location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* `StyleManager.locationFor(styleManager:)` now allows for an optional CLLocation to be returned. [#1523](https://github.com/mapbox/mapbox-navigation-ios/pull/1523)
+
 ## v0.18.1 (June 19, 2018)
 
 ### Packaging

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -608,16 +608,8 @@ extension NavigationViewController: TunnelIntersectionManagerDelegate {
 
 extension NavigationViewController: StyleManagerDelegate {
     
-    public func locationFor(styleManager: StyleManager) -> CLLocation {
-        guard let location = routeController.location else {
-            if let coordinate = routeController.routeProgress.route.coordinates?.first {
-                return CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
-            } else {
-                return CLLocation()
-            }
-        }
-        
-        return location
+    public func locationFor(styleManager: StyleManager) -> CLLocation? {
+        return routeController.location
     }
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -609,7 +609,13 @@ extension NavigationViewController: TunnelIntersectionManagerDelegate {
 extension NavigationViewController: StyleManagerDelegate {
     
     public func locationFor(styleManager: StyleManager) -> CLLocation? {
-        return routeController.location
+        if let location = routeController.location {
+            return location
+        } else if let firstCoord = routeController.routeProgress.route.coordinates?.first {
+            return CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
+        } else {
+            return nil
+        }
     }
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -9,7 +9,7 @@ public protocol StyleManagerDelegate: NSObjectProtocol {
     /**
      Asks the delegate for a location to use when calculating sunset and sunrise.
      */
-    @objc func locationFor(styleManager: StyleManager) -> CLLocation
+    @objc func locationFor(styleManager: StyleManager) -> CLLocation?
     
     /**
      Informs the delegate that a style was applied.

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -210,7 +210,7 @@ class NavigationViewControllerTests: XCTestCase {
 }
 
 extension NavigationViewControllerTests: NavigationViewControllerDelegate, StyleManagerDelegate {
-    func locationFor(styleManager: StyleManager) -> CLLocation {
+    func locationFor(styleManager: StyleManager) -> CLLocation? {
         return dependencies.poi.first!
     }
     

--- a/MapboxNavigationTests/StyleManagerTests.swift
+++ b/MapboxNavigationTests/StyleManagerTests.swift
@@ -79,7 +79,7 @@ extension StyleManagerTests: StyleManagerDelegate {
     func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) { }
     func styleManager(_ styleManager: StyleManager, didApply style: Style) { }
     
-    func locationFor(styleManager: StyleManager) -> CLLocation {
+    func locationFor(styleManager: StyleManager) -> CLLocation? {
         return location
     }
 }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1511

This makes `StyleManager.locationFor(styleManager:)` allows developer to optionally return a location. The optionality we do in https://github.com/mapbox/mapbox-navigation-ios/blob/96b2d6e7902c529b475e939288615935c2197c2b/MapboxNavigation/NavigationViewController.swift#L611-L621

doesn't seem to help us much in the case where `routeController.location ` is nil.

/cc @mapbox/navigation-ios 