### PR TITLE
CarPlay EventsManager fixes

### DIFF
--- a/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -2,12 +2,9 @@ import Foundation
 import MapboxMobileEvents
 import MapboxDirections
 
-/**
- The `NavigationEventsManager` is responsible for being the liaison between MapboxCoreNavigation and the Mapbox telemetry framework.
- 
- `SessionState` is a struct that stores all memoized statistics that we later send to the telemetry engine.
+ /**
+ The `EventsManagerDataSource` protocol declares values required for recording route following events.
  */
-
 @objc public protocol EventsManagerDataSource: class {
     var routeProgress: RouteProgress { get }
     var location: CLLocation? { get }
@@ -17,6 +14,9 @@ import MapboxDirections
 
 public typealias EventsManager = NavigationEventsManager
 
+/**
+ The `NavigationEventsManager` is responsible for being the liaison between MapboxCoreNavigation and the Mapbox telemetry framework.
+ */
 @objc(MBEventsManager)
 open class NavigationEventsManager: NSObject {
 
@@ -24,7 +24,7 @@ open class NavigationEventsManager: NSObject {
     
     var outstandingFeedbackEvents = [CoreFeedbackEvent]()
     
-    unowned var dataSource: EventsManagerDataSource
+    weak var dataSource: EventsManagerDataSource?
     
     /// :nodoc: This is used internally when the navigation UI is being used
     var usesDefaultUserInterface = false
@@ -44,7 +44,7 @@ open class NavigationEventsManager: NSObject {
         return token
     }()
     
-    @objc public required init(dataSource source: EventsManagerDataSource, accessToken possibleToken: String? = nil, mobileEventsManager: MMEEventsManager = .shared()) {
+    @objc public required init(dataSource source: EventsManagerDataSource?, accessToken possibleToken: String? = nil, mobileEventsManager: MMEEventsManager = .shared()) {
         dataSource = source
         super.init()
         if let tokenOverride = possibleToken {
@@ -87,8 +87,9 @@ open class NavigationEventsManager: NSObject {
         mobileEventsManager.sendTurnstileEvent()
     }
     
-    func navigationCancelEvent(rating potentialRating: Int? = nil, comment: String? = nil) -> EventDetails {
-        
+    func navigationCancelEvent(rating potentialRating: Int? = nil, comment: String? = nil) -> EventDetails? {
+        guard let dataSource = dataSource else { return nil }
+
         let rating = potentialRating ?? MMEEventsManager.unrated
         var event = EventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = MMEEventTypeNavigationCancel
@@ -104,13 +105,17 @@ open class NavigationEventsManager: NSObject {
         return event
     }
     
-    func navigationDepartEvent() -> EventDetails {
+    func navigationDepartEvent() -> EventDetails? {
+        guard let dataSource = dataSource else { return nil }
+
         var event = EventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = MMEEventTypeNavigationDepart
         return event
     }
     
-    func navigationArriveEvent() -> EventDetails {
+    func navigationArriveEvent() -> EventDetails? {
+        guard let dataSource = dataSource else { return nil }
+
         var event = EventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = MMEEventTypeNavigationArrive
         return event
@@ -124,7 +129,9 @@ open class NavigationEventsManager: NSObject {
         return eventDictionary
     }
     
-    func navigationFeedbackEvent(type: FeedbackType, description: String?) -> EventDetails {
+    func navigationFeedbackEvent(type: FeedbackType, description: String?) -> EventDetails? {
+        guard let dataSource = dataSource else { return nil }
+
         var event = EventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = MMEEventTypeNavigationFeedback
         
@@ -137,9 +144,10 @@ open class NavigationEventsManager: NSObject {
         return event
     }
     
-    func navigationRerouteEvent(eventType: String = MMEEventTypeNavigationReroute) -> EventDetails {
+    func navigationRerouteEvent(eventType: String = MMEEventTypeNavigationReroute) -> EventDetails? {
+        guard let dataSource = dataSource else { return nil }
+
         let timestamp = Date()
-        
         var event = EventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = eventType
         if let lastRerouteDate = sessionState?.lastRerouteDate {
@@ -147,7 +155,6 @@ open class NavigationEventsManager: NSObject {
         } else {
             event.secondsSinceLastReroute = -1
         }
-        
         
         // These are placeholders until the route controller's RouteProgress is updated after rerouting
         event.newDistanceRemaining = -1
@@ -162,21 +169,20 @@ open class NavigationEventsManager: NSObject {
 extension EventsManager {
     
     func sendDepartEvent() {
-        guard let attributes = try? navigationDepartEvent().asDictionary() else { return }
-        mobileEventsManager.enqueueEvent(withName: MMEEventTypeNavigationDepart, attributes: attributes)
+        guard let attributes = try? navigationDepartEvent()?.asDictionary() else { return }
+        mobileEventsManager.enqueueEvent(withName: MMEEventTypeNavigationDepart, attributes: attributes ?? [:])
         mobileEventsManager.flush()
     }
     
-    
     func sendArriveEvent() {
-        guard let attributes = try? navigationArriveEvent().asDictionary() else { return }
-        mobileEventsManager.enqueueEvent(withName: MMEEventTypeNavigationArrive, attributes: attributes)
+        guard let attributes = try? navigationArriveEvent()?.asDictionary() else { return }
+        mobileEventsManager.enqueueEvent(withName: MMEEventTypeNavigationArrive, attributes: attributes ?? [:])
         mobileEventsManager.flush()
     }
     
     func sendCancelEvent(rating: Int? = nil, comment: String? = nil) {
-        guard let attributes = try? navigationCancelEvent(rating: rating, comment: comment).asDictionary() else { return }
-        mobileEventsManager.enqueueEvent(withName: MMEEventTypeNavigationCancel, attributes: attributes)
+        guard let attributes = try? navigationCancelEvent(rating: rating, comment: comment)?.asDictionary() else { return }
+        mobileEventsManager.enqueueEvent(withName: MMEEventTypeNavigationCancel, attributes: attributes ?? [:])
         mobileEventsManager.flush()
     }
     
@@ -195,45 +201,41 @@ extension EventsManager {
         mobileEventsManager.flush()
     }
     
-    func enqueueFeedbackEvent(type: FeedbackType, description: String?) -> UUID {
-        let eventDictionary = try! navigationFeedbackEvent(type: type, description: description).asDictionary()
-        let event = FeedbackEvent(timestamp: Date(), eventDictionary: eventDictionary)
+    func enqueueFeedbackEvent(type: FeedbackType, description: String?) -> UUID? {
+        guard let eventDictionary = try? navigationFeedbackEvent(type: type, description: description)?.asDictionary() else { return nil }
+        let event = FeedbackEvent(timestamp: Date(), eventDictionary: eventDictionary ?? [:])
         outstandingFeedbackEvents.append(event)
         return event.id
     }
-    
-    @discardableResult
-    func enqueueRerouteEvent() -> String {
+
+    func enqueueRerouteEvent() {
+        guard let eventDictionary = try? navigationRerouteEvent()?.asDictionary() else { return }
         let timestamp = Date()
-        let eventDictionary = try! navigationRerouteEvent().asDictionary()
         
         sessionState.lastRerouteDate = timestamp
         sessionState.numberOfReroutes += 1
         
-        let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
+        let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary ?? [:])
         
         outstandingFeedbackEvents.append(event)
-        
-        return event.id.uuidString
     }
     
     func resetSession() {
+        guard let dataSource = dataSource else { return }
+
         let route = dataSource.routeProgress.route
         sessionState = SessionState(currentRoute: route, originalRoute: route)
     }
-    
-    @discardableResult
-    func enqueueFoundFasterRouteEvent() -> String {
+
+    func enqueueFoundFasterRouteEvent() {
+        guard let eventDictionary = try? navigationRerouteEvent()?.asDictionary() else { return }
+
         let timestamp = Date()
-        let eventDictionary = try! navigationRerouteEvent().asDictionary()
-        
         sessionState?.lastRerouteDate = timestamp
         
-        let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary)
+        let event = RerouteEvent(timestamp: Date(), eventDictionary: eventDictionary ?? [:])
         
         outstandingFeedbackEvents.append(event)
-        
-        return event.id.uuidString
     }
     
     func sendOutstandingFeedbackEvents(forceAll: Bool) {

--- a/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -74,8 +74,8 @@ open class NavigationEventsManager: NSObject {
      When set to `false`, flushing of telemetry events is not delayed. Is set to `true` by default.
      */
     @objc public var delaysEventFlushing = true
-    
-    func start() {
+
+    public func start() {
         let eventLoggingEnabled = UserDefaults.standard.bool(forKey: NavigationMetricsDebugLoggingEnabled)
         
         mobileEventsManager.isDebugLoggingEnabled = eventLoggingEnabled
@@ -164,10 +164,21 @@ open class NavigationEventsManager: NSObject {
         
         return event
     }
-}
 
-extension EventsManager {
-    
+    public func sendCarPlayConnectEvent() {
+        let date = Date()
+        let dateCreatedAttribute = [MMEEventKeyCreated: date.ISO8601]
+        mobileEventsManager.enqueueEvent(withName: MMEventTypeCarplayConnect, attributes: dateCreatedAttribute)
+        mobileEventsManager.flush()
+    }
+
+    public func sendCarPlayDisconnectEvent() {
+        let date = Date()
+        let dateCreatedAttribute = [MMEEventKeyCreated: date.ISO8601]
+        mobileEventsManager.enqueueEvent(withName: MMEventTypeCarplayDisconnect, attributes: dateCreatedAttribute)
+        mobileEventsManager.flush()
+    }
+
     func sendDepartEvent() {
         guard let attributes = try? navigationDepartEvent()?.asDictionary() else { return }
         mobileEventsManager.enqueueEvent(withName: MMEEventTypeNavigationDepart, attributes: attributes ?? [:])

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -154,7 +154,7 @@ public class MapboxNavigationService: NSObject, NavigationService, DefaultInterf
     /**
      The events manager. Sends telemetry back to the Mapbox platform.
     */
-    public var eventsManager: EventsManager!
+    public var eventsManager: NavigationEventsManager!
     
     /**
      The `NavigationService` delegate. Wraps `RouterDelegate` messages.
@@ -238,7 +238,7 @@ public class MapboxNavigationService: NSObject, NavigationService, DefaultInterf
     @objc required public init(route: Route,
                                directions: Directions? = nil,
                                locationSource: NavigationLocationManager? = nil,
-                               eventsManagerType: EventsManager.Type? = nil,
+                               eventsManagerType: NavigationEventsManager.Type? = nil,
                                simulating simulationMode: SimulationMode = .onPoorGPS,
                                routerType: Router.Type? = DefaultRouter.self)
     {
@@ -251,7 +251,7 @@ public class MapboxNavigationService: NSObject, NavigationService, DefaultInterf
         let routerType = routerType ?? DefaultRouter.self
         router = routerType.init(along: route, directions: self.directions, dataSource: self)
         
-        let eventType = eventsManagerType ?? EventsManager.self
+        let eventType = eventsManagerType ?? NavigationEventsManager.self
         eventsManager = eventType.init(dataSource: self, accessToken: route.accessToken)
         locationManager.activityType = route.routeOptions.activityType
         bootstrapEvents()

--- a/MapboxCoreNavigation/SessionState.swift
+++ b/MapboxCoreNavigation/SessionState.swift
@@ -3,10 +3,11 @@ import CoreLocation
 import MapboxDirections
 import UIKit.UIDevice
 
-
+/**
+ `SessionState` is a struct which stores information needed to send to the Mapbox telemetry platform.
+ */
 struct SessionState {
 
-    
     let identifier = UUID()
     var departureTimestamp: Date?
     var arrivalTimestamp: Date?

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -3,25 +3,8 @@ import MapboxDirections
 import Turf
 import MapboxMobileEvents
 @testable import MapboxCoreNavigation
-import CoreLocation
 
 fileprivate let mbTestHeading: CLLocationDirection = 50
-
-class EventsManagerSpy: EventsManager {
-    override var manager: MMEEventsManager {
-        get {
-            return spy
-        }
-        set {
-            fatalError("Don't do this")
-        }
-    }
-    
-    var spy: MMEEventsManagerSpy = MMEEventsManagerSpy()
-    func reset() {
-        spy.reset()
-    }
-}
 
 class NavigationServiceTests: XCTestCase {
 
@@ -399,6 +382,7 @@ class NavigationServiceTests: XCTestCase {
     func testRouteControllerDoesNotRetainDataSource() {
         
         weak var subject: RouterDataSource? = nil
+        
         autoreleasepool {
             let fakeDataSource = RouteControllerDataSourceFake()
             _ = RouteController(along: initialRoute, directions: directionsClientSpy, dataSource: fakeDataSource)
@@ -420,22 +404,6 @@ class NavigationServiceTests: XCTestCase {
     }
     
 }
-
-class RouteControllerDataSourceFake: RouterDataSource {
-    
-    let manager = NavigationLocationManager()
-    
-    var location: CLLocation? {
-        return manager.location
-    }
-    
-    var locationProvider: NavigationLocationManager.Type {
-        return type(of: manager)
-    }
-    
-    
-}
-
 
 fileprivate func futureEcho(location: CLLocation, times: Int = 4) -> [CLLocation] {
     let loop = 0...times

--- a/MapboxCoreNavigationTests/Support/EventsManagerTestDoubles.swift
+++ b/MapboxCoreNavigationTests/Support/EventsManagerTestDoubles.swift
@@ -1,7 +1,24 @@
 import Foundation
 import MapboxMobileEvents
-import MapboxCoreNavigation
+@testable import MapboxCoreNavigation
 import MapboxDirections
+
+class EventsManagerSpy: EventsManager {
+    override var manager: MMEEventsManager {
+        get {
+            return spy
+        }
+        set {
+            fatalError("Don't do this")
+        }
+    }
+
+    var spy: MMEEventsManagerSpy = MMEEventsManagerSpy()
+
+    func reset() {
+        spy.reset()
+    }
+}
 
 typealias MockTelemetryEvent = (name: String, attributes: [String: Any])
 

--- a/MapboxCoreNavigationTests/Support/NavigationEventsManagerTestDoubles.swift
+++ b/MapboxCoreNavigationTests/Support/NavigationEventsManagerTestDoubles.swift
@@ -7,9 +7,13 @@ class NavigationEventsManagerSpy: NavigationEventsManager {
 
     private var mobileEventsManagerSpy: MMEEventsManagerSpy!
 
-    required init(dataSource source: EventsManagerDataSource, accessToken possibleToken: String?, mobileEventsManager: MMEEventsManager) {
+    required init() {
         mobileEventsManagerSpy = MMEEventsManagerSpy()
-        super.init(dataSource: source, accessToken: possibleToken, mobileEventsManager: mobileEventsManagerSpy)
+        super.init(dataSource: nil, accessToken: "fake token", mobileEventsManager: mobileEventsManagerSpy)
+    }
+
+    @objc required convenience init(dataSource source: EventsManagerDataSource?, accessToken possibleToken: String?, mobileEventsManager: MMEEventsManager) {
+        self.init()
     }
 
     func reset() {
@@ -36,7 +40,7 @@ class NavigationEventsManagerSpy: NavigationEventsManager {
 typealias FakeTelemetryEvent = (name: String, attributes: [String: Any])
 
 @objc(MBEventsManagerSpy)
-class MMEEventsManagerSpy: MMEEventsManager {
+private class MMEEventsManagerSpy: MMEEventsManager {
 
     private var enqueuedEvents = [FakeTelemetryEvent]()
     private var flushedEvents = [FakeTelemetryEvent]()

--- a/MapboxCoreNavigationTests/Support/NavigationServiceTestDoubles.swift
+++ b/MapboxCoreNavigationTests/Support/NavigationServiceTestDoubles.swift
@@ -2,6 +2,19 @@ import Foundation
 import MapboxCoreNavigation
 import MapboxDirections
 
+class RouteControllerDataSourceFake: RouterDataSource {
+
+    let manager = NavigationLocationManager()
+
+    var location: CLLocation? {
+        return manager.location
+    }
+
+    var locationProvider: NavigationLocationManager.Type {
+        return type(of: manager)
+    }
+}
+
 class NavigationServiceDelegateSpy: NavigationServiceDelegate {
     private(set) var recentMessages: [String] = []
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		352BBC401E5E6C9F00703DF1 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C6A3471E5E418D0004CA57 /* AppDelegate.m */; };
 		352BBC4A1E5E78D700703DF1 /* Example_SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352BBC491E5E78D700703DF1 /* Example_SwiftTests.swift */; };
 		352BBC581E5E78EA00703DF1 /* Example_Objective_CTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 352BBC571E5E78EA00703DF1 /* Example_Objective_CTests.m */; };
-		352F464D20EB74C200147886 /* EventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352F464C20EB74C200147886 /* EventsManager.swift */; };
+		352F464D20EB74C200147886 /* NavigationEventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352F464C20EB74C200147886 /* NavigationEventsManager.swift */; };
 		3531C2701F9E095400D92F9A /* InstructionsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3531C26F1F9E095400D92F9A /* InstructionsBannerView.swift */; };
 		353280A11FA72871005175F3 /* InstructionLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353280A01FA72871005175F3 /* InstructionLabel.swift */; };
 		353610CE1FAB6A8F00FB1746 /* BottomBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353610CD1FAB6A8F00FB1746 /* BottomBannerView.swift */; };
@@ -615,7 +615,7 @@
 		352BBC571E5E78EA00703DF1 /* Example_Objective_CTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Example_Objective_CTests.m; sourceTree = "<group>"; };
 		352BBC591E5E78EA00703DF1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		352C35BF2134958F00D77796 /* RecentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RecentItem.swift; path = ../Examples/Swift/RecentItem.swift; sourceTree = "<group>"; };
-		352F464C20EB74C200147886 /* EventsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManager.swift; sourceTree = "<group>"; };
+		352F464C20EB74C200147886 /* NavigationEventsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEventsManager.swift; sourceTree = "<group>"; };
 		3531C2671F9DDC6E00D92F9A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Main.strings"; sourceTree = "<group>"; };
 		3531C2681F9DDC6E00D92F9A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Main.strings"; sourceTree = "<group>"; };
 		3531C2691F9DDC6F00D92F9A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Navigation.strings"; sourceTree = "<group>"; };
@@ -1260,8 +1260,8 @@
 				354A9BCC20EA9C8100F03325 /* CoreFeedbackEvent.swift */,
 				354A9BCA20EA9BDA00F03325 /* EventDetails.swift */,
 				C5CFE4871EF2FD4C006F48E8 /* MMEEventsManager.swift */,
+				352F464C20EB74C200147886 /* NavigationEventsManager.swift */,
 				354A9BC520EA991900F03325 /* SessionState.swift */,
-				352F464C20EB74C200147886 /* EventsManager.swift */,
 			);
 			name = Events;
 			sourceTree = "<group>";
@@ -2368,7 +2368,7 @@
 				3582A25020EEC46B0029C5DE /* Router.swift in Sources */,
 				8D75F991212B5C7F00F99CF3 /* TunnelAuthority.swift in Sources */,
 				C5E7A31C1F4F6828001CB015 /* NavigationRouteOptions.swift in Sources */,
-				352F464D20EB74C200147886 /* EventsManager.swift in Sources */,
+				352F464D20EB74C200147886 /* NavigationEventsManager.swift in Sources */,
 				351174F41EF1C0530065E248 /* ReplayLocationManager.swift in Sources */,
 				C5C94C1C1DDCD2340097296A /* RouteController.swift in Sources */,
 				359574A81F28CC5A00838209 /* CLLocation.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		160A4A712127A46C0028B070 /* CPBarButton+MBTestable.m in Sources */ = {isa = PBXBuildFile; fileRef = 160A4A69212791010028B070 /* CPBarButton+MBTestable.m */; };
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
 		160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D827A2059973C00D278D6 /* DataCacheTests.swift */; };
-		16120A4D20645D6E007EA21D /* EventsManagerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */; };
+		16120A4D20645D6E007EA21D /* NavigationEventsManagerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* NavigationEventsManagerTestDoubles.swift */; };
 		1622E882215D776C006A2E5F /* MapboxNavigationNative.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35C98734212E042C00808B82 /* MapboxNavigationNative.framework */; };
 		1622E883215D7824006A2E5F /* MapboxNavigationNative.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 35C98734212E042C00808B82 /* MapboxNavigationNative.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		16435E03206EE32F00AF48B6 /* DirectionsSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */; };
@@ -26,7 +26,7 @@
 		16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.mm */; };
 		16B63DCD205C8EEF002D56D4 /* route-with-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = 16B63DCC205C8EEF002D56D4 /* route-with-instructions.json */; };
 		16C2A421211526EE00FE6E68 /* CarPlayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C2A420211526EE00FE6E68 /* CarPlayManager.swift */; };
-		16C6E6012147194A0057098D /* EventsManagerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */; };
+		16C6E6012147194A0057098D /* NavigationEventsManagerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* NavigationEventsManagerTestDoubles.swift */; };
 		16E3625C201265D600DF0592 /* ImageDownloadOperationSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E3625B201265D600DF0592 /* ImageDownloadOperationSpy.swift */; };
 		16E4F97F205B05FE00531791 /* MapboxVoiceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4F97E205B05FE00531791 /* MapboxVoiceControllerTests.swift */; };
 		16EF6C1E21193A9600AA580B /* CarPlayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EF6C1D21193A9600AA580B /* CarPlayManagerTests.swift */; };
@@ -551,7 +551,7 @@
 		160A4A69212791010028B070 /* CPBarButton+MBTestable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CPBarButton+MBTestable.m"; sourceTree = "<group>"; };
 		160D8278205996DA00D278D6 /* DataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
 		160D827A2059973C00D278D6 /* DataCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCacheTests.swift; sourceTree = "<group>"; };
-		16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerTestDoubles.swift; sourceTree = "<group>"; };
+		16120A4C20645D6E007EA21D /* NavigationEventsManagerTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEventsManagerTestDoubles.swift; sourceTree = "<group>"; };
 		16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectionsSpy.swift; sourceTree = "<group>"; };
 		16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyURLSessionDataTask.swift; sourceTree = "<group>"; };
 		166224442025699600EA4824 /* ImageRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryTests.swift; sourceTree = "<group>"; };
@@ -1069,7 +1069,7 @@
 			children = (
 				16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */,
 				16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */,
-				16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */,
+				16120A4C20645D6E007EA21D /* NavigationEventsManagerTestDoubles.swift */,
 				3EA93EBD6E6BEC966BBE51D6 /* NavigationServiceTestDoubles.swift */,
 			);
 			path = Support;
@@ -2319,7 +2319,7 @@
 				35B1AEBC20AD9B3C00C8544E /* LeaksSpec.swift in Sources */,
 				16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */,
 				8D54F14A206ECF720038736D /* InstructionPresenterTests.swift in Sources */,
-				16C6E6012147194A0057098D /* EventsManagerTestDoubles.swift in Sources */,
+				16C6E6012147194A0057098D /* NavigationEventsManagerTestDoubles.swift in Sources */,
 				166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */,
 				160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */,
 				35B1AEBE20AD9C7800C8544E /* LeakTest.swift in Sources */,
@@ -2401,7 +2401,7 @@
 			files = (
 				16435E05206EE37800AF48B6 /* DummyURLSessionDataTask.swift in Sources */,
 				C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */,
-				16120A4D20645D6E007EA21D /* EventsManagerTestDoubles.swift in Sources */,
+				16120A4D20645D6E007EA21D /* NavigationEventsManagerTestDoubles.swift in Sources */,
 				C551B0E620D42222009A986F /* NavigationLocationManagerTests.swift in Sources */,
 				359A8AED1FA78D3000BDB486 /* DistanceFormatterTests.swift in Sources */,
 				C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		160A4A712127A46C0028B070 /* CPBarButton+MBTestable.m in Sources */ = {isa = PBXBuildFile; fileRef = 160A4A69212791010028B070 /* CPBarButton+MBTestable.m */; };
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
 		160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D827A2059973C00D278D6 /* DataCacheTests.swift */; };
-		16120A4D20645D6E007EA21D /* MMEEventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */; };
+		16120A4D20645D6E007EA21D /* EventsManagerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */; };
 		1622E882215D776C006A2E5F /* MapboxNavigationNative.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35C98734212E042C00808B82 /* MapboxNavigationNative.framework */; };
 		1622E883215D7824006A2E5F /* MapboxNavigationNative.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 35C98734212E042C00808B82 /* MapboxNavigationNative.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		16435E03206EE32F00AF48B6 /* DirectionsSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */; };
@@ -20,12 +20,13 @@
 		166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166224442025699600EA4824 /* ImageRepositoryTests.swift */; };
 		1662244720256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662244620256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift */; };
 		1662244B2029059C00EA4824 /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662244A2029059C00EA4824 /* ImageCacheTests.swift */; };
+		169A970A216440820082A6A0 /* NavigationViewControllerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169A9709216440820082A6A0 /* NavigationViewControllerTestDoubles.swift */; };
 		16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A509D4202A87B20011D788 /* ImageDownloaderTests.swift */; };
 		16A509D7202BC0CA0011D788 /* ImageDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A509D6202BC0CA0011D788 /* ImageDownload.swift */; };
 		16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 16AC9D10212E356200CECE44 /* CPMapTemplate+MBTestable.mm */; };
 		16B63DCD205C8EEF002D56D4 /* route-with-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = 16B63DCC205C8EEF002D56D4 /* route-with-instructions.json */; };
 		16C2A421211526EE00FE6E68 /* CarPlayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C2A420211526EE00FE6E68 /* CarPlayManager.swift */; };
