### PR TITLE
Fix retain cycle if dead reckoning is enabled on RouteController.

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -184,6 +184,7 @@ open class RouteController: NSObject, Router {
         locationManager.stopUpdatingLocation()
         locationManager.stopUpdatingHeading()
         locationManager.delegate = nil
+        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(interpolateLocation), object: nil)
     }
     
     /**
@@ -340,7 +341,6 @@ extension RouteController: CLLocationManagerDelegate {
         let currentStep = currentStepProgress.step
 
         updateIntersectionIndex(for: currentStepProgress)
-
         // Notify observers if the step’s remaining distance has changed.
         let polyline = Polyline(routeProgress.currentLegProgress.currentStep.coordinates!)
         if let closestCoordinate = polyline.closestCoordinate(to: location.coordinate) {


### PR DESCRIPTION
Proposed solution is to make *suspendLocationUpdates* cancel the next scheduled location interpolation. This way calling *suspendLocationUpdates* or *endNavigation* then releasing all references to the RouteController allows it to be released.

Note that releasing all references to the RouteController object without calling *suspendLocationUpdates* first still leads to a memory leak + parasites notifications being triggered, etc

fixes #1623