### PR TITLE
Expose additional properties on StyleManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Resolved the partially styled user interface issue that occurs when the style theme is switched between the `NightStyle` and `DayStyle`, after the resume  button was tapped. ([#1589](https://github.com/mapbox/mapbox-navigation-ios/pull/1589))
 * Fixed a rare crash associated with the keyboard when showing the end of route view controller. [#1599](https://github.com/mapbox/mapbox-navigation-ios/pull/1599/)
 * Added a `MapboxVoiceController.audioPlayer` property. You can use this property to interrupt a spoken instruction or adjust the volume. [#1596](https://github.com/mapbox/mapbox-navigation-ios/pull/1596)
+* Added `StyleManager.automaticallyAdjustsStyleForTimeOfDay`, `StyleManager.delegate`, and `StyleManager.styles` properties so that you can control same time-based style switching just as NavigationViewController does. [#1617](https://github.com/mapbox/mapbox-navigation-ios/pull/1617)
 
 ## v0.19.1 (August 15, 2018)
 

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -29,16 +29,39 @@ public protocol StyleManagerDelegate: NSObjectProtocol {
 @objc(MBStyleManager)
 open class StyleManager: NSObject {
     
-    weak var delegate: StyleManagerDelegate?
+    /**
+     The receiver of the delegate. See `StyleManagerDelegate` for more information.
+     */
+    @objc public weak var delegate: StyleManagerDelegate?
     
-    internal var date: Date?
-    var currentStyleType: StyleType?
-    var styles = [Style]() { didSet { applyStyle() } }
-    var automaticallyAdjustsStyleForTimeOfDay = true {
+    /**
+     Determines whether the style manager should apply a new style given the time of day.
+     
+     - precondition: Two styles must be provided for this property to have any effect.
+     */
+    @objc public var automaticallyAdjustsStyleForTimeOfDay = true {
         didSet {
-            resumeNotifications()
+            resetTimeOfDayTimer()
         }
     }
+    
+    /**
+     The styles that are in circulation. Active style is set based on
+     the sunrise and sunset at your current location. A change of
+     preferred content size by the user will also trigger an update.
+     
+     - precondition: Two styles must be provided for
+     `StyleManager.automaticallyAdjustsStyleForTimeOfDay` to have any effect.
+     */
+    @objc public var styles = [Style]() {
+        didSet {
+            applyStyle()
+        }
+    }
+    
+    internal var date: Date?
+    
+    var currentStyleType: StyleType?
     
     /**
      Initializes a new `StyleManager`.


### PR DESCRIPTION
Fixes #1603

This change exposes `automaticallyAdjustsStyleForTimeOfDay`, `delegate`, and
`styles` on StyleManager. It also fixes a bug which could lead to duplicated observers where setting `automaticallyAdjustsStyleForTimeOfDay` called `resumeNotifications()` instead of `resetTimeOfDayTimer()`.

@mapbox/navigation-ios 