### PR TITLE
Add location fallback for CarPlay navigation style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixed an issue where the map view while navigating in CarPlay displayed the day style even at night. ([#1762](https://github.com/mapbox/mapbox-navigation-ios/pull/1762))
+
 ## v0.22.0 (October 1, 2018)
 
 ### Packaging

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -398,7 +398,13 @@ public class CarPlayNavigationViewController: UIViewController, MGLMapViewDelega
 @available(iOS 12.0, *)
 extension CarPlayNavigationViewController: StyleManagerDelegate {
     public func location(for styleManager: StyleManager) -> CLLocation? {
-        return navService.location
+        if let location = navService.router.location {
+            return location
+        } else if let origin = navService.route.coordinates?.first {
+            return CLLocation(latitude: origin.latitude, longitude: origin.longitude)
+        } else {
+            return nil
+        }
     }
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {


### PR DESCRIPTION
Copied the `NavigationViewController.location(for:)` implementation over to `CarPlayNavigationViewController.location(for:)` so that the CarPlay navigation map view can show the night style even before the navigation service is able to say where the day/night choice should be made from.

Fixes #1760.

/cc @JThramer @frederoni