### PR TITLE
Remove stray reference to nonexistent script

### DIFF
--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -4,8 +4,6 @@ set -e
 set -o pipefail
 set -u
 
-./scripts/update-guides.sh
-
 if [ -z `which jazzy` ]; then
     echo "Installing jazzy…"
     gem install jazzy


### PR DESCRIPTION
#1552 removed update-guides.sh but not the reference to it within document.sh. So generating the jazzy docset at release time resulted in a shell error. This PR removes the stray reference, fixing the documentation generation script.

/cc @JThramer @vincethecoder