### PR TITLE
Fix metric measurements in CarPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `CarPlayManager(styles:directions:eventsManager:)` also allows you to pass in a custom `Directions` object to use when calculating routes. ([#1834](https://github.com/mapbox/mapbox-navigation-ios/pull/1834/))
 * Removed the `StyleManager(_:)` initializer. After initializing a `StyleManager` object, set the `StyleManager.delegate` property to ensure that the style manager’s settings take effect. ([#1836](https://github.com/mapbox/mapbox-navigation-ios/pull/1836))
 * Some additional members of `CarPlayManager` are now accessible in Objective-C code. ([#1836](https://github.com/mapbox/mapbox-navigation-ios/pull/1836))
+* Fixed an issue where distances are incorrectly displayed as “0 m” in regions that use the metric system. ([#1854](https://github.com/mapbox/mapbox-navigation-ios/pull/1854))
 * Fixed an issue where the user puck pointed away from the route line during turn-by-turn navigation in CarPlay. The map’s vanishing point now accounts for safe area insets, including the side maneuver view. ([#1845](https://github.com/mapbox/mapbox-navigation-ios/pull/1845))
 
 ### Other changes

--- a/MapboxCoreNavigation/DistanceFormatter.swift
+++ b/MapboxCoreNavigation/DistanceFormatter.swift
@@ -68,11 +68,11 @@ struct RoundingTable {
         func measurement(for distance: CLLocationDistance) -> Measurement<UnitLength> {
             switch unit {
             case .millimeter:
-                return Measurement(value: distance.kilometers / 1e6, unit: .millimeters)
+                return Measurement(value: distance * 1_000, unit: .millimeters)
             case .centimeter:
-                return Measurement(value: distance.kilometers / 1e5, unit: .centimeters)
+                return Measurement(value: distance * 100, unit: .centimeters)
             case .meter:
-                return Measurement(value: distance.kilometers / 1e3, unit: .meters)
+                return Measurement(value: distance, unit: .meters)
             case .kilometer:
                 return Measurement(value: distance.kilometers, unit: .kilometers)
             case .inch:

--- a/MapboxCoreNavigationTests/DistanceFormatterTests.swift
+++ b/MapboxCoreNavigationTests/DistanceFormatterTests.swift
@@ -156,6 +156,13 @@ class DistanceFormatterTests: XCTestCase {
         assertDistance(384_400_000, displayed: "३,८४,४०० कि॰मी॰", quantity: "३,८४,४००")
     }
     
+    @available(iOS 10.0, *)
+    func testMeters() {
+        let oneMeter: CLLocationDistance = 1
+        let measurement = DistanceFormatter().roundingTableMetric.thresholds.first?.measurement(for: oneMeter)
+        XCTAssertEqual(measurement?.value, oneMeter)
+    }
+    
     func testInches() {
         let oneMeter: CLLocationDistance = 1
         let oneMeterInInches = oneMeter.converted(to: .inch)


### PR DESCRIPTION
In CarPlay, the meter is once again defined as the distance such that the speed of light in vacuum _c_ is 299&nbsp;792&nbsp;458 when expressed in meters per second, where the second is defined in terms of the cesium frequency Δν<sub>Cs</sub>. Likewise with the centimeter and millimeter.

<img src="https://user-images.githubusercontent.com/1231218/48906166-8272fd80-ee18-11e8-8aed-dcfa289ac353.png" width="300" alt="de anza">

Fixes #1853.

/cc @frederoni @JThramer