### PR TITLE
Set initial location

### DIFF
--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -315,6 +315,14 @@ public class MapboxNavigationService: NSObject, NavigationService, DefaultInterf
     }
     
     public func start() {
+        // Jump to the first coordinate on the route if the location source does
+        // not yet have a fixed location.
+        if router.location == nil,
+            let coordinate = route.coordinates?.first {
+            let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+            router.locationManager?(nativeLocationSource, didUpdateLocations: [location])
+        }
+        
         nativeLocationSource.startUpdatingHeading()
         nativeLocationSource.startUpdatingLocation()
         


### PR DESCRIPTION
A navigation session always begins from the first coordinate on the route but it can take a few seconds until we get a fixed location. By using the first coordinate on the route if the location source doesn't have a fixed location, we can improve the perceived lag and reduce initial unwanted reroute.


cc @JThramer 