### PR TITLE
Customize Directions Client in CarPlayManager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-* Added the ability to specify a custom directions client to be used by the CarPlayManager. ([#1834](https://github.com/mapbox/mapbox-navigation-ios/pull/1834/))
+* Renamed `CarPlayManager(_:)` to `CarPlayManager(directions:eventsManager:)`, allowing you to pass in a custom `Directions` object to use when calculating routes. ([#1834](https://github.com/mapbox/mapbox-navigation-ios/pull/1834/))
 * Fixed a crash during turn-by-turn navigation. ([#1820](https://github.com/mapbox/mapbox-navigation-ios/pull/1820))
 * Fixed a crash that could happen while simulating a route. ([#1820](https://github.com/mapbox/mapbox-navigation-ios/pull/1820))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* Added the ability to specify a custom directions client to be used by the CarPlayManager. ([#1834](https://github.com/mapbox/mapbox-navigation-ios/pull/1834/))
 * Fixed a crash during turn-by-turn navigation. ([#1820](https://github.com/mapbox/mapbox-navigation-ios/pull/1820))
 * Fixed a crash that could happen while simulating a route. ([#1820](https://github.com/mapbox/mapbox-navigation-ios/pull/1820))
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.5.0"
-binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "3.2.0"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.6.0"
+binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "3.4.0"
 github "CedarBDD/Cedar" "v1.0"
 github "Quick/Nimble" "v7.3.1"
 github "Quick/Quick" "v1.3.2"

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		8D2AA745211CDD4000EB7F72 /* NavigationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2AA744211CDD4000EB7F72 /* NavigationService.swift */; };
 		8D391CE21FD71E78006BB91F /* Waypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D391CE11FD71E78006BB91F /* Waypoint.swift */; };
 		8D424F28215ECAF200432491 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D424F26215ECA5D00432491 /* CoreLocation.framework */; };
+		8D4B60E7219CBEB300C41906 /* CarPlayManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4B60E6219CBEB300C41906 /* CarPlayManagerDelegate.swift */; };
 		8D4CF9C621349FFB009C3FEE /* NavigationServiceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4CF9C521349FFB009C3FEE /* NavigationServiceDelegate.swift */; };
 		8D53136B20653FA20044891E /* ExitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D53136A20653FA20044891E /* ExitView.swift */; };
 		8D54F14A206ECF720038736D /* InstructionPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D54F149206ECF720038736D /* InstructionPresenterTests.swift */; };
@@ -756,6 +757,7 @@
 		8D2AA744211CDD4000EB7F72 /* NavigationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationService.swift; sourceTree = "<group>"; };
 		8D391CE11FD71E78006BB91F /* Waypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Waypoint.swift; sourceTree = "<group>"; };
 		8D424F26215ECA5D00432491 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		8D4B60E6219CBEB300C41906 /* CarPlayManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayManagerDelegate.swift; sourceTree = "<group>"; };
 		8D4CF9C521349FFB009C3FEE /* NavigationServiceDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationServiceDelegate.swift; sourceTree = "<group>"; };
 		8D53136A20653FA20044891E /* ExitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitView.swift; sourceTree = "<group>"; };
 		8D54F149206ECF720038736D /* InstructionPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionPresenterTests.swift; sourceTree = "<group>"; };
@@ -1106,6 +1108,7 @@
 			isa = PBXGroup;
 			children = (
 				16C2A420211526EE00FE6E68 /* CarPlayManager.swift */,
+				8D4B60E6219CBEB300C41906 /* CarPlayManagerDelegate.swift */,
 				16EF6C21211BA4B300AA580B /* CarPlayMapViewController.swift */,
 				C5FFAC1420D96F5B009E7F98 /* CarPlayNavigationViewController.swift */,
 				35379D0121480E1300FD402E /* CarPlayManager+Search.swift */,
@@ -2259,6 +2262,7 @@
 				3EA937B1F4DF73EB004BA6BE /* InstructionPresenter.swift in Sources */,
 				3EA93A1FEFDDB709DE84BED9 /* ImageRepository.swift in Sources */,
 				3EA9371104016CD402547F1A /* ImageCache.swift in Sources */,
+				8D4B60E7219CBEB300C41906 /* CarPlayManagerDelegate.swift in Sources */,
 				3EA9369C33A8F10DAE9043AA /* ImageDownloader.swift in Sources */,
 				3EA9301B03F8679BEDD4795F /* Cache.swift in Sources */,
 				35379D0321480E5700FD402E /* RecentItem.swift in Sources */,

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -423,12 +423,12 @@ extension CarPlayManager: CPListTemplateDelegate {
     
     internal func calculate(_ options: RouteOptions, completionHandler: @escaping () -> Void) {
         directions.calculate(options) { [weak self] (waypoints, routes, error) in
-            self?.handleDirectionsResponse(options: options, waypoints: waypoints, routes: routes, error: error, completionHandler: completionHandler)
+            self?.didCalculate(routes, for: options, between: waypoints, error: error, completionHandler: completionHandler)
         }
     }
     
     
-    internal func handleDirectionsResponse(options routeOptions: RouteOptions, waypoints: [Waypoint]?, routes: [Route]?, error: NSError?, completionHandler: @escaping () -> Void) {
+    internal func didCalculate(_ routes: [Route]?, for routeOptions: RouteOptions, between waypoints: [Waypoint]?, error: NSError?, completionHandler: @escaping () -> Void) {
         defer {
             completionHandler()
         }

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -418,10 +418,10 @@ extension CarPlayManager: CPListTemplateDelegate {
         let originWaypoint = fromWaypoint ?? Waypoint(location: location, heading: userLocation.heading, name: name)
         
         let routeOptions = NavigationRouteOptions(waypoints: [originWaypoint, toWaypoint])
-        fetchNewRoute(options: routeOptions, completionHandler: completionHandler)
+        calculate(routeOptions, completionHandler: completionHandler)
     }
     
-    internal func fetchNewRoute(options: RouteOptions, completionHandler: @escaping () -> Void) {
+    internal func calculate(_ options: RouteOptions, completionHandler: @escaping () -> Void) {
         directions.calculate(options) { [weak self] (waypoints, routes, error) in
             self?.handleDirectionsResponse(options: options, waypoints: waypoints, routes: routes, error: error, completionHandler: completionHandler)
         }

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -22,123 +22,6 @@ public enum CarPlayActivity: Int {
 }
 
 /**
- `CarPlayManagerDelegate` is the main integration point for Mapbox CarPlay support.
- 
- Implement this protocol and assign an instance to the `delegate` property of the shared instance of `CarPlayManager`.
- */
-@available(iOS 12.0, *)
-@objc(MBCarPlayManagerDelegate)
-public protocol CarPlayManagerDelegate {
-
-    /**
-     Offers the delegate an opportunity to provide a customized list of leading bar buttons.
-     
-     These buttons' tap handlers encapsulate the action to be taken, so it is up to the developer to ensure the hierarchy of templates is adequately navigable.
-     If this method is not implemented, or if nil is returned, an implementation of CPSearchTemplate will be provided which uses the Mapbox Geocoder.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
-     - parameter template: The template into which the returned bar buttons will be inserted.
-     - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
-     - returns: An array of bar buttons to display on the leading side of the navigation bar while `template` is visible.
-     */
-    @objc(carPlayManager:leadingNavigationBarButtonsWithTraitCollection:inTemplate:forActivity:)
-    optional func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]?
-
-    /**
-     Offers the delegate an opportunity to provide a customized list of trailing bar buttons.
-     
-     These buttons' tap handlers encapsulate the action to be taken, so it is up to the developer to ensure the hierarchy of templates is adequately navigable.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
-     - parameter template: The template into which the returned bar buttons will be inserted.
-     - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
-     - returns: An array of bar buttons to display on the trailing side of the navigation bar while `template` is visible.
-     */
-    @objc(carPlayManager:trailingNavigationBarButtonsWithTraitCollection:inTemplate:forActivity:)
-    optional func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]?
-
-    /**
-     Offers the delegate an opportunity to provide a customized list of buttons displayed on the map.
-     
-     These buttons handle the gestures on the map view, so it is up to the developer to ensure the map template is interactive.
-     If this method is not implemented, or if nil is returned, a default set of zoom and pan buttons will be provided.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
-     - parameter template: The template into which the returned map buttons will be inserted.
-     - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
-     - returns: An array of map buttons to display on the map while `template` is visible.
-     */
-    @objc(carPlayManager:mapButtonsCompatibleWithTraitCollection:inTemplate:forActivity:)
-    optional func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]?
-
-    
-    /**
-     Offers the delegate an opportunity to provide an alternate navigation service, otherwise a default built-in MapboxNavigationService will be created and used.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     - parameter route: The route for which the returned route controller will manage location updates.
-     - returns: A navigation service that manages location updates along `route`.
-     */
-    
-    @objc(carPlayManager:navigationServiceAlongRoute:)
-    optional func carPlayManager(_ carPlayManager: CarPlayManager, navigationServiceAlong route: Route) -> NavigationService
-
-    /**
-     Offers the delegate an opportunity to react to updates in the search text.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     - parameter searchTemplate: The search template currently accepting user input.
-     - parameter searchText: The updated search text in `searchTemplate`.
-     - parameter completionHandler: Called when the search is complete. Accepts a list of search results.
-     
-     - postcondition: You must call `completionHandler` within this method.
-     */
-    @objc(carPlayManager:searchTemplate:updatedSearchText:completionHandler:)
-    optional func carPlayManager(_ carPlayManager: CarPlayManager, searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([CPListItem]) -> Void)
-
-    /**
-     Offers the delegate an opportunity to react to selection of a search result.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     - parameter searchTemplate: The search template currently accepting user input.
-     - parameter item: The search result the user has selected.
-     - parameter completionHandler: Called when the delegate is done responding to the selection.
-     
-     - postcondition: You must call `completionHandler` within this method.
-     */
-    @objc(carPlayManager:searchTemplate:selectedResult:completionHandler:)
-    optional func carPlayManager(_ carPlayManager: CarPlayManager, searchTemplate: CPSearchTemplate, selectedResult item: CPListItem, completionHandler: @escaping () -> Void)
-
-    /**
-     Called when navigation begins so that the containing app can update accordingly.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     - parameter service: The navigation service that has begun managing location updates for a navigation session.
-     */
-    @objc(carPlayManager:didBeginNavigationWithNavigationService:)
-    func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith service: NavigationService) -> ()
-
-    /**
-     Called when navigation ends so that the containing app can update accordingly.
-     
-     - parameter carPlayManager: The shared CarPlay manager.
-     */
-    @objc func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) -> ()
-
-    /**
-     Called when the carplay manager will disable the idle timer.
-
-     Implementing this method will allow developers to change whether idle timer is disabled when carplay is connected and the vice-versa when disconnected.
-
-     - parameter carPlayManager: The shared CarPlay manager.
-     - returns: A Boolean value indicating whether to disable idle timer when carplay is connected and enable when disconnected.
-     */
-    @objc optional func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool
-}
-/**
  `CarPlayManager` is the main object responsible for orchestrating interactions with a Mapbox map on CarPlay.
  
  Messages declared in the `CPApplicationDelegate` protocol should be sent to this object in the containing application's application delegate. Implement `CarPlayManagerDelegate` in the containing application and assign an instance to the `delegate` property of your `CarPlayManager` instance.
@@ -196,6 +79,11 @@ public class CarPlayManager: NSObject {
     public let eventsManager: NavigationEventsManager
     public let directions: Directions
 
+    /**
+     Initializes a new CarPlayManager, which manages a connection to the CarPlay interface.
+     - parameter directions: An optional directions client. Pass `nil` to use the default shared client.
+     - parameter eventsManager: And optional events manager. Pass `nil` to use the default events manager.
+    */
     public init(directions: Directions? = nil, eventsManager: NavigationEventsManager? = nil) {
         self.directions = directions ?? .shared
         self.eventsManager = eventsManager ?? NavigationEventsManager(dataSource: nil)

--- a/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -1,0 +1,127 @@
+#if canImport(CarPlay)
+import CarPlay
+#if canImport(MapboxGeocoder)
+import MapboxGeocoder
+#endif
+import Turf
+import MapboxCoreNavigation
+import MapboxDirections
+
+/**
+ `CarPlayManagerDelegate` is the main integration point for Mapbox CarPlay support.
+ 
+ Implement this protocol and assign an instance to the `delegate` property of the shared instance of `CarPlayManager`.
+ */
+@available(iOS 12.0, *)
+@objc(MBCarPlayManagerDelegate)
+public protocol CarPlayManagerDelegate {
+    
+    /**
+     Offers the delegate an opportunity to provide a customized list of leading bar buttons.
+     
+     These buttons' tap handlers encapsulate the action to be taken, so it is up to the developer to ensure the hierarchy of templates is adequately navigable.
+     If this method is not implemented, or if nil is returned, an implementation of CPSearchTemplate will be provided which uses the Mapbox Geocoder.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
+     - parameter template: The template into which the returned bar buttons will be inserted.
+     - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
+     - returns: An array of bar buttons to display on the leading side of the navigation bar while `template` is visible.
+     */
+    @objc(carPlayManager:leadingNavigationBarButtonsWithTraitCollection:inTemplate:forActivity:)
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]?
+    
+    /**
+     Offers the delegate an opportunity to provide a customized list of trailing bar buttons.
+     
+     These buttons' tap handlers encapsulate the action to be taken, so it is up to the developer to ensure the hierarchy of templates is adequately navigable.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
+     - parameter template: The template into which the returned bar buttons will be inserted.
+     - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
+     - returns: An array of bar buttons to display on the trailing side of the navigation bar while `template` is visible.
+     */
+    @objc(carPlayManager:trailingNavigationBarButtonsWithTraitCollection:inTemplate:forActivity:)
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]?
+    
+    /**
+     Offers the delegate an opportunity to provide a customized list of buttons displayed on the map.
+     
+     These buttons handle the gestures on the map view, so it is up to the developer to ensure the map template is interactive.
+     If this method is not implemented, or if nil is returned, a default set of zoom and pan buttons will be provided.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
+     - parameter template: The template into which the returned map buttons will be inserted.
+     - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
+     - returns: An array of map buttons to display on the map while `template` is visible.
+     */
+    @objc(carPlayManager:mapButtonsCompatibleWithTraitCollection:inTemplate:forActivity:)
+    optional func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]?
+    
+    
+    /**
+     Offers the delegate an opportunity to provide an alternate navigation service, otherwise a default built-in MapboxNavigationService will be created and used.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter route: The route for which the returned route controller will manage location updates.
+     - returns: A navigation service that manages location updates along `route`.
+     */
+    
+    @objc(carPlayManager:navigationServiceAlongRoute:)
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, navigationServiceAlong route: Route) -> NavigationService
+    
+    /**
+     Offers the delegate an opportunity to react to updates in the search text.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter searchTemplate: The search template currently accepting user input.
+     - parameter searchText: The updated search text in `searchTemplate`.
+     - parameter completionHandler: Called when the search is complete. Accepts a list of search results.
+     
+     - postcondition: You must call `completionHandler` within this method.
+     */
+    @objc(carPlayManager:searchTemplate:updatedSearchText:completionHandler:)
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([CPListItem]) -> Void)
+    
+    /**
+     Offers the delegate an opportunity to react to selection of a search result.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter searchTemplate: The search template currently accepting user input.
+     - parameter item: The search result the user has selected.
+     - parameter completionHandler: Called when the delegate is done responding to the selection.
+     
+     - postcondition: You must call `completionHandler` within this method.
+     */
+    @objc(carPlayManager:searchTemplate:selectedResult:completionHandler:)
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, searchTemplate: CPSearchTemplate, selectedResult item: CPListItem, completionHandler: @escaping () -> Void)
+    
+    /**
+     Called when navigation begins so that the containing app can update accordingly.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter service: The navigation service that has begun managing location updates for a navigation session.
+     */
+    @objc(carPlayManager:didBeginNavigationWithNavigationService:)
+    func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith service: NavigationService) -> ()
+    
+    /**
+     Called when navigation ends so that the containing app can update accordingly.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     */
+    @objc func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) -> ()
+    
+    /**
+     Called when the carplay manager will disable the idle timer.
+     
+     Implementing this method will allow developers to change whether idle timer is disabled when carplay is connected and the vice-versa when disconnected.
+     
+     - parameter carPlayManager: The shared CarPlay manager.
+     - returns: A Boolean value indicating whether to disable idle timer when carplay is connected and enable when disconnected.
+     */
+    @objc optional func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool
+}
+#endif

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -1,9 +1,9 @@
 import XCTest
