### PR TITLE
Changes to ensure user puck switches back when pan gesture is complete.

### DIFF
--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -259,6 +259,11 @@ public class CarPlayManager: NSObject {
             guard let strongSelf = self, let mapButtons = strongSelf.defaultMapButtons else {
                 return
             }
+            
+            if let carPlayMapViewController = strongSelf.carWindow?.rootViewController as? CarPlayMapViewController {
+                let mapView = carPlayMapViewController.mapView
+                mapView.setUserTrackingMode(.followWithCourse, animated: true)
+            }
 
             mapTemplate.mapButtons = mapButtons
             mapTemplate.dismissPanningInterface(animated: true)


### PR DESCRIPTION
Upon tapping the close button, user puck must switch back to original state (`. followWithCourse`) when in pan mode.

/cc @mapbox/navigation-ios 