### PR TITLE
Update Maps SDK, use new camera fitting api

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.1
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.2
 github "mapbox/MapboxDirections.swift" ~> 0.22.0
 github "mapbox/turf-swift" ~> 0.2
 github "mapbox/mapbox-events-ios" ~> 0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.1.1"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.2.0"
 github "Quick/Nimble" "v7.1.3"
-github "Quick/Quick" "v1.3.0"
+github "Quick/Quick" "v1.3.1"
 github "ceeK/Solar" "2.1.0"
 github "mapbox/MapboxDirections.swift" "v0.22.0"
 github "mapbox/mapbox-events-ios" "v0.4.2"

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxDirections.swift", "~> 0.22.0"
-  s.dependency "Mapbox-iOS-SDK", "~> 4.1"
+  s.dependency "Mapbox-iOS-SDK", "~> 4.2"
   s.dependency "MapboxMobileEvents", "~> 0.4"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.2"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "Mapbox-iOS-SDK", "~> 4.1"
+  s.dependency "Mapbox-iOS-SDK", "~> 4.2"
   s.dependency "Solar", "~> 2.1"
   s.dependency "MapboxSpeech", "~> 0.0.1"
 

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1046,13 +1046,11 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             return
         }
         
-        // Sadly, `MGLMapView.cameraThatFitsShape(_:direction:edgePadding:)` uses the current pitch of the mapview.
-        // Because of this, we need to set it before or it will create a camera for the current pitch instead of 0.
-        let camera = self.camera
-        camera.pitch = 0
-        self.camera = camera
+        let cam = self.camera
+        cam.pitch = 0
+        cam.direction = 0
         
-        let cameraForLine = cameraThatFitsShape(line, direction: 0, edgePadding: bounds)
+        let cameraForLine = camera(cam, fitting: line, edgePadding: bounds)
         setCamera(cameraForLine, withDuration: 1, animationTimingFunction: nil) { [weak self] in
             self?.isAnimatingToOverheadMode = false
         }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1048,7 +1048,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
         let cam = self.camera
         cam.pitch = 0
-        cam.direction = 0
+        cam.heading = 0
         
         let cameraForLine = camera(cam, fitting: line, edgePadding: bounds)
         setCamera(cameraForLine, withDuration: 1, animationTimingFunction: nil) { [weak self] in


### PR DESCRIPTION
This updates the maps SDK to v4.2.0 and takes advantage of a newly exposed API, `MGLMapCamera(_:fitting:edgePadding:)`. This makes the transition to overhead view much smoother since we no longer need to first set the pitch and heading to zero.

- [x] wait for v4.2.0 to be released

/cc @mapbox/navigation-ios 