-import MapboxNavigation
 import MapboxCoreNavigation
 import MapboxDirections
 import MapboxMobileEvents
 @testable import TestHelper
+@testable import MapboxNavigation
 
 
 #if canImport(CarPlay)
@@ -20,9 +20,8 @@ class CarPlayManagerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        manager = CarPlayManager()
         eventsManagerSpy = NavigationEventsManagerSpy()
-        manager!.eventsManager = eventsManagerSpy!
+        manager = CarPlayManager(eventsManager: eventsManagerSpy)
     }
 
     override func tearDown() {
@@ -170,7 +169,34 @@ class CarPlayManagerTests: XCTestCase {
 
         XCTAssertTrue(exampleDelegate.navigationEnded, "The CarPlayManagerDelegate should have been told that navigation ended.")
     }
+    func testDirectionsOverride() {
+        let expectation = XCTestExpectation(description: "Ensuring Spy is called")
+        let spy = DirectionsInvocationSpy(accessToken: "DeadBeefCafe", host: nil)
+        spy.payload = expectation.fulfill
+        
+        let subject = CarPlayManager(directions: spy)
+      
+        let waypoint1 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.795042, longitude: -122.413165))
+        let waypoint2 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.7727, longitude: -122.433378))
+        let options = RouteOptions(waypoints: [waypoint1, waypoint2])
+        subject.fetchNewRoute(options: options, completionHandler: {})
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssert(subject.directions == spy, "Directions client is not overridden properly.")
+    }
 }
