### PR TITLE
Publicize VisualInstruction helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * When selecting a search result in CarPlay, the resulting routes lead to the search result’s routable location when available. Routes to a routable location are more likely to be passable. ([#1859](https://github.com/mapbox/mapbox-navigation-ios/pull/1859))
 * Fixed an issue where the CarPlay navigation map’s vanishing point and user puck initially remained centered on screen, instead of accounting for the maneuver panel, until the navigation bar was shown. ([#1856](https://github.com/mapbox/mapbox-navigation-ios/pull/1856))
 
+### CarPlay
+* `VisualInstruction.containsLaneIndications`, `VisualInstruction.maneuverImageSet(side:)`, `VisualInstruction.shouldFlipImage(side:)`, and `VisualInstruction.carPlayManeuverLabelAttributedText(bounds:shieldHeight:window:)` are now public. ([#1860](https://github.com/mapbox/mapbox-navigation-ios/pull/1860))
+
 ## v0.25.0 (November 22, 2018)
 
 ### CarPlay

--- a/MapboxNavigation/VisualInstruction.swift
+++ b/MapboxNavigation/VisualInstruction.swift
@@ -5,13 +5,13 @@ import CarPlay
 
 extension VisualInstruction {
     
-    var containsLaneIndications: Bool {
+    public var containsLaneIndications: Bool {
         return components.contains(where: { $0 is LaneIndicationComponent })
     }
 
 #if canImport(CarPlay)
     @available(iOS 12.0, *)
-    func maneuverImageSet(side: DrivingSide) -> CPImageSet? {
+    public func maneuverImageSet(side: DrivingSide) -> CPImageSet? {
         let colors: [UIColor] = [.black, .white]
         let blackAndWhiteManeuverIcons: [UIImage] = colors.compactMap { (color) in
             let mv = ManeuverView()
@@ -27,7 +27,7 @@ extension VisualInstruction {
         return CPImageSet(lightContentImage: blackAndWhiteManeuverIcons[1], darkContentImage: blackAndWhiteManeuverIcons[0])
     }
     
-    func shouldFlipImage(side: DrivingSide) -> Bool {
+    public func shouldFlipImage(side: DrivingSide) -> Bool {
         let leftDirection = [.left, .slightLeft, .sharpLeft].contains(maneuverDirection)
         
         switch maneuverType {
@@ -42,7 +42,7 @@ extension VisualInstruction {
     }
 
     @available(iOS 12.0, *)
-    func carPlayManeuverLabelAttributedText(bounds: @escaping () -> (CGRect), shieldHeight: CGFloat, window: UIWindow?) -> NSAttributedString? {
+    public func carPlayManeuverLabelAttributedText(bounds: @escaping () -> (CGRect), shieldHeight: CGFloat, window: UIWindow?) -> NSAttributedString? {
         let instructionLabel = InstructionLabel()
         instructionLabel.availableBounds = bounds
         instructionLabel.shieldHeight = shieldHeight


### PR DESCRIPTION
Fixes #1851 

Made `VisualInstruction.containsLaneIndications`, `VisualInstruction.maneuverImageSet(side:)`, `VisualInstruction.shouldFlipImage(side:)`, and `VisualInstruction.carPlayManeuverLabelAttributedText(bounds:shieldHeight:window:)` public.

cc @1ec5 @JThramer 