### PR TITLE
Removes code hiding map template buttons during panning

### DIFF
--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -600,8 +600,6 @@ extension CarPlayManager: CPMapTemplateDelegate {
     public func mapTemplateDidBeginPanGesture(_ mapTemplate: CPMapTemplate) {
         if let navigationViewController = currentNavigator, mapTemplate == navigationViewController.mapTemplate {
             navigationViewController.beginPanGesture()
-        } else {
-            mapTemplate.mapButtons.forEach { $0.isHidden = true }
         }
     }
 


### PR DESCRIPTION
We can reintroduce this later if needed, as a part of a bigger design discussion around managing the navigation bar and map buttons during different navigation states.