### PR TITLE
Updates views on BaseInstructionsBannerView to be public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Fixed an issue where the CarPlay navigation map’s vanishing point and user puck initially remained centered on screen, instead of accounting for the maneuver panel, until the navigation bar was shown. ([#1856](https://github.com/mapbox/mapbox-navigation-ios/pull/1856))
+* Updated views on `BaseInstructionsBannerView` to be public to help with being able to build custom instruction banners. This is considered experiential and could change at any time.
 
 ## v0.25.0 (November 22, 2018)
 
@@ -33,7 +34,7 @@
 * Fixed an issue where the map view while navigating in CarPlay showed labels in the style’s original language instead of the local language. ([#1601](https://github.com/mapbox/mapbox-navigation-ios/pull/1601))
 * Fixed an issue where rerouting could still occur after arrival, even though `NavigationServiceDelegate.navigationService(_:shouldPreventReroutesWhenArrivingAt:)` returned `true`. ([#1833](https://github.com/mapbox/mapbox-navigation-ios/pull/1833))
 * `NavigationMapViewDelegate.navigationMapView(_:routeStyleLayerWithIdentifier:source:)`, `NavigationMapViewDelegate.navigationMapView(_:routeCasingStyleLayerWithIdentifier:source:)`, `NavigationViewControllerDelegate.navigationViewController(_:routeStyleLayerWithIdentifier:source:)`, and `NavigationViewControllerDelegate.navigationViewController(_:routeCasingStyleLayerWithIdentifier:source:)` can now set the `MGLLineStyleLayer.lineGradient` property. ([#1799](https://github.com/mapbox/mapbox-navigation-ios/pull/1799))
-* Reduced the `NavigationMapView.minimumFramesPerSecond` property’s default value from 30 frames per second to 20 frames per second for improved performance on battery power. ([#1818](https://github.com/mapbox/mapbox-navigation-ios/pull/1818)) 
+* Reduced the `NavigationMapView.minimumFramesPerSecond` property’s default value from 30 frames per second to 20 frames per second for improved performance on battery power. ([#1818](https://github.com/mapbox/mapbox-navigation-ios/pull/1818))
 
 ## v0.23.0 (October 24, 2018)
 * `CarPlayManager` is no longer a singleton; your application delegate is responsible for creating and owning an instance of this class. This fixes a crash in applications that specify the access token programmatically instead of in the Info.plist file. ([#1792](https://github.com/mapbox/mapbox-navigation-ios/pull/1792))

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -36,14 +36,14 @@ open class InstructionsBannerView: BaseInstructionsBannerView { }
 /// :nodoc:
 open class BaseInstructionsBannerView: UIControl {
     
-    weak var maneuverView: ManeuverView!
-    weak var primaryLabel: PrimaryLabel!
-    weak var secondaryLabel: SecondaryLabel!
-    weak var distanceLabel: DistanceLabel!
-    weak var dividerView: UIView!
+    public weak var maneuverView: ManeuverView!
+    public weak var primaryLabel: PrimaryLabel!
+    public weak var secondaryLabel: SecondaryLabel!
+    public weak var distanceLabel: DistanceLabel!
+    public weak var dividerView: UIView!
     weak var _separatorView: UIView!
-    weak var separatorView: SeparatorView!
-    weak var stepListIndicatorView: StepListIndicatorView!
+    public weak var separatorView: SeparatorView!
+    public weak var stepListIndicatorView: StepListIndicatorView!
     
     @IBInspectable
     public var swipeable: Bool = false
@@ -75,7 +75,7 @@ open class BaseInstructionsBannerView: UIControl {
     
     let distanceFormatter = DistanceFormatter(approximate: true)
     
-    var distance: CLLocationDistance? {
+    public var distance: CLLocationDistance? {
         didSet {
             distanceLabel.attributedDistanceString = nil
             


### PR DESCRIPTION
This PR updates most of the views, and distance members public so it is easier to build custom UI's on top of the `BaseInstructionsBannerView`

**cc** @akitchen @vincethecoder @1ec5 