-		16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */; };
+		16C6E6012147194A0057098D /* EventsManagerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */; };
 		16E3625C201265D600DF0592 /* ImageDownloadOperationSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E3625B201265D600DF0592 /* ImageDownloadOperationSpy.swift */; };
 		16E4F97F205B05FE00531791 /* MapboxVoiceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4F97E205B05FE00531791 /* MapboxVoiceControllerTests.swift */; };
 		16EF6C1E21193A9600AA580B /* CarPlayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EF6C1D21193A9600AA580B /* CarPlayManagerTests.swift */; };
@@ -225,9 +226,8 @@
 		8D424F1E215EB07500432491 /* MapboxNavigationNative.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 35C98734212E042C00808B82 /* MapboxNavigationNative.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8D424F1F215EB08D00432491 /* MapboxGeocoder.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3507F9F92134305C0086B39E /* MapboxGeocoder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8D424F20215EB69400432491 /* DirectionsSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */; };
-		8D424F21215EB80700432491 /* NavigationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ABB50D20408D2C00AFA92C /* NavigationServiceTests.swift */; };
-		8D424F22215EB93A00432491 /* RouteControllerDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */; };
-		8D424F23215EB93D00432491 /* RouteControllerDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */; };
+		8D424F22215EB93A00432491 /* NavigationServiceTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93EBD6E6BEC966BBE51D6 /* NavigationServiceTestDoubles.swift */; };
+		8D424F23215EB93D00432491 /* NavigationServiceTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93EBD6E6BEC966BBE51D6 /* NavigationServiceTestDoubles.swift */; };
 		8D424F24215EC4CE00432491 /* routeWithInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = C5387A9C1F8FDB13000D2E93 /* routeWithInstructions.json */; };
 		8D424F25215EC54A00432491 /* straight-line.json in Resources */ = {isa = PBXBuildFile; fileRef = C5EF397420599120009A2C50 /* straight-line.json */; };
 		8D424F28215ECAF200432491 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D424F26215ECA5D00432491 /* CoreLocation.framework */; };
