### PR TITLE
Renames tracksUserCourse to showsUserCourse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue where the U-turn icon in the turn banner pointed in the wrong direction. ([#1647](https://github.com/mapbox/mapbox-navigation-ios/pull/1647))
 * Fixed an issue where the user puck was positioned too close to the bottom of the map view, underlapping the current road name label. ([#1766](https://github.com/mapbox/mapbox-navigation-ios/pull/1766])
 * Added `InstructionsBannerView.showStepIndicator` to enable showing/hiding the drag indicator ([#1772](https://github.com/mapbox/mapbox-navigation-ios/pull/1772))
+* Renamed `NavigationMapView.tracksUserCourse` to `NavigationMapView.showsUserCourse`. [#1741](https://github.com/mapbox/mapbox-navigation-ios/pull/1741)
 
 ## v0.22.1 (October 2, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fixed an issue where the U-turn icon in the turn banner pointed in the wrong direction. ([#1647](https://github.com/mapbox/mapbox-navigation-ios/pull/1647))
 * Fixed an issue where the user puck was positioned too close to the bottom of the map view, underlapping the current road name label. ([#1766](https://github.com/mapbox/mapbox-navigation-ios/pull/1766])
 * Added `InstructionsBannerView.showStepIndicator` to enable showing/hiding the drag indicator ([#1772](https://github.com/mapbox/mapbox-navigation-ios/pull/1772))
-* Renamed `NavigationMapView.tracksUserCourse` to `NavigationMapView.showsUserCourse`. [#1741](https://github.com/mapbox/mapbox-navigation-ios/pull/1741)
+* Added ability to show user course icon `NavigationMapView.showsUserCourse` in cases where you want to manage your own user tracking using `MapView.userTrackingMode`. [#1741](https://github.com/mapbox/mapbox-navigation-ios/pull/1741)
 
 ## v0.22.1 (October 2, 2018)
 

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -52,22 +52,26 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         resumeNotifications()
 
         // Start navigation
-        navigationService.start()
-        
-        // Center map on user
-        mapView.recenterMap()
+        startNavigation()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // This applies a default style to the top banner.
         DayStyle().apply()
+        startNavigation()
     }
 
     deinit {
         suspendNotifications()
     }
 
+    func startNavigation() {
+        navigationService.start()
+        mapView.showsUserCourse = true
+        mapView.userTrackingMode = .followWithCourse
+    }
+    
     func resumeNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(progressDidChange(_ :)), name: .routeControllerProgressDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(rerouted(_:)), name: .routeControllerDidReroute, object: nil)

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -68,8 +68,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
 
     func startNavigation() {
         navigationService.start()
-        mapView.showsUserCourse = true
-        mapView.userTrackingMode = .followWithCourse
+        mapView.tracksUserCourse = true
     }
     
     func resumeNotifications() {

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -565,9 +565,9 @@ extension CarPlayManager: CPMapTemplateDelegate {
             guard let navigationViewController = self?.currentNavigator else {
                 return
             }
-            navigationViewController.tracksUserCourse = !navigationViewController.tracksUserCourse
+            navigationViewController.showsUserCourse = !navigationViewController.showsUserCourse
 
-            let imageName = navigationViewController.tracksUserCourse ? "carplay_overview" : "carplay_locate"
+            let imageName = navigationViewController.showsUserCourse ? "carplay_overview" : "carplay_locate"
             button.image = UIImage(named: imageName, in: .mapboxNavigation, compatibleWith: nil)
         }
         overviewButton.image = UIImage(named: "carplay_overview", in: .mapboxNavigation, compatibleWith: nil)

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -565,9 +565,9 @@ extension CarPlayManager: CPMapTemplateDelegate {
             guard let navigationViewController = self?.currentNavigator else {
                 return
             }
-            navigationViewController.showsUserCourse = !navigationViewController.showsUserCourse
+            navigationViewController.tracksUserCourse = !navigationViewController.tracksUserCourse
 
-            let imageName = navigationViewController.showsUserCourse ? "carplay_overview" : "carplay_locate"
+            let imageName = navigationViewController.tracksUserCourse ? "carplay_overview" : "carplay_locate"
             button.image = UIImage(named: imageName, in: .mapboxNavigation, compatibleWith: nil)
         }
         overviewButton.image = UIImage(named: "carplay_overview", in: .mapboxNavigation, compatibleWith: nil)

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -154,18 +154,18 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
      
      When this property is true, the map follows the user’s location and rotates when their course changes. Otherwise, the map shows an overview of the route.
      */
-    @objc public var tracksUserCourse: Bool {
+    @objc public var showsUserCourse: Bool {
         get {
-            return mapView?.tracksUserCourse ?? false
+            return mapView?.showsUserCourse ?? false
         }
         set {
             let progress = navService.routeProgress
-            if !tracksUserCourse && newValue {
+            if !showsUserCourse && newValue {
                 mapView?.recenterMap()
                 mapView?.addArrow(route: progress.route,
                                  legIndex: progress.legIndex,
                                  stepIndex: progress.currentLegProgress.stepIndex + 1)
-            } else if tracksUserCourse && !newValue {
+            } else if showsUserCourse && !newValue {
                 guard let userLocation = self.navService.location?.coordinate else {
                     return
                 }
@@ -176,7 +176,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
     }
     
     public func beginPanGesture() {
-        mapView?.tracksUserCourse = false
+        mapView?.showsUserCourse = false
         mapView?.enableFrameByFrameCourseViewTracking(for: 1)
     }
     

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -56,7 +56,6 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         self.navService = navigationService
         self.mapTemplate = mapTemplate
         self.carInterfaceController = interfaceController
-        self.showsUserCourse = false
         
         super.init(nibName: nil, bundle: nil)
         carFeedbackTemplate = createFeedbackUI()
@@ -91,8 +90,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         resumeNotifications()
 
         navService.start()
-        mapView.showsUserCourse = true
-        mapView.userTrackingMode = .followWithCourse
+        mapView.recenterMap()
     }
     
     override public func viewWillDisappear(_ animated: Bool) {
@@ -157,15 +155,13 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
      
      When this property is true, the map follows the user’s location and rotates when their course changes. Otherwise, the map shows an overview of the route.
      */
-    @objc public var showsUserCourse: Bool {
+    @objc public var tracksUserCourse: Bool = false {
         didSet {
-            guard let progress = navService.router else { return }
-            mapView?.showsUserCourse = showsUserCourse
+            mapView?.tracksUserCourse = tracksUserCourse
             
-            if showsUserCourse {
-                mapView?.userTrackingMode = .followWithCourse
-            } else {
-                guard let userLocation = progress.location?.coordinate else { return }
+            if !tracksUserCourse,
+               let progress = navService.router,
+               let userLocation = progress.location?.coordinate {
                 mapView?.enableFrameByFrameCourseViewTracking(for: 3)
                 mapView?.setOverheadCameraView(from: userLocation, along: progress.route.coordinates!, for: self.edgePadding)
             }
@@ -173,7 +169,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
     }
     
     public func beginPanGesture() {
-        mapView?.showsUserCourse = false
+        mapView?.tracksUserCourse = false
         mapView?.enableFrameByFrameCourseViewTracking(for: 1)
     }
     

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -122,7 +122,14 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         }
     }
     
-    
+    open override var userTrackingMode: MGLUserTrackingMode {
+        didSet {
+            if userTrackingMode == .followWithCourse && showsUserCourse {
+                startUserCourseTracking()
+            }
+        }
+    }
+
     /**
      Center point of the user course view in screen coordinates relative to the map view.
      - seealso: NavigationMapViewDelegate.navigationMapViewUserAnchorPoint(_:)
@@ -153,12 +160,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     open var showsUserCourse: Bool = false {
         didSet {
             if showsUserCourse {
-                if userTrackingMode == .followWithCourse {
-                    showsUserLocation = false
-                }
-                enableFrameByFrameCourseViewTracking(for: 3)
-                altitude = defaultAltitude
-                courseTrackingDelegate?.navigationMapViewDidStartTrackingCourse?(self)
+                startUserCourseTracking()
             } else {
                 courseTrackingDelegate?.navigationMapViewDidStopTrackingCourse?(self)
             }
@@ -168,6 +170,16 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         }
     }
 
+    func startUserCourseTracking() {
+        if userTrackingMode != .followWithCourse {
+            return
+        }
+        showsUserLocation = false
+        enableFrameByFrameCourseViewTracking(for: 3)
+        altitude = defaultAltitude
+        courseTrackingDelegate?.navigationMapViewDidStartTrackingCourse?(self)
+    }
+    
     /**
      A `UIView` used to indicate the user’s location and course on the map.
      

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -154,7 +154,26 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     }
     
     /**
-     Determines whether the map should follow the user location and rotate when the course changes.
+     Determines whether the map should follow the user location, rotate when the course changes, and show the user navigation annotation.
+     - seealso: NavigationMapViewCourseTrackingDelegate
+     */
+    open var tracksUserCourse: Bool = false {
+        didSet {
+            if tracksUserCourse {
+                showsUserCourse = true
+                userTrackingMode = .followWithCourse
+            } else {
+                showsUserCourse = false
+                
+                if userTrackingMode == .followWithCourse {
+                    userTrackingMode = .none
+                }
+            }
+        }
+    }
+    
+    /**
+     Determines whether the map show the users navigation annotation.
      - seealso: NavigationMapViewCourseTrackingDelegate
      */
     open var showsUserCourse: Bool = false {
@@ -1085,7 +1104,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
      Recenters the camera and begins tracking the user's location.
      */
     @objc public func recenterMap() {
-        showsUserCourse = true
+        tracksUserCourse = true
         enableFrameByFrameCourseViewTracking(for: 3)
     }
 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -129,6 +129,7 @@ class RouteMapViewController: UIViewController {
         mapView.contentInset = contentInsets
         view.layoutIfNeeded()
 
+        mapView.userTrackingMode = .followWithCourse
         mapView.showsUserCourse = true
         instructionsBannerView.swipeable = true
 
@@ -156,6 +157,7 @@ class RouteMapViewController: UIViewController {
         navigationView.muteButton.isSelected = NavigationSettings.shared.voiceMuted
         mapView.compassView.isHidden = true
 
+        mapView.userTrackingMode = .followWithCourse
         mapView.showsUserCourse = true
 
         if let camera = pendingCamera {
@@ -206,6 +208,7 @@ class RouteMapViewController: UIViewController {
     }
 
     @objc func recenter(_ sender: AnyObject) {
+        mapView.userTrackingMode = .followWithCourse
         mapView.showsUserCourse = true
         mapView.enableFrameByFrameCourseViewTracking(for: 3)
         isInOverviewMode = false
@@ -295,6 +298,7 @@ class RouteMapViewController: UIViewController {
                 mapView.setOverheadCameraView(from: userLocation, along: coordinates, for: overheadInsets)
             }
         } else {
+            mapView.userTrackingMode = .followWithCourse
             mapView.showsUserCourse = true
             navigationView.wayNameView.isHidden = true
         }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -129,7 +129,7 @@ class RouteMapViewController: UIViewController {
         mapView.contentInset = contentInsets
         view.layoutIfNeeded()
 
-        mapView.tracksUserCourse = true
+        mapView.showsUserCourse = true
         instructionsBannerView.swipeable = true
 
         distanceFormatter.numberFormatter.locale = .nationalizedCurrent
@@ -156,7 +156,7 @@ class RouteMapViewController: UIViewController {
         navigationView.muteButton.isSelected = NavigationSettings.shared.voiceMuted
         mapView.compassView.isHidden = true
 
-        mapView.tracksUserCourse = true
+        mapView.showsUserCourse = true
 
         if let camera = pendingCamera {
             mapView.camera = camera
@@ -206,7 +206,7 @@ class RouteMapViewController: UIViewController {
     }
 
     @objc func recenter(_ sender: AnyObject) {
-        mapView.tracksUserCourse = true
+        mapView.showsUserCourse = true
         mapView.enableFrameByFrameCourseViewTracking(for: 3)
         isInOverviewMode = false
 
@@ -295,7 +295,7 @@ class RouteMapViewController: UIViewController {
                 mapView.setOverheadCameraView(from: userLocation, along: coordinates, for: overheadInsets)
             }
         } else {
-            mapView.tracksUserCourse = true
+            mapView.showsUserCourse = true
             navigationView.wayNameView.isHidden = true
         }
 
@@ -367,7 +367,7 @@ class RouteMapViewController: UIViewController {
     }
 
     func updateCameraAltitude(for routeProgress: RouteProgress) {
-        guard mapView.tracksUserCourse else { return } //only adjust when we are actively tracking user course
+        guard mapView.showsUserCourse else { return } //only adjust when we are actively tracking user course
 
         let zoomOutAltitude = mapView.zoomedOutMotorwayAltitude
         let defaultAltitude = mapView.defaultAltitude
@@ -495,7 +495,7 @@ class RouteMapViewController: UIViewController {
 
         guard duration > 0.0 else { return noAnimation() }
 
-        navigationView.mapView.tracksUserCourse = false
+        navigationView.mapView.showsUserCourse = false
         UIView.animate(withDuration: duration, delay: 0.0, options: [.curveLinear], animations: animate, completion: completion)
 
         guard let height = navigationView.endOfRouteHeightConstraint?.constant else { return }
@@ -582,7 +582,7 @@ extension RouteMapViewController: NavigationViewDelegate {
     // MARK: MGLMapViewDelegate
     func mapView(_ mapView: MGLMapView, regionDidChangeAnimated animated: Bool) {
         var userTrackingMode = mapView.userTrackingMode
-        if let mapView = mapView as? NavigationMapView, mapView.tracksUserCourse {
+        if let mapView = mapView as? NavigationMapView, mapView.showsUserCourse {
             userTrackingMode = .followWithCourse
         }
         if userTrackingMode == .none && !isInOverviewMode {
@@ -1000,7 +1000,7 @@ extension RouteMapViewController: StepsViewControllerDelegate {
         }
 
         mapView.enableFrameByFrameCourseViewTracking(for: 1)
-        mapView.tracksUserCourse = false
+        mapView.showsUserCourse = false
         mapView.setCenter(upcomingStep.maneuverLocation, zoomLevel: mapView.zoomLevel, direction: upcomingStep.initialHeading!, animated: true, completionHandler: nil)
 
         guard isViewLoaded && view.window != nil else { return }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -960,7 +960,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         addPreviewInstructions(step: legProgress.currentStep, maneuverStep: upcomingStep, distance: instructionsBannerView.distance)
         
         mapView.enableFrameByFrameCourseViewTracking(for: 1)
-        mapView.tracksUserCourse = false
+        mapView.showsUserCourse = false
         mapView.setCenter(upcomingStep.maneuverLocation, zoomLevel: mapView.zoomLevel, direction: upcomingStep.initialHeading!, animated: true, completionHandler: nil)
         
         guard isViewLoaded && view.window != nil else { return }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -128,7 +128,7 @@ class RouteMapViewController: UIViewController {
 
         mapView.contentInset = contentInsets
         view.layoutIfNeeded()
-
+        
         mapView.userTrackingMode = .followWithCourse
         mapView.showsUserCourse = true
         instructionsBannerView.swipeable = true
@@ -753,7 +753,7 @@ extension RouteMapViewController: NavigationViewDelegate {
      */
     func labelCurrentRoad(at rawLocation: CLLocation, for snappedLoction: CLLocation? = nil) {
 
-        guard navigationView.resumeButton.isHidden else {
+        guard mapView.showsUserCourse else {
                 return
         }
 


### PR DESCRIPTION
This was started in https://github.com/mapbox/mapbox-navigation-ios/pull/1594. For those that don't want to click into the PR

When using a single `NavigationMapView` and reusing the map when inside and outside of navigation mode, it needs to be possible to toggle between the course tracking mode in navigation mode and the default tracking modes when outside of navigation.

Once navigation has begun, this if statement is never false:

https://github.com/mapbox/mapbox-navigation-ios/blob/05096e5729c2a79a3eaa36b97c71c34dbc9c10f4/MapboxNavigation/NavigationMapView.swift#L123

because `userLocationForCourseTracking ` is never nil. Because of this, once exiting navigation, the user location view remains in puck mode instead of allowing for the normal view when setting `mapView.userTrackingMode = .follow`.

Now, when the user resets the user tracking mode, tracksUserCourse and userLocationForCourseTracking is set to false to make sure the blue dot returns.

/cc @mapbox/navigation-ios @apavani 