### PR TITLE
Fixed the partial style of user interface whenever styles are switched. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixed banner stuck on rerouting past the reroute threshold when navigation is set to simulation mode. ([#1583](https://github.com/mapbox/mapbox-navigation-ios/pull/1583))
 * Modified the current road name displayed with new map attribute fields. We use the road feature `ref` attribute's `shield` and `reflen` to retrieve the shield image presented next to the current road name. ([#1576](https://github.com/mapbox/mapbox-navigation-ios/pull/1576)) 
+* Fixed an issue where the steps list drag handlebar disappears whenever the user taps the resume button. ([#1588](https://github.com/mapbox/mapbox-navigation-ios/pull/1588))
+* Resolved the partially styled user interface issue that occurs when the style theme is switched between the `NightStyle` and `DayStyle`, after the resume was tapped. ([#1589](https://github.com/mapbox/mapbox-navigation-ios/pull/1589))  
 
 ## v0.19.0 (July, 24, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * Fixed banner stuck on rerouting past the reroute threshold when navigation is set to simulation mode. ([#1583](https://github.com/mapbox/mapbox-navigation-ios/pull/1583))
 * Modified the current road name displayed with new map attribute fields. We use the road feature `ref` attribute's `shield` and `reflen` to retrieve the shield image presented next to the current road name. ([#1576](https://github.com/mapbox/mapbox-navigation-ios/pull/1576)) 
+* Added the `shouldManageApplicationIdleTimer` flag to `NavigationViewController` to allow applications to opt out of automatic `UIApplication.isIdleTimerDisabled` management. ([#1591](https://github.com/mapbox/mapbox-navigation-ios/pull/1591))
 * Fixed an issue where the steps list drag handlebar disappears whenever the user taps the resume button. ([#1588](https://github.com/mapbox/mapbox-navigation-ios/pull/1588))
 * Resolved the partially styled user interface issue that occurs when the style theme is switched between the `NightStyle` and `DayStyle`, after the resume was tapped. ([#1589](https://github.com/mapbox/mapbox-navigation-ios/pull/1589))  
-* Added the `shouldManageApplicationIdleTimer` flag to `NavigationViewController` to allow applications to opt out of automatic `UIApplication.isIdleTimerDisabled` management. ([#1591](https://github.com/mapbox/mapbox-navigation-ios/pull/1591))
 
 ## v0.19.0 (July, 24, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Modified the current road name displayed with new map attribute fields. We use the road feature `ref` attribute's `shield` and `reflen` to retrieve the shield image presented next to the current road name. ([#1576](https://github.com/mapbox/mapbox-navigation-ios/pull/1576)) 
 * Added the `shouldManageApplicationIdleTimer` flag to `NavigationViewController` to allow applications to opt out of automatic `UIApplication.isIdleTimerDisabled` management. ([#1591](https://github.com/mapbox/mapbox-navigation-ios/pull/1591))
 * Fixed an issue where the steps list drag handlebar disappears whenever the user taps the resume button. ([#1588](https://github.com/mapbox/mapbox-navigation-ios/pull/1588))
-* Resolved the partially styled user interface issue that occurs when the style theme is switched between the `NightStyle` and `DayStyle`, after the resume was tapped. ([#1589](https://github.com/mapbox/mapbox-navigation-ios/pull/1589))  
+* Resolved the partially styled user interface issue that occurs when the style theme is switched between the `NightStyle` and `DayStyle`, after the resume  button was tapped. ([#1589](https://github.com/mapbox/mapbox-navigation-ios/pull/1589))  
 
 ## v0.19.0 (July, 24, 2018)
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -324,7 +324,12 @@ open class NavigationViewController: UIViewController {
     
     var styleManager: StyleManager!
     
-    var currentStatusBarStyle: UIStatusBarStyle = .default
+    var currentStatusBarStyle: UIStatusBarStyle = .default {
+        didSet {
+            mapViewController?.instructionsBannerView.backgroundColor = InstructionsBannerView.appearance().backgroundColor
+            mapViewController?.instructionsBannerContentView.backgroundColor = InstructionsBannerContentView.appearance().backgroundColor
+        }
+    }
     
     open override var preferredStatusBarStyle: UIStatusBarStyle {
         get {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -18,6 +18,7 @@ class RouteMapViewController: UIViewController {
     var lanesView: LanesView { return navigationView.lanesView }
     var nextBannerView: NextBannerView { return navigationView.nextBannerView }
     var instructionsBannerView: InstructionsBannerView { return navigationView.instructionsBannerView }
+    var instructionsBannerContentView: InstructionsBannerContentView { return navigationView.instructionsBannerContentView }
     
     lazy var endOfRouteViewController: EndOfRouteViewController = {
         let storyboard = UIStoryboard(name: "Navigation", bundle: .mapboxNavigation)
@@ -226,6 +227,7 @@ class RouteMapViewController: UIViewController {
         if let view = previewInstructionsView {
             view.removeFromSuperview()
             navigationView.instructionsBannerContentView.backgroundColor = InstructionsBannerView.appearance().backgroundColor
+            navigationView.instructionsBannerView.delegate = self
             previewInstructionsView = nil
         }
     }


### PR DESCRIPTION
When the style manager made changes to the current theme, we formerly updated the banner instruction view's background color at the wrong spot. This pull request addresses the issue by setting the banner instruction view's background color within the `NavigationViewController`. 

Fixes #1540 

TODO:
- [x] Update change log with an entry regarding this fix.