### PR TITLE
Refactor RouteController's dependency on EventsManager to remove implicit creation

### DIFF
--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -126,7 +126,8 @@
                                                                                     directions:[MBDirections sharedDirections]
                                                                                         styles:nil
                                                                                locationManager:locationManager
-                                                                               voiceController:nil];
+                                                                               voiceController:nil
+                                                                                 eventsManager:nil];
     [self presentViewController:controller animated:YES completion:nil];
     
     // Suspend notifications and let `MBNavigationViewController` handle all progress and voice updates.

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -33,7 +33,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         super.viewDidLoad()
         
         let locationManager = simulateLocation ? SimulatedLocationManager(route: userRoute!) : NavigationLocationManager()
-        routeController = RouteController(along: userRoute!, locationManager: locationManager)
+        routeController = RouteController(along: userRoute!, locationManager: locationManager, eventsManager: EventsManager())
         
         mapView.delegate = self
         mapView.compassView.isHidden = true

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -118,12 +118,12 @@ open class RouteController: NSObject, Router {
      - parameter locationManager: The associated location manager.
      */
     @objc(initWithRoute:directions:locationManager:eventsManager:)
-    public init(along route: Route, directions: Directions = Directions.shared, locationManager: NavigationLocationManager = NavigationLocationManager(), eventsManager eventsOverride: EventsManager? = nil) {
+    public init(along route: Route, directions: Directions = Directions.shared, locationManager: NavigationLocationManager = NavigationLocationManager(), eventsManager: EventsManager) {
         self.directions = directions
         self.routeProgress = RouteProgress(route: route)
         self.locationManager = locationManager
         self.locationManager.activityType = route.routeOptions.activityType
-        self.eventsManager = eventsOverride ?? EventsManager(accessToken: route.accessToken)
+        self.eventsManager = eventsManager
         UIDevice.current.isBatteryMonitoringEnabled = true
 
         super.init()

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -19,7 +19,7 @@ class MapboxCoreNavigationTests: XCTestCase {
     
     func testDepart() {
         route.accessToken = "foo"
-        navigation = RouteController(along: route, directions: directions)
+        navigation = RouteController(along: route, directions: directions, eventsManager: TestNavigationEventsManager())
         let depart = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.795042, longitude: -122.413165), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 0, speed: 10, timestamp: Date())
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
@@ -42,7 +42,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         route.accessToken = "foo"
         let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.78895, longitude: -122.42543), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
         let locationManager = ReplayLocationManager(locations: [location, location])
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
@@ -64,7 +64,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.77386, longitude: -122.43085), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
         
         let locationManager = ReplayLocationManager(locations: [location, location])
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
@@ -92,7 +92,7 @@ class MapboxCoreNavigationTests: XCTestCase {
                                         timestamp: Date(timeIntervalSinceNow: 1))
         
         let locationManager = ReplayLocationManager(locations: [firstLocation, secondLocation])
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerWillReroute, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
@@ -114,7 +114,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         let locationManager = ReplayLocationManager(locations: locations)
         locationManager.speedMultiplier = 20
         
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerProgressDidChange, object: navigation) { (notification) -> Bool in
             let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
@@ -132,7 +132,7 @@ class MapboxCoreNavigationTests: XCTestCase {
     func testFailToReroute() {
         route.accessToken = "foo"
         let directionsClientSpy = DirectionsSpy(accessToken: "garbage", host: nil)
-        navigation = RouteController(along: route, directions: directionsClientSpy)
+        navigation = RouteController(along: route, directions: directionsClientSpy, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerWillReroute, object: navigation) { (notification) -> Bool in
             return true

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -167,7 +167,7 @@ class RouteControllerTests: XCTestCase {
         let route = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], options: NavigationRouteOptions(waypoints: [waypoint1, waypoint2]))
 
         route.accessToken = "foo"
-        let navigation = RouteController(along: route, directions: directions)
+        let navigation = RouteController(along: route, directions: directions, eventsManager: TestNavigationEventsManager())
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         let firstLocation = CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
         let coordNearStart = Polyline(navigation.routeProgress.currentLegProgress.nearbyCoordinates).coordinateFromStart(distance: 10)!

--- a/MapboxCoreNavigationTests/Support/MMEEventsManagerSpy.swift
+++ b/MapboxCoreNavigationTests/Support/MMEEventsManagerSpy.swift
@@ -57,3 +57,12 @@ class MMEEventsManagerSpy: MMEEventsManager {
         }.count
     }
 }
+
+import MapboxCoreNavigation
+
+class TestNavigationEventsManager: EventsManager {
+    init() {
+        super.init(accessToken: "not a real token")
+        self.manager = MMEEventsManagerSpy()
+    }
+}

--- a/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
+++ b/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
@@ -20,7 +20,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
     
     lazy var tunnelSetup: (tunnelIntersectionManager: TunnelIntersectionManager, routeController: RouteController, firstLocation: CLLocation) = {
         tunnelRoute.accessToken = "foo"
-        let navigation = RouteController(along: tunnelRoute, directions: directions)
+        let navigation = RouteController(along: tunnelRoute, directions: directions, eventsManager: TestNavigationEventsManager())
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         let tunnelIntersectionManager = TunnelIntersectionManager()
         

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A509D4202A87B20011D788 /* ImageDownloaderTests.swift */; };
 		16A509D7202BC0CA0011D788 /* ImageDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A509D6202BC0CA0011D788 /* ImageDownload.swift */; };
 		16B63DCD205C8EEF002D56D4 /* route-with-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = 16B63DCC205C8EEF002D56D4 /* route-with-instructions.json */; };
