### PR TITLE
Let's not strip symbols out of debug builds

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -2674,7 +2674,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2849,7 +2849,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
![Dwarfs and DIPs and dSYMs, oh my!](https://78.media.tumblr.com/d75f63744b56122f31132278da60c034/tumblr_no2f1fluUa1tv8g5qo1_540.gif)


* Fixing issue where we were stripping symbols out of debug-builds of MapboxNavigation.

/cc @mapbox/navigation-ios 