### PR TITLE
Pin podspec to pre-release

### DIFF
--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative"
+  s.dependency "MapboxNavigationNative", "~> 0.0.1-pr236-SNAPSHOT"
   s.dependency "MapboxDirections.swift", "~> 0.21.0"
   s.dependency "MapboxMobileEvents", "~> 0.4"
   s.dependency "Turf", "~> 0.1"

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile
@@ -1,5 +1,12 @@
 platform :ios, '9.0'
+
+inhibit_all_warnings!
 use_frameworks!
+
+pre_install do |installer|
+# workaround for #3289
+Pod::Installer::Xcode::TargetValidator.send(:define_method, :verify_no_static_framework_transitive_dependencies) {}
+end
 
 target 'PodInstall' do
   # The branch of MapboxNavigation and MapboxNavigation will be replaced by Bitrise to use the current branch.
@@ -8,7 +15,3 @@ target 'PodInstall' do
   pod 'MapboxNavigationNative', '0.0.1-pr236-SNAPSHOT'
 end
 
-pre_install do |installer|
-    # workaround for https://github.com/CocoaPods/CocoaPods/issues/3289
-    def installer.verify_no_static_framework_transitive_dependencies; end
-end


### PR DESCRIPTION
Pin to the pre-release to satisfy the CocoaPods integration test

_note that this PR is targeting the `navigation-native` branch_