### PR TITLE
Balance safe area insets when initializing CarPlay navigation map view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixed an issue where the CarPlay navigation map’s vanishing point and user puck initially remained centered on screen, instead of accounting for the maneuver panel, until the navigation bar was shown. ([#1856](https://github.com/mapbox/mapbox-navigation-ios/pull/1856))
+
 ## v0.25.0 (November 22, 2018)
 
 ### CarPlay

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -114,9 +114,9 @@ public class CarPlayNavigationViewController: UIViewController {
         // These constraints don’t account for language direction, because the
         // safe area insets are nondirectional and may be affected by the side
         // on which the driver is sitting.
-        mapViewRightSafeAreaBalancingConstraint = NSLayoutConstraint(item: mapView, attribute: .left, relatedBy: .equal, toItem: view, attribute: .left, multiplier: 1, constant: 0)
+        mapViewRightSafeAreaBalancingConstraint = NSLayoutConstraint(item: mapView, attribute: .left, relatedBy: .equal, toItem: view, attribute: .left, multiplier: 1, constant: -mapView.safeArea.right)
         view.addConstraint(mapViewRightSafeAreaBalancingConstraint!)
-        mapViewLeftSafeAreaBalancingConstraint = NSLayoutConstraint(item: mapView, attribute: .right, relatedBy: .equal, toItem: view, attribute: .right, multiplier: 1, constant: 0)
+        mapViewLeftSafeAreaBalancingConstraint = NSLayoutConstraint(item: mapView, attribute: .right, relatedBy: .equal, toItem: view, attribute: .right, multiplier: 1, constant: mapView.safeArea.left)
         view.addConstraint(mapViewLeftSafeAreaBalancingConstraint!)
         view.addConstraint(NSLayoutConstraint(item: mapView, attribute: .top, relatedBy: .equal, toItem: view, attribute: .top, multiplier: 1, constant: 0))
         view.addConstraint(NSLayoutConstraint(item: mapView, attribute: .bottom, relatedBy: .equal, toItem: view, attribute: .bottom, multiplier: 1, constant: 0))


### PR DESCRIPTION
This is a followup to #1845 that balances out the CarPlay navigation map view’s safe area insets, accounting for the maneuver panel, on initialization. #1845 had waited until the first change to the safe area insets, which meant that the user puck was also incorrectly positioned (though consistent with the vanishing point) when starting navigation.

/cc @frederoni @JThramer