### PR TITLE
Fix off by one when selecting steps view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixed an issue when selecting a step from the steps list, you could be brought to the wrong step. [#1524](https://github.com/mapbox/mapbox-navigation-ios/pull/1524/)
+
 ## v0.18.1 (June 19, 2018)
 
 ### Packaging

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -845,25 +845,23 @@ extension RouteMapViewController: NavigationViewDelegate {
 
 extension RouteMapViewController: StepsViewControllerDelegate {
     
-    func stepsViewController(_ viewController: StepsViewController, didSelect step: RouteStep, cell: StepTableViewCell) {
+    func stepsViewController(_ viewController: StepsViewController, didSelect legIndex: Int, stepIndex: Int, cell: StepTableViewCell) {
+        
+        let legProgress = RouteLegProgress(leg: routeController.routeProgress.route.legs[legIndex], stepIndex: stepIndex)
+        let step = legProgress.currentStep
+        guard let upcomingStep = legProgress.upComingStep else { return }
         
         viewController.dismiss {
-            guard let stepBefore = self.routeController.routeProgress.currentLegProgress.stepBefore(step) else { return }
-            self.addPreviewInstructions(step: stepBefore, maneuverStep: step, distance: cell.instructionsView.distance)
+            self.addPreviewInstructions(step: step, maneuverStep: upcomingStep, distance: cell.instructionsView.distance)
             self.stepsViewController = nil
         }
         
         mapView.enableFrameByFrameCourseViewTracking(for: 1)
         mapView.tracksUserCourse = false
-        mapView.setCenter(step.maneuverLocation, zoomLevel: mapView.zoomLevel, direction: step.initialHeading!, animated: true, completionHandler: nil)
+        mapView.setCenter(upcomingStep.maneuverLocation, zoomLevel: mapView.zoomLevel, direction: upcomingStep.initialHeading!, animated: true, completionHandler: nil)
         
         guard isViewLoaded && view.window != nil else { return }
-        if let legIndex = routeController.routeProgress.route.legs.index(where: { !$0.steps.filter { $0 == step }.isEmpty }) {
-            let leg = routeController.routeProgress.route.legs[legIndex]
-            if let stepIndex = leg.steps.index(where: { $0 == step }), leg.steps.last != step {
-               mapView.addArrow(route: routeController.routeProgress.route, legIndex: legIndex, stepIndex: stepIndex)
-            }
-        }
+        mapView.addArrow(route: routeController.routeProgress.route, legIndex: legIndex, stepIndex: stepIndex + 1)
     }
     
     func addPreviewInstructions(step: RouteStep, maneuverStep: RouteStep, distance: CLLocationDistance?) {

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -7,7 +7,7 @@ import Turf
 open class StepsBackgroundView: UIView { }
 
 protocol StepsViewControllerDelegate: class {
-    func stepsViewController(_ viewController: StepsViewController, didSelect step: RouteStep, cell: StepTableViewCell)
+    func stepsViewController(_ viewController: StepsViewController, didSelect legIndex: Int, stepIndex: Int, cell: StepTableViewCell)
     func didDismissStepsViewController(_ viewController: StepsViewController)
 }
 
@@ -209,9 +209,17 @@ open class StepsViewController: UIViewController {
 extension StepsViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        let step = sections[indexPath.section][indexPath.row]
         let cell = tableView.cellForRow(at: indexPath) as! StepTableViewCell
-        delegate?.stepsViewController(self, didSelect: step, cell: cell)
+        // Since as we progress, steps are removed from the list, we need to map the row the user tapped to the actual step on the leg.
+        // If the user selects a step on future leg, all steps are going to be there.
+        var stepIndex: Int
+        if indexPath.section > 0 {
+            stepIndex = indexPath.row
+        } else {
+            stepIndex = indexPath.row + routeProgress.currentLegProgress.stepIndex
+            stepIndex += indexPath.row + 1 > sections[indexPath.section].count ? 0 : 1
+        }
+        delegate?.stepsViewController(self, didSelect: indexPath.section, stepIndex: stepIndex, cell: cell)
     }
 }
 

--- a/MapboxNavigation/StepsViewController.swift
+++ b/MapboxNavigation/StepsViewController.swift
@@ -217,6 +217,7 @@ extension StepsViewController: UITableViewDelegate {
             stepIndex = indexPath.row
         } else {
             stepIndex = indexPath.row + routeProgress.currentLegProgress.stepIndex
+            // For the current leg, we need to know the upcoming step.
             stepIndex += indexPath.row + 1 > sections[indexPath.section].count ? 0 : 1
         }
         delegate?.stepsViewController(self, didSelect: indexPath.section, stepIndex: stepIndex, cell: cell)


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1497

There were a handful of issues here:

* We were using the currentLegProgress. This means you can only look at steps on the current leg.
* `sections` is continually being groomed and only includes the remaining steps. We need to make sure the selected index maps correctly to the correct step.

/cc @frederoni @JThramer 