### PR TITLE
Nav-native deferral

### DIFF
--- a/MapboxCoreNavigation/PortableRouteController.swift
+++ b/MapboxCoreNavigation/PortableRouteController.swift
@@ -61,7 +61,7 @@ open class PortableRouteController: RouteController {
         super.locationManager(manager, didUpdateLocations: locations)
     }
     
-    override internal func userIsWithinRadiusOfRoute(location: CLLocation) -> Bool {
+    override internal func userIsWithinEnvelope(of step: RouteStep, at location: CLLocation) -> Bool {
         let status = navigator.getStatusForTimestamp(location.timestamp)
         let offRoute = status.routeState == .offRoute
         return !offRoute


### PR DESCRIPTION
Completely deferring to nav-native's authority on on-route status for `PortableRouteController`, also cleaning up code for legacy `RouteController` 

/cc @mapbox/navigation-ios 