+		16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */; };
 		16E3625C201265D600DF0592 /* ImageDownloadOperationSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E3625B201265D600DF0592 /* ImageDownloadOperationSpy.swift */; };
 		16E4F97F205B05FE00531791 /* MapboxVoiceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4F97E205B05FE00531791 /* MapboxVoiceControllerTests.swift */; };
 		35002D611E5F6ADB0090E733 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35002D5F1E5F6ADB0090E733 /* Assets.xcassets */; };
@@ -280,13 +281,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = C5ADFBC81DDCC7840011824B;
 			remoteInfo = MapboxCoreNavigation;
-		};
-		352BBC3E1E5E6ADC00703DF1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C5ADFBC01DDCC7840011824B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 358D14621E5E3B7700ADE590;
-			remoteInfo = "Example-Swift";
 		};
 		352BBC4C1E5E78D700703DF1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1527,7 +1521,6 @@
 			);
 			dependencies = (
 				C5ADFBD51DDCC7840011824B /* PBXTargetDependency */,
-				352BBC3F1E5E6ADC00703DF1 /* PBXTargetDependency */,
 			);
 			name = MapboxCoreNavigationTests;
 			productName = MapboxNavigationTests;
@@ -1996,6 +1989,7 @@
 				35B1AEBC20AD9B3C00C8544E /* LeaksSpec.swift in Sources */,
 				16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */,
 				8D54F14A206ECF720038736D /* InstructionPresenterTests.swift in Sources */,
+				16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */,
 				166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */,
 				160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */,
 				35B1AEBE20AD9C7800C8544E /* LeakTest.swift in Sources */,
@@ -2077,11 +2071,6 @@
 			isa = PBXTargetDependency;
 			target = C5ADFBC81DDCC7840011824B /* MapboxCoreNavigation */;
 			targetProxy = 3525449B1E663D2C004C8F1C /* PBXContainerItemProxy */;
