### PR TITLE
Store CI test results

### DIFF
--- a/MapboxCoreNavigationTests/Info.plist
+++ b/MapboxCoreNavigationTests/Info.plist
@@ -16,6 +16,10 @@
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.20.1</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location Usage Description</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Location Usage Description</string>
 	<key>CFBundleVersion</key>
 	<string>33</string>
 </dict>

--- a/MapboxNavigationTests/Info.plist
+++ b/MapboxNavigationTests/Info.plist
@@ -16,6 +16,10 @@
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.20.1</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Location Usage Description</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location Usage Description</string>
 	<key>CFBundleVersion</key>
 	<string>33</string>
 </dict>

--- a/circle.yml
+++ b/circle.yml
@@ -85,25 +85,25 @@ step-library:
       run:
         name: Build and Test MapboxCoreNavigation
         command: |
-          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=11.4,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation clean build test | tee MapboxCoreNavigation-xcodebuild.log | xcpretty
+          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=11.4,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation  -resultBundlePath MapboxCoreNavigationResults clean build test | tee MapboxCoreNavigation-xcodebuild.log | xcpretty
 
   - &build-test-MapboxCoreNavigation-ios-12
       run:
         name: Build and Test MapboxCoreNavigation
         command: |
-          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation clean build test | tee MapboxCoreNavigation-xcodebuild.log | xcpretty
+          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation -resultBundlePath MapboxCoreNavigationResults clean build test | tee MapboxCoreNavigation-xcodebuild.log | xcpretty
 
   - &build-test-MapboxNavigation-ios-11
       run:
         name: Build and Test MapboxNavigation
         command: |
-          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=11.4,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation clean build test | tee MapboxNavigation-xcodebuild.log | xcpretty
+          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=11.4,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation -resultBundlePath MapboxNavigationResults clean build test | tee MapboxNavigation-xcodebuild.log | xcpretty
 
   - &build-test-MapboxNavigation-ios-12
       run:
-        name: Build MapboxNavigation
+        name: Build and Test MapboxNavigation
         command: |
-          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation clean build test | tee MapboxNavigation-xcodebuild.log | xcpretty
+          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation -resultBundlePath MapboxNavigationResults clean build test | tee MapboxNavigation-xcodebuild.log | xcpretty
 
   - &build-Example-Obj-C
       run:
@@ -136,6 +136,12 @@ step-library:
         name: Print MapboxCoreNavigation-xcodebuild.log
         when: on_fail
         command: cat MapboxCoreNavigation-xcodebuild.log
+  
+  - &store-test-artifacts
+      store_artifacts:
+          path: MapboxNavigationResults
+      store_artifacts:
+          path: MapboxCoreNavigationResults
 
 jobs:
   xcode-10:
@@ -154,6 +160,7 @@ jobs:
       - *build-test-MapboxNavigation-ios-12
       - *print-MapboxNavigation-xcodebuild-log
       - *print-MapboxCoreNavigation-xcodebuild-log
+      - *store-test-artifacts
       - *save-cache
   
   xcode-9:
@@ -172,6 +179,7 @@ jobs:
       - *build-test-MapboxNavigation-ios-11
       - *print-MapboxNavigation-xcodebuild-log
       - *print-MapboxCoreNavigation-xcodebuild-log
+      - *store-test-artifacts
       - *save-cache
 
   xcode-10-cocoapods-integration:

--- a/circle.yml
+++ b/circle.yml
@@ -51,6 +51,7 @@ step-library:
         command: |
           git submodule sync
           brew install carthage
+          echo "foo" > ~/.mapbox
 
   - &prepare-iphone6s-plus-ios-11
       run:
@@ -137,9 +138,11 @@ step-library:
         when: on_fail
         command: cat MapboxCoreNavigation-xcodebuild.log
   
-  - &store-test-artifacts
+  - &store-MapboxNavigationResults-artifacts
       store_artifacts:
           path: MapboxNavigationResults
+
+  - &store-MapboxCoreNavigationResults-artifacts
       store_artifacts:
           path: MapboxCoreNavigationResults
 
@@ -160,7 +163,8 @@ jobs:
       - *build-test-MapboxNavigation-ios-12
       - *print-MapboxNavigation-xcodebuild-log
       - *print-MapboxCoreNavigation-xcodebuild-log
-      - *store-test-artifacts
+      - *store-MapboxNavigationResults-artifacts
+      - *store-MapboxCoreNavigationResults-artifacts
       - *save-cache
   
   xcode-9:
@@ -179,7 +183,8 @@ jobs:
       - *build-test-MapboxNavigation-ios-11
       - *print-MapboxNavigation-xcodebuild-log
       - *print-MapboxCoreNavigation-xcodebuild-log
-      - *store-test-artifacts
+      - *store-MapboxNavigationResults-artifacts
+      - *store-MapboxCoreNavigationResults-artifacts
       - *save-cache
 
   xcode-10-cocoapods-integration:


### PR DESCRIPTION
The output of the XCT process contains relevant information needed to track down an async crash in tests.

@akitchen 