### PR TITLE
Make NavigationSettings.shared accessible in Objective-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Other changes
 
 * This release includes a possible fix for spurious rerouting when passing an intermediate waypoint. ([#1869](https://github.com/mapbox/mapbox-navigation-ios/pull/1869))
+* The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
 
 ## v0.25.0 (November 22, 2018)
 

--- a/MapboxCoreNavigation/NavigationSettings.swift
+++ b/MapboxCoreNavigation/NavigationSettings.swift
@@ -49,6 +49,10 @@ public class NavigationSettings: NSObject {
         }
     }
     
+    /*
+     The shared navigation settings object that affects the entire application.
+     */
+    @objc(sharedSettings)
     public static let shared = NavigationSettings()
     
     /// Returns a reflection of this class excluding the `properties` variable.


### PR DESCRIPTION
The `NavigationSettings.shared` property is now accessible in Objective-C code as the class property `MBNavigationSettings.sharedSettings`.

/cc @frederoni @JThramer @riastrad