### PR TITLE
Remove need for developers to implement NavigationMapView.updateCourseTracking(location:animated:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* `NavigationMapView.updateCourseTracking(location:animated:)` is no longer public and it is no longer necessary to call if you have created a custom navigation experience. `NavigationMapView` will now automatically update the user puck as locations become available. [#1542](https://github.com/mapbox/mapbox-navigation-ios/pull/1542)
 * Fixed an issue when selecting a step from the steps list, you could be brought to the wrong step. [#1524](https://github.com/mapbox/mapbox-navigation-ios/pull/1524/)
 * `StyleManager.locationFor(styleManager:)` now allows for an optional CLLocation to be returned. [#1523](https://github.com/mapbox/mapbox-navigation-ios/pull/1523)
 * NavigationViewController now uses the recommended way `.preferredStatusBarStyle` to set the style of the status bar. [#1535](https://github.com/mapbox/mapbox-navigation-ios/pull/1535)

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -69,7 +69,6 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
     // Notifications sent on all location updates
     @objc func progressDidChange(_ notification: NSNotification) {
         let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
-        let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
         
         // Add maneuver arrow
         if routeProgress.currentLegProgress.followOnStep != nil {
@@ -81,9 +80,6 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         // Update the top banner with progress updates
         instructionsBannerView.update(for: routeProgress.currentLegProgress)
         instructionsBannerView.isHidden = false
-        
-        // Update the user puck
-        mapView.updateCourseTracking(location: location, animated: true)
     }
 
     // Fired when the user is no longer on the route.

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -31,6 +31,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         
         mapView.delegate = self
         mapView.compassView.isHidden = true
+        mapView.routeController = routeController
 
         // Add listeners for progress updates
         resumeNotifications()

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -287,8 +287,8 @@ open class RouteController: NSObject {
         UIDevice.current.isBatteryMonitoringEnabled = true
 
         super.init()
+        self.locationManager.delegate = self
 
-        self.resume()
         resumeNotifications()
         resetSession()
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -288,7 +288,7 @@ open class RouteController: NSObject {
 
         super.init()
 
-        self.locationManager.delegate = self
+        self.resume()
         resumeNotifications()
         resetSession()
 
@@ -569,6 +569,10 @@ extension RouteController: CLLocationManagerDelegate {
 
     @objc public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
         heading = newHeading
+    }
+    
+    @objc public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        locationManager.delegate?.locationManager?(manager, didFailWithError: error)
     }
 
     @objc public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -284,9 +284,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     }
     
     @objc func progressDidChange(_ notification: Notification) {
-        guard tracksUserCourse else { return }
+        guard !isAnimatingToOverheadMode else { return }
         
         let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
+        let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
         
         let stepProgress = routeProgress.currentLegProgress.currentStepProgress
         let expectedTravelTime = stepProgress.step.expectedTravelTime
@@ -306,6 +307,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         } else {
             preferredFramesPerSecond = FrameIntervalOptions.pluggedInFramesPerSecond
         }
+        
+        updateCourseTracking(location: location, animated: true)
     }
     
     
@@ -329,7 +332,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         tracksUserCourse = false
     }
     
-    @objc public func updateCourseTracking(location: CLLocation?, animated: Bool) {
+    @objc func updateCourseTracking(location: CLLocation?, animated: Bool) {
         // While animating to overhead mode, don't animate the puck.
         let duration: TimeInterval = animated && !isAnimatingToOverheadMode ? 1 : 0
         animatesUserLocation = animated

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -160,12 +160,23 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
                               contentFrame.minY + contentFrame.height * 0.5))
     }
     
+    open var routeController: RouteController? {
+        didSet {
+            resumeNotifications()
+        }
+    }
+    
     /**
      Determines whether the map should follow the user location and rotate when the course changes.
      - seealso: NavigationMapViewCourseTrackingDelegate
      */
     open var tracksUserCourse: Bool = false {
         didSet {
+            guard let _ = routeController, tracksUserCourse == true else {
+                print("NavigationMapView.routeController must non-nil to set tracksUserCourse to true.")
+                tracksUserCourse = false
+                return
+            }
             if tracksUserCourse {
                 enableFrameByFrameCourseViewTracking(for: 3)
                 altitude = NavigationMapView.defaultAltitude
@@ -221,8 +232,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     fileprivate func commonInit() {
         makeGestureRecognizersRespectCourseTracking()
         makeGestureRecognizersUpdateCourseView()
-        
-        resumeNotifications()
     }
     
     deinit {
@@ -271,7 +280,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     // MARK: - Notifications
     
     func resumeNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(progressDidChange(_:)), name: .routeControllerProgressDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(progressDidChange(_:)), name: .routeControllerProgressDidChange, object: routeController!)
         
         let gestures = gestureRecognizers ?? []
         let mapTapGesture = self.mapTapGesture

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -583,10 +583,8 @@ extension NavigationViewController: RouteControllerDelegate {
             let snappedLocation = routeController.location ?? locations.last,
             let rawLocation = locations.last,
             userHasArrivedAndShouldPreventRerouting {
-            mapViewController?.mapView.updateCourseTracking(location: snappedLocation, animated: true)
             mapViewController?.labelCurrentRoad(at: rawLocation, for: snappedLocation)
         } else if let rawlocation = locations.last {
-            mapViewController?.mapView.updateCourseTracking(location: rawlocation, animated: true)
             mapViewController?.labelCurrentRoad(at: rawlocation)
         }
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -353,6 +353,7 @@ open class NavigationViewController: UIViewController {
         self.routeController.usesDefaultUserInterface = true
         self.routeController.delegate = self
         self.routeController.tunnelIntersectionManager.delegate = self
+        self.routeController.resume()
         
         self.directions = directions
         self.route = route
@@ -396,7 +397,6 @@ open class NavigationViewController: UIViewController {
         _ = voiceController
         
         UIApplication.shared.isIdleTimerDisabled = true
-        routeController.resume()
         
         if routeController.locationManager is SimulatedLocationManager {
             let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -127,6 +127,7 @@ class RouteMapViewController: UIViewController {
         super.viewDidLoad()
         
         mapView.contentInset = contentInsets
+        mapView.routeController = routeController
         view.layoutIfNeeded()
         
         mapView.tracksUserCourse = true

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -159,13 +159,6 @@ class RouteMapViewController: UIViewController {
         
         if let camera = pendingCamera {
             mapView.camera = camera
-        } else if let location = routeController.location, location.course > 0 {
-            mapView.updateCourseTracking(location: location, animated: false)
-        } else if let coordinates = routeController.routeProgress.currentLegProgress.currentStep.coordinates, let firstCoordinate = coordinates.first, coordinates.count > 1 {
-            let secondCoordinate = coordinates[1]
-            let course = firstCoordinate.direction(to: secondCoordinate)
-            let newLocation = CLLocation(coordinate: routeController.location?.coordinate ?? firstCoordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: course, speed: 0, timestamp: Date())
-            mapView.updateCourseTracking(location: newLocation, animated: false)
         } else {
             mapView.setCamera(tiltedCamera, animated: false)
         }


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1539

It's not very obvious developers need to update the user puck if they implement their own NavigationMapView and this view can easily handle update the puck when progress notifications occur.

This PR makes `NavigationMapView.updateCourseTracking(location:animated:)` private turns on the location manager sooner. This way, when `NavigationMapView` is inited, we already have a location and the view will be properly centered.

/cc @1ec5 @frederoni 