### PR TITLE
Use location manager for overview, style switching in CarPlay

### DIFF
--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -6,6 +6,12 @@ import CarPlay
 class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
     
     var styleManager: StyleManager!
+    /// A very coarse location manager used for distinguishing between daytime and nighttime.
+    fileprivate let coarseLocationManager: CLLocationManager = {
+        let coarseLocationManager = CLLocationManager()
+        coarseLocationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
+        return coarseLocationManager
+    }()
     
     var mapView: NavigationMapView {
         get {
@@ -92,7 +98,7 @@ class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
 @available(iOS 12.0, *)
 extension CarPlayMapViewController: StyleManagerDelegate {
     func locationFor(styleManager: StyleManager) -> CLLocation? {
-        return mapView.userLocationForCourseTracking ?? mapView.userLocation?.location
+        return mapView.userLocationForCourseTracking ?? mapView.userLocation?.location ?? coarseLocationManager.location
     }
     
     func styleManager(_ styleManager: StyleManager, didApply style: Style) {

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -112,8 +112,11 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         set {
             if !tracksUserCourse && newValue {
                 mapView?.recenterMap()
+                mapView?.addArrow(route: routeController.routeProgress.route,
+                                 legIndex: routeController.routeProgress.legIndex,
+                                 stepIndex: routeController.routeProgress.currentLegProgress.stepIndex + 1)
             } else if tracksUserCourse && !newValue {
-                guard let userLocation = self.routeController.location?.coordinate else {
+                guard let userLocation = self.routeController.locationManager.location?.coordinate else {
                     return
                 }
                 mapView?.enableFrameByFrameCourseViewTracking(for: 3)

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -299,7 +299,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
 @available(iOS 12.0, *)
 extension CarPlayNavigationViewController: StyleManagerDelegate {
     public func locationFor(styleManager: StyleManager) -> CLLocation? {
-        return routeController.location
+        return routeController.locationManager.location
     }
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {


### PR DESCRIPTION
This PR fixes switching between day and night styles in CarPlay (following up on #1654), as well as the Overview button in CarPlay turn-by-turn navigation.

In both the main map view and the navigation map view, switch between day and night styles based on a location retrieved from a location manager, not a route controller or map view. The route controller may disqualify any location in the iOS simulator due to a lack of course readings, while the map view may not have a location by the time the style manager asks for it.

![night](https://user-images.githubusercontent.com/1231218/45260618-d71de500-b3a0-11e8-9a06-d242005b9130.png)

When tapping the Overview button in turn-by-turn navigation in CarPlay, use the location manager’s location instead of the route controller’s location, just as RouteMapViewController does. Once again, the route controller disqualifies just about any location in the iOS simulator, so overview mode ends up nonfunctional. Also add the maneuver arrow back onto the map when returning to turn-by-turn mode.

![overview night](https://user-images.githubusercontent.com/1231218/45260619-dedd8980-b3a0-11e8-951e-dc7aeb342b54.png)

Depends on #1660.

/cc @frederoni @vincethecoder