### PR TITLE
Allow style customization in CarPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## master
 
-* Renamed `CarPlayManager(_:)` to `CarPlayManager(directions:eventsManager:)`, allowing you to pass in a custom `Directions` object to use when calculating routes. ([#1834](https://github.com/mapbox/mapbox-navigation-ios/pull/1834/))
+### CarPlay
+
+* Renamed `CarPlayManager(_:)` to `CarPlayManager(styles:directions:eventsManager:)` and `CarPlayNavigationViewController(with:mapTemplate:interfaceController:manager:styles:)` to `CarPlayNavigationViewController(navigationService:mapTemplate:interfaceController:manager:styles:)`. These initializers now accept an array of `Style` objects to apply throughout the CarPlay interface, similar to `NavigationViewController`. You can also change the styles at any time by setting the `CarPlayManager.styles` property. ([#1836](https://github.com/mapbox/mapbox-navigation-ios/pull/1836))
+* `CarPlayManager(styles:directions:eventsManager:)` also allows you to pass in a custom `Directions` object to use when calculating routes. ([#1834](https://github.com/mapbox/mapbox-navigation-ios/pull/1834/))
+* Removed the `StyleManager(_:)` initializer. After initializing a `StyleManager` object, set the `StyleManager.delegate` property to ensure that the style manager’s settings take effect. ([#1836](https://github.com/mapbox/mapbox-navigation-ios/pull/1836))
+* Some additional members of `CarPlayManager` are now accessible in Objective-C code. ([#1836](https://github.com/mapbox/mapbox-navigation-ios/pull/1836))
+
+### Other changes
+
 * Fixed a crash during turn-by-turn navigation. ([#1820](https://github.com/mapbox/mapbox-navigation-ios/pull/1820))
 * Fixed a crash that could happen while simulating a route. ([#1820](https://github.com/mapbox/mapbox-navigation-ios/pull/1820))
 

--- a/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -58,7 +58,7 @@ public protocol CarPlayManagerDelegate {
      - returns: An array of map buttons to display on the map while `template` is visible.
      */
     @objc(carPlayManager:mapButtonsCompatibleWithTraitCollection:inTemplate:forActivity:)
-    optional func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]?
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]?
     
     
     /**

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -7,7 +7,17 @@ class CarPlayMapViewController: UIViewController {
     
     static let defaultAltitude: CLLocationDistance = 16000
     
-    var styleManager: StyleManager!
+    var styleManager: StyleManager?
+    
+    /**
+     The interface styles available to `styleManager` for display.
+     */
+    var styles: [Style] {
+        didSet {
+            styleManager?.styles = styles
+        }
+    }
+    
     /// A very coarse location manager used for distinguishing between daytime and nighttime.
     fileprivate let coarseLocationManager: CLLocationManager = {
         let coarseLocationManager = CLLocationManager()
@@ -40,6 +50,32 @@ class CarPlayMapViewController: UIViewController {
     
     var styleObservation: NSKeyValueObservation?
     
+    /**
+     Initializes a new CarPlay map view controller.
+     
+     - parameter styles: The interface styles initially available to the style manager for display.
+     */
+    required init(styles: [Style]) {
+        self.styles = styles
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        guard let styles = aDecoder.decodeObject(of: [NSArray.self, Style.self], forKey: "styles") as? [Style] else {
+            return nil
+        }
+        self.styles = styles
+        
+        super.init(coder: aDecoder)
+    }
+    
+    override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        
+        aCoder.encode(styles, forKey: "styles")
+    }
+    
     override func loadView() {
         let mapView = NavigationMapView()
 //        mapView.navigationMapDelegate = self
@@ -58,9 +94,10 @@ class CarPlayMapViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        styleManager = StyleManager(self)
-        styleManager.styles = [DayStyle(), NightStyle()]
+        
+        styleManager = StyleManager()
+        styleManager!.delegate = self
+        styleManager!.styles = styles
         
         resetCamera(animated: false, altitude: CarPlayMapViewController.defaultAltitude)
         mapView.setUserTrackingMode(.followWithCourse, animated: true)

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -354,10 +354,15 @@ open class NavigationViewController: UIViewController {
      Initializes a `NavigationViewController` that provides turn by turn navigation for the given route. A optional `direction` object is needed for  potential rerouting.
 
      See [Mapbox Directions](https://mapbox.github.io/mapbox-navigation-ios/directions/) for further information.
+     
+     - parameter route: The route to navigate along.
+     - parameter styles: The styles that the view controller’s internal `StyleManager` object can select from for display.
+     - parameter navigationService: The navigation service that manages navigation along the route.
+     - parameter voiceController: The voice controller that manages the delivery of voice instructions during navigation.
      */
     @objc(initWithRoute:styles:navigationService:voiceController:)
     required public init(for route: Route,
-                         styles: [Style]? = [DayStyle(), NightStyle()],
+                         styles: [Style]? = nil,
                          navigationService: NavigationService? = nil,
                          voiceController: RouteVoiceController? = nil) {
         
@@ -387,8 +392,9 @@ open class NavigationViewController: UIViewController {
         mapSubview.pinInSuperview()
         mapViewController.reportButton.isHidden = !showsReportFeedback
         
-        self.styleManager = StyleManager(self)
-        self.styleManager.styles = styles ?? [DayStyle(), NightStyle()]
+        styleManager = StyleManager()
+        styleManager.delegate = self
+        styleManager.styles = styles ?? [DayStyle(), NightStyle()]
         
         if !(route.routeOptions is NavigationRouteOptions) {
             print("`Route` was created using `RouteOptions` and not `NavigationRouteOptions`. Although not required, this may lead to a suboptimal navigation experience. Without `NavigationRouteOptions`, it is not guaranteed you will get congestion along the route line, better ETAs and ETA label color dependent on congestion.")

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -65,13 +65,7 @@ open class StyleManager: NSObject {
     
     var currentStyleType: StyleType?
     
-    /**
-     Initializes a new `StyleManager`.
-     
-     - parameter delegate: The receiver’s delegate
-     */
-    required public init(_ delegate: StyleManagerDelegate) {
-        self.delegate = delegate
+    @objc public override init() {
         super.init()
         resumeNotifications()
         resetTimeOfDayTimer()

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -313,7 +313,7 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
         return trailingBarButtons
     }
 
-    func carPlayManager(_ carplayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]? {
+    func carPlayManager(_ carPlayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]? {
         return mapButtons
     }
 

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -169,6 +169,7 @@ class CarPlayManagerTests: XCTestCase {
 
         XCTAssertTrue(exampleDelegate.navigationEnded, "The CarPlayManagerDelegate should have been told that navigation ended.")
     }
+    
     func testDirectionsOverride() {
         
         class DirectionsInvocationSpy: Directions {
@@ -195,6 +196,17 @@ class CarPlayManagerTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         
         XCTAssert(subject.directions == spy, "Directions client is not overridden properly.")
+    }
+    
+    func testCustomStyles() {
+        class CustomStyle: DayStyle {}
+        
+        XCTAssertEqual(manager?.styles.count, 2)
+        XCTAssertEqual(manager?.styles.first?.styleType, StyleType.day)
+        XCTAssertEqual(manager?.styles.last?.styleType, StyleType.night)
+        
+        let styles = [CustomStyle()]
+        XCTAssertEqual(CarPlayManager(styles: styles).styles, styles, "CarPlayManager should persist the initial styles given to it.")
     }
 }
 

--- a/MapboxNavigationTests/StyleManagerTests.swift
+++ b/MapboxNavigationTests/StyleManagerTests.swift
@@ -15,7 +15,8 @@ class StyleManagerTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        styleManager = StyleManager(self)
+        styleManager = StyleManager()
+        styleManager.delegate = self
         styleManager.automaticallyAdjustsStyleForTimeOfDay = true
     }
     

--- a/TestHelper/Fixture.swift
+++ b/TestHelper/Fixture.swift
@@ -47,7 +47,7 @@ public class Fixture: NSObject {
         let filePath = (NSTemporaryDirectory() as NSString).appendingPathComponent(fileName)
         
         _ = directions.calculate(options, completionHandler: { (waypoints, routes, error) in
-            guard let route = routes?.first else { return }
+            guard let _ = routes?.first else { return }
             print("Route downloaded to \(filePath)")
             completion()
         })


### PR DESCRIPTION
Applications can now customize the style of the map in CarPlay (nominally the rest of the CarPlay interface, but really just the map style).

Renamed `CarPlayManager(_:)` to `CarPlayManager(styles:eventsManager:)` and `CarPlayNavigationViewController(with:mapTemplate:interfaceController:manager:styles:)` to `CarPlayNavigationViewController(navigationService:mapTemplate:interfaceController:manager:styles:)`. These initializers now accept Style objects as arguments, which are applied throughout the CarPlay interface, similar to NavigationViewController. DayStyle and NightStyle are still used by default but no longer hard-coded everywhere. The application can set `CarPlayManager.styles` at any time to change the map style, for example if it sets the style of NavigationViewController or a standalone NavigationMapView on the phone and needs to synchronize the change on CarPlay.

Renamed `StyleManager(_:)` to `StyleManager()`. The previous initializer looked like it gave ownership of the delegate to StyleManager, whereas it was just a weak reference. Client code is now expected to set the `delegate` property explicitly.

Exposed a few more CarPlayManager members to Objective-C code. Fixed some build warnings.

Fixes #1823.

/cc @mapbox/navigation-ios