### PR TITLE
Application sleep mode is disabled when carplay is connected.

### DIFF
--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -91,8 +91,7 @@ public protocol CarPlayManagerDelegate {
      - parameter carPlayManager: The carplay manager that will change the state of idle timer.
      - returns: A bool indicating whether to disable idle timer when carplay is connected and enable when disconnected.
      */
-    @objc(carplayManagerShouldDisableIdleTimer:)
-    optional func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool
+    @objc optional func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool
 
 }
 

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -86,10 +86,10 @@ public protocol CarPlayManagerDelegate {
     /**
      Called when the carplay manager will disable the idle timer.
      
-     Implementing this method will allow developers to change whether idle timer is disabled when `CarPlayManager` is initialized.
+     Implementing this method will allow developers to change whether idle timer is disabled when carplay is connected and the vice-versa when disconnected.
      
      - parameter carPlayManager: The carplay manager that will change the state of idle timer.
-     - returns: A bool indicating whether to disable idle timer when the CarPlayManager is initialized.
+     - returns: A bool indicating whether to disable idle timer when carplay is connected and enable when disconnected.
      */
     @objc(carplayManagerShouldDisableIdleTimer:)
     optional func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool


### PR DESCRIPTION
The intention is to prevent the scenario where the system puts the device into a sleep state. Unfortunately, this impacts the map interactions on a carplay head unit. As a recommendation by Apple developer documentation, mapping apps should disable the idle timer to allow the continuous display or interaction with content.

/cc @mapbox/navigation-ios 