### PR TITLE
Fixed the warnings for deprecated events manager.

### DIFF
--- a/MapboxCoreNavigation/Feedback.swift
+++ b/MapboxCoreNavigation/Feedback.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /**
- Feedback type is used to specify the type of feedback being recorded with `EventsManager.recordFeedback(type:description:)`.
+ Feedback type is used to specify the type of feedback being recorded with `NavigationEventsManager.recordFeedback(type:description:)`.
  */
 @objc(MBFeedbackType)
 public enum FeedbackType: Int, CustomStringConvertible {
     /**
-     Indicates general feedback. You should provide a `description` string to `EventsManager.recordFeedback(type:description:)` to elaborate on the feedback if possible.
+     Indicates general feedback. You should provide a `description` string to `NavigationEventsManager.recordFeedback(type:description:)` to elaborate on the feedback if possible.
      */
     case general
     

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -113,7 +113,7 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
 }
 
 /**
- A `NavigationService` is the entry-point interface into MapboxCoreNavigation. This service manages a `locationManager` (which feeds it location updates), a `Directions` service (for rerouting), a `Router` (for route-following), an `eventsManager` (for telemetry), and a simulation engine for use during poor GPS conditions.
+ A `NavigationService` is the entry-point interface into MapboxCoreNavigation. This service manages a `locationManager` (which feeds it location updates), a `Directions` service (for rerouting), a `Router` (for route-following), a `NavigationEventsManager` (for telemetry), and a simulation engine for use during poor GPS conditions.
  */
 @objc(MBNavigationService)
 public class MapboxNavigationService: NSObject, NavigationService, DefaultInterfaceFlag {

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -63,7 +63,7 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
     /**
      The events manager, responsible for all telemetry.
      */
-    var eventsManager: EventsManager! { get }
+    var eventsManager: NavigationEventsManager! { get }
     
     /**
      The route along which the user is expected to travel.
@@ -491,7 +491,7 @@ extension MapboxNavigationService {
     }
 }
 
-fileprivate extension EventsManager {
+fileprivate extension NavigationEventsManager {
     func incrementDistanceTraveled(by distance: CLLocationDistance) {
        sessionState?.totalDistanceCompleted += distance
     }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -639,7 +639,7 @@ public extension RouteController {
     @available(*, obsoleted: 0.1, message: "MapboxNavigationService is now the point-of-entry to MapboxCoreNavigation. Direct use of RouteController is no longer reccomended. See MapboxNavigationService for more information.")
     /// :nodoc: Obsoleted method.
     @objc(initWithRoute:directions:locationManager:eventsManager:)
-    public convenience init(along route: Route, directions: Directions = Directions.shared, locationManager: NavigationLocationManager = NavigationLocationManager(), eventsManager: EventsManager) {
+    public convenience init(along route: Route, directions: Directions = Directions.shared, locationManager: NavigationLocationManager = NavigationLocationManager(), eventsManager: NavigationEventsManager) {
         fatalError()
     }
     
@@ -665,7 +665,7 @@ public extension RouteController {
     }
     @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages an EventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
     /// :nodoc: obsoleted
-    @objc public final var eventsManager: EventsManager! {
+    @objc public final var eventsManager: NavigationEventsManager! {
         get {
             fatalError()
         }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -663,7 +663,7 @@ public extension RouteController {
             fatalError()
         }
     }
-    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages an EventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
+    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages an NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var eventsManager: NavigationEventsManager! {
         get {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -663,7 +663,7 @@ public extension RouteController {
             fatalError()
         }
     }
-    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages an NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
+    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages a NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var eventsManager: NavigationEventsManager! {
         get {

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -106,7 +106,7 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
     
     /**
-     Initialize a new FeedbackViewController from an `EventsManager`.
+     Initialize a new FeedbackViewController from an `NavigationEventsManager`.
      */
     @objc public init(eventsManager: NavigationEventsManager) {
         self.eventsManager = eventsManager

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -115,7 +115,7 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
 
     public override func encode(with aCoder: NSCoder) {
-        aCoder.encode(eventsManager, forKey: "EventsManager")
+        aCoder.encode(eventsManager, forKey: "NavigationEventsManager")
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -106,7 +106,7 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
     
     /**
-     Initialize a new FeedbackViewController from an `NavigationEventsManager`.
+     Initialize a new FeedbackViewController from a `NavigationEventsManager`.
      */
     @objc public init(eventsManager: NavigationEventsManager) {
         self.eventsManager = eventsManager

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -742,7 +742,7 @@ public extension NavigationViewController {
         }
     }
     
-    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages an NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
+    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages a NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var eventsManager: NavigationEventsManager! {
         get {

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -742,7 +742,7 @@ public extension NavigationViewController {
         }
     }
     
-    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages an EventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
+    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages an NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var eventsManager: NavigationEventsManager! {
         get {


### PR DESCRIPTION
- Resolved warnings for deprecated `EventsManager`, renamed `NavigationEventsManager`.

/cc @akitchen @JThramer @frederoni 