### PR TITLE
Add incidents to any style

### DIFF
--- a/Examples/Swift/ViewController.swift
+++ b/Examples/Swift/ViewController.swift
@@ -258,6 +258,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         self.mapView?.localizeLabels()
+        self.mapView?.showsIncidents = true
         
         if let routes = routes, let currentRoute = routes.first, let coords = currentRoute.coordinates {
             mapView.setVisibleCoordinateBounds(MGLPolygon(coordinates: coords, count: currentRoute.coordinateCount).overlayBounds, animated: false)

--- a/MapboxNavigation/MGLMapView.swift
+++ b/MapboxNavigation/MGLMapView.swift
@@ -3,6 +3,17 @@ import Mapbox
 import MapboxDirections
 import MapboxCoreNavigation
 
+extension UIColor {
+    /**
+     Initializes a color object using the given opacity and HSL (HSV) color space component values.
+     */
+    convenience init(hue: CGFloat, saturation: CGFloat, value: CGFloat, alpha: CGFloat) {
+        let brightness = (2 * value + saturation * (1 - abs(2 * value - 1))) / 2
+        let hsbSaturation = 2 * (brightness - value) / brightness
+        self.init(hue: hue, saturation: hsbSaturation, brightness: brightness, alpha: alpha)
+    }
+}
+
 /**
  An extension on `MGLMapView` that allows for toggling traffic on a map style that contains a [Mapbox Traffic source](https://www.mapbox.com/vector-tiles/mapbox-traffic-v1/).
  */
@@ -79,6 +90,81 @@ extension MGLMapView {
     }
     
     /**
+     Adds layers to the style that indicate incidents, such as road closures and detours.
+     */
+    func addIncidentsLayers() {
+        guard let style = style else {
+            return
+        }
+        
+        let incidentsSources = sourceIdentifiers(forTileSetIdentifier: "mapbox.mapbox-incidents-v1")
+        guard incidentsSources.isEmpty else {
+            return
+        }
+        
+        let incidentsSource = MGLVectorTileSource(identifier: "incidents", configurationURL: URL(string: "mapbox://mapbox.mapbox-incidents-v1")!)
+        style.addSource(incidentsSource)
+        
+        let streetsSourceIdentifiers = sourceIdentifiers(forTileSetIdentifier: "mapbox.mapbox-streets-v7")
+        var topmostRoadLayer: MGLLineStyleLayer?
+        for layer in style.layers.reversed() {
+            if let layer = layer as? MGLLineStyleLayer, let sourceIdentifier = layer.sourceIdentifier {
+                if streetsSourceIdentifiers.contains(sourceIdentifier) && layer.sourceLayerIdentifier == "road" {
+                    topmostRoadLayer = layer
+                    break
+                }
+            }
+        }
+        
+        let closureLineLayer = MGLLineStyleLayer(identifier: "incident-closure-lines", source: incidentsSource)
+        closureLineLayer.sourceLayerIdentifier = "closures"
+        closureLineLayer.minimumZoomLevel = 8
+        closureLineLayer.predicate = NSPredicate(format: "$geometryType = 'LineString' AND type = 'full'")
+        closureLineLayer.lineJoin = NSExpression(forConstantValue: "round")
+        closureLineLayer.lineRoundLimit = NSExpression(forConstantValue: 1.5)
+        closureLineLayer.lineColor = NSExpression(forConstantValue: UIColor(red: 0xf2/255.0, green: 0xf6/255.0, blue: 0xfa/255.0, alpha: 1))
+        closureLineLayer.lineWidth = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'exponential', 1.5, %@)", [5: 1, 18: 7])
+        if let topmostRoadLayer = topmostRoadLayer {
+            style.insertLayer(closureLineLayer, above: topmostRoadLayer)
+        } else {
+            style.addLayer(closureLineLayer)
+        }
+        
+        let closureHighlightLineLayer = MGLLineStyleLayer(identifier: "incident-closure-line-highlights", source: incidentsSource)
+        closureHighlightLineLayer.sourceLayerIdentifier = "closures"
+        closureHighlightLineLayer.minimumZoomLevel = 8
+        closureHighlightLineLayer.predicate = NSPredicate(format: "$geometryType = 'LineString' AND type = 'full'")
+        closureHighlightLineLayer.lineJoin = NSExpression(forConstantValue: "round")
+        closureHighlightLineLayer.lineRoundLimit = NSExpression(forConstantValue: 1.5)
+        closureHighlightLineLayer.lineColor = NSExpression(forConstantValue: UIColor(hue: 210/360.0, saturation: 0.2, value: 0.24, alpha: 1))
+        closureHighlightLineLayer.lineWidth = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'exponential', 1.5, %@)", [5: 0.6, 18: 4.2])
+        closureHighlightLineLayer.lineOffset = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'exponential', 1.5, %@)", [12: 1, 18: 10])
+        closureHighlightLineLayer.lineDashPattern = NSExpression(format: "mgl_step:from:stops:($zoomLevel, {1, 0}, %@)", [14: NSExpression(format: "{1, 1}")])
+        style.insertLayer(closureHighlightLineLayer, above: closureLineLayer)
+        
+        let incidentEndpointImage = Bundle.mapboxNavigation.image(named: "road-closure-red-icon")!
+        style.setImage(incidentEndpointImage, forName: "road-closure-red-icon")
+        
+        let incidentEndLayer = MGLSymbolStyleLayer(identifier: "incident-endpoints", source: incidentsSource)
+        incidentEndLayer.sourceLayerIdentifier = "closures"
+        incidentEndLayer.minimumZoomLevel = 8
+        incidentEndLayer.predicate = NSPredicate(format: "$geometryType IN {'LineString', 'Point'} AND type = 'endpoint:full'")
+        incidentEndLayer.iconImageName = NSExpression(forConstantValue: "road-closure-red-icon")
+        incidentEndLayer.iconScale = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'exponential', 1.5, %@)", [5: 0.15, 18: 0.6])
+        incidentEndLayer.iconAllowsOverlap = NSExpression(forConstantValue: true)
+        style.insertLayer(incidentEndLayer, above: closureHighlightLineLayer)
+        
+        let incidentStartLayer = MGLSymbolStyleLayer(identifier: "incident-startpoints", source: incidentsSource)
+        incidentStartLayer.sourceLayerIdentifier = "closures"
+        incidentStartLayer.minimumZoomLevel = 8
+        incidentStartLayer.predicate = NSPredicate(format: "$geometryType IN {'LineString', 'Point'} AND type = 'startpoint:full'")
+        incidentStartLayer.iconImageName = NSExpression(forConstantValue: "road-closure-red-icon")
+        incidentStartLayer.iconScale = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'exponential', 1.5, %@)", [5: 0.15, 18: 0.6])
+        incidentStartLayer.iconAllowsOverlap = NSExpression(forConstantValue: true)
+        style.insertLayer(incidentStartLayer, above: incidentEndLayer)
+    }
+    
+    /**
      A Boolean value indicating whether incidents, such as road closures and detours, are visible in the map view’s style.
      */
     public var showsIncidents: Bool {
@@ -86,6 +172,7 @@ extension MGLMapView {
             return showsTileSet(withIdentifier: "mapbox.mapbox-incidents-v1", layerIdentifier: "closures")
         }
         set {
+            addIncidentsLayers()
             setShowsTileSet(newValue, withIdentifier: "mapbox.mapbox-incidents-v1", layerIdentifier: "closures")
         }
     }

