### PR TITLE
Add CI bot to test cocoapods update

### DIFF
--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -41,9 +41,9 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxCoreNavigation"
 
   s.dependency "MapboxNavigationNative", "~> 3.1"
-  s.dependency "MapboxDirections.swift", "~> 0.24.0"
-  s.dependency "MapboxMobileEvents", "~> 0.6.0"
-  s.dependency "Turf", "~> 0.2"
+  s.dependency "MapboxDirections.swift", "~> 0.24.0"    # Always pin to a patch release if pre-1.0
+  s.dependency "MapboxMobileEvents", "~> 0.6.0"         # Always pin to a patch release if pre-1.0
+  s.dependency "Turf", "~> 0.2.0"                       # Always pin to a patch release if pre-1.0
 
   # `swift_version` was introduced in CocoaPods 1.4.0. Without this check, if a user were to
   # directly specify this podspec while using <1.4.0, ruby would throw an unknown method error.

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,8 @@ workflows:
     jobs:
       - xcode-10
       - xcode-9
-      - xcode-10-cocoapods-integration
+      - xcode-10-cocoapods-install
+      - xcode-10-cocoapods-update
       - xcode-9-examples
 
 step-library:
@@ -111,12 +112,20 @@ step-library:
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=11.4,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme Example-Swift clean build | xcpretty
 
-  - &cocoapods-integration-test
+  - &cocoapods-integration-install
       run:
         name: CocoaPods integration test
         command: |
           cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall
           pod install --repo-update
+          xcodebuild -workspace PodInstall.xcworkspace/ -scheme PodInstall -destination 'platform=iOS Simulator,name=iPhone 6 Plus' clean build | xcpretty
+
+  - &cocoapods-integration-update
+      run:
+        name: CocoaPods integration test
+        command: |
+          cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall
+          pod update --repo-update
           xcodebuild -workspace PodInstall.xcworkspace/ -scheme PodInstall -destination 'platform=iOS Simulator,name=iPhone 6 Plus' clean build | xcpretty
 
 jobs:
@@ -151,7 +160,7 @@ jobs:
       - *build-test-MapboxNavigation-ios-11
       - *save-cache
 
-  xcode-10-cocoapods-integration:
+  xcode-10-cocoapods-install:
     macos:
       xcode: "10.0.0"
     environment:
@@ -160,7 +169,20 @@ jobs:
       - checkout
       - *restore-cache-podmaster
       - *restore-cache-cocoapods
-      - *cocoapods-integration-test
+      - *cocoapods-integration-install
+      - *save-cache-cocoapods
+      - *save-cache-podmaster
+
+  xcode-10-cocoapods-update:
+    macos:
+      xcode: "10.0.0"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *restore-cache-podmaster
+      - *restore-cache-cocoapods
+      - *cocoapods-integration-update
       - *save-cache-cocoapods
       - *save-cache-podmaster
 


### PR DESCRIPTION
In addition to `pod install` we should test `pod update` to make sure we're compliant with recent releases of the dependencies.


cc @akitchen @JThramer @vincethecoder 