### PR TITLE
Adjust codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,9 @@ ignore:
   - "MapboxNavigationTests"
   - "MapboxCoreNavigationTests"
   - "TestHelper"
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
Fluctuations of ~0.1% occur now and then but should not mark the PR with a big 🔴.
As the tests stabilize, we can try to lower the threshold until we find a sweet spot.

cc @JThramer @akitchen 