### PR TITLE
Fold CarPlay-specific styles into main styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Introduced a breaking change the to `RouteController` initializer: Passing an EventsManager is now required. `NavigationViewController` can optionally take an `eventsManager` argument to its initializer, and the value will be passed to future instances of `RouteController`.   ([#1671](https://github.com/mapbox/mapbox-navigation-ios/pull/1671))
+* Added the `Style.previewMapStyleURL` property for customizing the style displayed by a preview map. ([#1695](https://github.com/mapbox/mapbox-navigation-ios/pull/1695))
 
 ## v0.20.1 (September 10, 2018)
 

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -52,7 +52,7 @@ class CarPlayMapViewController: UIViewController, MGLMapViewDelegate {
         super.viewDidLoad()
 
         styleManager = StyleManager(self)
-        styleManager.styles = [CarPlayDayStyle(), CarPlayNightStyle()]
+        styleManager.styles = [DayStyle(), NightStyle()]
         
         resetCamera(animated: false, altitude: CarPlayMapViewController.defaultAltitude)
         mapView.setUserTrackingMode(.followWithCourse, animated: true)
@@ -127,12 +127,7 @@ extension CarPlayMapViewController: StyleManagerDelegate {
     }
     
     func styleManager(_ styleManager: StyleManager, didApply style: Style) {
-        let styleURL: URL
-        if let style = style as? CarPlayStyle {
-            styleURL = style.previewStyleURL
-        } else {
-            styleURL = style.mapStyleURL
-        }
+        let styleURL = style.previewMapStyleURL
         if mapView.styleURL != styleURL {
             mapView.style?.transition = MGLTransition(duration: 0.5, delay: 0)
             mapView.styleURL = styleURL

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -69,7 +69,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         view.addSubview(mapView)
         
         styleManager = StyleManager(self)
-        styleManager.styles = [CarPlayDayStyle(), CarPlayNightStyle()]
+        styleManager.styles = [DayStyle(), NightStyle()]
         
         resumeNotifications()
         routeController.resume()

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -89,12 +89,14 @@ open class DayStyle: Style {
         ExitView.appearance().borderWidth = 1.0
         ExitView.appearance().cornerRadius = 5.0
         ExitView.appearance().foregroundColor = .black
+        ExitView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
         FloatingButton.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         FloatingButton.appearance().tintColor = tintColor
         GenericRouteShield.appearance().backgroundColor = .clear
         GenericRouteShield.appearance().borderWidth = 1.0
         GenericRouteShield.appearance().cornerRadius = 5.0
         GenericRouteShield.appearance().foregroundColor = .black
+        GenericRouteShield.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
         InstructionsBannerContentView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         InstructionsBannerView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         LaneView.appearance().primaryColor = .defaultLaneArrowPrimary
@@ -165,6 +167,7 @@ open class NightStyle: DayStyle {
     public required init() {
         super.init()
         mapStyleURL = MGLStyle.navigationGuidanceNightStyleURL
+        previewMapStyleURL = MGLStyle.navigationPreviewNightStyleURL
         styleType = .night
         statusBarStyle = .lightContent
     }
@@ -232,32 +235,3 @@ open class NightStyle: DayStyle {
         WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
     }
 }
-
-#if canImport(CarPlay)
-@available(iOS 12.0, *)
-public protocol CarPlayStyle {
-    var previewStyleURL: URL { get }
-}
-
-@available(iOS 12.0, *)
-open class CarPlayDayStyle: DayStyle, CarPlayStyle {
-    public var previewStyleURL = URL(string: "mapbox://styles/mapbox/navigation-preview-day-v4")!
-    
-    open override func apply() {
-        super.apply()
-        ExitView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
-        GenericRouteShield.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
-    }
-}
-
-@available(iOS 12.0, *)
-open class CarPlayNightStyle: NightStyle, CarPlayStyle {
-    public var previewStyleURL = URL(string: "mapbox://styles/mapbox/navigation-preview-night-v4")!
-    
-    open override func apply() {
-        super.apply()
-        ExitView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
-        GenericRouteShield.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).foregroundColor = .white
-    }
-}
-#endif

--- a/MapboxNavigation/MGLStyle.swift
+++ b/MapboxNavigation/MGLStyle.swift
@@ -58,4 +58,53 @@ extension MGLStyle {
         }
         return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v\(version)")!
     }
+    
+    /**
+     Returns the URL to the current version of the Mapbox Navigation Preview Day style.
+     */
+    @objc public class var navigationPreviewDayStyleURL: URL {
+        get {
+            if MGLAccountManager.hasChinaBaseURL {
+                return mapboxChinaDayStyleURL
+            }
+            return URL(string:"mapbox://styles/mapbox/navigation-preview-day-v4")!
+        }
+    }
+    
+    /**
+     Returns the URL to the current version of the Mapbox Navigation Preview Night style.
+     */
+    @objc public class var navigationPreviewNightStyleURL: URL {
+        get {
+            if MGLAccountManager.hasChinaBaseURL {
+                return mapboxChinaDayStyleURL
+            }
+            return URL(string:"mapbox://styles/mapbox/navigation-preview-night-v4")!
+        }
+    }
+    
+    /**
+     Returns the URL to the given version of the Mapbox Navigation Preview Day style. Available versions are 1, 2, 3, and 4.
+     
+     We only have one version of Navigation Preview style in China, so if you switch your endpoint to .cn, it will return the default day style.
+     */
+    @objc public class func navigationPreviewDayStyleURL(version: Int) -> URL {
+        if MGLAccountManager.hasChinaBaseURL {
+            return mapboxChinaDayStyleURL
+        }
+        return URL(string:"mapbox://styles/mapbox/navigation-guidance-day-v\(version)")!
+    }
+    
+    
+    /**
+     Returns the URL to the given version of the Mapbox Navigation Preview Night style. Available versions are 2, 3, and 4.
+     
+     We only have one version of Navigation Preview style in China, so if you switch your endpoint to .cn, it will return the default night style.
+     */
+    @objc public class func navigationPreviewNightStyleURL(version: Int) -> URL {
+        if MGLAccountManager.hasChinaBaseURL {
+            return mapboxChinaNightStyleURL
+        }
+        return URL(string: "mapbox://styles/mapbox/navigation-guidance-night-v\(version)")!
+    }
 }

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -32,9 +32,23 @@ open class Style: NSObject {
     @objc public var styleType: StyleType = .day
     
     /**
-     Map style to be used for the style.
+     URL of the style to display on the map during turn-by-turn navigation.
      */
     @objc open var mapStyleURL: URL = MGLStyle.navigationGuidanceDayStyleURL
+    
+    #if canImport(CarPlay)
+    /**
+     URL of the style to display on the map when previewing a route, for example on CarPlay.
+     */
+    @objc open var previewMapStyleURL = MGLStyle.navigationPreviewDayStyleURL
+    #else
+    /**
+     URL of the style to display on the map when previewing a route.
+     
+     This property is currently unused by default, but you can use it to present your own route preview map.
+     */
+    @objc open var previewMapStyleURL = MGLStyle.navigationPreviewDayStyleURL
+    #endif
     
     /**
      Applies the style for all changed properties.


### PR DESCRIPTION
Removed CarPlayDayStyle and CarPlayNightStyle in favor of using DayStyle and NightStyle in all user interface idioms. Vary ExitView and GenericShieldView by idiom.

Added a `Style.previewMapStyleURL` property, which is used by CarPlayMapViewController but can also be used in the future for the preview view controller proposed by #808. In the meantime, the property is visible to applications for custom preview view controller implementations.

/cc @mapbox/navigation-ios