### PR TITLE
Updates carplay branch with master and fixes tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
-## master
+## v0.20.1 (September 10, 2018)
 
+* Upgraded mapbox-events-ios to v0.5.0 to avoid a potential incompatibility when using Carthage to install the SDK.
 * Fixed a bug which prevented automatic day and night style switching. ([#1629](https://github.com/mapbox/mapbox-navigation-ios/pull/1629))
 
 ## v0.20.0 (September 6, 2018)

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -2,3 +2,4 @@ github "mapbox/MapboxGeocoder.swift" ~> 0.10
 github "uber/ios-snapshot-test-case" ~> 3.0.0
 github "Quick/Quick" ~> 1.3
 github "Quick/Nimble" ~> 7.1
+github "CedarBDD/Cedar" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.3.0"
+github "CedarBDD/Cedar" "v1.0"
 github "Quick/Nimble" "v7.3.0"
 github "Quick/Quick" "v1.3.1"
 github "ceeK/Solar" "2.1.0"

--- a/Examples/Objective-C/ViewController.m
+++ b/Examples/Objective-C/ViewController.m
@@ -126,7 +126,8 @@
                                                                                     directions:[MBDirections sharedDirections]
                                                                                         styles:nil
                                                                                locationManager:locationManager
-                                                                               voiceController:nil];
+                                                                               voiceController:nil
+                                                                                 eventsManager:nil];
     [self presentViewController:controller animated:YES completion:nil];
     
     // Suspend notifications and let `MBNavigationViewController` handle all progress and voice updates.

--- a/Examples/Objective-CTests/Info.plist
+++ b/Examples/Objective-CTests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 </dict>
 </plist>

--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -115,9 +115,9 @@ extension AppDelegate: CarPlayManagerDelegate {
         if simulatesLocationsInCarPlay {
             let locationManager = SimulatedLocationManager(route: route)
             locationManager.speedMultiplier = 5
-            return RouteController(along: route, locationManager: locationManager)
+            return RouteController(along: route, locationManager: locationManager, eventsManager: carPlayManager.eventsManager)
         } else {
-            return RouteController(along: route)
+            return RouteController(along: route, eventsManager: carPlayManager.eventsManager)
         }
     }
     

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -33,7 +33,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         super.viewDidLoad()
         
         let locationManager = simulateLocation ? SimulatedLocationManager(route: userRoute!) : NavigationLocationManager()
-        routeController = RouteController(along: userRoute!, locationManager: locationManager)
+        routeController = RouteController(along: userRoute!, locationManager: locationManager, eventsManager: EventsManager())
         
         mapView.delegate = self
         mapView.compassView.isHidden = true

--- a/Examples/SwiftTests/Info.plist
+++ b/Examples/SwiftTests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 </dict>
 </plist>

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = "MapboxCoreNavigation"
-  s.version = "0.20.0"
+  s.version = "0.20.1"
   s.summary = "Core components for turn-by-turn navigation on iOS."
 
   s.description  = <<-DESC
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxCoreNavigation"
 
   s.dependency "MapboxDirections.swift", "~> 0.22.0"
-  s.dependency "MapboxMobileEvents", "~> 0.4"
+  s.dependency "MapboxMobileEvents", "~> 0.5"
   s.dependency "Turf", "~> 0.2"
 
   # `swift_version` was introduced in CocoaPods 1.4.0. Without this check, if a user were to

