### PR TITLE
Avoid abusing a compiler bug

### DIFF
--- a/Examples/Swift/AppDelegate+CarPlay.swift
+++ b/Examples/Swift/AppDelegate+CarPlay.swift
@@ -72,9 +72,9 @@ extension AppDelegate: CarPlayManagerDelegate {
             return [simulationButton]
         case .browsing:
             let favoriteTemplateButton = CPBarButton(type: .image) { [weak self] button in
-                guard let `self` = self else { return }
-                let listTemplate = self.favoritesListTemplate()
-                listTemplate.delegate = self
+                guard let strongSelf = self else { return }
+                let listTemplate = strongSelf.favoritesListTemplate()
+                listTemplate.delegate = strongSelf
                 carPlayManager.interfaceController?.pushTemplate(listTemplate, animated: true)
             }
             favoriteTemplateButton.image = UIImage(named: "carplay_star", in: nil, compatibleWith: traitCollection)

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -435,7 +435,7 @@ extension CarPlayManager: CPListTemplateDelegate {
                 completionHandler()
             }
 
-            guard let `self` = self, let mapTemplate = mapTemplate else {
+            guard let strongSelf = self, let mapTemplate = mapTemplate else {
                 return
             }
             if let error = error {
@@ -457,9 +457,9 @@ extension CarPlayManager: CPListTemplateDelegate {
 
             let routeChoices = routes.map { (route) -> CPRouteChoice in
                 let summaryVariants = [
-                    self.fullDateComponentsFormatter.string(from: route.expectedTravelTime)!,
-                    self.shortDateComponentsFormatter.string(from: route.expectedTravelTime)!,
-                    self.briefDateComponentsFormatter.string(from: route.expectedTravelTime)!
+                    strongSelf.fullDateComponentsFormatter.string(from: route.expectedTravelTime)!,
+                    strongSelf.shortDateComponentsFormatter.string(from: route.expectedTravelTime)!,
+                    strongSelf.briefDateComponentsFormatter.string(from: route.expectedTravelTime)!
                 ]
                 let routeChoice = CPRouteChoice(summaryVariants: summaryVariants, additionalInformationVariants: [route.description], selectionSummaryVariants: [route.description])
                 routeChoice.userInfo = route
@@ -476,7 +476,7 @@ extension CarPlayManager: CPListTemplateDelegate {
             let overviewTitle = NSLocalizedString("CARPLAY_OVERVIEW", bundle: .mapboxNavigation, value: "Overview", comment: "Title for overview button in CPTripPreviewTextConfiguration")
             let defaultPreviewText = CPTripPreviewTextConfiguration(startButtonTitle: goTitle, additionalRoutesButtonTitle: alternativeRoutesTitle, overviewButtonTitle: overviewTitle)
 
-            let previewMapTemplate = self.mapTemplate(forPreviewing: trip)
+            let previewMapTemplate = strongSelf.mapTemplate(forPreviewing: trip)
             interfaceController.pushTemplate(previewMapTemplate, animated: true)
 
             previewMapTemplate.showTripPreviews([trip], textConfiguration: defaultPreviewText)

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -221,22 +221,22 @@ open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {
         super.speechSynth.stopSpeaking(at: .immediate)
         
         audioQueue.async { [weak self] in
-            guard let `self` = self else { return }
+            guard let strongSelf = self else { return }
             do {
-                self.audioPlayer = try self.audioPlayerType.init(data: data)
-                self.audioPlayer?.prepareToPlay()
-                self.audioPlayer?.delegate = self
-                try self.duckAudio()
-                let played = self.audioPlayer?.play() ?? false
+                strongSelf.audioPlayer = try strongSelf.audioPlayerType.init(data: data)
+                strongSelf.audioPlayer?.prepareToPlay()
+                strongSelf.audioPlayer?.delegate = strongSelf
+                try strongSelf.duckAudio()
+                let played = strongSelf.audioPlayer?.play() ?? false
                 
                 guard played else {
-                    try self.unDuckAudio()
-                    self.speakWithDefaultSpeechSynthesizer(self.lastSpokenInstruction!, error: NSError(code: .spokenInstructionFailed, localizedFailureReason: self.localizedErrorMessage, spokenInstructionCode: .audioPlayerFailedToPlay))
+                    try strongSelf.unDuckAudio()
+                    strongSelf.speakWithDefaultSpeechSynthesizer(strongSelf.lastSpokenInstruction!, error: NSError(code: .spokenInstructionFailed, localizedFailureReason: strongSelf.localizedErrorMessage, spokenInstructionCode: .audioPlayerFailedToPlay))
                     return
                 }
                 
             } catch  let error as NSError {
-                self.speakWithDefaultSpeechSynthesizer(self.lastSpokenInstruction!, error: error)
+                strongSelf.speakWithDefaultSpeechSynthesizer(strongSelf.lastSpokenInstruction!, error: error)
             }
         }
     }


### PR DESCRIPTION
We're relying on a compiler bug in a few places:
```swift
guard let `self` = self else { return }
```
according to https://github.com/apple/swift-evolution/blob/master/proposals/0079-upgrade-self-from-weak-to-strong.md#relying-on-a-compiler-bug

However, Swift 4.2 supports the following syntax:
```swift
guard let self = self else { return }
```

@mapbox/navigation-ios 