### PR TITLE
Remove dependency on debug build of MapboxDirections

### DIFF
--- a/MapboxNavigationTests/Fixtures/Fixture.swift
+++ b/MapboxNavigationTests/Fixtures/Fixture.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Foundation
 import CoreLocation
-@testable import MapboxDirections
+import MapboxDirections
 
 internal class Fixture {
     internal class func stringFromFileNamed(name: String) -> String {
@@ -68,12 +68,24 @@ internal class Fixture {
         let path = Bundle(for: Fixture.self).path(forResource: filePath, ofType: "json")
         let url = URL(fileURLWithPath: path!)
         let data = try! Data(contentsOf: url)
-        let json = try! JSONSerialization.jsonObject(with: data, options: []) as! JSONDictionary
+        let json = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
         let tracepoints = json["tracepoints"] as! [Any]
-        let coordinates = (0...tracepoints.count-1).map { _ in CLLocationCoordinate2D(latitude: 0, longitude: 0) }
-        let options = MatchOptions(coordinates: coordinates, profileIdentifier: .automobile)
-        let response = options.response(containingRoutesFrom: json)
-        return response.1
+        let coordinates = Array(repeating: CLLocationCoordinate2D(latitude: 0, longitude: 0), count: tracepoints.count)
+        
+        // Adapted from MatchOptions.response(containingRoutesFrom:) in MapboxDirections.
+        let jsonWaypoints = json["tracepoints"] as! [Any]
+        // Assume MatchOptions.waypointIndices contains the first and last indices only.
+        let waypoints = [jsonWaypoints.first!, jsonWaypoints.last!].map { jsonWaypoint -> Waypoint in
+            let jsonWaypoint = jsonWaypoint as! [String: Any]
+            let location = jsonWaypoint["location"] as! [Double]
+            let coordinate = CLLocationCoordinate2D(latitude: location[1], longitude: location[0])
+            return Waypoint(coordinate: coordinate, name: jsonWaypoint["name"] as? String)
+        }
+        let opts = RouteOptions(coordinates: coordinates, profileIdentifier: .automobile)
+        
+        return (json["matchings"] as? [[String: Any]])?.map {
+            Route(json: $0, waypoints: waypoints, options: opts)
+        }
     }
 
     class func routeWithBannerInstructions() -> Route {

--- a/MapboxNavigationTests/RouteControllerSnapshotTests.swift
+++ b/MapboxNavigationTests/RouteControllerSnapshotTests.swift
@@ -3,7 +3,7 @@ import FBSnapshotTestCase
 import Turf
 @testable import MapboxCoreNavigation
 @testable import MapboxNavigation
-@testable import MapboxDirections
+import MapboxDirections
 
 
 class RouteControllerSnapshotTests: FBSnapshotTestCase {
@@ -28,7 +28,7 @@ class RouteControllerSnapshotTests: FBSnapshotTestCase {
         let filePath = bundle.path(forResource: "sthlm-double-back-replay", ofType: "json")
         let jsonData = try! Data(contentsOf: URL(fileURLWithPath: filePath!))
         
-        let jsonLocations = try! JSONSerialization.jsonObject(with: jsonData, options: []) as! [JSONDictionary]
+        let jsonLocations = try! JSONSerialization.jsonObject(with: jsonData, options: []) as! [[String: Any]]
         let locations = jsonLocations.map { CLLocation(dictionary: $0) }
         let locationManager = ReplayLocationManager(locations: locations)
         replayManager = locationManager

--- a/MapboxNavigationTests/SimulatedLocationManagerTests.swift
+++ b/MapboxNavigationTests/SimulatedLocationManagerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import FBSnapshotTestCase
 @testable import MapboxCoreNavigation
 @testable import MapboxNavigation
-@testable import MapboxDirections
+import MapboxDirections
 
 class SimulatedLocationManagerTests: FBSnapshotTestCase {
 


### PR DESCRIPTION
~~Stick to MapboxDirections’ public API but stub out Map Matching API access using OHHTTPStubs, the same library that MapboxDirections.swift’s unit tests use.~~ Stick to MapboxDirections’ public API, adapting some internal MapboxDirections code for converting a Map Matching API response to a Route.

Fixes #1753.

/cc @frederoni @JThramer