@@ -551,12 +551,13 @@
 		160A4A69212791010028B070 /* CPBarButton+MBTestable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CPBarButton+MBTestable.m"; sourceTree = "<group>"; };
 		160D8278205996DA00D278D6 /* DataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
 		160D827A2059973C00D278D6 /* DataCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCacheTests.swift; sourceTree = "<group>"; };
-		16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MMEEventsManagerSpy.swift; sourceTree = "<group>"; };
+		16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerTestDoubles.swift; sourceTree = "<group>"; };
 		16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectionsSpy.swift; sourceTree = "<group>"; };
 		16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyURLSessionDataTask.swift; sourceTree = "<group>"; };
 		166224442025699600EA4824 /* ImageRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryTests.swift; sourceTree = "<group>"; };
 		1662244620256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadingURLProtocolSpy.swift; sourceTree = "<group>"; };
 		1662244A2029059C00EA4824 /* ImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
+		169A9709216440820082A6A0 /* NavigationViewControllerTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTestDoubles.swift; sourceTree = "<group>"; };
 		16A509D4202A87B20011D788 /* ImageDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloaderTests.swift; sourceTree = "<group>"; };
 		16A509D6202BC0CA0011D788 /* ImageDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownload.swift; sourceTree = "<group>"; };
 		16AC9D0F212E356200CECE44 /* CPMapTemplate+MBTestable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CPMapTemplate+MBTestable.h"; sourceTree = "<group>"; };
@@ -736,7 +737,7 @@
 		3EA938479CF48D7AD1B6369B /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		3EA938BE5468824787100228 /* ImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		3EA93A10227A7DAF1861D9F5 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
-		3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteControllerDelegateSpy.swift; sourceTree = "<group>"; };
+		3EA93EBD6E6BEC966BBE51D6 /* NavigationServiceTestDoubles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationServiceTestDoubles.swift; sourceTree = "<group>"; };
 		6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaypointConfirmationViewController.swift; sourceTree = "<group>"; };
 		64847A031F04629D003F3A69 /* Feedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
 		8D07C5A720B612310093D779 /* EmptyStyle.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = EmptyStyle.json; sourceTree = "<group>"; };
@@ -1068,8 +1069,8 @@
 			children = (
 				16435E02206EE32F00AF48B6 /* DirectionsSpy.swift */,
 				16435E04206EE37800AF48B6 /* DummyURLSessionDataTask.swift */,
