### PR TITLE
Add incidents toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* Added an `MGLMapView.showsIncidents` property to toggle the visibility of any Mapbox Incidents data on a map view. ([#1613](https://github.com/mapbox/mapbox-navigation-ios/pull/1613))
 * Added the `shouldManageApplicationIdleTimer` flag to `NavigationViewController` to allow applications to opt out of automatic `UIApplication.isIdleTimerDisabled` management. ([#1591](https://github.com/mapbox/mapbox-navigation-ios/pull/1591))
 * Fixed an issue where the banner was stuck on rerouting past the reroute threshold, when navigation was set to simulation mode. ([#1583](https://github.com/mapbox/mapbox-navigation-ios/pull/1583))
 * Modified the label at the bottom of the map to display the route shield in addition to the road name. ([#1576](https://github.com/mapbox/mapbox-navigation-ios/pull/1576)) 

--- a/MapboxNavigation/MGLMapView.swift
+++ b/MapboxNavigation/MGLMapView.swift
@@ -7,33 +7,86 @@ import MapboxCoreNavigation
  An extension on `MGLMapView` that allows for toggling traffic on a map style that contains a [Mapbox Traffic source](https://www.mapbox.com/vector-tiles/mapbox-traffic-v1/).
  */
 extension MGLMapView {
+    /**
+     Returns a set of source identifiers for tilesets that are or include the Mapbox Incidents source.
+     */
+    func sourceIdentifiers(forTileSetIdentifier tileSetIdentifier: String) -> Set<String> {
+        guard let style = style else {
+            return []
+        }
+        return Set(style.sources.compactMap {
+            $0 as? MGLVectorTileSource
+        }.filter {
+            $0.configurationURL?.host?.components(separatedBy: ",").contains(tileSetIdentifier) ?? false
+        }.map {
+            $0.identifier
+        })
+    }
+    
+    /**
+     Returns a Boolean value indicating whether data from the given tile set layer is currently visible in the map view’s style.
+     
+     - parameter tileSetIdentifier: Identifier of the tile set in the form `user.tileset`.
+     - parameter layerIdentifier: Identifier of the layer in the tile set; in other words, a source layer identifier. Not to be confused with a style layer.
+     */
+    func showsTileSet(withIdentifier tileSetIdentifier: String, layerIdentifier: String) -> Bool {
+        guard let style = style else {
+            return false
+        }
+        
+        let incidentsSourceIdentifiers = sourceIdentifiers(forTileSetIdentifier: tileSetIdentifier)
+        for layer in style.layers {
+            if let layer = layer as? MGLVectorStyleLayer, let sourceIdentifier = layer.sourceIdentifier {
+                if incidentsSourceIdentifiers.contains(sourceIdentifier) && layer.sourceLayerIdentifier == layerIdentifier {
+                    return layer.isVisible
+                }
+            }
+        }
+        return false
+    }
+    
+    /**
+     Shows or hides data from the given tile set layer.
+     
+     - parameter tileSetIdentifier: Identifier of the tile set in the form `user.tileset`.
+     - parameter layerIdentifier: Identifier of the layer in the tile set; in other words, a source layer identifier. Not to be confused with a style layer.
+     */
+    func setShowsTileSet(_ isVisible: Bool, withIdentifier tileSetIdentifier: String, layerIdentifier: String) {
+        guard let style = style else {
+            return
+        }
+        
+        let incidentsSourceIdentifiers = sourceIdentifiers(forTileSetIdentifier: tileSetIdentifier)
+        for layer in style.layers {
+            if let layer = layer as? MGLVectorStyleLayer, let sourceIdentifier = layer.sourceIdentifier {
+                if incidentsSourceIdentifiers.contains(sourceIdentifier) && layer.sourceLayerIdentifier == layerIdentifier {
+                    layer.isVisible = isVisible
+                }
+            }
+        }
+    }
 
     /**
-     Toggle traffic on a map style that contains a Mapbox Traffic source.
+     A Boolean value indicating whether traffic congestion lines are visible in the map view’s style.
      */
     public var showsTraffic: Bool {
         get {
-            if let style = style {
-                for layer in style.layers {
-                    if let l = layer as? MGLForegroundStyleLayer {
-                        if l.sourceIdentifier == "mapbox://mapbox.mapbox-traffic-v1" {
-                            return l.isVisible
-                        }
-                    }
-                }
-            }
-            return false
+            return showsTileSet(withIdentifier: "mapbox.mapbox-traffic-v1", layerIdentifier: "traffic")
         }
         set {
-            if let style = style {
-                for layer in style.layers {
-                    if let layer = layer as? MGLForegroundStyleLayer {
-                        if layer.sourceIdentifier == "mapbox://mapbox.mapbox-traffic-v1" {
-                            layer.isVisible = newValue
-                        }
-                    }
-                }
-            }
+            setShowsTileSet(newValue, withIdentifier: "mapbox.mapbox-traffic-v1", layerIdentifier: "traffic")
+        }
+    }
+    
+    /**
+     A Boolean value indicating whether incidents, such as road closures and detours, are visible in the map view’s style.
+     */
+    public var showsIncidents: Bool {
+        get {
+            return showsTileSet(withIdentifier: "mapbox.mapbox-incidents-v1", layerIdentifier: "incidents")
+        }
+        set {
+            setShowsTileSet(newValue, withIdentifier: "mapbox.mapbox-incidents-v1", layerIdentifier: "incidents")
         }
     }
 }


### PR DESCRIPTION
Added an `MGLMapView.showsIncidents` property to toggle the visibility of any Mapbox Incidents data on a map view. Mapbox Incidents source v1 is a new public tileset that indicates incidents, such as road closures and detours. It is a companion to [Mapbox Traffic source v1](https://www.mapbox.com/vector-tiles/mapbox-traffic-v1/).

The `MGLMapView.showsIncidents` property is based on the existing `MGLMapView.showsTraffic` property. Like `showsTraffic`, `showsIncidents` only toggles the visibility of the relevant layers; it doesn’t add incidents to a style that lacks those layers. (Public styles that come with incidents layers are forthcoming.) Applications that provide a “Shows Traffic” toggle may want to set both `showsTraffic` and `showsIncidents`, since users generally conflate the two kinds of data.

/cc @mapbox/navigation-ios @danesfeder