### PR TITLE
remaining coordinates to end of step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 `StyleManagerDelegate.locationFor(styleManager:)` has been renamed to `StyleManagerDelegate.location(for:)`  ([#1724](https://github.com/mapbox/mapbox-navigation-ios/pull/1724))
+Added a `RouteProgress.coordinatesRemaining` property. This property is updates on every location update. It contains a slice of the current route step's polyline from the current location to the end of the step. ([#1728](https://github.com/mapbox/mapbox-navigation-ios/pull/1728))
 
 ## v0.21.0 (September 17, 2018)
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -346,6 +346,7 @@ extension RouteController: CLLocationManagerDelegate {
         // Notify observers if the step’s remaining distance has changed.
         let polyline = Polyline(routeProgress.currentLegProgress.currentStep.coordinates!)
         if let closestCoordinate = polyline.closestCoordinate(to: location.coordinate) {
+            currentStepProgress.coordinatesRemaining = polyline.sliced(from: closestCoordinate.coordinate).coordinates
             let remainingDistance = polyline.distance(from: closestCoordinate.coordinate)
             let distanceTraveled = currentStep.distance - remainingDistance
             currentStepProgress.distanceTraveled = distanceTraveled

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -432,6 +432,11 @@ open class RouteStepProgress: NSObject {
     }
     
     /**
+     Coordinates from current location to end of current step
+     */
+    @objc public var coordinatesRemaining: [CLLocationCoordinate2D] = []
+
+    /**
      Intializes a new `RouteStepProgress`.
 
      - parameter step: Step on a `RouteLeg`.

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -434,7 +434,7 @@ open class RouteStepProgress: NSObject {
     /**
      Coordinates from current location to end of current step
      */
-    @objc public var coordinatesRemaining: [CLLocationCoordinate2D] = []
+    @objc public var coordinatesRemaining: [CLLocationCoordinate2D]?
 
     /**
      Intializes a new `RouteStepProgress`.


### PR DESCRIPTION
This PR adds a property on the `RouteProgress` object called `coordinatesRemaining`

This property is updated on every location update with a slice of the current route step's polyline from the current location to the end of the step.