--- a/MapboxCoreNavigation/Info.plist
+++ b/MapboxCoreNavigation/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -120,12 +120,12 @@ open class RouteController: NSObject, Router {
      - parameter locationManager: The associated location manager.
      */
     @objc(initWithRoute:directions:locationManager:eventsManager:)
-    public init(along route: Route, directions: Directions = Directions.shared, locationManager: NavigationLocationManager = NavigationLocationManager(), eventsManager eventsOverride: EventsManager? = nil) {
+    public init(along route: Route, directions: Directions = Directions.shared, locationManager: NavigationLocationManager = NavigationLocationManager(), eventsManager: EventsManager) {
         self.directions = directions
         self.routeProgress = RouteProgress(route: route)
         self.locationManager = locationManager
         self.locationManager.activityType = route.routeOptions.activityType
-        self.eventsManager = eventsOverride ?? EventsManager(accessToken: route.accessToken)
+        self.eventsManager = eventsManager
         UIDevice.current.isBatteryMonitoringEnabled = true
 
         super.init()

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - Mapbox-iOS-SDK (4.3.0)
-  - MapboxCoreNavigation (0.19.2):
+  - MapboxCoreNavigation (0.20.1):
     - MapboxDirections.swift (~> 0.22.0)
-    - MapboxMobileEvents (~> 0.4)
+    - MapboxMobileEvents (~> 0.5)
     - Turf (~> 0.2)
   - MapboxDirections.swift (0.22.0):
     - Polyline (~> 4.2)
-  - MapboxMobileEvents (0.4.51)
-  - MapboxNavigation (0.19.2):
+  - MapboxMobileEvents (0.5.0)
+  - MapboxNavigation (0.20.1):
     - Mapbox-iOS-SDK (~> 4.3)
-    - MapboxCoreNavigation (= 0.19.2)
+    - MapboxCoreNavigation (= 0.20.1)
     - MapboxSpeech (~> 0.0.1)
     - Solar (~> 2.1)
   - MapboxSpeech (0.0.1)
@@ -22,6 +22,16 @@ DEPENDENCIES:
   - MapboxMobileEvents (from `https://github.com/mapbox/mapbox-events-ios.git`, branch `master`)
   - MapboxNavigation (from `../../../`)
 
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - Mapbox-iOS-SDK
+    - MapboxDirections.swift
+    - MapboxMobileEvents
+    - MapboxSpeech
+    - Polyline
+    - Solar
+    - Turf
+
 EXTERNAL SOURCES:
   MapboxCoreNavigation:
     :path: ../../../
@@ -29,7 +39,7 @@ EXTERNAL SOURCES:
     :branch: master
     :git: https://github.com/mapbox/mapbox-events-ios.git
   MapboxNavigation:
-    :path: ../../../
+    :path: "../../../"
 
 CHECKOUT OPTIONS:
   MapboxMobileEvents:
@@ -38,10 +48,10 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 7d8d510088ba7900d11aa3ceb98f563b040efca1
-  MapboxCoreNavigation: e4fe458ab71b2a345a5df40e6398e639435f3bf7
+  MapboxCoreNavigation: b1217fd91973fc79ffa114804de445bf1c982a70
   MapboxDirections.swift: 67da008c3bff72ab68b0fc166185eebda23303be
-  MapboxMobileEvents: 83ed9a5ea8f81ca455c350cb15f05ce287d5d2a3
-  MapboxNavigation: d10c8ee497250f9609fe43d3602e2070057a0e25
+  MapboxMobileEvents: e4aa629e4e2e3c250b5dadc15b63d67b91469a79
+  MapboxNavigation: c69ce7e9b7487bee4b8e5260f86426d036961c51
   MapboxSpeech: 6cc9b3d53adc2988af3ebc704dd17907b84a3f9f
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
@@ -49,4 +59,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 5f10c5b41bbe71dd3b95306d2641d7ec9f47f7fa
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.0

--- a/MapboxCoreNavigationTests/Info.plist
+++ b/MapboxCoreNavigationTests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 </dict>
 </plist>

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -19,7 +19,7 @@ class MapboxCoreNavigationTests: XCTestCase {
     
     func testDepart() {
         route.accessToken = "foo"
-        navigation = RouteController(along: route, directions: directions)
+        navigation = RouteController(along: route, directions: directions, eventsManager: TestNavigationEventsManager())
         let depart = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.795042, longitude: -122.413165), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 0, speed: 10, timestamp: Date())
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
@@ -42,7 +42,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         route.accessToken = "foo"
         let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.78895, longitude: -122.42543), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
         let locationManager = ReplayLocationManager(locations: [location, location])
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
@@ -64,7 +64,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 37.77386, longitude: -122.43085), altitude: 1, horizontalAccuracy: 1, verticalAccuracy: 1, course: 171, speed: 10, timestamp: Date())
         
         let locationManager = ReplayLocationManager(locations: [location, location])
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
@@ -92,7 +92,7 @@ class MapboxCoreNavigationTests: XCTestCase {
                                         timestamp: Date(timeIntervalSinceNow: 1))
         
         let locationManager = ReplayLocationManager(locations: [firstLocation, secondLocation])
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerWillReroute, object: navigation) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
@@ -114,7 +114,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         let locationManager = ReplayLocationManager(locations: locations)
         locationManager.speedMultiplier = 20
         
