### PR TITLE
Update UserCourseView instantaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixed an issue causing `UserCourseView` to lag behind `NavigationMapView` whenever the map’s camera or content insets change significantly or when the map rotates. ([#1838](https://github.com/mapbox/mapbox-navigation-ios/pull/1838))
+
 ## v0.24.0 (November 7, 2018)
 
 * It is now safe to set the `NavigationMapView.delegate` property of the `NavigationMapView` in `NavigationViewController.mapView`. Implement `MGLMapViewDelegate` in your own class to customize annotations and other details. ([#1601](https://github.com/mapbox/mapbox-navigation-ios/pull/1601))

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -225,6 +225,11 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         addGestureRecognizer(mapTapGesture)
     }
     
+    open override func layoutMarginsDidChange() {
+        super.layoutMarginsDidChange()
+        enableFrameByFrameCourseViewTracking(for: 3)
+    }
+    
     //MARK: - Overrides
     
     open override func prepareForInterfaceBuilder() {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -389,8 +389,14 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
         if sender.state == .changed {
             guard let location = userLocationForCourseTracking else { return }
-            userCourseView?.layer.removeAllAnimations()
-            userCourseView?.center = convert(location.coordinate, toPointTo: self)
+            
+            if let userCourseView = userCourseView as? UserCourseView {
+                userCourseView.update?(location: location,
+                                       pitch: camera.pitch,
+                                       direction: direction,
+                                       animated: false,
+                                       tracksUserCourse: tracksUserCourse)
+            }
         }
     }
     


### PR DESCRIPTION
Fixes #1731 

- Update UserCourseView instantaneously when a camera change is triggered by a user interaction.
- Update UserCourseView instantaneously when the map view’s layout margin changes.

| Before  | After         |
| ------------- |:-------------:|
| ![before](https://user-images.githubusercontent.com/764476/48488042-2ad50080-e820-11e8-8160-245ca5508042.gif) | ![after](https://user-images.githubusercontent.com/764476/48488049-2dcff100-e820-11e8-9f81-2d2cf9ab38a9.gif) |
| ![rotate_before](https://user-images.githubusercontent.com/764476/48488056-3294a500-e820-11e8-9ff3-7a5d3711b16b.gif) | ![rotate_after](https://user-images.githubusercontent.com/764476/48488064-36282c00-e820-11e8-92be-d5091a8f93d4.gif) |


cc @1ec5 @vincethecoder @JThramer 