### PR TITLE
Fix generic shields in CarPlay

### DIFF
--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -244,9 +244,14 @@ class InstructionPresenter {
     }
     
     private func takeSnapshot(on view: UIView) -> UIImage? {
-        let window = UIApplication.shared.delegate!.window!!
+        let window: UIWindow
+        if let hostView = dataSource as? UIView, let hostWindow = hostView.window {
+            window = hostWindow
+        } else {
+            window = UIApplication.shared.delegate!.window!!
+        }
         
-        //We have to temporarily add the view to the view heirarchy in order for UIAppearance to work it's magic.
+        // Temporarily add the view to the view hierarchy for UIAppearance to work its magic.
         window.addSubview(view)
         let image = view.imageRepresentation
         view.removeFromSuperview()

--- a/MapboxNavigation/VisualInstruction.swift
+++ b/MapboxNavigation/VisualInstruction.swift
@@ -28,11 +28,20 @@ extension VisualInstruction {
 
     @available(iOS 12.0, *)
     func maneuverLabelAttributedText(bounds: @escaping () -> (CGRect), shieldHeight: CGFloat) -> NSAttributedString? {
-        let instructionLabelPrimary = InstructionLabel()
-        instructionLabelPrimary.availableBounds = bounds
-        instructionLabelPrimary.shieldHeight = shieldHeight
-        instructionLabelPrimary.instruction = self
-        return instructionLabelPrimary.attributedText
+        let instructionLabel = InstructionLabel()
+        instructionLabel.availableBounds = bounds
+        instructionLabel.shieldHeight = shieldHeight
+        
+        // Temporarily add the view to the view hierarchy for UIAppearance to work its magic.
+        if let carWindow = CarPlayManager.shared.carWindow {
+            carWindow.addSubview(instructionLabel)
+            instructionLabel.instruction = self
+            instructionLabel.removeFromSuperview()
+        } else {
+            instructionLabel.instruction = self
+        }
+        
+        return instructionLabel.attributedText
     }
 #endif
 }


### PR DESCRIPTION
Add CarPlay’s throwaway instruction label to the car window while rendering the instruction. While taking a snapshot of GenericShieldView or ExitView, add the view to the data source’s window if the data source is a view, but not necessarily the application’s main window.

Depends on #1695. I’ll retarget this PR against the `carplay` branch before merging.

/cc @JThramer @frederoni