### PR TITLE
Make NavigationMapView’s frame rate more easily configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * `StyleManagerDelegate.locationFor(styleManager:)` has been renamed to `StyleManagerDelegate.location(for:)`  ([#1724](https://github.com/mapbox/mapbox-navigation-ios/pull/1724))
 * Fixed inaccurate maneuver arrows along the route line when the route doubles back on itself. ([#1735](https://github.com/mapbox/mapbox-navigation-ios/pull/1735))
-* `NavigationMapView` no longer mutates its own frame rate implicitly. A new `NavigationMapView.updatePreferredFrameRate(for:)` method allows you to update the frame rate in response to route progress change notifications. The `NavigationMapView.minimumFramesPerSecond` property determines the frame rate while the application runs on battery power. ([#https://github.com/mapbox/mapbox-navigation-ios/pull/1749](https://github.com/mapbox/mapbox-navigation-ios/pull/1749))
+* `NavigationMapView` no longer mutates its own frame rate implicitly. A new `NavigationMapView.updatePreferredFrameRate(for:)` method allows you to update the frame rate in response to route progress change notifications. The `NavigationMapView.minimumFramesPerSecond` property determines the frame rate while the application runs on battery power. By default, the map views in `NavigationViewController` and CarPlay’s navigation activity animate at a higher frame rate on battery power than before. ([#https://github.com/mapbox/mapbox-navigation-ios/pull/1749](https://github.com/mapbox/mapbox-navigation-ios/pull/1749))
 
 ## v0.21.0 (September 17, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `StyleManagerDelegate.locationFor(styleManager:)` has been renamed to `StyleManagerDelegate.location(for:)`  ([#1724](https://github.com/mapbox/mapbox-navigation-ios/pull/1724))
 * Fixed inaccurate maneuver arrows along the route line when the route doubles back on itself. ([#1735](https://github.com/mapbox/mapbox-navigation-ios/pull/1735))
+* `NavigationMapView` no longer mutates its own frame rate implicitly. A new `NavigationMapView.updatePreferredFrameRate(for:)` method allows you to update the frame rate in response to route progress change notifications. The `NavigationMapView.minimumFramesPerSecond` property determines the frame rate while the application runs on battery power. ([#https://github.com/mapbox/mapbox-navigation-ios/pull/1749](https://github.com/mapbox/mapbox-navigation-ios/pull/1749))
 
 ## v0.21.0 (September 17, 2018)
 

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -86,6 +86,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         styleManager = StyleManager(self)
         styleManager.styles = [DayStyle(), NightStyle()]
         
+        makeGestureRecognizersResetFrameRate()
         resumeNotifications()
         navService.start()
         mapView.recenterMap()
@@ -196,6 +197,7 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
         
         // Update the user puck
+        mapView?.updatePreferredFrameRate(for: routeProgress)
         let camera = MGLMapCamera(lookingAtCenter: location.coordinate, fromDistance: 120, pitch: 60, heading: location.course)
         mapView?.updateCourseTracking(location: location, camera: camera, animated: true)
         
@@ -211,6 +213,17 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
         let stepDistance = distanceFormatter.measurement(of: stepProgress.distanceRemaining)
         let stepEstimates = CPTravelEstimates(distanceRemaining: stepDistance, timeRemaining: stepProgress.durationRemaining)
         carSession.updateEstimates(stepEstimates, for: maneuver)
+    }
+    
+    /** Modifies the gesture recognizers to also update the map’s frame rate. */
+    func makeGestureRecognizersResetFrameRate() {
+        for gestureRecognizer in mapView?.gestureRecognizers ?? [] {
+            gestureRecognizer.addTarget(self, action: #selector(resetFrameRate(_:)))
+        }
+    }
+    
+    @objc func resetFrameRate(_ sender: UIGestureRecognizer) {
+        mapView?.preferredFramesPerSecond = NavigationMapView.FrameIntervalOptions.defaultFramesPerSecond
     }
     
     @objc func rerouted(_ notification: NSNotification) {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -22,9 +22,9 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     /**
      The minimum preferred frames per second at which to render map animations.
      
-     This property takes effect when the application has limited resources for animation, such as when the device is running on battery power. By default, this property is set to 5 frames per second.
+     This property takes effect when the application has limited resources for animation, such as when the device is running on battery power. By default, this property is set to `MGLMapViewPreferredFramesPerSecond.lowPower`.
      */
-    @objc public var minimumFramesPerSecond = MGLMapViewPreferredFramesPerSecond(rawValue: 5)
+    @objc public var minimumFramesPerSecond = MGLMapViewPreferredFramesPerSecond.lowPower
     
     /**
      Returns the altitude that the map camera initally defaults to.

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -133,6 +133,7 @@ class RouteMapViewController: UIViewController {
 
         distanceFormatter.numberFormatter.locale = .nationalizedCurrent
 
+        makeGestureRecognizersResetFrameRate()
         navigationView.overviewButton.addTarget(self, action: Actions.overview, for: .touchUpInside)
         navigationView.muteButton.addTarget(self, action: Actions.mute, for: .touchUpInside)
         navigationView.reportButton.addTarget(self, action: Actions.feedback, for: .touchUpInside)
@@ -404,6 +405,7 @@ class RouteMapViewController: UIViewController {
 
         instructionsBannerView.updateDistance(for: routeProgress.currentLegProgress.currentStepProgress)
 
+        mapView.updatePreferredFrameRate(for: routeProgress)
         if currentLegIndexMapped != routeProgress.legIndex {
             mapView.showWaypoints(routeProgress.route, legIndex: routeProgress.legIndex)
             mapView.showRoutes([routeProgress.route], legIndex: routeProgress.legIndex)
@@ -419,6 +421,17 @@ class RouteMapViewController: UIViewController {
         if annotatesSpokenInstructions {
             mapView.showVoiceInstructionsOnMap(route: route)
         }
+    }
+    
+    /** Modifies the gesture recognizers to also update the map’s frame rate. */
+    func makeGestureRecognizersResetFrameRate() {
+        for gestureRecognizer in mapView.gestureRecognizers ?? [] {
+            gestureRecognizer.addTarget(self, action: #selector(resetFrameRate(_:)))
+        }
+    }
+    
+    @objc func resetFrameRate(_ sender: UIGestureRecognizer) {
+        mapView.preferredFramesPerSecond = NavigationMapView.FrameIntervalOptions.defaultFramesPerSecond
     }
 
     var contentInsets: UIEdgeInsets {


### PR DESCRIPTION
`NavigationMapView` no longer mutates its own frame rate implicitly. A new `NavigationMapView.updatePreferredFrameRate(for:)` method allows the developer to update the frame rate in response to route progress change notifications. Previously, if the developer wanted to customize the frame rate, they would’ve had to install their own notification observer anyways and hope that it would respond to route progress change notifications after NavigationMapView’s built-in observer.

This change gets NavigationMapView out of the business of snooping on the stream of route progress updates coming from every active route controller. This is particularly beneficial when CarPlay is connected, because there are two active route controllers in that case that may deliver staggered route progress updates. However, it does mean that a developer implementing a custom navigation UI will need to call `NavigationMapView.updatePreferredFrameRate(for:)` explicitly to get the power-saving behavior that NavigationMapView used to provide by default.

The `NavigationMapView.minimumFramesPerSecond` property determines the frame rate while the application runs on battery power. By default, the map views in `NavigationViewController` and CarPlay’s navigation activity animate at a higher frame rate on battery power than before: 30&nbsp;frames per second, up from 5&nbsp;frames per second and equivalent to the behavior when running plugged in. This change has the potential to shorten battery life, but users overwhelmingly perceived 5&nbsp;fps animation as a buggy stuttering effect rather than a best-effort animation.

/cc @mapbox/navigation-ios