### PR TITLE
Show rating on CarPlay if connected

### DIFF
--- a/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -8,7 +8,14 @@ import UIKit
  `NavigationLocationManager` is the base location manager which handles permissions and background modes.
  */
 @objc(MBNavigationLocationManager)
-open class NavigationLocationManager: CLLocationManager {
+open class NavigationLocationManager: CLLocationManager, NSCopying {
+    
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let copy = NavigationLocationManager()
+        copy.lastKnownLocation = lastKnownLocation
+        return copy
+    }
+    
     
     var lastKnownLocation: CLLocation?
     

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -53,6 +53,17 @@ open class SimulatedLocationManager: NavigationLocationManager {
         }
     }
     
+    public override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = SimulatedLocationManager(route: route!)
+        copy.currentDistance = currentDistance
+        copy.currentLocation = currentLocation
+        copy.currentSpeed = currentSpeed
+        copy.locations = locations
+        copy.routeLine = routeLine
+        copy.speedMultiplier = speedMultiplier
+        return copy
+    }
+    
     var routeProgress: RouteProgress?
     
     /**

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -243,10 +243,10 @@ public class CarPlayManager: NSObject {
         let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
         eventsManager.manager.enqueueEvent(withName: MMEventTypeCarplayDisconnect, attributes: dateCreatedAttribute)
         eventsManager.manager.flush()
-        isConnectedToCarPlay = false
     }
 
     public func application(_ application: UIApplication, didDisconnectCarInterfaceController interfaceController: CPInterfaceController, from window: CPWindow) {
+        isConnectedToCarPlay = false
         self.interfaceController = nil
         carWindow?.isHidden = true
         let timestamp = Date().ISO8601
@@ -616,17 +616,11 @@ extension CarPlayManager: CarPlayNavigationDelegate {
         delegate?.carPlayManagerDidEndNavigation(self)
     }
 }
+#else
+@objc(MBCarPlayManager)
+class CarPlayManager: NSObject {
+    public static var shared = CarPlayManager()
+    var isConnectedToCarPlay: Bool = false
+}
 #endif
 
-struct CarPlayManagerHelper {
-    
-    static var isConnectedToCarPlay: Bool {
-        #if canImport(CarPlay)
-        if #available(iOS 12.0, *) {
-            return CarPlayManager.shared.isConnectedToCarPlay
-        }
-        #endif
-        return false
-    }
-    
-}

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -110,6 +110,11 @@ public class CarPlayManager: NSObject {
     private var defaultMapButtons: [CPMapButton]?
     
     /**
+     A boolean value indicating whether the phone is connected to a CarPlay device or not.
+     */
+    public var isConnectedToCarPlay: Bool = false
+    
+    /**
      * This property manages the relevant events recorded for telemetry analysis.
      */
     public var eventsManager = EventsManager()
@@ -141,7 +146,7 @@ public class CarPlayManager: NSObject {
         
         // WIP - For telemetry testing purposes
         // eventsManager.start()
-        
+        isConnectedToCarPlay = true
         interfaceController.delegate = self
         self.interfaceController = interfaceController
 
@@ -238,6 +243,7 @@ public class CarPlayManager: NSObject {
         let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
         eventsManager.manager.enqueueEvent(withName: MMEventTypeCarplayDisconnect, attributes: dateCreatedAttribute)
         eventsManager.manager.flush()
+        isConnectedToCarPlay = false
     }
 
     public func application(_ application: UIApplication, didDisconnectCarInterfaceController interfaceController: CPInterfaceController, from window: CPWindow) {
@@ -611,3 +617,16 @@ extension CarPlayManager: CarPlayNavigationDelegate {
     }
 }
 #endif
+
+struct CarPlayManagerHelper {
+    
+    static var isConnectedToCarPlay: Bool {
+        #if canImport(CarPlay)
+        if #available(iOS 12.0, *) {
+            return CarPlayManager.shared.isConnectedToCarPlay
+        }
+        #endif
+        return false
+    }
+    
+}

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -655,7 +655,8 @@ extension NavigationViewController: RouteControllerDelegate {
     @objc public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) -> Bool {
         let advancesToNextLeg = delegate?.navigationViewController?(self, didArriveAt: waypoint) ?? true
         
-        if routeController.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
+        if !CarPlayManagerHelper.isConnectedToCarPlay, // Shows rating on CarPlay if connected
+            routeController.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
             self.mapViewController?.showEndOfRoute { _ in }
         }
         return advancesToNextLeg

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -312,6 +312,14 @@ open class NavigationViewController: UIViewController {
         }
     }
     
+    var isConnectedToCarPlay: Bool {
+        if #available(iOS 12.0, *) {
+            return CarPlayManager.shared.isConnectedToCarPlay
+        } else {
+            return false
+        }
+    }
+    
     var mapViewController: RouteMapViewController?
     
     /**
@@ -517,7 +525,7 @@ open class NavigationViewController: UIViewController {
             
             if !navigationViewControllerExistsInStack {
                 
-                let locationManager = routeController.locationManager
+                let locationManager = routeController.locationManager.copy() as! NavigationLocationManager
                 let directions = routeController.directions
                 let route = routeController.routeProgress.route
                 let navigationViewController = NavigationViewController(for: route, directions: directions, locationManager: locationManager)
@@ -655,7 +663,7 @@ extension NavigationViewController: RouteControllerDelegate {
     @objc public func routeController(_ routeController: RouteController, didArriveAt waypoint: Waypoint) -> Bool {
         let advancesToNextLeg = delegate?.navigationViewController?(self, didArriveAt: waypoint) ?? true
         
-        if !CarPlayManagerHelper.isConnectedToCarPlay, // Shows rating on CarPlay if connected
+        if !isConnectedToCarPlay, // CarPlayManager shows rating on CarPlay if it's connected
             routeController.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
             self.mapViewController?.showEndOfRoute { _ in }
         }


### PR DESCRIPTION
The regression was caused by passing a reference to the location manager instead of copying which lead to the NavigationViewController receiving the location updates and the RouteController associated with CarPlay never arrived at the destination.

![screenshot 2018-09-11 14 46 09](https://user-images.githubusercontent.com/764476/45361932-cf925200-b5d3-11e8-87ea-d7fbdfea702d.png)


cc @akitchen @1ec5 