-				16120A4C20645D6E007EA21D /* MMEEventsManagerSpy.swift */,
-				3EA93EBD6E6BEC966BBE51D6 /* RouteControllerDelegateSpy.swift */,
+				16120A4C20645D6E007EA21D /* EventsManagerTestDoubles.swift */,
+				3EA93EBD6E6BEC966BBE51D6 /* NavigationServiceTestDoubles.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1091,10 +1092,11 @@
 		16E3625A2012656C00DF0592 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				8D5CF3AF215054AF005592D6 /* FBSnapshotTestCase.swift */,
 				16E3625B201265D600DF0592 /* ImageDownloadOperationSpy.swift */,
 				1662244620256C0700EA4824 /* ImageLoadingURLProtocolSpy.swift */,
+				169A9709216440820082A6A0 /* NavigationViewControllerTestDoubles.swift */,
 				3EA93170CB959F3065ACFFC3 /* SpeechAPISpy.swift */,
-				8D5CF3AF215054AF005592D6 /* FBSnapshotTestCase.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -2295,7 +2297,7 @@
 			files = (
 				8D9CD7FF20880581004DC4B3 /* XCTestCase.swift in Sources */,
 				35DC585D1FABC61100B5A956 /* InstructionsBannerViewIntegrationTests.swift in Sources */,
