### PR TITLE
Calculate route to routable location in CarPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* When selecting a search result in CarPlay, the resulting routes lead to the search result’s routable location when available. Routes to a routable location are more likely to be passable. ([#1859](https://github.com/mapbox/mapbox-navigation-ios/pull/1859))
 * Fixed an issue where the CarPlay navigation map’s vanishing point and user puck initially remained centered on screen, instead of accounting for the maneuver panel, until the navigation bar was shown. ([#1856](https://github.com/mapbox/mapbox-navigation-ios/pull/1856))
 
 ## v0.25.0 (November 22, 2018)

--- a/MapboxNavigation/CarPlayManager+Search.swift
+++ b/MapboxNavigation/CarPlayManager+Search.swift
@@ -111,7 +111,7 @@ extension CarPlayManager: CPSearchTemplateDelegate {
         
         guard let userInfo = item.userInfo as? [String: Any],
             let placemark = userInfo[CarPlayManager.CarPlayGeocodedPlacemarkKey] as? GeocodedPlacemark,
-            let location = placemark.location else {
+            let location = placemark.routableLocations?.first ?? placemark.location else {
                 completionHandler()
                 return
         }


### PR DESCRIPTION
When selecting a search result in CarPlay, the resulting routes lead to the search result’s routable location when available. `CarPlayManager.forwardGeocodeOptions(_:)` was already requesting routable locations from the geocoder.

Fixes #1739.

/cc @frederoni @vincethecoder