### PR TITLE
Swipeable Banner Custom UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue where the U-turn icon in the turn banner pointed in the wrong direction. ([#1647](https://github.com/mapbox/mapbox-navigation-ios/pull/1647))
 * Fixed an issue where the user puck was positioned too close to the bottom of the map view, underlapping the current road name label. ([#1766](https://github.com/mapbox/mapbox-navigation-ios/pull/1766])
+* Added `InstructionsBannerView.showStepIndicator` to enable showing/hiding the drag indicator ([#1772](https://github.com/mapbox/mapbox-navigation-ios/pull/1772))
 
 ## v0.22.1 (October 2, 2018)
 

--- a/Examples/Swift/CustomViewController.swift
+++ b/Examples/Swift/CustomViewController.swift
@@ -21,6 +21,12 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
     
     var stepsViewController: StepsViewController?
 
+    // Preview index of step, this will be nil if we are not previewing an instruction
+    var previewStepIndex: Int?
+    
+    // View that is placed over the instructions banner while we are previewing
+    var previewInstructionsView: StepInstructionsView?
+    
     @IBOutlet var mapView: NavigationMapView!
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var instructionsBannerView: InstructionsBannerView!
@@ -40,6 +46,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         mapView.compassView.isHidden = true
         
         instructionsBannerView.delegate = self
+        instructionsBannerView.swipeable = true
 
         // Add listeners for progress updates
         resumeNotifications()
@@ -79,6 +86,9 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
 
     // Notifications sent on all location updates
     @objc func progressDidChange(_ notification: NSNotification) {
+        // do not update if we are previewing instruction steps
+        guard previewInstructionsView == nil else { return }
+        
         let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
         let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
         
@@ -121,6 +131,9 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
     }
     
     func toggleStepsList() {
+        // remove the preview banner while viewing the steps list
+        removePreviewInstruction()
+
         if let controller = stepsViewController {
             controller.dismiss()
             stepsViewController = nil
@@ -144,6 +157,64 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
             return
         }
     }
+    
+    func addPreviewInstructions(step: RouteStep) {
+        let route = navigationService.route
+        
+        // find the leg that contains the step, legIndex, and stepIndex
+        guard let leg       = route.legs.first(where: { $0.steps.contains(step) }),
+              let legIndex  = route.legs.index(of: leg),
+              let stepIndex = leg.steps.index(of: step) else {
+            return
+        }
+        
+        // find the upcoming manuever step, and update instructions banner to show preview
+        guard stepIndex + 1 < leg.steps.endIndex else { return }
+        guard let maneuverStep: RouteStep = leg.steps[stepIndex + 1] else { return }
+        updatePreviewBannerWith(step: step, maneuverStep: maneuverStep)
+        
+        // stop tracking user, and move camera to step location
+        mapView.tracksUserCourse = false
+        mapView.userTrackingMode = .none
+        mapView.enableFrameByFrameCourseViewTracking(for: 1)
+        mapView.setCenter(maneuverStep.maneuverLocation, zoomLevel: mapView.zoomLevel, direction: maneuverStep.initialHeading!, animated: true, completionHandler: nil)
+        
+        // add arrow to map for preview instruction
+        mapView.addArrow(route: route, legIndex: legIndex, stepIndex: stepIndex + 1)
+    }
+    
+    func updatePreviewBannerWith(step: RouteStep, maneuverStep: RouteStep) {
+        // remove preview banner if it exists
+        removePreviewInstruction()
+        
+        // grab the last instruction for step
+        guard let instructions = step.instructionsDisplayedAlongStep?.last else { return }
+        
+        // create a StepInstructionsView and display that over the current instructions banner
+        let previewInstructionsView = StepInstructionsView(frame: instructionsBannerView.frame)
+        previewInstructionsView.delegate = self
+        previewInstructionsView.swipeable = true
+        previewInstructionsView.backgroundColor = instructionsBannerView.backgroundColor
+        view.addSubview(previewInstructionsView)
+        
+        // update instructions banner to show all information about this step
+        previewInstructionsView.updateDistance(for: RouteStepProgress(step: step))
+        previewInstructionsView.update(for: instructions)
+        
+        self.previewInstructionsView = previewInstructionsView
+    }
+    
+    func removePreviewInstruction() {
+        guard let view = previewInstructionsView else { return }
+        view.removeFromSuperview()
+        
+         // reclaim the delegate, from the preview banner
+        instructionsBannerView.delegate = self
+        
+        // nil out both the view and index
+        previewInstructionsView = nil
+        previewStepIndex = nil
+    }
 }
 
 extension CustomViewController: InstructionsBannerViewDelegate {
@@ -154,6 +225,45 @@ extension CustomViewController: InstructionsBannerViewDelegate {
     func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizerDirection) {
         if direction == .down {
             toggleStepsList()
+            return
+        }
+        
+        // preventing swiping if the steps list is visible
+        guard stepsViewController == nil else { return }
+        
+        // Make sure that we actually have remaining steps left
+        guard let remainingSteps = navigationService?.routeProgress.remainingSteps else { return }
+        
+        var previewIndex = -1
+        var previewStep: RouteStep?
+        
+        if direction == .left {
+            // get the next step from our current preview step index
+            if let currentPreviewIndex = previewStepIndex {
+                previewIndex = currentPreviewIndex + 1
+            } else {
+                previewIndex = 0
+            }
+            
+            // index is out of bounds, we have no step to show
+            guard previewIndex < remainingSteps.count else { return }
+            previewStep = remainingSteps[previewIndex]
+        } else {
+            // we are already at step 0, no need to show anything
+            guard let currentPreviewIndex = previewStepIndex else { return }
+            
+            if currentPreviewIndex > 0 {
+                previewIndex = currentPreviewIndex - 1
+                previewStep = remainingSteps[previewIndex]
+            } else {
+                previewStep = navigationService.routeProgress.currentLegProgress.currentStep
+                previewIndex = -1
+            }
+        }
+        
+        if let step = previewStep {
+            addPreviewInstructions(step: step)
+            previewStepIndex = previewIndex
         }
     }
 }

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -87,7 +87,7 @@ open class BaseInstructionsBannerView: UIControl {
         }
     }
     
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -48,9 +48,18 @@ open class BaseInstructionsBannerView: UIControl {
     @IBInspectable
     public var swipeable: Bool = false
     
+    @IBInspectable
+    public var showStepIndicator: Bool = true {
+        didSet {
+            stepListIndicatorView.isHidden = !showStepIndicator
+        }
+    }
+    
     public weak var delegate: InstructionsBannerViewDelegate? {
         didSet {
-            stepListIndicatorView.isHidden = false
+            if showStepIndicator {
+               stepListIndicatorView.isHidden = false
+            }
         }
     }
     
@@ -93,7 +102,7 @@ open class BaseInstructionsBannerView: UIControl {
         setupLayout()
         centerYAlignInstructions()
         setupAvailableBounds()
-        stepListIndicatorView.isHidden = true
+        stepListIndicatorView.isHidden = !showStepIndicator
     }
     
     @objc func swipedInstructionBannerLeft(_ sender: Any) {
@@ -122,7 +131,9 @@ open class BaseInstructionsBannerView: UIControl {
     
     @objc func swipedInstructionBannerDown(_ sender: Any) {
         if let gestureRecognizer = sender as? UISwipeGestureRecognizer, gestureRecognizer.state == .ended {
-            stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
+            if showStepIndicator {
+               stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
+            }
             
             if let delegate = delegate {
                 delegate.didSwipeInstructionsBanner?(self, swipeDirection: .down)
@@ -133,7 +144,9 @@ open class BaseInstructionsBannerView: UIControl {
         
     @objc func tappedInstructionsBanner(_ sender: Any) {
         if let delegate = delegate {
-            stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
+            if showStepIndicator {
+                stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
+            }
             delegate.didTapInstructionsBanner?(self)
         }
     }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -291,8 +291,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         }
     }
     
-    // Track position on a frame by frame basis. Used for first location update and when resuming tracking mode
-    func enableFrameByFrameCourseViewTracking(for duration: TimeInterval) {
+    /**
+     Track position on a frame by frame basis. Used for first location update and when resuming tracking mode
+     */
+    public func enableFrameByFrameCourseViewTracking(for duration: TimeInterval) {
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(disableFrameByFramePositioning), object: nil)
         perform(#selector(disableFrameByFramePositioning), with: nil, afterDelay: duration)
         shouldPositionCourseViewFrameByFrame = true


### PR DESCRIPTION
* Adds ` InstructionsBannerView.showStepIndicator` so we have control over whether we want to show the indicator in our custom UI or not. Not everyone will show the steps list from the top so this needs to be configurable.
* Makes `BaseInstructionsBannerView.init(frame: CGRect)` public so we can actually initialize this outside of the SDK.
* Makes `NavigationMapView.enableFrameByFrameCourseViewTracking` public so when you want to move the map camera in navigation, this can help prevent the puck from flying across the screen.

@mapbox/navigation-ios 