### PR TITLE
Permit routeless events manager for unique telemetry events

### DIFF
--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -306,8 +306,11 @@ extension EventDetails {
         }
     }
     
-    static func defaultEvents(router: Router) -> EventDetails {
-        return EventDetails(router: router, session: router.eventsManager.sessionState)
+    static func defaultEvents(router: Router) -> EventDetails? {
+        guard let sessionState = router.eventsManager.sessionState else  {
+            return nil
+        }
+        return EventDetails(router: router, session: sessionState)
     }
 }
 

--- a/MapboxCoreNavigation/EventsManager.swift
+++ b/MapboxCoreNavigation/EventsManager.swift
@@ -79,17 +79,21 @@ open class EventsManager: NSObject {
             return nil
         }
         
+        guard var event = EventDetails.defaultEvents(router: routeController) else {
+            return nil
+        }
+        
         let rating = potentialRating ?? MMEEventsManager.unrated
-        var event = EventDetails.defaultEvents(router: routeController)
-        event?.event = MMEEventTypeNavigationCancel
-        event?.arrivalTimestamp = sessionState?.arrivalTimestamp
+        
+        event.event = MMEEventTypeNavigationCancel
+        event.arrivalTimestamp = sessionState?.arrivalTimestamp
         
         let validRating: Bool = (rating >= MMEEventsManager.unrated && rating <= 100)
         assert(validRating, "MMEEventsManager: Invalid Rating. Values should be between \(MMEEventsManager.unrated) (none) and 100.")
         guard validRating else { return event }
         
-        event?.rating = rating
-        event?.comment = comment
+        event.rating = rating
+        event.comment = comment
         
         return event
     }
@@ -99,8 +103,11 @@ open class EventsManager: NSObject {
             return nil
         }
         
-        var event = EventDetails.defaultEvents(router: routeController)
-        event?.event = MMEEventTypeNavigationDepart
+        guard var event = EventDetails.defaultEvents(router: routeController) else {
+            return nil
+        }
+        
+        event.event = MMEEventTypeNavigationDepart
         return event
     }
     
@@ -109,8 +116,11 @@ open class EventsManager: NSObject {
             return nil
         }
         
-        var event = EventDetails.defaultEvents(router: routeController)
-        event?.event = MMEEventTypeNavigationArrive
+        guard var event = EventDetails.defaultEvents(router: routeController) else {
+            return nil
+        }
+        
+        event.event = MMEEventTypeNavigationArrive
         return event
     }
     
@@ -127,14 +137,17 @@ open class EventsManager: NSObject {
             return nil
         }
         
-        var event = EventDetails.defaultEvents(router: routeController)
-        event?.event = MMEEventTypeNavigationFeedback
+        guard var event = EventDetails.defaultEvents(router: routeController) else {
+            return nil
+        }
         
-        event?.userId = UIDevice.current.identifierForVendor?.uuidString
-        event?.feedbackType = type.description
-        event?.description = description
+        event.event = MMEEventTypeNavigationFeedback
         
-        event?.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
+        event.userId = UIDevice.current.identifierForVendor?.uuidString
+        event.feedbackType = type.description
+        event.description = description
+        
+        event.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
         
         return event
     }
@@ -144,22 +157,25 @@ open class EventsManager: NSObject {
             return nil
         }
         
+        guard var event = EventDetails.defaultEvents(router: routeController) else {
+            return nil
+        }
+        
         let timestamp = Date()
         
-        var event = EventDetails.defaultEvents(router: routeController)
-        event?.event = eventType
+        event.event = eventType
         if let lastRerouteDate = sessionState?.lastRerouteDate {
-            event?.secondsSinceLastReroute = round(timestamp.timeIntervalSince(lastRerouteDate))
+            event.secondsSinceLastReroute = round(timestamp.timeIntervalSince(lastRerouteDate))
         } else {
-            event?.secondsSinceLastReroute = -1
+            event.secondsSinceLastReroute = -1
         }
         
         
         // These are placeholders until the route controller's RouteProgress is updated after rerouting
-        event?.newDistanceRemaining = -1
-        event?.newDurationRemaining = -1
-        event?.newGeometry = nil
-        event?.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
+        event.newDistanceRemaining = -1
+        event.newDurationRemaining = -1
+        event.newGeometry = nil
+        event.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
         
         return event
     }
