### PR TITLE
Fix missing instruction on first step

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -386,7 +386,8 @@ open class NavigationViewController: UIViewController {
     
     override open func viewDidLoad() {
         super.viewDidLoad()
-        //initialize voice controller if it hasn't been overridden
+        // Initialize voice controller if it hasn't been overridden.
+        // This is optional and lazy so it can be mutated by the developer after init.
         _ = voiceController
         resumeNotifications()
         view.clipsToBounds = true

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -386,15 +386,14 @@ open class NavigationViewController: UIViewController {
     
     override open func viewDidLoad() {
         super.viewDidLoad()
+        //initialize voice controller if it hasn't been overridden
+        _ = voiceController
         resumeNotifications()
         view.clipsToBounds = true
     }
     
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        //initialize voice controller if it hasn't been overridden
-        _ = voiceController
         
         UIApplication.shared.isIdleTimerDisabled = true
         


### PR DESCRIPTION
https://github.com/mapbox/mapbox-navigation-ios/pull/1547 caused a regression where the first instruction on the first step was never announced.

We need to first initialize the voice controller before we begin listening in on spoken instruction notifications.

/cc @mapbox/navigation-ios 