-        navigation = RouteController(along: route, directions: directions, locationManager: locationManager)
+        navigation = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerProgressDidChange, object: navigation) { (notification) -> Bool in
             let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
@@ -132,7 +132,7 @@ class MapboxCoreNavigationTests: XCTestCase {
     func testFailToReroute() {
         route.accessToken = "foo"
         let directionsClientSpy = DirectionsSpy(accessToken: "garbage", host: nil)
-        navigation = RouteController(along: route, directions: directionsClientSpy)
+        navigation = RouteController(along: route, directions: directionsClientSpy, eventsManager: TestNavigationEventsManager())
         
         expectation(forNotification: .routeControllerWillReroute, object: navigation) { (notification) -> Bool in
             return true

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -167,7 +167,7 @@ class RouteControllerTests: XCTestCase {
         let route = Route(json: jsonRoute, waypoints: [waypoint1, waypoint2], options: NavigationRouteOptions(waypoints: [waypoint1, waypoint2]))
 
         route.accessToken = "foo"
-        let navigation = RouteController(along: route, directions: directions)
+        let navigation = RouteController(along: route, directions: directions, eventsManager: TestNavigationEventsManager())
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         let firstLocation = CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
         let coordNearStart = Polyline(navigation.routeProgress.currentLegProgress.nearbyCoordinates).coordinateFromStart(distance: 10)!

--- a/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
+++ b/MapboxCoreNavigationTests/TunnelIntersectionManagerTests.swift
@@ -20,7 +20,7 @@ class TunnelIntersectionManagerTests: XCTestCase {
     
     lazy var tunnelSetup: (tunnelIntersectionManager: TunnelIntersectionManager, routeController: RouteController, firstLocation: CLLocation) = {
         tunnelRoute.accessToken = "foo"
-        let navigation = RouteController(along: tunnelRoute, directions: directions)
+        let navigation = RouteController(along: tunnelRoute, directions: directions, eventsManager: TestNavigationEventsManager())
         let firstCoord = navigation.routeProgress.currentLegProgress.nearbyCoordinates.first!
         let tunnelIntersectionManager = TunnelIntersectionManager()
         

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = "MapboxNavigation-Documentation"
-  s.version = "0.19.2"
+  s.version = "0.20.1"
   s.summary = "Complete turn-by-turn navigation interface for iOS."
 
   s.description  = <<-DESC
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
 
   s.dependency "MapboxDirections.swift", "~> 0.22.0"
   s.dependency "Mapbox-iOS-SDK", "~> 4.3"
-  s.dependency "MapboxMobileEvents", "~> 0.4"
+  s.dependency "MapboxMobileEvents", "~> 0.5"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.2"
   s.dependency "MapboxSpeech", "~> 0.0.1"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = "MapboxNavigation"
-  s.version = "0.20.0"
+  s.version = "0.20.1"
   s.summary = "Complete turn-by-turn navigation interface for iOS."
 
   s.description  = <<-DESC

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		16A509D7202BC0CA0011D788 /* ImageDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A509D6202BC0CA0011D788 /* ImageDownload.swift */; };
 		16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.m in Sources */ = {isa = PBXBuildFile; fileRef = 16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.m */; };
 		16B63DCD205C8EEF002D56D4 /* route-with-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = 16B63DCC205C8EEF002D56D4 /* route-with-instructions.json */; };
+		16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */; };
 		16C2A421211526EE00FE6E68 /* CarPlayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C2A420211526EE00FE6E68 /* CarPlayManager.swift */; };
 		16E3625C201265D600DF0592 /* ImageDownloadOperationSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E3625B201265D600DF0592 /* ImageDownloadOperationSpy.swift */; };
 		16E4F97F205B05FE00531791 /* MapboxVoiceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4F97E205B05FE00531791 /* MapboxVoiceControllerTests.swift */; };
@@ -2231,6 +2232,7 @@
 				35B1AEBC20AD9B3C00C8544E /* LeaksSpec.swift in Sources */,
 				16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */,
 				8D54F14A206ECF720038736D /* InstructionPresenterTests.swift in Sources */,
+				16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */,
 				166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */,
 				160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */,
 				35B1AEBE20AD9C7800C8544E /* LeakTest.swift in Sources */,
@@ -2579,7 +2581,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 32;
+				DYLIB_CURRENT_VERSION = 33;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2603,7 +2605,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 32;
+				DYLIB_CURRENT_VERSION = 33;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2953,7 +2955,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -3017,7 +3019,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -3050,7 +3052,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 32;
+				DYLIB_CURRENT_VERSION = 33;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3076,7 +3078,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 32;
+				DYLIB_CURRENT_VERSION = 33;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1603C891214351EE00167D95 /* Cedar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1603C890214351EE00167D95 /* Cedar.framework */; };
 		160A4A712127A46C0028B070 /* CPBarButton+MBTestable.m in Sources */ = {isa = PBXBuildFile; fileRef = 160A4A69212791010028B070 /* CPBarButton+MBTestable.m */; };
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
 		160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D827A2059973C00D278D6 /* DataCacheTests.swift */; };
