### PR TITLE
Adjust optionality of CarPlayManagerDelegate methods

### DIFF
--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -87,10 +87,6 @@ extension AppDelegate: CarPlayManagerDelegate {
         }
     }
     
-    func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]? {
-        return nil
-    }
-    
     func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]? {
         guard let template = template as? CPListTemplate, template.title == "Favorites List" else {
             return nil

--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -108,10 +108,6 @@ extension AppDelegate: CarPlayManagerDelegate {
         return [simulationButton]
     }
     
-    func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPMapButton]? {
-        return nil
-    }
-    
     func carPlayManager(_ carPlayManager: CarPlayManager, routeControllerAlong route: Route) -> RouteController {
         if simulatesLocationsInCarPlay {
             let locationManager = SimulatedLocationManager(route: route)

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -29,9 +29,10 @@ public protocol CarPlayManagerDelegate {
      * Offers the delegate an opportunity to provide a customized list of buttons displayed on the map.
      *
      * These buttons handle the gestures on the map view, so it is up to the developer to ensure the map template is interactive.
+     * If this method is not implemented, or if nil is returned, a default set of zoom and pan buttons will be provided.
      */
     @objc(carPlayManager:mapButtonsCompatibleWithTraitCollection:inTemplate:)
-    func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPMapButton]?
+    optional func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPMapButton]?
 
     /**
      * Offers the delegate an opportunity to provide an alternate navigator, otherwise a default built-in RouteController will be created and used.
@@ -148,7 +149,7 @@ public class CarPlayManager: NSObject, CPInterfaceControllerDelegate, CPSearchTe
             mapTemplate.trailingNavigationBarButtons = [favoriteButton]
         }
         
-        if let mapButtons = delegate?.carPlayManager(self, mapButtonsCompatibleWith: traitCollection, in: mapTemplate) {
+        if let mapButtons = delegate?.carPlayManager?(self, mapButtonsCompatibleWith: traitCollection, in: mapTemplate) {
             mapTemplate.mapButtons = mapButtons
         } else if let vc = viewController as? CarPlayMapViewController {
             mapTemplate.mapButtons = [vc.zoomInButton(), vc.zoomOutButton(), panMapButton(for: mapTemplate, traitCollection: traitCollection)]

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -13,9 +13,10 @@ public protocol CarPlayManagerDelegate {
      * Offers the delegate an opportunity to provide a customized list of leading bar buttons.
      *
      * These buttons' tap handlers encapsulate the action to be taken, so it is up to the developer to ensure the hierarchy of templates is adequately navigable.
+     * If this method is not implemented, or if nil is returned, an implementation of CPSearchTemplate will be provided which uses the Mapbox Geocoder.
      */
     @objc(carPlayManager:leadingNavigationBarButtonsWithTraitCollection:inTemplate:)
-    func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]?
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]?
 
     /**
      * Offers the delegate an opportunity to provide a customized list of trailing bar buttons.
@@ -132,7 +133,7 @@ public class CarPlayManager: NSObject, CPInterfaceControllerDelegate, CPSearchTe
         let mapTemplate = CPMapTemplate()
         mapTemplate.mapDelegate = self
 
-        if let leadingButtons = delegate?.carPlayManager(self, leadingNavigationBarButtonsCompatibleWith: traitCollection, in: mapTemplate) {
+        if let leadingButtons = delegate?.carPlayManager?(self, leadingNavigationBarButtonsCompatibleWith: traitCollection, in: mapTemplate) {
             mapTemplate.leadingNavigationBarButtons = leadingButtons
         } else {
             let searchTemplate = CPSearchTemplate()
@@ -274,7 +275,7 @@ public class CarPlayManager: NSObject, CPInterfaceControllerDelegate, CPSearchTe
                                        detailText: CPFavoritesList.POI.timesSquare.subTitle)
             let listSection = CPListSection(items: [mapboxSFItem, timesSquareItem])
             let listTemplate = CPListTemplate(title: "Favorites List", sections: [listSection])
-            if let leadingButtons = strongSelf.delegate?.carPlayManager(strongSelf, leadingNavigationBarButtonsCompatibleWith: traitCollection, in: listTemplate) {
+            if let leadingButtons = strongSelf.delegate?.carPlayManager?(strongSelf, leadingNavigationBarButtonsCompatibleWith: traitCollection, in: listTemplate) {
                 listTemplate.leadingNavigationBarButtons = leadingButtons
             }
             if let trailingButtons = strongSelf.delegate?.carPlayManager(strongSelf, trailingNavigationBarButtonsCompatibleWith: traitCollection, in: listTemplate) {


### PR DESCRIPTION
The goal here is to avoid developers needing to implement an empty stub that returns nil. I've kept the optional return values, but made the methods for map buttons and leading buttons optional

I've left the method for trailing buttons alone for now, as we need to do a bit more to decouple it from our stubbed example locations for testing. Ideally it would follow this pattern as well, but more thought on organizing the example stub locations is needed. 