--- a/MapboxNavigation/Resources/Assets.xcassets/road-closure-red-icon.imageset/Contents.json
+++ b/MapboxNavigation/Resources/Assets.xcassets/road-closure-red-icon.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "filename" : "road-closure-red-icon.pdf"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MapboxNavigation/Resources/Assets.xcassets/road-closure-red-icon.imageset/road-closure-red-icon.pdf
+++ b/MapboxNavigation/Resources/Assets.xcassets/road-closure-red-icon.imageset/road-closure-red-icon.pdf
@@ -1,0 +1,70 @@
+%PDF-1.5
+%µí®û
+3 0 obj
+<< /Length 4 0 R
+   /Filter /FlateDecode
+>>
+stream
+xœURÛm1û÷š@µ$?ÇèÅI?Ò¶û¥l¹HpÀ™”E‰Ìå;ey\(³”
+PèçNo™î¿©(©Ğáœ\²’)Wïòr¦+ªÏA¸¸pDã®Æ¼¯s\ô‰,ÙçÿÂ[òV\È5)l:lyâ]•*÷:ü®áãY³‘f¸CQ@:Ï2¼˜­•­y'$¹
+Yg[ğ²Á}v—˜ ·±nÓÆ~iÜ¦$—Toi]»y "<&Æâ…E˜=<  EœÊÕæf’á´“	«ÈÊem\l,ƒcİ,®5iÉ—•jç¸¢M¡ù¶G_gSìMÛÄ“¡¨p™p?Öô8N1r¼fÂgSV7¯‹ëäŞm³‡³¯½˜e?t#íîX ÑĞ¾IÃÿ'„`õŒ\÷ºÅÎí‹‰†:ì+¸½íØ=„p9{Nàé^İÒ{úáW¯
+endstream
+endobj
+4 0 obj
+   355
+endobj
+2 0 obj
+<<
+   /ExtGState <<
+      /a0 << /CA 1 /ca 1 >>
+   >>
+>>
+endobj
+5 0 obj
+<< /Type /Page
+   /Parent 1 0 R
+   /MediaBox [ 0 0 42 42 ]
+   /Contents 3 0 R
+   /Group <<
+      /Type /Group
+      /S /Transparency
+      /I true
+      /CS /DeviceRGB
+   >>
+   /Resources 2 0 R
+>>
+endobj
+1 0 obj
+<< /Type /Pages
+   /Kids [ 5 0 R ]
+   /Count 1
+>>
+endobj
+6 0 obj
+<< /Creator (cairo 1.14.8 (http://cairographics.org))
+   /Producer (cairo 1.14.8 (http://cairographics.org))
+>>
+endobj
+7 0 obj
+<< /Type /Catalog
+   /Pages 1 0 R
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000753 00000 n 
+0000000469 00000 n 
+0000000015 00000 n 
+0000000447 00000 n 
+0000000541 00000 n 
+0000000818 00000 n 
+0000000945 00000 n 
+trailer
+<< /Size 8
+   /Root 7 0 R
+   /Info 6 0 R
+>>
+startxref
+997
+%%EOF


### PR DESCRIPTION
This is a proof of concept of using the runtime styling API to dynamically add the same incidents layers described in #1613 to any style, not just the forthcoming Mapbox-designed styles that come with incidents layers. This is the Streets v10 style showing incidents:

<img src="https://user-images.githubusercontent.com/1231218/44288533-8560bf80-a225-11e8-8a41-c89acde9e2a0.png" width="300" alt="streets">

This PR is based on a draft of an incidents-enabled style. Given that the navigation SDK’s default styles will come with incidents layers baked in, it probably won’t be necessary for the navigation SDK to add incidents to arbitrary styles – the SDK tries to be as style-agnostic as possible. As with the [iOS traffic plugin](https://github.com/mapbox/mapbox-plugins-ios/tree/master/TrafficPlugin), it may make sense for this code to be ported to Objective-C and made into a plugin, with an eye toward folding it into the map SDK along the lines of mapbox/mapbox-gl-native#12330.

Depends on #1613.

/cc @mapbox/navigation-ios @danesfeder