### PR TITLE
Service yo-yo fix

### DIFF
--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -206,7 +206,7 @@ extension MapboxNavigationService: CLLocationManagerDelegate {
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         //If we're always simulating, make sure this is a simulated update.
-        if simulationMode == .always, manager != simulatedLocationSource { return }
+        guard simulationMode != .always || manager == simulatedLocationSource else { return }
         
         //update the events manager with the received locations
         eventsManager.record(locations: locations)

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -205,6 +205,8 @@ extension MapboxNavigationService: CLLocationManagerDelegate {
     }
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        //If we're always simulating, make sure this is a simulated update.
+        if simulationMode == .always, manager != simulatedLocationSource { return }
         
         //update the events manager with the received locations
         eventsManager.record(locations: locations)


### PR DESCRIPTION
That was fun.

* Fixing issue where merge clobber caused regression where native location source could influence progress during location updates when simulationMode is `.always`.

/cc @mapbox/navigation-ios @nitaliano 