### PR TITLE
Add missing MapboxDirections.swift classes to docs

### DIFF
--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -30,7 +30,7 @@ BASE_URL="https://www.mapbox.com/mapbox-navigation-ios"
 
 # Link to directions documentation
 DIRECTIONS_VERSION=$(grep 'MapboxDirections.swift' Cartfile.resolved | grep -oE '"v.+?"' | grep -oE '[^"v]+')
-DIRECTIONS_SYMBOLS="Directions|DirectionsOptions|DirectionsResult|Intersection|Lane|Match|MatchOptions|Route|RouteLeg|RouteOptions|RouteStep|SpokenInstruction|Tracepoint|VisualInstruction|VisualInstructionComponent|Waypoint|RoadClasses|ComponentRepresentable"
+DIRECTIONS_SYMBOLS="ComponentRepresentable|Directions|DirectionsOptions|DirectionsResult|Intersection|Lane|Match|MatchOptions|RoadClasses|Route|RouteLeg|RouteOptions|RouteStep|SpokenInstruction|Tracepoint|VisualInstruction|VisualInstructionBanner|VisualInstructionComponent|Waypoint"
 
 rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -30,7 +30,7 @@ BASE_URL="https://www.mapbox.com/mapbox-navigation-ios"
 
 # Link to directions documentation
 DIRECTIONS_VERSION=$(grep 'MapboxDirections.swift' Cartfile.resolved | grep -oE '"v.+?"' | grep -oE '[^"v]+')
-DIRECTIONS_SYMBOLS="Directions|DirectionsOptions|DirectionsResult|Intersection|Lane|Match|MatchOptions|Route|RouteLeg|RouteOptions|RouteStep|SpokenInstruction|Tracepoint|VisualInstruction|VisualInstructionComponent|Waypoint"
+DIRECTIONS_SYMBOLS="Directions|DirectionsOptions|DirectionsResult|Intersection|Lane|Match|MatchOptions|Route|RouteLeg|RouteOptions|RouteStep|SpokenInstruction|Tracepoint|VisualInstruction|VisualInstructionComponent|Waypoint|RoadClasses|ComponentRepresentable"
 
 rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}


### PR DESCRIPTION
Adds a few missing classes to our docs.

/cc @1ec5 