### PR TITLE
Fix crash displaying shields in CarPlay

### DIFF
--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -210,6 +210,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
                 instruction.append(attributedSecondary)
             }
             
+            instruction.canonicalizeAttachments()
             primaryManeuver.attributedInstructionVariants = [instruction]
         }
         
@@ -224,6 +225,8 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
                 tertiaryManeuver.instructionVariants = [text]
             }
             if let attributedTertiary = tertiaryInstruction.maneuverLabelAttributedText(bounds: bounds, shieldHeight: shieldHeight) {
+                let attributedTertiary = NSMutableAttributedString(attributedString: attributedTertiary)
+                attributedTertiary.canonicalizeAttachments()
                 tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]
             }
             

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -187,8 +187,11 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         primaryManeuver.initialTravelEstimates = CPTravelEstimates(distanceRemaining: distance, timeRemaining: step.expectedTravelTime)
         
         // Just incase, set some default text
-        let backupText = visualInstruction.primaryInstruction.text ?? step.instructions
-        primaryManeuver.instructionVariants = [backupText]
+        var text = visualInstruction.primaryInstruction.text ?? step.instructions
+        if let secondaryText = visualInstruction.secondaryInstruction?.text {
+            text += "\n\(secondaryText)"
+        }
+        primaryManeuver.instructionVariants = [text]
         
         // Add maneuver arrow
         primaryManeuver.symbolSet = visualInstruction.primaryInstruction.maneuverImageSet
@@ -213,10 +216,16 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         var maneuvers: [CPManeuver] = [primaryManeuver]
         
         // Add tertiary text if available. TODO: handle lanes.
-        if let tertiaryInstruction = visualInstruction.tertiaryInstruction, !tertiaryInstruction.containsLaneIndications, let tertiaryText = tertiaryInstruction.maneuverLabelAttributedText(bounds: bounds, shieldHeight: shieldHeight) {
+        if let tertiaryInstruction = visualInstruction.tertiaryInstruction, !tertiaryInstruction.containsLaneIndications {
             let tertiaryManeuver = CPManeuver()
-            tertiaryManeuver.attributedInstructionVariants = [ tertiaryText ]
             tertiaryManeuver.symbolSet = tertiaryInstruction.maneuverImageSet
+            
+            if let text = tertiaryInstruction.text {
+                tertiaryManeuver.instructionVariants = [text]
+            }
+            if let attributedTertiary = tertiaryInstruction.maneuverLabelAttributedText(bounds: bounds, shieldHeight: shieldHeight) {
+                tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]
+            }
             
             if let upcomingStep = routeController.routeProgress.currentLegProgress.upComingStep {
                 let distance = distanceFormatter.measurement(of: upcomingStep.distance)

--- a/MapboxNavigation/NSAttributedString.swift
+++ b/MapboxNavigation/NSAttributedString.swift
@@ -1,12 +1,25 @@
 import Foundation
 
 extension NSAttributedString {
-    static func + (left: NSAttributedString, right: NSAttributedString) -> NSAttributedString
-    {
+    static func + (left: NSAttributedString, right: NSAttributedString) -> NSAttributedString {
         let result = NSMutableAttributedString()
         result.append(left)
         result.append(right)
         return result
     }
+}
 
+extension NSMutableAttributedString {
+    func canonicalizeAttachments() {
+        enumerateAttribute(.attachment, in: NSRange(location: 0, length: length), options: []) { (value, range, stop) in
+            guard let attachment = value as? NSTextAttachment, type(of: attachment) != NSTextAttachment.self else {
+                return
+            }
+            
+            let sanitizedAttachment = NSTextAttachment()
+            sanitizedAttachment.image = attachment.image
+            sanitizedAttachment.bounds = attachment.bounds
+            setAttributes([.attachment: sanitizedAttachment], range: range)
+        }
+    }
 }

--- a/MapboxNavigationTests/InstructionsBannerViewIntegrationTests.swift
+++ b/MapboxNavigationTests/InstructionsBannerViewIntegrationTests.swift
@@ -170,13 +170,12 @@ class InstructionsBannerViewIntegrationTests: XCTestCase {
         guard let attributed = view.primaryLabel.attributedText else { return XCTFail("No attributed string") }
         let stringRange = NSRange(location: 0, length: attributed.length)
         let foundAttachment = XCTestExpectation(description: "Attachment found")
-        attributed.enumerateAttribute(.attachment, in: stringRange, options: [],
-        using: { (value, range, stop) in
+        attributed.enumerateAttribute(.attachment, in: stringRange, options: []) { (value, range, stop) in
             guard let attachment = value else { return }
             foundAttachment.fulfill()
             XCTAssert(range == NSRange(location: 0, length: 1), "Unexpected Range:" + String(describing: range))
             XCTAssert(type(of: attachment) == GenericShieldAttachment.self, "Unexpected Attachment type:" + String(describing: attachment))
-        })
+        }
         wait(for: [foundAttachment], timeout: 0)
         
     }


### PR DESCRIPTION
Before adding an attributed string to a maneuver’s attributed instructions, downgrade any instance of a custom text attachment subclass, such as ShieldAttachment, to NSTextAttachment. This ensures that the attributed string can be marshaled over to the CarPlay unit. Unfortunately, even standard NSTextAttachments don’t show up in the CarPlay simulator, but apparently they do show up on an actual CarPlay device.

Along the way, secondary and tertiary text instructions are now included in plain-text maneuver instructions for CarPlay units that lack support for attributed strings.

Fixes #1652.

/cc @JThramer