@@ -21,10 +22,10 @@
 		167538222138A783000E9836 /* RecentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352C35BF2134958F00D77796 /* RecentItem.swift */; };
 		16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A509D4202A87B20011D788 /* ImageDownloaderTests.swift */; };
 		16A509D7202BC0CA0011D788 /* ImageDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A509D6202BC0CA0011D788 /* ImageDownload.swift */; };
-		16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.m in Sources */ = {isa = PBXBuildFile; fileRef = 16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.m */; };
+		16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.mm */; };
 		16B63DCD205C8EEF002D56D4 /* route-with-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = 16B63DCC205C8EEF002D56D4 /* route-with-instructions.json */; };
-		16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */; };
 		16C2A421211526EE00FE6E68 /* CarPlayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C2A420211526EE00FE6E68 /* CarPlayManager.swift */; };
+		16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */; };
 		16E3625C201265D600DF0592 /* ImageDownloadOperationSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E3625B201265D600DF0592 /* ImageDownloadOperationSpy.swift */; };
 		16E4F97F205B05FE00531791 /* MapboxVoiceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4F97E205B05FE00531791 /* MapboxVoiceControllerTests.swift */; };
 		16EF6C1E21193A9600AA580B /* CarPlayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EF6C1D21193A9600AA580B /* CarPlayManagerTests.swift */; };
