### PR TITLE
Fix visual index when rerouting

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -276,17 +276,6 @@ open class RouteController: NSObject {
 
     var userSnapToStepDistanceFromManeuver: CLLocationDistance?
     
-    private var currentVisualInstructionIndex: Int {
-        let currentStepProgress = routeProgress.currentLegProgress.currentStepProgress
-        guard let visualInstructions = currentStepProgress.remainingVisualInstructions else { return 0 }
-        
-        let visualInstructionDistances = visualInstructions.map { $0.distanceAlongStep }
-        
-        return visualInstructionDistances.index { currentStepProgress.distanceRemaining <= $0 } ?? visualInstructions.startIndex
-    }
-    
-    private var currentStepIndex: Int = NSNotFound
-    
     /**
      Intializes a new `RouteController`.
 
@@ -661,14 +650,14 @@ extension RouteController: CLLocationManagerDelegate {
         updateDistanceToIntersection(from: location)
         updateRouteStepProgress(for: location)
         updateRouteLegProgress(for: location)
+        updateVisualInstructionProgress()
 
         guard userIsOnRoute(location) || !(delegate?.routeController?(self, shouldRerouteFrom: location) ?? true) else {
             reroute(from: location)
             return
         }
 
-        updateSpokenInstructionProgress(for: location)
-        updateVisualInstructionProgress()
+        updateSpokenInstructionProgress()
 
         // Check for faster route given users current location
         guard reroutesProactively else { return }
@@ -976,7 +965,7 @@ extension RouteController: CLLocationManagerDelegate {
         routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation = userAbsoluteDistance
     }
 
-    func updateSpokenInstructionProgress(for location: CLLocation) {
+    func updateSpokenInstructionProgress() {
         guard let userSnapToStepDistanceFromManeuver = userSnapToStepDistanceFromManeuver else { return }
         guard let spokenInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingSpokenInstructions else { return }
 
@@ -997,19 +986,22 @@ extension RouteController: CLLocationManagerDelegate {
     }
     
     func updateVisualInstructionProgress() {
-        let currentLegProgress = routeProgress.currentLegProgress
-        let currentStepProgress = currentLegProgress.currentStepProgress
-        guard currentStepIndex != currentLegProgress.stepIndex ||
-              currentVisualInstructionIndex != currentStepProgress.visualInstructionIndex else {
-                return
-        }
+        guard let userSnapToStepDistanceFromManeuver = userSnapToStepDistanceFromManeuver else { return }
+        guard let visualInstructions = routeProgress.currentLegProgress.currentStepProgress.remainingVisualInstructions else { return }
         
-        currentStepIndex = currentLegProgress.stepIndex
-        currentStepProgress.visualInstructionIndex = currentVisualInstructionIndex
-
-        NotificationCenter.default.post(name: .routeControllerDidPassVisualInstructionPoint, object: self, userInfo: [
-            RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress
-            ])
+        let firstInstructionOnFirstStep = routeProgress.currentLegProgress.stepIndex == 0 && routeProgress.currentLegProgress.currentStepProgress.visualInstructionIndex == 0
+        
+        for visualInstruction in visualInstructions {
+            if userSnapToStepDistanceFromManeuver <= visualInstruction.distanceAlongStep || firstInstructionOnFirstStep {
+                
+                NotificationCenter.default.post(name: .routeControllerDidPassVisualInstructionPoint, object: self, userInfo: [
+                    RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress
+                    ])
+                
+                routeProgress.currentLegProgress.currentStepProgress.visualInstructionIndex += 1
+                return
+            }
+        }
     }
 
     func advanceStepIndex(to: Array<RouteStep>.Index? = nil) {


### PR DESCRIPTION
Followup to https://github.com/mapbox/mapbox-navigation-ios/pull/1534

This fixes an issue where the past fist instruction on a previous route stuck around and uses the same logic we have in place for calculating the currentSpokenInstruction.

/cc @vincethecoder 