-				8D424F22215EB93A00432491 /* RouteControllerDelegateSpy.swift in Sources */,
+				8D424F22215EB93A00432491 /* NavigationServiceTestDoubles.swift in Sources */,
 				3502231A205BC94E00E1449A /* Constants.swift in Sources */,
 				DA0557252155040700A1F2AA /* RouteTests.swift in Sources */,
 				C55C299920D2E2F600B0406C /* NavigationMapViewTests.swift in Sources */,
@@ -2317,7 +2319,7 @@
 				35B1AEBC20AD9B3C00C8544E /* LeaksSpec.swift in Sources */,
 				16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */,
 				8D54F14A206ECF720038736D /* InstructionPresenterTests.swift in Sources */,
-				16C6E6012147194A0057098D /* MMEEventsManagerSpy.swift in Sources */,
+				16C6E6012147194A0057098D /* EventsManagerTestDoubles.swift in Sources */,
 				166224452025699600EA4824 /* ImageRepositoryTests.swift in Sources */,
 				160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */,
 				35B1AEBE20AD9C7800C8544E /* LeakTest.swift in Sources */,
@@ -2328,8 +2330,8 @@
 				352690491ECC843700E387BD /* Fixture.swift in Sources */,
 				160A4A712127A46C0028B070 /* CPBarButton+MBTestable.m in Sources */,
 				3EA932D8F44915EFF3B8A088 /* SpeechAPISpy.swift in Sources */,