+
+private class DirectionsInvocationSpy: Directions {
+    typealias VoidClosure = () -> Void
+    var payload: VoidClosure?
+
+    override func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> URLSessionDataTask {
+        payload?()
+
+        return URLSessionDataTask()
+    }
+}
+
 
 @available(iOS 12.0, *)
 func simulateCarPlayConnection(_ manager: CarPlayManager) {

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -179,7 +179,7 @@ class CarPlayManagerTests: XCTestCase {
         let waypoint1 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.795042, longitude: -122.413165))
         let waypoint2 = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.7727, longitude: -122.433378))
         let options = RouteOptions(waypoints: [waypoint1, waypoint2])
-        subject.fetchNewRoute(options: options, completionHandler: {})
+        subject.calculate(options, completionHandler: {})
         wait(for: [expectation], timeout: 1.0)
         
         XCTAssert(subject.directions == spy, "Directions client is not overridden properly.")

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -170,6 +170,18 @@ class CarPlayManagerTests: XCTestCase {
         XCTAssertTrue(exampleDelegate.navigationEnded, "The CarPlayManagerDelegate should have been told that navigation ended.")
     }
     func testDirectionsOverride() {
+        
+        class DirectionsInvocationSpy: Directions {
+            typealias VoidClosure = () -> Void
+            var payload: VoidClosure?
+            
+            override func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> URLSessionDataTask {
+                payload?()
+                
+                return URLSessionDataTask()
+            }
+        }
+        
         let expectation = XCTestExpectation(description: "Ensuring Spy is called")
         let spy = DirectionsInvocationSpy(accessToken: "DeadBeefCafe", host: nil)
         spy.payload = expectation.fulfill
@@ -186,16 +198,7 @@ class CarPlayManagerTests: XCTestCase {
     }
 }
 
-private class DirectionsInvocationSpy: Directions {
-    typealias VoidClosure = () -> Void
-    var payload: VoidClosure?
 
-    override func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> URLSessionDataTask {
-        payload?()
-
-        return URLSessionDataTask()
-    }
-}
 
 
 @available(iOS 12.0, *)


### PR DESCRIPTION
Fixes #1824. Allowing user to inject custom Directions client @ `CarPlayManager` init time.

/cc @mapbox/navigation-ios 