### PR TITLE
Remove RouteMapViewController dependency on MGLMapViewDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* It is now safe to set the `NavigationMapView.delegate` property of the `NavigationMapView` in `NavigationViewController.mapView`. Implement `MGLMapViewDelegate` in your own class to customize annotations and other details. ([#1601](https://github.com/mapbox/mapbox-navigation-ios/pull/1601))
+* Fixed an issue where the map view while navigating in CarPlay showed labels in the style’s original language instead of the local language. ([#1601](https://github.com/mapbox/mapbox-navigation-ios/pull/1601))
 * `NavigationMapViewDelegate.navigationMapView(_:routeStyleLayerWithIdentifier:source:)`, `NavigationMapViewDelegate.navigationMapView(_:routeCasingStyleLayerWithIdentifier:source:)`, `NavigationViewControllerDelegate.navigationViewController(_:routeStyleLayerWithIdentifier:source:)`, and `NavigationViewControllerDelegate.navigationViewController(_:routeCasingStyleLayerWithIdentifier:source:)` can now set the `MGLLineStyleLayer.lineGradient` property. ([#1799](https://github.com/mapbox/mapbox-navigation-ios/pull/1799))
 
 ## v0.23.0 (October 24, 2018)

--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -8,8 +8,7 @@ import UserNotifications
 private typealias RouteRequestSuccess = (([Route]) -> Void)
 private typealias RouteRequestFailure = ((NSError) -> Void)
 
-
-class ViewController: UIViewController, MGLMapViewDelegate {
+class ViewController: UIViewController {
     
     // MARK: - IBOutlets
     @IBOutlet weak var longPressHintView: UIView!
@@ -207,6 +206,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
 
         let navigationViewController = NavigationViewController(for: route, navigationService: navigationService())
         navigationViewController.delegate = self
+        navigationViewController.mapView?.delegate = self
         
         presentAndRemoveMapview(navigationViewController)
     }
@@ -274,8 +274,14 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         mapView.gestureRecognizers?.filter({ $0 is UILongPressGestureRecognizer }).forEach(singleTap.require(toFail:))
         mapView.addGestureRecognizer(singleTap)
     }
+}
 
+extension ViewController: MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+        guard mapView == self.mapView else {
+            return
+        }
+        
         self.mapView?.localizeLabels()
         
         if let routes = routes, let currentRoute = routes.first, let coords = currentRoute.coordinates {

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -73,7 +73,6 @@ open class NavigationView: UIView {
     
     lazy var mapView: NavigationMapView = {
         let map: NavigationMapView = .forAutoLayout(frame: self.bounds)
-        map.delegate = delegate
         map.navigationMapDelegate = delegate
         map.courseTrackingDelegate = delegate
         map.showsUserLocation = true
@@ -221,7 +220,6 @@ open class NavigationView: UIView {
     }
     
     private func updateDelegates() {
-        mapView.delegate = delegate
         mapView.navigationMapDelegate = delegate
         mapView.courseTrackingDelegate = delegate
         instructionsBannerView.delegate = delegate
@@ -231,6 +229,6 @@ open class NavigationView: UIView {
     }
 }
 
-protocol NavigationViewDelegate: NavigationMapViewDelegate, MGLMapViewDelegate, StatusViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
+protocol NavigationViewDelegate: NavigationMapViewDelegate, StatusViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton)
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -252,7 +252,7 @@ open class NavigationViewController: UIViewController {
     /**
      The main map view displayed inside the view controller.
      
-     - note: Do not change this map view’s delegate.
+     - note: Do not change this map view’s `NavigationMapView.navigationMapDelegate` property; instead, implement the corresponding methods on `NavigationViewControllerDelegate`.
      */
     @objc public var mapView: NavigationMapView? {
         get {

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -176,9 +176,9 @@ class NavigationViewControllerTests: XCTestCase {
     }
     
     func testDestinationAnnotationUpdatesUponReroute() {
-        let styleLoaded = XCTestExpectation(description: "Style Loaded")
         let service = MapboxNavigationService(route: initialRoute, directions: DirectionsSpy(accessToken: "beef"), simulating: .never)
-        let navigationViewController = NavigationViewControllerTestable(for: initialRoute,  styles: [TestableDayStyle()], navigationService: service, styleLoaded: styleLoaded)
+        let navigationViewController = NavigationViewController(for: initialRoute,  styles: [TestableDayStyle()], navigationService: service)
+        let styleLoaded = keyValueObservingExpectation(for: navigationViewController, keyPath: "mapView.style", expectedValue: nil)
         
         //wait for the style to load -- routes won't show without it.
         wait(for: [styleLoaded], timeout: 5)
@@ -241,37 +241,13 @@ extension CLLocationCoordinate2D: Hashable {
 }
 
 extension NavigationViewControllerTests {
-        fileprivate func location(at coordinate: CLLocationCoordinate2D) -> CLLocation {
-                return CLLocation(coordinate: coordinate,
-                                    altitude: 5,
+    fileprivate func location(at coordinate: CLLocationCoordinate2D) -> CLLocation {
+        return CLLocation(coordinate: coordinate,
+                          altitude: 5,
                           horizontalAccuracy: 10,
-                            verticalAccuracy: 5,
-                                      course: 20,
-                                       speed: 15,
-                                   timestamp: Date())
-            }
-}
-
-class NavigationViewControllerTestable: NavigationViewController {
-    var styleLoadedExpectation: XCTestExpectation
-    
-    required init(for route: Route,
-                  styles: [Style]? = [DayStyle(), NightStyle()],
-                  navigationService: NavigationService? = nil,
-                  styleLoaded: XCTestExpectation) {
-        styleLoadedExpectation = styleLoaded
-        super.init(for: route, styles: styles, navigationService: navigationService, voiceController: RouteVoiceControllerStub())
-    }
-    
-    required init(for route: Route, styles: [Style]?, navigationService: NavigationService?, voiceController: RouteVoiceController?) {
-        fatalError("This initalizer is not supported in this testing subclass.")
-    }
-    
-    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
-        styleLoadedExpectation.fulfill()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("This initalizer is not supported in this testing subclass.")
+                          verticalAccuracy: 5,
+                          course: 20,
+                          speed: 15,
+                          timestamp: Date())
     }
 }


### PR DESCRIPTION
Removed RouteMapViewController dependency on MGLMapViewDelegate. It’s now safe to set `NavigationMapView.delegate` on the value of `NavigationViewController.mapView` and implement MGLMapViewDelegate in application code. RouteMapViewController now relies on key-value observation to manipulate NavigationMapView, including localizing the style’s labels.

The upside is that developers automatically get access to any customization hooks as they’re added to the map SDK, without any intervention on the part of the navigation SDK. This is feasible today because the navigation SDK wasn’t actually using a whole lot from MGLMapViewDelegate. The downside is that we may in the future need to hook into more of MGLMapViewDelegate, requiring some code that’s a lot more obtuse than key-value observation.

Here’s a demonstration of adding an interactive annotation to the map along the route line:

<img src="https://user-images.githubusercontent.com/1231218/44046536-99fba452-9ee0-11e8-930a-f9824c492970.png" width="300" alt="first step">

Along the way, I also implemented map label localization during navigation in CarPlay.

Fixes #685 and fixes #1761. Depends on #1759.

/cc @mapbox/navigation-ios @lemwerks