### PR TITLE
Do not fire progress updates when the user is not moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added `StyleManager.automaticallyAdjustsStyleForTimeOfDay`, `StyleManager.delegate`, and `StyleManager.styles` properties so that you can control same time-based style switching just as `NavigationViewController` does. [#1617](https://github.com/mapbox/mapbox-navigation-ios/pull/1617)
 * Fixed an issue where the banner was stuck on rerouting past the reroute threshold when simulating navigation. ([#1583](https://github.com/mapbox/mapbox-navigation-ios/pull/1583))
 * Fixed an issue where the banner appears in the wrong colors after you tap the Resume button. ([#1588](https://github.com/mapbox/mapbox-navigation-ios/pull/1588), [#1589](https://github.com/mapbox/mapbox-navigation-ios/pull/1589))
+* Incoming location updates that are close together and nearly identical are now filtered out of progress notifications. [#1635](https://github.com/mapbox/mapbox-navigation-ios/pull/1635)
 
 ### Feedback
 

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -180,3 +180,8 @@ public var RouteControllerMinimumDistanceForProgressNotification: CLLocationDist
  The minimum difference between the user's course before a location update is filtered out.
  */
 public var RouteControllerMinimumDifferenceBetweenCourse: CLLocationDirection = 1
+
+/**
+ The minimum elapsed time between location updates before a location update is filtered out.
+ */
+public var RouteControllerMinimumElapsedTimeBetweenLocations: TimeInterval = 60

--- a/MapboxCoreNavigation/Constants.swift
+++ b/MapboxCoreNavigation/Constants.swift
@@ -170,3 +170,13 @@ extension Notification.Name {
      */
     public static let routeControllerDidPassVisualInstructionPoint = MBRouteControllerDidPassVisualInstructionPoint
 }
+
+/**
+ The minimum distance between location updates before a location update is filtered out.
+ */
+public var RouteControllerMinimumDistanceForProgressNotification: CLLocationDistance = 1
+
+/**
+ The minimum difference between the user's course before a location update is filtered out.
+ */
+public var RouteControllerMinimumDifferenceBetweenCourse: CLLocationDirection = 1

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -327,6 +327,10 @@ extension RouteController: CLLocationManagerDelegate {
         guard let location = potentialLocation else {
             return
         }
+        
+        if rawLocation?.coordinate == location.coordinate && rawLocation?.course == location.course {
+            return
+        }
 
         self.rawLocation = location
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -328,7 +328,8 @@ extension RouteController: CLLocationManagerDelegate {
             return
         }
         
-        if rawLocation?.coordinate == location.coordinate && rawLocation?.course == location.course {
+        if let raw = rawLocation, raw.coordinate.distance(to: location.coordinate) < RouteControllerMinimumDistanceForProgressNotification &&
+            raw.course - location.course < RouteControllerMinimumDifferenceBetweenCourse {
             return
         }
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -329,7 +329,8 @@ extension RouteController: CLLocationManagerDelegate {
         }
         
         if let raw = rawLocation, raw.coordinate.distance(to: location.coordinate) < RouteControllerMinimumDistanceForProgressNotification &&
-            raw.course - location.course < RouteControllerMinimumDifferenceBetweenCourse {
+            raw.course - location.course < RouteControllerMinimumDifferenceBetweenCourse &&
+            location.timestamp.timeIntervalSince(raw.timestamp) < RouteControllerMinimumElapsedTimeBetweenLocations {
             return
         }
 

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -106,6 +106,18 @@ class RouteControllerTests: XCTestCase {
         XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
     }
     
+    func testFilterOutCloseLocation() {
+        let navigation = dependencies.routeController
+        let firstLocation = dependencies.routeLocations.firstLocation
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
+        
+        let veryCloseCoordinate = firstLocation.coordinate.coordinate(at: 0.5, facing: 0)
+        let veryCLoseLocation = CLLocation(coordinate: veryCloseCoordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: firstLocation.course, speed: 0, timestamp: Date())
+        navigation.locationManager(navigation.locationManager, didUpdateLocations: [veryCLoseLocation])
+        
+        XCTAssertEqual(navigation.location!.coordinate, firstLocation.coordinate, "Check close location filtering is working")
+    }
+    
     func testSnappedAtEndOfStepLocationWhenMovingSlowly() {
         let navigation = dependencies.routeController
         let firstLocation = dependencies.routeLocations.firstLocation
@@ -119,7 +131,7 @@ class RouteControllerTests: XCTestCase {
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithNoSpeed])
         XCTAssertEqual(navigation.location!.coordinate, navigation.routeProgress.currentLegProgress.currentStep.coordinates!.last!, "When user is not moving, snap to current leg only")
         
-        let firstLocationOnNextStepWithSpeed = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, course: 10, speed: 5, timestamp: Date())
+        let firstLocationOnNextStepWithSpeed = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, course: 10, speed: 5, timestamp: Date().addingTimeInterval(200))
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithSpeed])
         XCTAssertEqual(navigation.location!.coordinate, firstCoordinateOnUpcomingStep, "User is snapped to upcoming step when moving")
     }
@@ -139,7 +151,7 @@ class RouteControllerTests: XCTestCase {
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithDifferentCourse])
         XCTAssertEqual(navigation.location!.coordinate, navigation.routeProgress.currentLegProgress.currentStep.coordinates!.last!, "When user's course is dissimilar from the finalHeading, they should not snap to upcoming step")
         
-        let firstLocationOnNextStepWithCorrectCourse = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 30, verticalAccuracy: 10, course: finalHeading, speed: 0, timestamp: Date())
+        let firstLocationOnNextStepWithCorrectCourse = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 30, verticalAccuracy: 10, course: finalHeading, speed: 0, timestamp: Date().addingTimeInterval(200))
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithCorrectCourse])
         XCTAssertEqual(navigation.location!.coordinate, firstCoordinateOnUpcomingStep, "User is snapped to upcoming step when their course is similar to the final heading")
     }
@@ -284,7 +296,7 @@ class RouteControllerTests: XCTestCase {
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [lastLocation])
 
         // MARK: And then navigation continues with another location update at the last location
-        let currentLocation = routeController.location!
+        let currentLocation = CLLocation(coordinate: routeController.location!.coordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, timestamp: Date().addingTimeInterval(200))
         routeController.locationManager(routeController.locationManager, didUpdateLocations: [currentLocation])
 
         // MARK: It tells the delegate that the user did arrive


### PR DESCRIPTION
If the incoming location is close to identical to the previous location, we can safely filter this location to prevent the map view from going through a render cycle. This is minor change but could add up for the amount of time people spend at stop lights.

To prevent UI elements from become outdated, I added a check to make sure that we're letting at least one progress update per minute.

/cc @mapbox/navigation-ios 