@@ -513,6 +514,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1603C890214351EE00167D95 /* Cedar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cedar.framework; path = Carthage/Build/iOS/Cedar.framework; sourceTree = "<group>"; };
 		160A4A68212791010028B070 /* CPBarButton+MBTestable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CPBarButton+MBTestable.h"; sourceTree = "<group>"; };
 		160A4A69212791010028B070 /* CPBarButton+MBTestable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CPBarButton+MBTestable.m"; sourceTree = "<group>"; };
 		160D8278205996DA00D278D6 /* DataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
@@ -526,7 +528,7 @@
 		16A509D4202A87B20011D788 /* ImageDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloaderTests.swift; sourceTree = "<group>"; };
 		16A509D6202BC0CA0011D788 /* ImageDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownload.swift; sourceTree = "<group>"; };
 		16AC9D0F212E356200CECE44 /* CPMapTemplate+MBTestable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CPMapTemplate+MBTestable.h"; sourceTree = "<group>"; };
-		16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CPMapTemplate+MBTestable.m"; sourceTree = "<group>"; };
+		16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "CPMapTemplate+MBTestable.mm"; sourceTree = "<group>"; };
 		16B63DCC205C8EEF002D56D4 /* route-with-instructions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-with-instructions.json"; sourceTree = "<group>"; };
 		16C2A420211526EE00FE6E68 /* CarPlayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayManager.swift; sourceTree = "<group>"; };
 		16E11B54212B40A900027CD3 /* MapboxNavigationTests-Bridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MapboxNavigationTests-Bridging.h"; sourceTree = "<group>"; };
@@ -965,6 +967,7 @@
 			files = (
 				3525449D1E663D32004C8F1C /* MapboxCoreNavigation.framework in Frameworks */,
 				35213DAF1EC456E800A62B21 /* FBSnapshotTestCase.framework in Frameworks */,
+				1603C891214351EE00167D95 /* Cedar.framework in Frameworks */,
 				35B711D41E5E7AD2001EDA8D /* MapboxNavigation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1020,7 +1023,7 @@
 				160A4A68212791010028B070 /* CPBarButton+MBTestable.h */,
 				160A4A69212791010028B070 /* CPBarButton+MBTestable.m */,
 				16AC9D0F212E356200CECE44 /* CPMapTemplate+MBTestable.h */,
-				16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.m */,
+				16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.mm */,
 			);
 			name = "Extensions and Categories";
 			sourceTree = "<group>";
@@ -1302,6 +1305,7 @@
 		A9E2B43473B53369153F54C6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1603C890214351EE00167D95 /* Cedar.framework */,
 				3507F9F92134305C0086B39E /* MapboxGeocoder.framework */,
 				35B1AEBA20AD9AEC00C8544E /* Nimble.framework */,
 				35B1AEB920AD9AE600C8544E /* Quick.framework */,
@@ -2017,13 +2021,14 @@
 				"$(SRCROOT)/Carthage/Build/iOS/MapboxSpeech.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Cedar.framework",
 			);
 			name = "Carthage copy frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		C53F2F0320EBC95600D9798F /* Apply Mapbox Access Token */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2225,7 +2230,7 @@
 				35EFD009207CA5E800BF3873 /* ManeuverViewTests.swift in Sources */,
 				16E4F97F205B05FE00531791 /* MapboxVoiceControllerTests.swift in Sources */,
 				35A262B92050A5CD00AEFF6D /* InstructionsBannerViewSnapshotTests.swift in Sources */,
-				16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.m in Sources */,
+				16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.mm in Sources */,
 				35F1F5931FD57EFD00F8E502 /* StyleManagerTests.swift in Sources */,
 				AE00A73A209A2C38006A3DC7 /* StepsViewControllerTests.swift in Sources */,
 				16435E06206EE37800AF48B6 /* DummyURLSessionDataTask.swift in Sources */,

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -446,7 +446,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         if let routeControllerFromDelegate = delegate?.carPlayManager?(self, routeControllerAlong: route) {
             routeController = routeControllerFromDelegate
         } else {
-            routeController = RouteController(along: route)
+            routeController = RouteController(along: route, eventsManager: eventsManager)
         }
         
         interfaceController.popToRootTemplate(animated: false)