+				169A970A216440820082A6A0 /* NavigationViewControllerTestDoubles.swift in Sources */,
 				3573EA71215A5A9F009899D7 /* RouteControllerSnapshotTests.swift in Sources */,
-				8D424F21215EB80700432491 /* NavigationServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2399,7 +2401,7 @@
 			files = (
 				16435E05206EE37800AF48B6 /* DummyURLSessionDataTask.swift in Sources */,
 				C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */,
-				16120A4D20645D6E007EA21D /* MMEEventsManagerSpy.swift in Sources */,
+				16120A4D20645D6E007EA21D /* EventsManagerTestDoubles.swift in Sources */,
 				C551B0E620D42222009A986F /* NavigationLocationManagerTests.swift in Sources */,
 				359A8AED1FA78D3000BDB486 /* DistanceFormatterTests.swift in Sources */,
 				C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */,
@@ -2411,7 +2413,7 @@
 				16435E03206EE32F00AF48B6 /* DirectionsSpy.swift in Sources */,
 				35EF782A212C324E001B4BB5 /* TunnelAuthorityTests.swift in Sources */,
 				C5ABB50E20408D2C00AFA92C /* NavigationServiceTests.swift in Sources */,
-				8D424F23215EB93D00432491 /* RouteControllerDelegateSpy.swift in Sources */,
+				8D424F23215EB93D00432491 /* NavigationServiceTestDoubles.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -204,7 +204,7 @@ public class CarPlayManager: NSObject {
      */
     @objc public var isConnectedToCarPlay = false
 
-    public lazy var eventsManager: MMEEventsManager = .shared()
+    public lazy var eventsManager: NavigationEventsManager = NavigationEventsManager(dataSource: nil)
 
     lazy var fullDateComponentsFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
