### PR TITLE
Revert user puck dead reckoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Introduced a breaking change the to `RouteController` initializer: Passing an EventsManager is now required. `NavigationViewController` can optionally take an `eventsManager` argument to its initializer, and the value will be passed to future instances of `RouteController`.   ([#1671](https://github.com/mapbox/mapbox-navigation-ios/pull/1671))
+* Fixed issues where the user puck would overshoot a turn or drift away from a curved road. ([#1710](https://github.com/mapbox/mapbox-navigation-ios/pull/1710))
 
 ## v0.20.1 (September 10, 2018)
 

--- a/MapboxCoreNavigationTests/LocationTests.swift
+++ b/MapboxCoreNavigationTests/LocationTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import CoreLocation
-import Turf
 @testable import MapboxCoreNavigation
 
 class LocationTests: XCTestCase {
@@ -41,20 +40,19 @@ class LocationTests: XCTestCase {
         XCTAssert(lhs == rhs)
     }
     
-    func testSnappedLocationShouldBeInFrontOfUser() {
+    func testSnappedLocation100MetersAlongRoute() {
         let progress = setup.progress
+        let firstLocation = setup.firstLocation
         
         let initialHeadingOnFirstStep = progress.currentLegProgress.currentStep.finalHeading!
-        let coordinateAlongFirstStep = Polyline(progress.currentLegProgress.nearbyCoordinates).coordinateFromStart(distance: 100)!
-        let locationAlongFirstStep = CLLocation(coordinate: coordinateAlongFirstStep, altitude: 0, horizontalAccuracy: 1, verticalAccuracy: 0, course: initialHeadingOnFirstStep, speed: 10, timestamp: Date())
+        let coordinateAlongFirstStep = firstLocation.coordinate.coordinate(at: 100, facing: initialHeadingOnFirstStep)
+        let locationAlongFirstStep = CLLocation(latitude: coordinateAlongFirstStep.latitude, longitude: coordinateAlongFirstStep.longitude)
         guard let snapped = locationAlongFirstStep.snapped(to: progress.currentLegProgress) else {
             return XCTFail("Location should have snapped to route")
         }
         
-        let distanceBetweenRealAndSnappedLocation = locationAlongFirstStep.distance(from: snapped)
-    
-
-        XCTAssertEqual(round(distanceBetweenRealAndSnappedLocation), 10, "The snapped location is 10 meters ahead of the user because they are moving.")
+        
+        XCTAssertTrue(locationAlongFirstStep.distance(from: snapped) < 1, "The location is less than 1 meter away from the calculated snapped location")
  
     }
     

--- a/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -139,7 +139,7 @@ class RouteControllerTests: XCTestCase {
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithDifferentCourse])
         XCTAssertEqual(navigation.location!.coordinate, navigation.routeProgress.currentLegProgress.currentStep.coordinates!.last!, "When user's course is dissimilar from the finalHeading, they should not snap to upcoming step")
         
-        let firstLocationOnNextStepWithCorrectCourse = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 30, verticalAccuracy: 10, course: finalHeading, speed: 0, timestamp: Date())
+        let firstLocationOnNextStepWithCorrectCourse = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 30, verticalAccuracy: 10, course: finalHeading, speed: 5, timestamp: Date())
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithCorrectCourse])
         XCTAssertEqual(navigation.location!.coordinate, firstCoordinateOnUpcomingStep, "User is snapped to upcoming step when their course is similar to the final heading")
     }


### PR DESCRIPTION
This reverts commit #1385, which resulted in the puck overshooting at turns and detaching from the route line along curved roads. In some cases, it may have exacerbated other issues with course tracking.

When we revisit this feature in the future, we’ll need to ensure that dead reckoning is only part of the solution: the result of dead reckoning needs to be snapped to the route line. That wasn’t happening before, so this feature tended to foil any attempt at snapping the user’s location to the route line, at least visually. As well, we’ll need to find an alternative to `CLLocation.speed`, which is an instantaneous reading that is documented to be unsuitable for dead reckoning.

/cc @mapbox/navigation-ios