@@ -320,7 +336,7 @@ extension EventsManager {
     }
     
     @objc private func applicationWillTerminate(_ notification: NSNotification) {
-        if let session_state = sessionState, !session_state.terminated {
+        if sessionState?.terminated == false {
             sendCancelEvent(rating: nil, comment: nil)
             sessionState?.terminated = true
         }

--- a/MapboxCoreNavigation/EventsManager.swift
+++ b/MapboxCoreNavigation/EventsManager.swift
@@ -12,11 +12,11 @@ open class EventsManager: NSObject {
     
     @objc public var manager = MMEEventsManager.shared()
     
-    var sessionState: SessionState!
+    var sessionState: SessionState?
     
     var outstandingFeedbackEvents = [CoreFeedbackEvent]()
     
-    weak var routeController: Router!
+    weak var routeController: Router?
     
     /// :nodoc: This is used internally when the navigation UI is being used
     var usesDefaultUserInterface = false
@@ -74,68 +74,92 @@ open class EventsManager: NSObject {
         manager.sendTurnstileEvent()
     }
     
-    func navigationCancelEvent(rating potentialRating: Int? = nil, comment: String? = nil) -> EventDetails {
+    func navigationCancelEvent(rating potentialRating: Int? = nil, comment: String? = nil) -> EventDetails? {
+        guard let routeController = routeController else {
+            return nil
+        }
+        
         let rating = potentialRating ?? MMEEventsManager.unrated
         var event = EventDetails.defaultEvents(router: routeController)
-        event.event = MMEEventTypeNavigationCancel
-        event.arrivalTimestamp = sessionState.arrivalTimestamp
+        event?.event = MMEEventTypeNavigationCancel
+        event?.arrivalTimestamp = sessionState?.arrivalTimestamp
         
         let validRating: Bool = (rating >= MMEEventsManager.unrated && rating <= 100)
         assert(validRating, "MMEEventsManager: Invalid Rating. Values should be between \(MMEEventsManager.unrated) (none) and 100.")
         guard validRating else { return event }
         
-        event.rating = rating
-        event.comment = comment
+        event?.rating = rating
+        event?.comment = comment
         
         return event
     }
     
-    func navigationDepartEvent() -> EventDetails {
+    func navigationDepartEvent() -> EventDetails? {
+        guard let routeController = routeController else {
+            return nil
+        }
+        
         var event = EventDetails.defaultEvents(router: routeController)
-        event.event = MMEEventTypeNavigationDepart
+        event?.event = MMEEventTypeNavigationDepart
         return event
     }
     
-    func navigationArriveEvent() -> EventDetails {
+    func navigationArriveEvent() -> EventDetails? {
+        guard let routeController = routeController else {
+            return nil
+        }
+        
         var event = EventDetails.defaultEvents(router: routeController)
-        event.event = MMEEventTypeNavigationArrive
+        event?.event = MMEEventTypeNavigationArrive
         return event
     }
     
     func navigationFeedbackEventWithLocationsAdded(event: CoreFeedbackEvent) -> [String: Any] {
         var eventDictionary = event.eventDictionary
         eventDictionary["feedbackId"] = event.id.uuidString
-        eventDictionary["locationsBefore"] = sessionState.pastLocations.allObjects.filter { $0.timestamp <= event.timestamp}.map {$0.dictionaryRepresentation}
-        eventDictionary["locationsAfter"] = sessionState.pastLocations.allObjects.filter {$0.timestamp > event.timestamp}.map {$0.dictionaryRepresentation}
+        eventDictionary["locationsBefore"] = sessionState?.pastLocations.allObjects.filter { $0.timestamp <= event.timestamp}.map {$0.dictionaryRepresentation}
+        eventDictionary["locationsAfter"] = sessionState?.pastLocations.allObjects.filter {$0.timestamp > event.timestamp}.map {$0.dictionaryRepresentation}
         return eventDictionary
     }
     
-    func navigationFeedbackEvent(type: FeedbackType, description: String?) -> EventDetails {
+    func navigationFeedbackEvent(type: FeedbackType, description: String?) -> EventDetails? {
+        guard let routeController = routeController else {
+            return nil
+        }
+        
         var event = EventDetails.defaultEvents(router: routeController)
-        event.event = MMEEventTypeNavigationFeedback
+        event?.event = MMEEventTypeNavigationFeedback
         
-        event.userId = UIDevice.current.identifierForVendor?.uuidString
-        event.feedbackType = type.description
-        event.description = description
+        event?.userId = UIDevice.current.identifierForVendor?.uuidString
+        event?.feedbackType = type.description
+        event?.description = description
         
-        event.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
+        event?.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
         
         return event
     }
     
-    func navigationRerouteEvent(eventType: String = MMEEventTypeNavigationReroute) -> EventDetails {
+    func navigationRerouteEvent(eventType: String = MMEEventTypeNavigationReroute) -> EventDetails? {
+        guard let routeController = routeController else {
+            return nil
+        }
+        
         let timestamp = Date()
         
         var event = EventDetails.defaultEvents(router: routeController)
-        event.event = eventType
-        event.secondsSinceLastReroute = sessionState.lastRerouteDate != nil ? round(timestamp.timeIntervalSince(sessionState.lastRerouteDate!)) : -1
+        event?.event = eventType
+        if let lastRerouteDate = sessionState?.lastRerouteDate {
+            event?.secondsSinceLastReroute = round(timestamp.timeIntervalSince(lastRerouteDate))
+        } else {
+            event?.secondsSinceLastReroute = -1
+        }
         
         
         // These are placeholders until the route controller's RouteProgress is updated after rerouting
-        event.newDistanceRemaining = -1
-        event.newDurationRemaining = -1
-        event.newGeometry = nil
-        event.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
+        event?.newDistanceRemaining = -1
+        event?.newDurationRemaining = -1
+        event?.newGeometry = nil
+        event?.screenshot = captureScreen(scaledToFit: 250)?.base64EncodedString()
         
         return event
     }
@@ -144,21 +168,22 @@ open class EventsManager: NSObject {
 extension EventsManager {
     
     func sendDepartEvent() {
-        guard let attributes = try? navigationDepartEvent().asDictionary() else { return }
+        guard let departEvent = navigationDepartEvent(),
+              let attributes = try? departEvent.asDictionary() else { return }
         manager.enqueueEvent(withName: MMEEventTypeNavigationDepart, attributes: attributes)
         manager.flush()
     }
     
     
     func sendArriveEvent() {
-        guard let attributes = try? navigationArriveEvent().asDictionary() else { return }
+        guard let arriveEvent = navigationArriveEvent(), let attributes = try? arriveEvent.asDictionary() else { return }
         manager.enqueueEvent(withName: MMEEventTypeNavigationArrive, attributes: attributes)
         manager.flush()
     }
     
     func sendCancelEvent(rating: Int? = nil, comment: String? = nil) {
         guard routeController != nil else { return }
-        guard let attributes = try? navigationCancelEvent(rating: rating, comment: comment).asDictionary() else { return }
+        guard let cancelEvent = navigationCancelEvent(rating: rating, comment: comment), let attributes = try? cancelEvent.asDictionary() else { return }
         manager.enqueueEvent(withName: MMEEventTypeNavigationCancel, attributes: attributes)
         manager.flush()
     }
@@ -178,19 +203,26 @@ extension EventsManager {
         manager.flush()
     }
     
-    func enqueueFeedbackEvent(type: FeedbackType, description: String?) -> UUID {
-        let eventDictionary = try! navigationFeedbackEvent(type: type, description: description).asDictionary()
+    func enqueueFeedbackEvent(type: FeedbackType, description: String?) -> UUID? {
+        guard let feedbackEvent = navigationFeedbackEvent(type: type, description: description) else {
+            return nil
+        }
+        let eventDictionary = try! feedbackEvent.asDictionary()
         let event = FeedbackEvent(timestamp: Date(), eventDictionary: eventDictionary)
         outstandingFeedbackEvents.append(event)
         return event.id
     }
     
-    func enqueueRerouteEvent() -> String {
-        let timestamp = Date()
-        let eventDictionary = try! navigationRerouteEvent().asDictionary()
+    func enqueueRerouteEvent() -> String? {
+        guard let rerouteEvent = navigationRerouteEvent() else {
+            return nil
+        }
         
-        sessionState.lastRerouteDate = timestamp
-        sessionState.numberOfReroutes += 1
+        let timestamp = Date()
+        let eventDictionary = try! rerouteEvent.asDictionary()
+        
+        sessionState?.lastRerouteDate = timestamp
+        sessionState?.numberOfReroutes += 1
         
         let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
         
@@ -200,15 +232,20 @@ extension EventsManager {
     }
     
     func resetSession() {
-        let route = routeController.routeProgress.route
+        guard let route = routeController?.routeProgress.route else {
+            return
+        }
         sessionState = SessionState(currentRoute: route, originalRoute: route)
     }
     
-    func enqueueFoundFasterRouteEvent() -> String {
+    func enqueueFoundFasterRouteEvent() -> String? {
+        guard let rerouteEvent = navigationRerouteEvent(eventType: FasterRouteFoundEvent) else {
+            return nil
+        }
         let timestamp = Date()
-        let eventDictionary = try! navigationRerouteEvent(eventType: FasterRouteFoundEvent).asDictionary()
+        let eventDictionary = try! rerouteEvent.asDictionary()
         
-        sessionState.lastRerouteDate = timestamp
+        sessionState?.lastRerouteDate = timestamp
         
         let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
         
@@ -249,7 +286,7 @@ extension EventsManager {
      
      You can then call `updateFeedback(uuid:type:source:description:)` with the returned feedback UUID to attach any additional metadata to the feedback.
      */
-    @objc public func recordFeedback(type: FeedbackType = .general, description: String? = nil) -> UUID {
+    @objc public func recordFeedback(type: FeedbackType = .general, description: String? = nil) -> UUID? {
         return enqueueFeedbackEvent(type: type, description: description)
     }
     
@@ -275,21 +312,17 @@ extension EventsManager {
     
     //MARK: - Session State Management
     @objc private func didChangeOrientation(_ notification: NSNotification) {
-        if sessionState != nil {
-            sessionState.reportChange(to: UIDevice.current.orientation)
-        }
+        sessionState?.reportChange(to: UIDevice.current.orientation)
     }
     
     @objc private func didChangeApplicationState(_ notification: NSNotification) {
-        if sessionState != nil {
-            sessionState.reportChange(to: UIApplication.shared.applicationState)
-        }
+        sessionState?.reportChange(to: UIApplication.shared.applicationState)
     }
     
     @objc private func applicationWillTerminate(_ notification: NSNotification) {
-        if !sessionState.terminated {
+        if let session_state = sessionState, !session_state.terminated {
             sendCancelEvent(rating: nil, comment: nil)
-            sessionState.terminated = true
+            sessionState?.terminated = true
         }
         
         sendOutstandingFeedbackEvents(forceAll: true)
@@ -304,14 +337,14 @@ extension EventsManager {
     }
     
     @objc func update(progress: RouteProgress) {
-        if sessionState.departureTimestamp == nil {
-            sessionState.departureTimestamp = Date()
+        if sessionState?.departureTimestamp == nil {
+            sessionState?.departureTimestamp = Date()
             sendDepartEvent()
         }
         
-        if sessionState.arrivalTimestamp == nil,
+        if sessionState?.arrivalTimestamp == nil,
             progress.currentLegProgress.userHasArrivedAtWaypoint {
-            sessionState.arrivalTimestamp = Date()
+            sessionState?.arrivalTimestamp = Date()
             sendArriveEvent()
         }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -59,7 +59,7 @@ open class RouteController: NSObject, Router {
     @objc public var routeProgress: RouteProgress {
         willSet {
             // Save any progress completed up until now
-            if let _ = eventsManager.sessionState {
+            if eventsManager.sessionState != nil {
                 eventsManager.sessionState?.totalDistanceCompleted += routeProgress.distanceTraveled
             }
         }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -59,14 +59,16 @@ open class RouteController: NSObject, Router {
     @objc public var routeProgress: RouteProgress {
         willSet {
             // Save any progress completed up until now
-            eventsManager.sessionState.totalDistanceCompleted += routeProgress.distanceTraveled
+            if let _ = eventsManager.sessionState {
+                eventsManager.sessionState?.totalDistanceCompleted += routeProgress.distanceTraveled
+            }
         }
         didSet {
             // if the user has already arrived and a new route has been set, restart the navigation session
-            if eventsManager.sessionState.arrivalTimestamp != nil {
+            if eventsManager.sessionState?.arrivalTimestamp != nil {
                 eventsManager.resetSession()
             } else {
-                eventsManager.sessionState.currentRoute = routeProgress.route
+                eventsManager.sessionState?.currentRoute = routeProgress.route
             }
 
             var userInfo = [RouteControllerNotificationUserInfoKey: Any]()
@@ -102,8 +104,8 @@ open class RouteController: NSObject, Router {
     var previousArrivalWaypoint: Waypoint? {
         didSet {
             if oldValue != previousArrivalWaypoint {
-                eventsManager.sessionState.arrivalTimestamp = nil
-                eventsManager.sessionState.departureTimestamp = nil
+                eventsManager.sessionState?.arrivalTimestamp = nil
+                eventsManager.sessionState?.departureTimestamp = nil
             }
         }
     }
@@ -291,7 +293,7 @@ extension RouteController: CLLocationManagerDelegate {
 
     @objc public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         let filteredLocations = locations.filter {
-            eventsManager.sessionState.pastLocations.push($0)
+            eventsManager.sessionState?.pastLocations.push($0)
             return $0.isQualified
         }
 

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -193,16 +193,16 @@ public class CarPlayManager: NSObject, CPInterfaceControllerDelegate, CPSearchTe
     
     func sendCarPlayConnectEvent(_ timestamp: String) {
         // TODO: The events manager depends on a RouteController but we can't set it up here since we don't have a route yet
-//        let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
-//        eventsManager.manager.enqueueEvent(withName: MMEventTypeCarplayConnect, attributes: dateCreatedAttribute)
-//        eventsManager.manager.flush()
+        let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
+        eventsManager.manager.enqueueEvent(withName: MMEventTypeCarplayConnect, attributes: dateCreatedAttribute)
+        eventsManager.manager.flush()
     }
     
     func sendCarPlayDisconnectEvent(_ timestamp: String) {
         // TODO: The events manager depends on a RouteController but we can't set it up here since we don't have a route yet
-//        let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
-//        eventsManager.manager.enqueueEvent(withName: MMEventTypeCarplayDisconnect, attributes: dateCreatedAttribute)
-//        eventsManager.manager.flush()
+        let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
+        eventsManager.manager.enqueueEvent(withName: MMEventTypeCarplayDisconnect, attributes: dateCreatedAttribute)
+        eventsManager.manager.flush()
     }
 
     public func application(_ application: UIApplication, didDisconnectCarInterfaceController interfaceController: CPInterfaceController, from window: CPWindow) {

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -101,7 +101,7 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
      */
     public var eventsManager: EventsManager
     
-    var uuid: UUID {
+    var uuid: UUID? {
         return eventsManager.recordFeedback()
     }
     
@@ -229,8 +229,10 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
     
     func send(_ item: FeedbackItem) {
-        delegate?.feedbackViewController?(self, didSend: item, uuid: uuid)
-        eventsManager.updateFeedback(uuid: uuid, type: item.feedbackType, source: .user, description: nil)
+        if let uuid = uuid {
+            delegate?.feedbackViewController?(self, didSend: item, uuid: uuid)
+            eventsManager.updateFeedback(uuid: uuid, type: item.feedbackType, source: .user, description: nil)
+        }
         
         guard let parent = presentingViewController else {
             dismiss(animated: true)
@@ -243,8 +245,11 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
     
     func dismissFeedbackItem() {
-        delegate?.feedbackViewControllerDidCancel?(self)
-        eventsManager.cancelFeedback(uuid: uuid)
+        if let uuid = uuid {
+            delegate?.feedbackViewControllerDidCancel?(self)
+            eventsManager.cancelFeedback(uuid: uuid)
+        }
+   
         dismiss(animated: true, completion: nil)
     }
 }

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -245,8 +245,9 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
     
     func dismissFeedbackItem() {
+        delegate?.feedbackViewControllerDidCancel?(self)
+
         if let uuid = uuid {
-            delegate?.feedbackViewControllerDidCancel?(self)
             eventsManager.cancelFeedback(uuid: uuid)
         }
    


### PR DESCRIPTION
Provided optional `sessionState` and `routeController` for specific telemetry events where these fields are not required.

/cc @frederoni @1ec5 @akitchen 