### PR TITLE
Nil out audioPlayer delegate when deiniting

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -110,6 +110,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate, AVAudioP
     deinit {
         suspendNotifications()
         speechSynth.stopSpeaking(at: .immediate)
+        audioPlayer?.delegate = nil
     }
     
     func resumeNotifications() {


### PR DESCRIPTION
Closes: https://github.com/mapbox/mapbox-navigation-ios/issues/1561

Per, https://github.com/mapbox/mapbox-navigation-ios/issues/1561 we have a hunch that that the spoken instruction audio player's delegate needs to be nilled out when deiniting. This could potentially be the root cause of https://github.com/mapbox/mapbox-navigation-ios/issues/1561 and also other issues we've seen before when multiple voice controllers are speaking instructions when starting/stopping navigation multiple times.

/cc @mapbox/navigation-ios 