@@ -341,14 +341,14 @@ extension CarPlayManager: CPApplicationDelegate {
 
     func sendCarPlayConnectEvent(_ timestamp: String) {
         let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
-        eventsManager.enqueueEvent(withName: MMEventTypeCarplayConnect, attributes: dateCreatedAttribute)
-        eventsManager.flush()
+//        eventsManager.enqueueEvent(withName: MMEventTypeCarplayConnect, attributes: dateCreatedAttribute)
+//        eventsManager.flush()
     }
 
     func sendCarPlayDisconnectEvent(_ timestamp: String) {
         let dateCreatedAttribute = [MMEEventKeyCreated: timestamp]
-        eventsManager.enqueueEvent(withName: MMEventTypeCarplayDisconnect, attributes: dateCreatedAttribute)
-        eventsManager.flush()
+//        eventsManager.enqueueEvent(withName: MMEventTypeCarplayDisconnect, attributes: dateCreatedAttribute)
+//        eventsManager.flush()
     }
 
     func resetPanButtons(_ mapTemplate: CPMapTemplate) {

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -99,7 +99,7 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     /**
      The events manager used to send feedback events.
      */
-    public weak var eventsManager: EventsManager?
+    public weak var eventsManager: NavigationEventsManager?
     
     var uuid: UUID? {
         return eventsManager?.recordFeedback()
@@ -119,7 +119,7 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        eventsManager = aDecoder.decodeObject(of: [EventsManager.self], forKey: "EventsManager") as? EventsManager
+        eventsManager = aDecoder.decodeObject(of: [NavigationEventsManager.self], forKey: "EventsManager") as? EventsManager
         super.init(coder: aDecoder)
         commonInit()
     }

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -2,10 +2,10 @@ import XCTest
 import MapboxNavigation
 import MapboxCoreNavigation
 import MapboxDirections
+import MapboxMobileEvents
 
 #if canImport(CarPlay)
 import CarPlay
-@testable import MapboxMobileEvents
 
 // For some reason XCTest bundles ignore @available annotations and these tests are run on iOS < 12 :(
 // This is a bug in XCTest which will hopefully get fixed in an upcoming release.
@@ -39,7 +39,6 @@ class CarPlayManagerTests: XCTestCase {
     func testEventsEnqueuedAndFlushedWhenCarPlayConnected() {
         // NOTE: Xcode is going to complain here - ignore. This is a known XCTest bug.
         guard #available(iOS 12, *) else { return }
-
 
         simulateCarPlayConnection(manager!)
 
@@ -207,6 +206,7 @@ class CarPlayManagerSpec: QuickSpec {
                 fakeRouteChoice.userInfo = Fixture.routeWithBannerInstructions()
                 let fakeTrip = CPTrip(origin: MKMapItem(), destination: MKMapItem(), routeChoices: [fakeRouteChoice])
 
+                //simulate starting a fake trip
                 manager!.mapTemplate(fakeTemplate, startedTrip: fakeTrip, using: fakeRouteChoice)
             }
 

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -275,7 +275,7 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
             return route
         }()
         let directionsClientSpy = DirectionsSpy(accessToken: "garbage", host: nil)
-        let service = MapboxNavigationService(route: initialRoute, directions: directionsClientSpy, locationSource: NavigationLocationManager(), eventsManagerType: EventsManagerSpy.self)
+        let service = MapboxNavigationService(route: initialRoute, directions: directionsClientSpy, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
         return service
     }
 

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -14,17 +14,13 @@ import CarPlay
 class CarPlayManagerTests: XCTestCase {
 
     var manager: CarPlayManager?
-
-    var eventsManagerSpy: MMEEventsManagerSpy {
-        get {
-            return manager!.eventsManager as! MMEEventsManagerSpy
-        }
-    }
+    var eventsManagerSpy: NavigationEventsManagerSpy?
 
     override func setUp() {
         super.setUp()
         manager = CarPlayManager.shared
-        manager!.eventsManager = MMEEventsManagerSpy()
+        eventsManagerSpy = NavigationEventsManagerSpy()
+        manager!.eventsManager = eventsManagerSpy!
     }
 
     override func tearDown() {
@@ -48,10 +44,10 @@ class CarPlayManagerTests: XCTestCase {
         simulateCarPlayConnection(manager!)
 
         let expectedEventName = MMEventTypeCarplayConnect
-        XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedEventName))
-        XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedEventName))
-        XCTAssertEqual(eventsManagerSpy.enqueuedEventCount(with: expectedEventName), 1)
-        XCTAssertEqual(eventsManagerSpy.enqueuedEventCount(with: expectedEventName), 1)
+        XCTAssertTrue(eventsManagerSpy!.hasEnqueuedEvent(with: expectedEventName))
+        XCTAssertTrue(eventsManagerSpy!.hasFlushedEvent(with: expectedEventName))
+        XCTAssertEqual(eventsManagerSpy!.enqueuedEventCount(with: expectedEventName), 1)
+        XCTAssertEqual(eventsManagerSpy!.enqueuedEventCount(with: expectedEventName), 1)
     }
 
     func testEventsEnqueuedAndFlushedWhenCarPlayDisconnected() {
@@ -61,8 +57,8 @@ class CarPlayManagerTests: XCTestCase {
         simulateCarPlayDisconnection()
 
         let expectedEventName = MMEventTypeCarplayDisconnect
-        XCTAssertTrue(eventsManagerSpy.hasEnqueuedEvent(with: expectedEventName))
-        XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedEventName))
+        XCTAssertTrue(eventsManagerSpy!.hasEnqueuedEvent(with: expectedEventName))
+        XCTAssertTrue(eventsManagerSpy!.hasFlushedEvent(with: expectedEventName))
     }
 
     // MARK: Upon connecting to CarPlay, window and interfaceController should be set up correctly

