### PR TITLE
Add license for Navigator

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,16 +1,8 @@
-The Mapbox Navigator dependency has the following license:
-
-Copyright © 2018 Mapbox, Inc. You may use this code with your Mapbox account and under the Mapbox Terms of Service (available at: https://www.mapbox.com/tos/). All other rights reserved.
-
----
-
 Copyright © 2014–2018, Mapbox
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----
 
 Copyright (c) 2016 Matthijs Hollemans and contributors
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,16 @@
+The Mapbox Navigator dependency has the following license:
+
+Copyright © 2018 Mapbox, Inc. You may use this code with your Mapbox account and under the Mapbox Terms of Service (available at: https://www.mapbox.com/tos/). All other rights reserved.
+
+---
+
 Copyright © 2014–2018, Mapbox
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
 
 Copyright (c) 2016 Matthijs Hollemans and contributors
 

--- a/README.md
+++ b/README.md
@@ -141,3 +141,6 @@ We welcome feedback and code contributions! Please see [CONTRIBUTING.md](./CONTR
 ## License
 
 Mapbox Navigation SDK for iOS is released under the ISC License. See [LICENSE.md](https://github.com/mapbox/mapbox-navigation-ios/blob/master/LICENSE.md) for details.
+
+Mapbox Navigation SDK uses [Mapbox Navigator](https://github.com/mapbox/mapbox-navigation-ios/blob/master/Cartfile#L2), a private binary, as a dependency. The Mapbox Navigator binary may be used with a Mapbox account and under the [Mapbox TOS](https://www.mapbox.com/tos/). If you do not wish to use this binary, make sure you swap out this dependency in [./Cartfile](https://github.com/mapbox/mapbox-navigation-ios/blob/master/Cartfile#L2). Code in this repo falls under the [MIT license](./LICENSE.md).
+


### PR DESCRIPTION
@frederoni @1ec5 - This is a first pass attempt at adding the Navigator license to this repo to create some license clarity for contributors and users.

This is related to the Android PR found here: https://github.com/mapbox/mapbox-navigation-android/pull/1494

cc @akitchen 