### PR TITLE
Speculative route-start course quick-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Speculatively fixed spurious rerouting when passing an intermediate waypoint. ([#1869](https://github.com/mapbox/mapbox-navigation-ios/pull/1869))
+
 ### CarPlay
 
 * When selecting a search result in CarPlay, the resulting routes lead to the search result’s routable location when available. Routes to a routable location are more likely to be passable. ([#1859](https://github.com/mapbox/mapbox-navigation-ios/pull/1859))

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -221,6 +221,11 @@ open class RouteController: NSObject, Router {
      Monitors the user's course to see if it is consistantly moving away from what we expect the course to be at a given point.
      */
     func userCourseIsOnRoute(_ location: CLLocation) -> Bool {
+        // if we have yet to travel along the current leg, don't check for heading conformance
+        guard routeProgress.currentLegProgress.distanceTraveled > 0 else {
+            return true
+        }
+        
         let nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
         guard let calculatedCourseForLocationOnStep = location.interpolatedCourse(along: nearByCoordinates) else { return true }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -223,6 +223,7 @@ open class RouteController: NSObject, Router {
     func userCourseIsOnRoute(_ location: CLLocation) -> Bool {
         // if we have yet to travel along the current leg, don't check for heading conformance
         guard routeProgress.currentLegProgress.distanceTraveled > 0 else {
+            movementsAwayFromRoute = 0
             return true
         }
         


### PR DESCRIPTION
* Speculatively fixing issue where, upon starting a new leg of a route, a situation can occur where the RouteController interpolates user-course incorrectly, causing it to think that an off-route event has occured.

/cc @mapbox/navigation-ios 