### PR TITLE
Camera Angle Fix

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -240,7 +240,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
         //If the map is in tracking mode, make sure we update the camera after the layout pass.
         if (tracksUserCourse) {
-            updateCourseTracking(location: userLocationForCourseTracking, animated: false)
+            updateCourseTracking(location: userLocationForCourseTracking, camera:self.camera, animated: false)
         }
     }
     


### PR DESCRIPTION
[Before Video](https://www.dropbox.com/s/yxzpn6vw4tnte43/camera-angle-before.mov?dl=0)
[After Video](https://www.dropbox.com/s/ymdxxjfh45ad2fp/nofly.mov?dl=0)

Fixing issue where layout update overrides custom camera with hardcoded camera, causing angle/distance shift when you tapped on the screen.

/cc @mapbox/navigation-ios 