### PR TITLE
Refine navigation among CarPlay templates

### DIFF
--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -95,7 +95,7 @@ extension AppDelegate: CarPlayManagerDelegate {
     }
     
     func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]? {
-        guard let template = template as? CPListTemplate, template.title == "Favorites List" else {
+        guard let template = template as? CPMapTemplate, template != carPlayManager.interfaceController?.rootTemplate else {
             return nil
         }
         

--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -94,8 +94,8 @@ extension AppDelegate: CarPlayManagerDelegate {
         }
     }
     
-    func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]? {
-        guard let template = template as? CPMapTemplate, template != carPlayManager.interfaceController?.rootTemplate else {
+    func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]? {
+        guard activity == .previewing else {
             return nil
         }
         

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -134,20 +134,19 @@ public class CarPlayManager: NSObject, CPSearchTemplateDelegate {
         window.rootViewController = viewController
         self.carWindow = window
         
-        let mapTemplate = createMapTemplate(for: interfaceController, viewController: viewController)
-        
-        interfaceController.setRootTemplate(mapTemplate, animated: false)
+        createMapTemplate(for: interfaceController, viewController: viewController)
         
         let timestamp = Date().ISO8601
         sendCarPlayConnectEvent(timestamp)
     }
 
-    func createMapTemplate(for interfaceController: CPInterfaceController, viewController: UIViewController) -> CPMapTemplate {
+    func createMapTemplate(for interfaceController: CPInterfaceController, viewController: UIViewController) {
         
         let traitCollection = viewController.traitCollection
         
         let mapTemplate = CPMapTemplate()
         mapTemplate.mapDelegate = self
+        interfaceController.setRootTemplate(mapTemplate, animated: false)
 
         if let leadingButtons = delegate?.carPlayManager?(self, leadingNavigationBarButtonsCompatibleWith: traitCollection, in: mapTemplate) {
             mapTemplate.leadingNavigationBarButtons = leadingButtons
@@ -171,8 +170,6 @@ public class CarPlayManager: NSObject, CPSearchTemplateDelegate {
         } else if let vc = viewController as? CarPlayMapViewController {
             mapTemplate.mapButtons = [vc.zoomInButton(), vc.zoomOutButton(), panMapButton(for: mapTemplate, traitCollection: traitCollection)]
         }
-        
-        return mapTemplate
     }
     
     func panMapButton(for mapTemplate: CPMapTemplate, traitCollection: UITraitCollection) -> CPMapButton {
@@ -352,6 +349,12 @@ extension CarPlayManager: CPListTemplateDelegate {
         
         let previewTemplate = CPMapTemplate()
         previewTemplate.mapDelegate = self
+        if let leadingButtons = delegate?.carPlayManager?(self, leadingNavigationBarButtonsCompatibleWith: rootViewController.traitCollection, in: previewTemplate) {
+            previewTemplate.leadingNavigationBarButtons = leadingButtons
+        }
+        if let trailingButtons = delegate?.carPlayManager(self, trailingNavigationBarButtonsCompatibleWith: rootViewController.traitCollection, in: previewTemplate) {
+            previewTemplate.trailingNavigationBarButtons = trailingButtons
+        }
         interfaceController.pushTemplate(previewTemplate, animated: true)
         
         let routeOptions = NavigationRouteOptions(waypoints: [originWaypoint, toWaypoint])

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -561,15 +561,18 @@ extension CarPlayManager: CPMapTemplateDelegate {
             return
         }
         
-        guard let carPlayMapViewController = self.carWindow?.rootViewController as? CarPlayMapViewController else {
+        let mapView: NavigationMapView
+        if let navigationViewController = currentNavigator, mapTemplate == navigationViewController.mapTemplate {
+            mapView = navigationViewController.mapView!
+        } else if let carPlayMapViewController = self.carWindow?.rootViewController as? CarPlayMapViewController {
+            mapView = carPlayMapViewController.mapView
+            mapView.userTrackingMode = .none
+        } else {
             return
         }
         
         let decelerationRate: CGFloat = 0.9
         let offset = CGPoint(x: velocity.x * decelerationRate / 4, y: velocity.y * decelerationRate / 4)
-        
-        let mapView = carPlayMapViewController.mapView
-        mapView.userTrackingMode = .none
         
         if let toCamera = cameraShouldPan(to: offset, mapView: mapView) {
             mapView.setCamera(toCamera, animated: true)
@@ -589,10 +592,9 @@ extension CarPlayManager: CPMapTemplateDelegate {
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate, didEndPanGestureWithVelocity velocity: CGPoint) {
         if let navigationViewController = currentNavigator, mapTemplate == navigationViewController.mapTemplate {
-            navigationViewController.endPanGesture(velocity: velocity)
-        } else {
-            mapTemplate.mapButtons.forEach { $0.isHidden = false }
+            return
         }
+        mapTemplate.mapButtons.forEach { $0.isHidden = false }
     }
     
     public func mapTemplateDidShowPanningInterface(_ mapTemplate: CPMapTemplate) {

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -13,7 +13,6 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
     
     var routeController: RouteController
     var mapView: NavigationMapView?
-    let decelerationRate:CGFloat = 0.9
     let shieldHeight: CGFloat = 16
     
     var carSession: CPNavigationSession!
@@ -22,13 +21,6 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
     var carInterfaceController: CPInterfaceController
     
     var styleManager: StyleManager!
-    
-    var showFeedbackButton: CPMapButton!
-    var overviewButton: CPMapButton!
-    var recenterButton: CPMapButton!
-    
-    var exitButton: CPBarButton!
-    var muteButton: CPBarButton!
     
     var edgePadding: UIEdgeInsets {
         let padding:CGFloat = 15
@@ -128,6 +120,10 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
                 mapView?.setOverheadCameraView(from: userLocation, along: routeController.routeProgress.route.coordinates!, for: self.edgePadding)
             }
         }
+    }
+    public func beginPanGesture() {
+        mapView?.tracksUserCourse = false
+        mapView?.enableFrameByFrameCourseViewTracking(for: 1)
     }
     
     public func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
@@ -346,35 +342,4 @@ public protocol CarPlayNavigationDelegate {
      */
     @objc func carPlayNavigationViewControllerDidArrive(_ carPlayNavigationViewController: CarPlayNavigationViewController)
 }
-
-@available(iOS 12.0, *)
-extension CarPlayNavigationViewController {
-    public func beginPanGesture() {
-        overviewButton.isHidden = true
-        recenterButton.isHidden = false
-        mapView?.tracksUserCourse = false
-        mapView?.enableFrameByFrameCourseViewTracking(for: 1)
-    }
-    
-    public func endPanGesture(velocity: CGPoint) {
-        // Not enough velocity to overcome friction
-        guard sqrtf(Float(velocity.x * velocity.x + velocity.y * velocity.y)) > 100 else { return }
-        
-        let offset = CGPoint(x: velocity.x * decelerationRate / 4, y: velocity.y * decelerationRate / 4)
-        guard let toCamera = camera(whenPanningTo: offset) else { return }
-        mapView?.tracksUserCourse = false
-        mapView?.setCamera(toCamera, animated: true)
-    }
-    
-    func camera(whenPanningTo endPoint: CGPoint) -> MGLMapCamera? {
-        guard let mapView = mapView else { return nil }
-        let camera = mapView.camera
-        let centerPoint = CGPoint(x: mapView.bounds.midX, y: mapView.bounds.midY)
-        let endCameraPoint = CGPoint(x: centerPoint.x - endPoint.x, y: centerPoint.y - endPoint.y)
-        camera.centerCoordinate = mapView.convert(endCameraPoint, toCoordinateFrom: mapView)
-        
-        return camera
-    }
-}
 #endif
-

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -187,8 +187,6 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
     func exitNavigation(canceled: Bool = false) {
         carSession.finishTrip()
         mapTemplateController.stopNavigationSession()
-        mapView?.removeRoutes()
-        mapView?.removeWaypoints()
         dismiss(animated: true, completion: nil)
         carPlayNavigationDelegate?.carPlayNavigationViewControllerDidDismiss(self, byCanceling: canceled)
     }


### PR DESCRIPTION
Added a back button to the CarPlay route preview screen. The key is to push a new map template onto the stack for previewing rather than blowing away the stack. (The map templates all share the same map view controller; this is only about managing overlays and such.) The same approach might allow us to effortlessly push and pop a navigation-centric map template as an alternative to #1644.

The route preview items have been refined to more closely match Maps. Each route is summarized by the expected travel time and secondarily by the major road names. Setting the major road names in a smaller font allows more of each name to be visible. The user can still compare travel times using the absolute travel times.

The Simulate / Don’t Simulate toggle button has been moved to the route preview screen, making it more discoverable than when it was in the Favorites list.

![route overview](https://user-images.githubusercontent.com/1231218/45241991-49100480-b2a3-11e8-987a-a02880fa3b5d.png)
![route selection](https://user-images.githubusercontent.com/1231218/45241992-49100480-b2a3-11e8-8b7c-e20e0fb4d89c.png)

This PR introduces a serious regression: a back button appears during turn-by-turn. Tapping it leads to the search or list template, and tapping cancel from there leads to a map template that still looks like it’s handling turn-by-turn navigation.

![back](https://user-images.githubusercontent.com/1231218/45242222-13b7e680-b2a4-11e8-81f0-bd11868ee588.png)
![stuck](https://user-images.githubusercontent.com/1231218/45242223-13b7e680-b2a4-11e8-8876-fce8ce6f8eba.png)

Fixes #1650.

/cc @akitchen @vincethecoder