--- a/MapboxNavigation/Info.plist
+++ b/MapboxNavigation/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -196,7 +196,7 @@ open class NavigationViewController: UIViewController {
     @objc public var route: Route! {
         didSet {
             if routeController == nil {
-                routeController = RouteController(along: route, directions: directions, locationManager: NavigationLocationManager())
+                routeController = RouteController(along: route, directions: directions, locationManager: locationManager, eventsManager: eventsManager)
                 routeController.delegate = self
             } else {
                 routeController.routeProgress = RouteProgress(route: route)
@@ -317,6 +317,9 @@ open class NavigationViewController: UIViewController {
     @objc public var annotatesSpokenInstructions = false
     
     var styleManager: StyleManager!
+
+    private var eventsManager: EventsManager!
+    private var locationManager: NavigationLocationManager!
     
     var currentStatusBarStyle: UIStatusBarStyle = .default {
         didSet {
@@ -340,20 +343,26 @@ open class NavigationViewController: UIViewController {
 
      See [Mapbox Directions](https://mapbox.github.io/mapbox-navigation-ios/directions/) for further information.
      */
-    @objc(initWithRoute:directions:styles:locationManager:voiceController:)
+    @objc(initWithRoute:directions:styles:locationManager:voiceController:eventsManager:)
     required public init(for route: Route,
                          directions: Directions = Directions.shared,
                          styles: [Style]? = [DayStyle(), NightStyle()],
-                         locationManager: NavigationLocationManager? = NavigationLocationManager(),
-                         voiceController: RouteVoiceController? = nil) {
+                         locationManager: NavigationLocationManager? = nil,
+                         voiceController: RouteVoiceController? = nil,
+                         eventsManager: EventsManager? = nil) {
         
         super.init(nibName: nil, bundle: nil)
         
-        self.routeController = RouteController(along: route, directions: directions, locationManager: locationManager ?? NavigationLocationManager())
+        self.eventsManager = eventsManager ?? EventsManager()
+        self.locationManager = locationManager ?? NavigationLocationManager()
+
+        self.routeController = RouteController(along: route, directions: directions, locationManager: self.locationManager, eventsManager: self.eventsManager)
         self.routeController.usesDefaultUserInterface = true
         self.routeController.delegate = self
         self.routeController.tunnelIntersectionManager.delegate = self
+
         self.voiceController = voiceController ?? MapboxVoiceController()
+
         self.directions = directions
         self.route = route
         NavigationSettings.shared.distanceUnit = route.routeOptions.locale.usesMetric ? .kilometer : .mile

--- a/MapboxNavigationTests/CPMapTemplate+MBTestable.mm
+++ b/MapboxNavigationTests/CPMapTemplate+MBTestable.mm
@@ -1,5 +1,8 @@
 #import "CPMapTemplate+MBTestable.h"
+#import <Cedar/Cedar.h>
 #import <objc/runtime.h>
+
+using namespace Cedar::Doubles;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
 
@@ -18,7 +21,7 @@
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 
 - (CPNavigationSession *)startNavigationSessionForTrip:(CPTrip *)trip {
-    return nil;
+    return nice_fake_for(CPNavigationSession.class);
 }
 
 #pragma clang diagnostic pop

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -215,15 +215,15 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
     public var trailingBarButtons: [CPBarButton]?
     public var mapButtons: [CPMapButton]?
 
-    func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]? {
+    func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]? {
         return leadingBarButtons
     }
 
-    func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPBarButton]? {
+    func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]? {
         return trailingBarButtons
     }
     
-    func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate) -> [CPMapButton]? {
+    func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]? {
         return mapButtons
     }
     

--- a/MapboxNavigationTests/Info.plist
+++ b/MapboxNavigationTests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 </dict>
 </plist>

--- a/MapboxNavigationTests/LaneTests.swift
+++ b/MapboxNavigationTests/LaneTests.swift
@@ -22,7 +22,7 @@ class LaneTests: FBSnapshotTestCase {
         isDeviceAgnostic = false
 
         route.accessToken = bogusToken
-        routeController = RouteController(along: route, directions: directions)
+        routeController = RouteController(along: route, directions: directions, eventsManager: TestNavigationEventsManager())
 
         steps = routeController.routeProgress.currentLeg.steps
         routeProgress = routeController.routeProgress

--- a/MapboxNavigationTests/LeaksSpec.swift
+++ b/MapboxNavigationTests/LeaksSpec.swift
@@ -38,7 +38,7 @@ class LeaksSpec: QuickSpec {
             let route = initialRoute
             
             let navigationViewController = LeakTest {
-                return NavigationViewController(for: route, directions: Directions.shared, styles: nil, locationManager: nil, voiceController: FakeVoiceController())
+                return NavigationViewController(for: route, directions: Directions.shared, styles: nil, locationManager: nil, voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
             }
             
             it("must not leak") {

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -18,7 +18,8 @@ class NavigationViewControllerTests: XCTestCase {
         let voice = FakeVoiceController()
         let nav = NavigationViewController(for: initialRoute,
                                            directions: Directions(accessToken: "garbage", host: nil),
-                                           voiceController: voice)
+                                           voiceController: voice,
+                                           eventsManager: TestNavigationEventsManager())
         
         nav.delegate = self
         
@@ -89,7 +90,7 @@ class NavigationViewControllerTests: XCTestCase {
     }
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithOneStyle() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle()], voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle()], voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -105,7 +106,7 @@ class NavigationViewControllerTests: XCTestCase {
     
     // If tunnel flags are enabled and we need to switch styles, we should not force refresh the map style because we have only 1 style.
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceWhenOnlyOneStyle() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()], voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()], voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -120,7 +121,7 @@ class NavigationViewControllerTests: XCTestCase {
     }
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithTwoStyles() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()], voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()], voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
         let routeController = navigationViewController.routeController!
         navigationViewController.styleManager.delegate = self
         
@@ -255,13 +256,13 @@ class NavigationViewControllerTestable: NavigationViewController {
                   locationManager: NavigationLocationManager? = NavigationLocationManager(),
                   styleLoaded: XCTestExpectation) {
         styleLoadedExpectation = styleLoaded
-        super.init(for: route, directions: directions,styles: styles, locationManager: locationManager, voiceController: FakeVoiceController())
+        super.init(for: route, directions: directions,styles: styles, locationManager: locationManager, voiceController: FakeVoiceController(), eventsManager: TestNavigationEventsManager())
     }
     
-    required init(for route: Route, directions: Directions, styles: [Style]?, locationManager: NavigationLocationManager?, voiceController: RouteVoiceController?) {
-        fatalError("This initalizer is not supported in this testing subclass.")
+    required init(for route: Route, directions: Directions, styles: [Style]?, locationManager: NavigationLocationManager?, voiceController: RouteVoiceController?, eventsManager: EventsManager?) {
+        fatalError("init(for:directions:styles:locationManager:voiceController:eventsManager:) is not supported in this testing subclass.")
     }
-    
+
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         styleLoadedExpectation.fulfill()
     }

--- a/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -15,7 +15,7 @@ class StepsViewControllerTests: XCTestCase {
         let bogusToken = "pk.feedCafeDeadBeefBadeBede"
         let directions = Directions(accessToken: bogusToken)
 
-        let routeController = RouteController(along: initialRoute, directions: directions)
+        let routeController = RouteController(along: initialRoute, directions: directions, eventsManager: TestNavigationEventsManager())
         
         let stepsViewController = StepsViewController(routeProgress: routeController.routeProgress)
         

--- a/RouteTest/Info.plist
+++ b/RouteTest/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/circle.yml
+++ b/circle.yml
@@ -122,7 +122,7 @@ step-library:
         name: CocoaPods integration test
         command: |
           cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall
-          pod install
+          pod install --repo-update
           xcodebuild -workspace PodInstall.xcworkspace/ -scheme PodInstall -destination 'platform=iOS Simulator,id=9F32C487-FAEC-4ABE-B00D-159EC007E50D' clean build | xcpretty
 
 jobs:


### PR DESCRIPTION
A few tests were failing due to optional delegate method signature changes. perhaps these should be required methods after all...

This PR also enables testing more codepaths otherwise out of reach in unit tests by introducing CedarDoubles. We have to figure out good patterns for containing the Cedar Doubles behind an Objective-C interface as they're implemented in C++, so this is a proof-of-concept but it also helps us move forward with increased test coverage.