### PR TITLE
Enable style manager in CarPlay

### DIFF
--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -5,6 +5,8 @@ import CarPlay
 @available(iOS 12.0, *)
 class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
     
+    var styleManager: StyleManager!
+    
     var mapView: NavigationMapView {
         get {
             return self.view as! NavigationMapView
@@ -24,7 +26,9 @@ class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        styleManager = StyleManager(self)
+        styleManager.styles = [CarPlayDayStyle(), CarPlayNightStyle()]
     }
     
     public func zoomInButton() -> CPMapButton {
@@ -57,6 +61,30 @@ class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
         if let mapView = mapView as? NavigationMapView {
             mapView.localizeLabels()
         }
+    }
+}
+
+@available(iOS 12.0, *)
+extension CarPlayMapViewController: StyleManagerDelegate {
+    func locationFor(styleManager: StyleManager) -> CLLocation? {
+        return mapView.userLocationForCourseTracking ?? mapView.userLocation?.location
+    }
+    
+    func styleManager(_ styleManager: StyleManager, didApply style: Style) {
+        let styleURL: URL
+        if let style = style as? CarPlayStyle {
+            styleURL = style.previewStyleURL
+        } else {
+            styleURL = style.mapStyleURL
+        }
+        if mapView.styleURL != styleURL {
+            mapView.style?.transition = MGLTransition(duration: 0.5, delay: 0)
+            mapView.styleURL = styleURL
+        }
+    }
+    
+    func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
+        mapView.reloadStyle(self)
     }
 }
 #endif

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -136,9 +136,6 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         self.routeController.delegate = self
         mapTemplateController.delegate = self
         mapTemplateController.mapDelegate = self
-        
-        self.styleManager = StyleManager(self)
-        self.styleManager.styles =  [CarPlayDayStyle(), CarPlayNightStyle()]
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -159,6 +156,9 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         mapView?.longManeuverDistance = 500
         
         view.addSubview(mapView!)
+        
+        styleManager = StyleManager(self)
+        styleManager.styles = [CarPlayDayStyle(), CarPlayNightStyle()]
         
         resumeNotifications()
         routeController.resume()

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -245,8 +245,8 @@ open class CarPlayDayStyle: DayStyle, CarPlayStyle {
     
     open override func apply() {
         super.apply()
-        ExitView.appearance().foregroundColor = .white
-        GenericRouteShield.appearance().foregroundColor = .white
+        ExitView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
+        GenericRouteShield.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
     }
 }
 
@@ -256,8 +256,8 @@ open class CarPlayNightStyle: NightStyle, CarPlayStyle {
     
     open override func apply() {
         super.apply()
-        ExitView.appearance().foregroundColor = .white
-        GenericRouteShield.appearance().foregroundColor = .white
+        ExitView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
+        GenericRouteShield.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
     }
 }
 #endif

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -233,8 +233,16 @@ open class NightStyle: DayStyle {
     }
 }
 
+#if canImport(CarPlay)
+@available(iOS 12.0, *)
+public protocol CarPlayStyle {
+    var previewStyleURL: URL { get }
+}
 
-open class CarPlayDayStyle: DayStyle {
+@available(iOS 12.0, *)
+open class CarPlayDayStyle: DayStyle, CarPlayStyle {
+    public var previewStyleURL = URL(string: "mapbox://styles/mapbox/navigation-preview-day-v4")!
+    
     open override func apply() {
         super.apply()
         ExitView.appearance().foregroundColor = .white
@@ -242,9 +250,14 @@ open class CarPlayDayStyle: DayStyle {
     }
 }
 
-open class CarPlayNightStyle: NightStyle {open override func apply() {
-    super.apply()
+@available(iOS 12.0, *)
+open class CarPlayNightStyle: NightStyle, CarPlayStyle {
+    public var previewStyleURL = URL(string: "mapbox://styles/mapbox/navigation-preview-night-v4")!
+    
+    open override func apply() {
+        super.apply()
         ExitView.appearance().foregroundColor = .white
         GenericRouteShield.appearance().foregroundColor = .white
     }
 }
+#endif


### PR DESCRIPTION
The navigation v4 styles are now visible in CarPlay, both on the main map and in turn-by-turn navigation.

/cc @vincethecoder @bsudekum