--- a/MapboxNavigationTests/LeaksSpec.swift
+++ b/MapboxNavigationTests/LeaksSpec.swift
@@ -39,7 +39,7 @@ class LeaksSpec: QuickSpec {
             
             let navigationViewController = LeakTest {
                 let directions = DirectionsSpy(accessToken: "deadbeef")
-                let service = MapboxNavigationService(route: route, directions: directions, eventsManagerType: EventsManagerSpy.self)
+                let service = MapboxNavigationService(route: route, directions: directions, eventsManagerType: NavigationEventsManagerSpy.self)
                 return NavigationViewController(for: route, navigationService: service, voiceController: RouteVoiceControllerStub())
             }
             

--- a/MapboxNavigationTests/LeaksSpec.swift
+++ b/MapboxNavigationTests/LeaksSpec.swift
@@ -40,7 +40,7 @@ class LeaksSpec: QuickSpec {
             let navigationViewController = LeakTest {
                 let directions = DirectionsSpy(accessToken: "deadbeef")
                 let service = MapboxNavigationService(route: route, directions: directions, eventsManagerType: EventsManagerSpy.self)
-                return NavigationViewController(for: route, navigationService: service, voiceController: FakeVoiceController())
+                return NavigationViewController(for: route, navigationService: service, voiceController: RouteVoiceControllerStub())
             }
             
             it("must not leak") {

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -14,9 +14,9 @@ class NavigationViewControllerTests: XCTestCase {
     var updatedStyleNumberOfTimes = 0
     lazy var dependencies: (navigationViewController: NavigationViewController, navigationService: NavigationService, startLocation: CLLocation, poi: [CLLocation], endLocation: CLLocation, voice: RouteVoiceController) = {
 
-        let fakeVoice: RouteVoiceController = FakeVoiceController()
+        let fakeVoice: RouteVoiceController = RouteVoiceControllerStub()
         let fakeDirections = DirectionsSpy(accessToken: "garbage", host: nil)
-        let fakeService = MapboxNavigationService(route: initialRoute, directions: fakeDirections, locationSource: NavigationLocationManagerFake(), simulating: .never)
+        let fakeService = MapboxNavigationService(route: initialRoute, directions: fakeDirections, locationSource: NavigationLocationManagerStub(), simulating: .never)
         let navigationViewController = NavigationViewController(for: initialRoute, navigationService: fakeService, voiceController: fakeVoice)
         
         navigationViewController.delegate = self
@@ -89,7 +89,7 @@ class NavigationViewControllerTests: XCTestCase {
     }
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithOneStyle() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle()], navigationService: dependencies.navigationService, voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle()], navigationService: dependencies.navigationService, voiceController: RouteVoiceControllerStub())
         let service = dependencies.navigationService
         navigationViewController.styleManager.delegate = self
         
@@ -105,7 +105,7 @@ class NavigationViewControllerTests: XCTestCase {
     
     // If tunnel flags are enabled and we need to switch styles, we should not force refresh the map style because we have only 1 style.
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceWhenOnlyOneStyle() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()], navigationService: dependencies.navigationService, voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [NightStyle()], navigationService: dependencies.navigationService, voiceController: RouteVoiceControllerStub())
         let service = dependencies.navigationService
         navigationViewController.styleManager.delegate = self
         
@@ -120,7 +120,7 @@ class NavigationViewControllerTests: XCTestCase {
     }
     
     func testNavigationShouldNotCallStyleManagerDidRefreshAppearanceMoreThanOnceWithTwoStyles() {
-        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()], navigationService: dependencies.navigationService, voiceController: FakeVoiceController())
+        let navigationViewController = NavigationViewController(for: initialRoute, styles: [DayStyle(), NightStyle()], navigationService: dependencies.navigationService, voiceController: RouteVoiceControllerStub())
         let service = dependencies.navigationService
         navigationViewController.styleManager.delegate = self
         
@@ -260,7 +260,7 @@ class NavigationViewControllerTestable: NavigationViewController {
                   navigationService: NavigationService? = nil,
                   styleLoaded: XCTestExpectation) {
         styleLoadedExpectation = styleLoaded
-        super.init(for: route, styles: styles, navigationService: navigationService, voiceController: FakeVoiceController())
+        super.init(for: route, styles: styles, navigationService: navigationService, voiceController: RouteVoiceControllerStub())
     }
     
     required init(for route: Route, styles: [Style]?, navigationService: NavigationService?, voiceController: RouteVoiceController?) {
@@ -273,34 +273,5 @@ class NavigationViewControllerTestable: NavigationViewController {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("This initalizer is not supported in this testing subclass.")
-    }
-
-}
-
-class TestableDayStyle: DayStyle {
-    required init() {
-        super.init()
-        mapStyleURL = Fixture.blankStyle
-    }
-}
-
-
-class FakeVoiceController: RouteVoiceController {
-    override func speak(_ instruction: SpokenInstruction) {
-        //no-op
-    }
-    
-    override func pauseSpeechAndPlayReroutingDing(notification: NSNotification) {
-        //no-op
-    }
-}
-
-class NavigationLocationManagerFake: NavigationLocationManager {
-    //Short-circut message that turns-on location updates.
-    override func startUpdatingLocation() {
-        return
-    }
-    override func startUpdatingHeading() {
-        return
     }
 }

--- a/MapboxNavigationTests/Support/NavigationViewControllerTestDoubles.swift
+++ b/MapboxNavigationTests/Support/NavigationViewControllerTestDoubles.swift
@@ -1,0 +1,33 @@
+import Foundation
+import MapboxDirections
+import MapboxCoreNavigation
+@testable import MapboxNavigation
+
+class TestableDayStyle: DayStyle {
+    required init() {
+        super.init()
+        mapStyleURL = Fixture.blankStyle
+    }
+}
+
+class RouteVoiceControllerStub: RouteVoiceController {
+
+    override func speak(_ instruction: SpokenInstruction) {
+        //no-op
+    }
+
+    override func pauseSpeechAndPlayReroutingDing(notification: NSNotification) {
+        //no-op
+    }
+}
+
+class NavigationLocationManagerStub: NavigationLocationManager {
+
+    override func startUpdatingLocation() {
+        return
+    }
+
+    override func startUpdatingHeading() {
+        return
+    }
+}


### PR DESCRIPTION
This PR includes a few things:

 - Undoing #1645 since it resulted in events never being sent
 - Renaming `EventsManager` -> `NavigationEventsManager` for improved clarity
 - Adjusting the `NavigationEventsManager`.`dataSource` to allow it to be optional for "routeless events"
 - Reorganizing and renaming our test doubles a bit, and enforcing some important privacy changes.

For routeless events, we could also consider writing a separate, simpler events manager -- this has pros & cons which we should consider.

I could also use some insights into debugging the sending of existing CarPlay events; while I don't think they're defined correctly and therefore need to be changed, I seem to be getting HTTP 422 or other unexpected errors when sending in the simulator.