### PR TITLE
Allow opting out of idle timer management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed banner stuck on rerouting past the reroute threshold when navigation is set to simulation mode. ([#1583](https://github.com/mapbox/mapbox-navigation-ios/pull/1583))
 * Modified the current road name displayed with new map attribute fields. We use the road feature `ref` attribute's `shield` and `reflen` to retrieve the shield image presented next to the current road name. ([#1576](https://github.com/mapbox/mapbox-navigation-ios/pull/1576)) 
+* Added the `shouldManageApplicationIdleTimer` flag to `NavigationViewController` to allow applications to opt out of automatic `UIApplication.isIdleTimerDisabled` management. ([#1591](https://github.com/mapbox/mapbox-navigation-ios/pull/1591))
 
 ## v0.19.0 (July, 24, 2018)
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -314,6 +314,11 @@ open class NavigationViewController: UIViewController {
             styleManager.automaticallyAdjustsStyleForTimeOfDay = automaticallyAdjustsStyleForTimeOfDay
         }
     }
+
+    /**
+     If `true`, `UIApplication.isIdleTimerDisabled` is set to `true` in `viewWillAppear(_:)` and `false` in `viewWillDisappear(_:)`. If your application manages the idle timer itself, set this property to `false`.
+     */
+    @objc public var shouldManageApplicationIdleTimer = true
     
     var mapViewController: RouteMapViewController?
     
@@ -395,8 +400,10 @@ open class NavigationViewController: UIViewController {
     
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        UIApplication.shared.isIdleTimerDisabled = true
+
+        if shouldManageApplicationIdleTimer {
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
         
         if routeController.locationManager is SimulatedLocationManager {
             let localized = String.Localized.simulationStatus(speed: 1)
@@ -406,8 +413,10 @@ open class NavigationViewController: UIViewController {
     
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
-        UIApplication.shared.isIdleTimerDisabled = false
+
+        if shouldManageApplicationIdleTimer {
+            UIApplication.shared.isIdleTimerDisabled = false
+        }
         
         routeController.suspendLocationUpdates()
     }


### PR DESCRIPTION
Removed UIApplication.shared.isIdleTimerDisabled management from NavigationViewController to avoid conflicting with app-specific idle timer strategies.