### PR TITLE
Gather Code Coverage data

### DIFF
--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C5ADFBC81DDCC7840011824B"
+            BuildableName = "MapboxCoreNavigation.framework"
+            BlueprintName = "MapboxCoreNavigation"
+            ReferencedContainer = "container:MapboxNavigation.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxNavigation.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxNavigation.xcscheme
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "351BEBD61E5BCC28006FE110"
+            BuildableName = "MapboxNavigation.framework"
+            BlueprintName = "MapboxNavigation"
+            ReferencedContainer = "container:MapboxNavigation.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/circle.yml
+++ b/circle.yml
@@ -86,7 +86,7 @@ step-library:
       run:
         name: Build and Test MapboxCoreNavigation
         command: |
-          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation clean build test
+          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation clean build test -enableCodeCoverage "YES"
           bash <(curl -s https://codecov.io/bash)
 
   - &build-test-MapboxNavigation-ios-11
@@ -99,7 +99,7 @@ step-library:
       run:
         name: Build and Test MapboxNavigation
         command: |
-          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation clean build test
+          xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation clean build test -enableCodeCoverage "YES"
           bash <(curl -s https://codecov.io/bash)
 
   - &build-Example-Obj-C

--- a/circle.yml
+++ b/circle.yml
@@ -87,7 +87,6 @@ step-library:
         name: Build and Test MapboxCoreNavigation
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation clean build test -enableCodeCoverage "YES"
-          bash <(curl -s https://codecov.io/bash)
 
   - &build-test-MapboxNavigation-ios-11
       run:
@@ -100,7 +99,6 @@ step-library:
         name: Build and Test MapboxNavigation
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation clean build test -enableCodeCoverage "YES"
-          bash <(curl -s https://codecov.io/bash)
 
   - &build-Example-Obj-C
       run:
@@ -129,6 +127,11 @@ step-library:
           cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall
           pod update --repo-update
           xcodebuild -workspace PodInstall.xcworkspace/ -scheme PodInstall -destination 'platform=iOS Simulator,name=iPhone 6 Plus' clean build | xcpretty
+  
+  - &publish-codecov
+      run:
+        name: Publish Code Coverage data
+        command: bash <(curl -s https://codecov.io/bash)
 
 jobs:
   xcode-10:
@@ -144,6 +147,7 @@ jobs:
       - *install-dependencies
       - *build-test-MapboxCoreNavigation-ios-12
       - *build-test-MapboxNavigation-ios-12
+      - *publish-codecov
       - *save-cache
 
   xcode-9:

--- a/circle.yml
+++ b/circle.yml
@@ -87,6 +87,7 @@ step-library:
         name: Build and Test MapboxCoreNavigation
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxCoreNavigation clean build test
+          bash <(curl -s https://codecov.io/bash)
 
   - &build-test-MapboxNavigation-ios-11
       run:
@@ -99,6 +100,7 @@ step-library:
         name: Build and Test MapboxNavigation
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.0,name=iPhone 6 Plus' -project MapboxNavigation.xcodeproj -scheme MapboxNavigation clean build test
+          bash <(curl -s https://codecov.io/bash)
 
   - &build-Example-Obj-C
       run:


### PR DESCRIPTION
Enabled code coverage for MapboxCoreNavigation and MapboxNavigation.

Let's give it a few iterations until we enforce ✅ covecov protection on the master branch.

cc @mapbox/navigation-ios 