-		};
-		352BBC3F1E5E6ADC00703DF1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 358D14621E5E3B7700ADE590 /* Example-Swift */;
-			targetProxy = 352BBC3E1E5E6ADC00703DF1 /* PBXContainerItemProxy */;
 		};
 		352BBC4D1E5E78D700703DF1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -196,7 +196,7 @@ open class NavigationViewController: UIViewController {
     @objc public var route: Route! {
         didSet {
             if routeController == nil {
-                routeController = RouteController(along: route, directions: directions, locationManager: NavigationLocationManager())
+                routeController = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: eventsManager)
                 routeController.delegate = self
             } else {
                 routeController.routeProgress = RouteProgress(route: route)
@@ -308,6 +308,9 @@ open class NavigationViewController: UIViewController {
     @objc public var annotatesSpokenInstructions = false
     
     var styleManager: StyleManager!
+
+    private var eventsManager: EventsManager!
+    private var locationManager: NavigationLocationManager!
     
     var currentStatusBarStyle: UIStatusBarStyle = .default {
         didSet {
@@ -331,20 +334,26 @@ open class NavigationViewController: UIViewController {
 
      See [Mapbox Directions](https://mapbox.github.io/mapbox-navigation-ios/directions/) for further information.
      */
-    @objc(initWithRoute:directions:styles:locationManager:voiceController:)
+    @objc(initWithRoute:directions:styles:locationManager:voiceController:eventsManager:)
     required public init(for route: Route,
                          directions: Directions = Directions.shared,
                          styles: [Style]? = [DayStyle(), NightStyle()],
-                         locationManager: NavigationLocationManager? = NavigationLocationManager(),
-                         voiceController: RouteVoiceController? = nil) {
+                         locationManager: NavigationLocationManager? = nil,
+                         voiceController: RouteVoiceController? = nil,
+                         eventsManager: EventsManager? = nil) {
         
         super.init(nibName: nil, bundle: nil)
         
-        self.routeController = RouteController(along: route, directions: directions, locationManager: locationManager ?? NavigationLocationManager())
+        self.eventsManager = eventsManager ?? EventsManager()
+        self.locationManager = locationManager ?? NavigationLocationManager()
+
+        self.routeController = RouteController(along: route, directions: directions, locationManager: self.locationManager, eventsManager: self.eventsManager)
         self.routeController.usesDefaultUserInterface = true
         self.routeController.delegate = self
         self.routeController.tunnelIntersectionManager.delegate = self
+
         self.voiceController = voiceController ?? MapboxVoiceController()
+
         self.directions = directions
         self.route = route
         NavigationSettings.shared.distanceUnit = route.routeOptions.locale.usesMetric ? .kilometer : .mile

--- a/MapboxNavigationTests/LaneTests.swift
+++ b/MapboxNavigationTests/LaneTests.swift
@@ -22,7 +22,7 @@ class LaneTests: FBSnapshotTestCase {
         isDeviceAgnostic = true
 
         route.accessToken = bogusToken
-        routeController = RouteController(along: route, directions: directions)
+        routeController = RouteController(along: route, directions: directions, eventsManager: TestNavigationEventsManager())
 
         steps = routeController.routeProgress.currentLeg.steps
         routeProgress = routeController.routeProgress

--- a/MapboxNavigationTests/LeaksSpec.swift
+++ b/MapboxNavigationTests/LeaksSpec.swift
@@ -38,7 +38,7 @@ class LeaksSpec: QuickSpec {
             let route = initialRoute
             
             let navigationViewController = LeakTest {
-                return NavigationViewController(for: route, directions: Directions.shared, styles: nil, locationManager: nil, voiceController: FakeVoiceController())
+                return NavigationViewController(for: route, directions: Directions.shared, styles: nil, locationManager: nil, voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
             }
             
             it("must not leak") {

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -262,7 +262,7 @@ class NavigationViewControllerTestable: NavigationViewController {
     }
     
     required init(for route: Route, directions: Directions, styles: [Style]?, locationManager: NavigationLocationManager?, voiceController: RouteVoiceController?, eventsManager: EventsManager?) {
-        fatalError("init(for:directions:styles:locationManager:voiceController:eventsManager:) has not been implemented")
+        fatalError("init(for:directions:styles:locationManager:voiceController:eventsManager:) is not supported in this testing subclass.")
     }
 
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -18,7 +18,8 @@ class NavigationViewControllerTests: XCTestCase {
         let voice = FakeVoiceController()
         let nav = NavigationViewController(for: initialRoute,
                                            directions: Directions(accessToken: "garbage", host: nil),
-                                           voiceController: voice)
+                                           voiceController: voice,
+                                           eventsManager: TestNavigationEventsManager())
         
         nav.delegate = self
         
@@ -89,7 +90,7 @@ class NavigationViewControllerTests: XCTestCase {
     }
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithOneStyle() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle()], voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle()], voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -105,7 +106,7 @@ class NavigationViewControllerTests: XCTestCase {
     
     // If tunnel flags are enabled and we need to switch styles, we should not force refresh the map style because we have only 1 style.
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceWhenOnlyOneStyle() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()], voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()], voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -120,7 +121,7 @@ class NavigationViewControllerTests: XCTestCase {
     }
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithTwoStyles() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()], voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()], voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -255,10 +256,9 @@ class NavigationViewControllerTestable: NavigationViewController {
                   directions: Directions = Directions.shared,
                   styles: [Style]? = [DayStyle(), NightStyle()],
                   locationManager: NavigationLocationManager? = NavigationLocationManager(),
-                  eventsManager: EventsManager = TestNavigationEventsManager(),
                   styleLoaded: XCTestExpectation) {
         styleLoadedExpectation = styleLoaded
-        super.init(for: route, directions: directions,styles: styles, locationManager: locationManager, voiceController: FakeVoiceController())
+        super.init(for: route, directions: directions,styles: styles, locationManager: locationManager, voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
     }
     
     required init(for route: Route, directions: Directions, styles: [Style]?, locationManager: NavigationLocationManager?, voiceController: RouteVoiceController?, eventsManager: EventsManager?) {

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -255,15 +255,16 @@ class NavigationViewControllerTestable: NavigationViewController {
                   directions: Directions = Directions.shared,
                   styles: [Style]? = [DayStyle(), NightStyle()],
                   locationManager: NavigationLocationManager? = NavigationLocationManager(),
+                  eventsManager: EventsManager = TestNavigationEventsManager(),
                   styleLoaded: XCTestExpectation) {
         styleLoadedExpectation = styleLoaded
         super.init(for: route, directions: directions,styles: styles, locationManager: locationManager, voiceController: FakeVoiceController())
     }
     
-    required init(for route: Route, directions: Directions, styles: [Style]?, locationManager: NavigationLocationManager?, voiceController: RouteVoiceController?) {
-        fatalError("This initalizer is not supported in this testing subclass.")
+    required init(for route: Route, directions: Directions, styles: [Style]?, locationManager: NavigationLocationManager?, voiceController: RouteVoiceController?, eventsManager: EventsManager?) {
+        fatalError("init(for:directions:styles:locationManager:voiceController:eventsManager:) has not been implemented")
     }
-    
+
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         styleLoadedExpectation.fulfill()
     }

--- a/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -15,7 +15,7 @@ class StepsViewControllerTests: XCTestCase {
         let bogusToken = "pk.feedCafeDeadBeefBadeBede"
         let directions = Directions(accessToken: bogusToken)
 
-        let routeController = RouteController(along: initialRoute, directions: directions)
+        let routeController = RouteController(along: initialRoute, directions: directions, eventsManager: TestNavigationEventsManager())
         
         let stepsViewController = StepsViewController(routeProgress: routeController.routeProgress)
         


### PR DESCRIPTION
By removing the implicit creation of the EventsManager inside RouteController's initializer a number of flaky test issues are resolved and our dependency graph is made more clear.

Once merged, I will need to port this over to the carplay branch