### PR TITLE
CarPlay delegate cancel event for the end of navigation.

### DIFF
--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -539,6 +539,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         let mapView = carPlayMapViewController.mapView
         mapView.removeRoutes()
         mapView.removeWaypoints()
+        delegate?.carPlayManagerDidEndNavigation(self)
     }
     
     public func mapTemplateDidBeginPanGesture(_ mapTemplate: CPMapTemplate) {


### PR DESCRIPTION
Added missing carPlayManagerdidEndNavigation delegate message during system cancel event.