### PR TITLE
Adjustable GPS Patience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changes to the Mapbox Navigation SDK for iOS
+## master
+
+### User Location
+
+* Added ability to adjust `poorGPSPatience` of a `NavigationService`.
+* Increased default Poor-GPS patience of `MapboxNavigationService` to 2.5 seconds.
 
 ## v0.22.0 (October 1, 2018)
 
@@ -8,11 +14,13 @@
 
 ### User location
 
-* Added a `NavigationService` protocol implemented by classes that provide location awareness functionality. `RouteController` and a new `MapboxNavigationService` class both conform to this protocol. ([#1602](https://github.com/mapbox/mapbox-navigation-ios/pull/1602))
+* Added a `NavigationService` protocol implemented by classes that provide location awareness functionality. Our default implementation, `MapboxNavigationService` conforms to this protocol. ([#1602](https://github.com/mapbox/mapbox-navigation-ios/pull/1602))
+  * Added a new `Router` protocol, which allows for custom route-following logic. Our default implementation, `RouteController` conforms to this protocol.
   * `NavigationViewController.init(for:styles:directions:styles:routeController:locationManager:voiceController:eventsManager)` has been renamed `NavigationViewController.init(for:styles:navigationService:voiceController:)`.
   * `NavigationViewController.routeController` has been replaced by `NavigationViewController.navigationService`.
-  * If you currently use `RouteController` directly, you should migrate to `NavigationService`.
+  * If you currently use `RouteController` directly, you should migrate to `MapboxNavigationService`.
   * If you currently use `SimulatedLocationManager` directly, you should instead pass `SimulationOption.always` into `MapboxNavigationService(route:directions:locationSource:eventsManagerType:simulating:)`.
+  * Note: the `MapboxNavigationService`, by default, will start simulating progress if more than 2.5 seconds elapses without any update from the GPS. This can happen when simulating locations in XCode, or selecting the "Custom Location" simulation option in the iOS Simulator. This is normal behavior, .
 * Improved the reliability of off-route detection. ([#1618](https://github.com/mapbox/mapbox-navigation-ios/pull/1618))
 
 ### User interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ### User Location
 
-* Added ability to adjust `poorGPSPatience` of a `NavigationService`.
-* Increased default Poor-GPS patience of `MapboxNavigationService` to 2.5 seconds.
+* Added ability to adjust `poorGPSPatience` of a `NavigationService`. [#1763](https://github.com/mapbox/mapbox-navigation-ios/pull/1763)
+* Increased default Poor-GPS patience of `MapboxNavigationService` to 2.5 seconds. [#1763](https://github.com/mapbox/mapbox-navigation-ios/pull/1763)
 
 ## v0.22.0 (October 1, 2018)
 
@@ -20,7 +20,7 @@
   * `NavigationViewController.routeController` has been replaced by `NavigationViewController.navigationService`.
   * If you currently use `RouteController` directly, you should migrate to `MapboxNavigationService`.
   * If you currently use `SimulatedLocationManager` directly, you should instead pass `SimulationOption.always` into `MapboxNavigationService(route:directions:locationSource:eventsManagerType:simulating:)`.
-  * Note: the `MapboxNavigationService`, by default, will start simulating progress if more than 2.5 seconds elapses without any update from the GPS. This can happen when simulating locations in XCode, or selecting the "Custom Location" simulation option in the iOS Simulator. This is normal behavior, .
+  * Note: the `MapboxNavigationService`, by default, will start simulating progress if more than 1.5 seconds elapses without any update from the GPS. This can happen when simulating locations in Xcode, or selecting the "Custom Location" simulation option in the iOS Simulator. This is normal behavior.
 * Improved the reliability of off-route detection. ([#1618](https://github.com/mapbox/mapbox-navigation-ios/pull/1618))
 
 ### User interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### User location
 
 * Added a `NavigationService` protocol implemented by classes that provide location awareness functionality. Our default implementation, `MapboxNavigationService` conforms to this protocol. ([#1602](https://github.com/mapbox/mapbox-navigation-ios/pull/1602))
-  * Added a new `Router` protocol, which allows for custom route-following logic. Our default implementation, `RouteController` conforms to this protocol.
+  * Added a new `Router` protocol, which allows for custom route-following logic. Our default implementation, `RouteController`, conforms to this protocol.
   * `NavigationViewController.init(for:styles:directions:styles:routeController:locationManager:voiceController:eventsManager)` has been renamed `NavigationViewController.init(for:styles:navigationService:voiceController:)`.
   * `NavigationViewController.routeController` has been replaced by `NavigationViewController.navigationService`.
   * If you currently use `RouteController` directly, you should migrate to `MapboxNavigationService`.

--- a/MapboxCoreNavigation/CountdownTimer.swift
+++ b/MapboxCoreNavigation/CountdownTimer.swift
@@ -8,7 +8,11 @@ class CountdownTimer {
     
     typealias Payload = DispatchSource.DispatchSourceHandler
     static let defaultAccuracy: DispatchTimeInterval = .milliseconds(500)
-    let countdownInterval: DispatchTimeInterval
+    var countdownInterval: DispatchTimeInterval {
+        didSet {
+            reset()
+        }
+    }
     private var deadline: DispatchTime { return .now() + countdownInterval }
     let accuracy: DispatchTimeInterval
     let payload: Payload

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -407,6 +407,18 @@ class NavigationServiceTests: XCTestCase {
         
         XCTAssertNil(subject, "Expected LocationManager's Delegate to be nil after RouteController Deinit")
     }
+    
+    func testCountdownTimerDefaultAndUpdate() {
+        let directions = DirectionsSpy(accessToken: "pk.feedCafeDeadBeefBadeBede")
+        let subject = MapboxNavigationService(route: initialRoute, directions: directions)
+        
+        XCTAssert(subject.poorGPSTimer.countdownInterval == .milliseconds(2500), "Default countdown interval should be 2500 milliseconds.")
+        
+        
+        subject.poorGPSPatience = 5.0
+        XCTAssert(subject.poorGPSTimer.countdownInterval == .milliseconds(5000), "Timer should now have a countdown interval of 5000 millseconds.")
+    }
+    
 }
 
 class RouteControllerDataSourceFake: RouterDataSource {


### PR DESCRIPTION
Fixes #1756.

![Turn it back!](http://weandthecolor.com/wp-content/uploads/2017/02/2-Nicola-Gastaldi-Turn-back-the-time.gif)

* Default GPS Patience is now 2.5 seconds.
* Ability to adjust patience has been added.


Todo: 
- [x] Changelog Entry


/cc @mapbox/navigation-ios 
