### PR TITLE
Downsize shields in instructions in CarPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## master
 
+### CarPlay
+
 * When selecting a search result in CarPlay, the resulting routes lead to the search result’s routable location when available. Routes to a routable location are more likely to be passable. ([#1859](https://github.com/mapbox/mapbox-navigation-ios/pull/1859))
 * Fixed an issue where the CarPlay navigation map’s vanishing point and user puck initially remained centered on screen, instead of accounting for the maneuver panel, until the navigation bar was shown. ([#1856](https://github.com/mapbox/mapbox-navigation-ios/pull/1856))
+* Fixed an issue where route shields and exit numbers appeared blurry in the maneuver panel on CarPlay devices and failed to appear in the CarPlay simulator. ([#1868](https://github.com/mapbox/mapbox-navigation-ios/pull/1868))
 * Added `VisualInstruction.containsLaneIndications`, `VisualInstruction.maneuverImageSet(side:)`, `VisualInstruction.shouldFlipImage(side:)`, and `VisualInstruction.carPlayManeuverLabelAttributedText(bounds:shieldHeight:window:)`. ([#1860](https://github.com/mapbox/mapbox-navigation-ios/pull/1860))
 
 ## v0.25.0 (November 22, 2018)

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -316,6 +316,13 @@ public class CarPlayNavigationViewController: UIViewController {
             return CGRect(x: 0, y: 0, width: widthOfManeuverView, height: 30)
         }
         
+        // Over a certain height, CarPlay devices downsize the image and CarPlay simulators hide the image.
+        let maximumImageSize = CGSize(width: .infinity, height: shieldHeight)
+        let imageRendererFormat = UIGraphicsImageRendererFormat(for: UITraitCollection(userInterfaceIdiom: .carPlay))
+        if let window = carPlayManager.carWindow {
+            imageRendererFormat.scale = window.screen.scale
+        }
+        
         if let attributedPrimary = visualInstruction.primaryInstruction.carPlayManeuverLabelAttributedText(bounds: bounds, shieldHeight: shieldHeight, window: carPlayManager.carWindow) {
             let instruction = NSMutableAttributedString(attributedString: attributedPrimary)
             
@@ -324,7 +331,7 @@ public class CarPlayNavigationViewController: UIViewController {
                 instruction.append(attributedSecondary)
             }
             
-            instruction.canonicalizeAttachments()
+            instruction.canonicalizeAttachments(maximumImageSize: maximumImageSize, imageRendererFormat: imageRendererFormat)
             primaryManeuver.attributedInstructionVariants = [instruction]
         }
         
@@ -340,7 +347,7 @@ public class CarPlayNavigationViewController: UIViewController {
             }
             if let attributedTertiary = tertiaryInstruction.carPlayManeuverLabelAttributedText(bounds: bounds, shieldHeight: shieldHeight, window: carPlayManager.carWindow) {
                 let attributedTertiary = NSMutableAttributedString(attributedString: attributedTertiary)
-                attributedTertiary.canonicalizeAttachments()
+                attributedTertiary.canonicalizeAttachments(maximumImageSize: maximumImageSize, imageRendererFormat: imageRendererFormat)
                 tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]
             }
             

--- a/MapboxNavigation/ImageDownload.swift
+++ b/MapboxNavigation/ImageDownload.swift
@@ -139,7 +139,7 @@ class ImageDownloadOperation: Operation, ImageDownload {
             return
         }
 
-        if let data = incomingData, let image = UIImage.init(data: data, scale: UIScreen.main.scale) {
+        if let data = incomingData, let image = UIImage(data: data, scale: UIScreen.main.scale) {
             fireAllCompletions(image, data: data, error: nil)
         } else {
             fireAllCompletions(nil, data: incomingData, error: DownloadError.noImageData)

--- a/MapboxNavigation/NSAttributedString.swift
+++ b/MapboxNavigation/NSAttributedString.swift
@@ -10,14 +10,25 @@ extension NSAttributedString {
 }
 
 extension NSMutableAttributedString {
-    func canonicalizeAttachments() {
+    @available(iOS 10.0, *)
+    func canonicalizeAttachments(maximumImageSize: CGSize, imageRendererFormat: UIGraphicsImageRendererFormat) {
         enumerateAttribute(.attachment, in: NSRange(location: 0, length: length), options: []) { (value, range, stop) in
             guard let attachment = value as? NSTextAttachment, type(of: attachment) != NSTextAttachment.self else {
                 return
             }
             
             let sanitizedAttachment = NSTextAttachment()
-            sanitizedAttachment.image = attachment.image
+            let maximumHeight = maximumImageSize.height
+            if #available(iOS 11.0, *), let image = attachment.image, image.size.height > maximumHeight {
+                // Scale down any oversized images.
+                let size = CGSize(width: image.size.width * maximumHeight / image.size.height, height: maximumHeight)
+                let resizedImage = UIGraphicsImageRenderer(size: size, format: imageRendererFormat).image { (context) in
+                    image.draw(in: CGRect(origin: .zero, size: size))
+                }
+                sanitizedAttachment.image = resizedImage
+            } else {
+                sanitizedAttachment.image = attachment.image
+            }
             sanitizedAttachment.bounds = attachment.bounds
             setAttributes([.attachment: sanitizedAttachment], range: range)
         }


### PR DESCRIPTION
When preparing attributed instruction strings for CarPlay, resize any text attachment image taller than 16 points, preserving the aspect ratio.

Here’s a before and after:

<img src="https://user-images.githubusercontent.com/1231218/49286500-2bd87580-f44f-11e8-8fe6-041b1c4289e8.png" width="400" alt="before">
<img src="https://user-images.githubusercontent.com/1231218/49286511-3a269180-f44f-11e8-8fdc-567d84b921c6.png" width="400" alt="after">

Shields on the phone are unaffected:

<img src="https://user-images.githubusercontent.com/1231218/49286518-427ecc80-f44f-11e8-9b07-92f67a43cecd.png" width="300" alt="after-phone">

Fixes #1867 and speculatively fixes #1866. A more correct fix for #1866 would require adjustments to the constraints in ExitView and GenericRouteShield.

/cc @mapbox/navigation-ios