### PR TITLE
Add missing VisualInstruction documentation

### DIFF
--- a/MapboxNavigation/VisualInstruction.swift
+++ b/MapboxNavigation/VisualInstruction.swift
@@ -5,11 +5,13 @@ import CarPlay
 
 extension VisualInstruction {
     
+    /// Returns true if `VisualInstruction.components` contains any `LaneIndicationComponent`.
     public var containsLaneIndications: Bool {
         return components.contains(where: { $0 is LaneIndicationComponent })
     }
 
 #if canImport(CarPlay)
+    /// Returns a `CPImageSet` representing the maneuver.
     @available(iOS 12.0, *)
     public func maneuverImageSet(side: DrivingSide) -> CPImageSet? {
         let colors: [UIColor] = [.black, .white]
@@ -27,6 +29,7 @@ extension VisualInstruction {
         return CPImageSet(lightContentImage: blackAndWhiteManeuverIcons[1], darkContentImage: blackAndWhiteManeuverIcons[0])
     }
     
+    /// Returns whether the `VisualInstruction`’s maneuver image should be flipped according to the driving side.
     public func shouldFlipImage(side: DrivingSide) -> Bool {
         let leftDirection = [.left, .slightLeft, .sharpLeft].contains(maneuverDirection)
         
@@ -41,6 +44,15 @@ extension VisualInstruction {
         }
     }
 
+    /**
+     Glanceable instruction given the available space, appearance styling, and attachments.
+     
+     - parameter bounds: A closure that calculates the available bounds for the maneuver text.
+     - parameter shieldHeight: The height of the shield.
+     - parameter window: A `UIWindow` that holds the `UIAppearance` styling properties, preferably the CarPlay window.
+     
+     - returns: An `NSAttributedString` with maneuver instructions.
+     */
     @available(iOS 12.0, *)
     public func carPlayManeuverLabelAttributedText(bounds: @escaping () -> (CGRect), shieldHeight: CGFloat, window: UIWindow?) -> NSAttributedString? {
         let instructionLabel = InstructionLabel()


### PR DESCRIPTION
Added missing documentation for `VisualInstruction` that were publicized in #1860 

cc @1ec5 @vincethecoder 

![screenshot 2018-12-03 16 19 39](https://user-images.githubusercontent.com/764476/49382769-8c99d380-f717-11e8-931a-91d74ffbe9ae.png)
![screenshot 2018-12-03 16 19 45](https://user-images.githubusercontent.com/764476/49382771-8e639700-f717-11e8-9196-dc7a0f8b9702.png)
![screenshot 2018-12-03 16 19 51](https://user-images.githubusercontent.com/764476/49382775-91f71e00-f717-11e8-8275-f3f85ad59018.png)
![screenshot 2018-12-03 16 19 59](https://user-images.githubusercontent.com/764476/49382785-94597800-f717-11e8-8b89-0d5c3c277c81.png)
