### PR TITLE
Re-use directions, location manager, and route controller from CarPlay

### DIFF
--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -52,8 +52,8 @@ public protocol CarPlayManagerDelegate {
 //public protocol CarPlayManagerNavigationDelegate {
 
     /***/
-    @objc(carPlayManager:didBeginNavigationWithRouteProgress:)
-    func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith progress: RouteProgress) -> ()
+    @objc(carPlayManager:didBeginNavigationWithRouteController:)
+    func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith routeController: RouteController) -> ()
 
     /***/
     @objc func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) -> ()
@@ -418,9 +418,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
 //            appViewFromCarPlayWindow.present(navigationViewController, animated: true)
 //        }
 
-        if let delegate = delegate {
-            delegate.carPlayManager(self, didBeginNavigationWith: routeController.routeProgress)
-        }
+        delegate?.carPlayManager(self, didBeginNavigationWith: routeController)
     }
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate, selectedPreviewFor trip: CPTrip, using routeChoice: CPRouteChoice) {

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -231,8 +231,8 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
     func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPMapButton]? {
         return mapButtons
     }
-
-    func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith progress: RouteProgress) {
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith routeController: RouteController) {
         navigationInitiated = true
     }
     


### PR DESCRIPTION
When navigation starts within CarPlay, we should reuse some of the
dependencies, not just the route.

Triggers needed to set up this flow should be provided in the CarPlay SDK but the implementation should be deferred to the developer.

- [x] Simulate navigation on device when simulating in CarPlay
- [x] Dismiss steps on device upon arrival

@akitchen 