### PR TITLE
Ensure compatibility with map SDK v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
 * Resolved the partially styled user interface issue that occurs when the style theme is switched between the `NightStyle` and `DayStyle`, after the resume  button was tapped. ([#1589](https://github.com/mapbox/mapbox-navigation-ios/pull/1589))
 * Fixed a rare crash associated with the keyboard when showing the end of route view controller. [#1599](https://github.com/mapbox/mapbox-navigation-ios/pull/1599/)
 
-## v0.19.0 (July, 24, 2018)
+## v0.19.1 (August 15, 2018)
+
+* Fixed build errors when installing this SDK with Mapbox Maps SDK for iOS v4.3.0 or above. ([#1608](https://github.com/mapbox/mapbox-navigation-ios/pull/1608))
+
+## v0.19.0 (July 24, 2018)
 
 ### Packaging
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.2
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.3
 github "mapbox/MapboxDirections.swift" ~> 0.22.0
 github "mapbox/turf-swift" ~> 0.2
 github "mapbox/mapbox-events-ios" ~> 0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.2.0"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.3.0"
 github "Quick/Nimble" "v7.1.3"
 github "Quick/Quick" "v1.3.1"
 github "ceeK/Solar" "2.1.0"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "Mapbox-iOS-SDK", "~> 4.2"
+  s.dependency "Mapbox-iOS-SDK", "~> 4.3"
   s.dependency "Solar", "~> 2.1"
   s.dependency "MapboxSpeech", "~> 0.0.1"
 

--- a/MapboxNavigation/MGLMapView+MGLNavigationAdditions.h
+++ b/MapboxNavigation/MGLMapView+MGLNavigationAdditions.h
@@ -4,6 +4,4 @@
 
 - (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered;
 
-@property (nonatomic, readonly) CADisplayLink  * _Nullable displayLink;
-
 @end

--- a/MapboxNavigation/MGLMapView+MGLNavigationAdditions.m
+++ b/MapboxNavigation/MGLMapView+MGLNavigationAdditions.m
@@ -5,8 +5,4 @@
 @implementation MGLMapView (MGLNavigationAdditions)
 #pragma clang diagnostic pop
 
-- (CADisplayLink *)displayLink {
-    return [self valueForKey:@"_displayLink"];
-}
-
 @end

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -15,9 +15,9 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     struct FrameIntervalOptions {
         fileprivate static let durationUntilNextManeuver: TimeInterval = 7
         fileprivate static let durationSincePreviousManeuver: TimeInterval = 3
-        fileprivate static let defaultFramesPerSecond: Int = 60
-        fileprivate static let pluggedInFramesPerSecond: Int = 30
-        fileprivate static let decreasedFramesPerSecond: Int = 5
+        fileprivate static let defaultFramesPerSecond = MGLMapViewPreferredFramesPerSecond.maximum
+        fileprivate static let pluggedInFramesPerSecond = MGLMapViewPreferredFramesPerSecond.lowPower
+        fileprivate static let decreasedFramesPerSecond = MGLMapViewPreferredFramesPerSecond(rawValue: 5)
     }
     
     /**
@@ -87,16 +87,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     var altitude: CLLocationDistance = defaultAltitude
     var routes: [Route]?
     var isAnimatingToOverheadMode = false
-    
-    fileprivate var preferredFramesPerSecond: Int = 60 {
-        didSet {
-            if #available(iOS 10.0, *) {
-                displayLink?.preferredFramesPerSecond = preferredFramesPerSecond
-            } else {
-                displayLink?.frameInterval = FrameIntervalOptions.defaultFramesPerSecond / preferredFramesPerSecond
-            }
-        }
-    }
     
     var shouldPositionCourseViewFrameByFrame = false {
         didSet {


### PR DESCRIPTION
Removed `NavigationMapView.preferredFramesPerSecond` in favor of MGLMapView’s implementation, which is coming in iOS map SDK v4.3.0.

/cc @mapbox/navigation-ios @friedbunny