### PR TITLE
Start route controller progress updates sooner

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -357,6 +357,7 @@ open class NavigationViewController: UIViewController {
         self.directions = directions
         self.route = route
         NavigationSettings.shared.distanceUnit = route.routeOptions.locale.usesMetric ? .kilometer : .mile
+        routeController.resume()
         
         let mapViewController = RouteMapViewController(routeController: self.routeController, delegate: self)
         self.mapViewController = mapViewController
@@ -396,7 +397,6 @@ open class NavigationViewController: UIViewController {
         _ = voiceController
         
         UIApplication.shared.isIdleTimerDisabled = true
-        routeController.resume()
         
         if routeController.locationManager is SimulatedLocationManager {
             let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")


### PR DESCRIPTION
One good piece of learning that has come out of #1542, is starting progress updates from the route controller sooner. This came out of the fact we could not call `NavigationMapView.updateCourseTracking(location:animated:)` when init in RouteMapViewController, [ref](https://github.com/mapbox/mapbox-navigation-ios/pull/1542/files#diff-292af689ce88d5b5aa06966456abc0e9L162). To make sure the user puck starts in the right place in the world, we need to make sure the route controller is emiting progress updates by the time we show the view.

While we figure out what is happening in #1542, let's merge this now so we don't have to rely on the user puck starting at the first coordinate on the route, but rather their actual location.

/cc @mapbox/navigation-ios 