### PR TITLE
Multi-leg nearby coordinate lookups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### Other changes
 
-* This release includes a possible fix for spurious rerouting when passing an intermediate waypoint. ([#1869](https://github.com/mapbox/mapbox-navigation-ios/pull/1869))
 * The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
 * Adding property `RouteController.nearbyCoordinates`, which offers similar behavior to `RouteLegProgress.nearbyCoordinates`, which the addition of step lookahead/lookbehind in multi-leg routes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * This release includes a possible fix for spurious rerouting when passing an intermediate waypoint. ([#1869](https://github.com/mapbox/mapbox-navigation-ios/pull/1869))
 * The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
+* Adding property `RouteController.nearbyCoordinates`, which offers similar behavior to `RouteLegProgress.nearbyCoordinates`, which the addition of step lookahead/lookbehind in multi-leg routes.
 
 ## v0.25.0 (November 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Other changes
 
 * The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
-* Adding property `RouteController.nearbyCoordinates`, which offers similar behavior to `RouteLegProgress.nearbyCoordinates`, which the addition of step lookahead/lookbehind in multi-leg routes.
+* Adding property `RouteController.nearbyCoordinates`, which offers similar behavior to `RouteLegProgress.nearbyCoordinates`, which the addition of step lookahead/lookbehind in multi-leg routes. ([#1883](https://github.com/mapbox/mapbox-navigation-ios/pull/1883))
 
 ## v0.25.0 (November 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed an issue where the CarPlay navigation map’s vanishing point and user puck initially remained centered on screen, instead of accounting for the maneuver panel, until the navigation bar was shown. ([#1856](https://github.com/mapbox/mapbox-navigation-ios/pull/1856))
 * Fixed an issue where route shields and exit numbers appeared blurry in the maneuver panel on CarPlay devices and failed to appear in the CarPlay simulator. ([#1868](https://github.com/mapbox/mapbox-navigation-ios/pull/1868))
 * Added `VisualInstruction.containsLaneIndications`, `VisualInstruction.maneuverImageSet(side:)`, `VisualInstruction.shouldFlipImage(side:)`, and `VisualInstruction.carPlayManeuverLabelAttributedText(bounds:shieldHeight:window:)`. ([#1860](https://github.com/mapbox/mapbox-navigation-ios/pull/1860))
+* `RouteLegProgress.upComingStep` has been renamed to `upcomingStep`.  ([#1860](https://github.com/mapbox/mapbox-navigation-ios/pull/1860))
 
 ### Other changes
 

--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -86,8 +86,9 @@ extension CLLocation {
     
     //MARK: - Route Snapping
     
-    func snapped(to legProgress: RouteLegProgress) -> CLLocation? {
-        let coords = coordinates(for: legProgress)
+    func snapped(to routeProgress: RouteProgress) -> CLLocation? {
+        let legProgress = routeProgress.currentLegProgress
+        let coords = coordinates(for: routeProgress)
         
         guard let closest = Polyline(coords).closestCoordinate(to: coordinate) else { return nil }
         guard let calculatedCourseForLocationOnStep = interpolatedCourse(along: coords) else { return nil }
@@ -104,8 +105,9 @@ extension CLLocation {
     /**
      Calculates the proper coordinates to use when calculating a snapped location.
      */
-    func coordinates(for legProgress: RouteLegProgress) -> [CLLocationCoordinate2D] {
-        let nearbyCoordinates = legProgress.nearbyCoordinates
+    func coordinates(for routeProgress: RouteProgress) -> [CLLocationCoordinate2D] {
+        let legProgress = routeProgress.currentLegProgress
+        let nearbyCoordinates = routeProgress.nearbyCoordinates
         let stepCoordinates = legProgress.currentStep.coordinates!
         
         // If the upcoming maneuver a sharp turn, only look at the current step for snapping.

--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -110,7 +110,7 @@ extension CLLocation {
         
         // If the upcoming maneuver a sharp turn, only look at the current step for snapping.
         // Otherwise, we may get false positives from nearby step coordinates
-        if let upcomingStep = legProgress.upComingStep,
+        if let upcomingStep = legProgress.upcomingStep,
             let initialHeading = upcomingStep.initialHeading,
             let finalHeading = upcomingStep.finalHeading {
             

--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -271,10 +271,10 @@ extension RouteLegProgress: Encodable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encodeIfPresent(upComingStep?.instructions, forKey: .upcomingInstruction)
-        try container.encodeIfPresent(upComingStep?.maneuverType.description, forKey: .upcomingType)
-        try container.encodeIfPresent(upComingStep?.maneuverDirection.description, forKey: .upcomingModifier)
-        try container.encodeIfPresent(upComingStep?.names?.joined(separator: ";"), forKey: .upcomingName)
+        try container.encodeIfPresent(upcomingStep?.instructions, forKey: .upcomingInstruction)
+        try container.encodeIfPresent(upcomingStep?.maneuverType.description, forKey: .upcomingType)
+        try container.encodeIfPresent(upcomingStep?.maneuverDirection.description, forKey: .upcomingModifier)
+        try container.encodeIfPresent(upcomingStep?.names?.joined(separator: ";"), forKey: .upcomingName)
         try container.encodeIfPresent(currentStep.instructions, forKey: .previousInstruction)
         try container.encode(currentStep.maneuverType.description, forKey: .previousType)
         try container.encode(currentStep.maneuverDirection.description, forKey: .previousModifier)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -227,7 +227,7 @@ open class RouteController: NSObject, Router {
             return true
         }
         
-        let nearByCoordinates = routeProgress.currentLegProgress.nearbyCoordinates
+        let nearByCoordinates = routeProgress.nearbyCoordinates
         guard let calculatedCourseForLocationOnStep = location.interpolatedCourse(along: nearByCoordinates) else { return true }
         
         let maxUpdatesAwayFromRouteGivenAccuracy = Int(location.horizontalAccuracy / Double(RouteControllerIncorrectCourseMultiplier))

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -221,12 +221,6 @@ open class RouteController: NSObject, Router {
      Monitors the user's course to see if it is consistantly moving away from what we expect the course to be at a given point.
      */
     func userCourseIsOnRoute(_ location: CLLocation) -> Bool {
-        // if we have yet to travel along the current leg, don't check for heading conformance
-        guard routeProgress.currentLegProgress.distanceTraveled > 0 else {
-            movementsAwayFromRoute = 0
-            return true
-        }
-        
         let nearByCoordinates = routeProgress.nearbyCoordinates
         guard let calculatedCourseForLocationOnStep = location.interpolatedCourse(along: nearByCoordinates) else { return true }
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -221,8 +221,8 @@ open class RouteController: NSObject, Router {
      Monitors the user's course to see if it is consistantly moving away from what we expect the course to be at a given point.
      */
     func userCourseIsOnRoute(_ location: CLLocation) -> Bool {
-        let nearByCoordinates = routeProgress.nearbyCoordinates
-        guard let calculatedCourseForLocationOnStep = location.interpolatedCourse(along: nearByCoordinates) else { return true }
+        let nearbyCoordinates = routeProgress.nearbyCoordinates
+        guard let calculatedCourseForLocationOnStep = location.interpolatedCourse(along: nearbyCoordinates) else { return true }
         
         let maxUpdatesAwayFromRouteGivenAccuracy = Int(location.horizontalAccuracy / Double(RouteControllerIncorrectCourseMultiplier))
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -415,7 +415,7 @@ extension RouteController: CLLocationManagerDelegate {
     }
     
     func checkForFasterRoute(from location: CLLocation) {
-        guard let currentUpcomingManeuver = routeProgress.currentLegProgress.upComingStep else {
+        guard let currentUpcomingManeuver = routeProgress.currentLegProgress.upcomingStep else {
             return
         }
 
@@ -533,7 +533,7 @@ extension RouteController: CLLocationManagerDelegate {
         let currentStepProgress = routeProgress.currentLegProgress.currentStepProgress
 
         // The intersections array does not include the upcoming maneuver intersection.
-        if let upcomingStep = routeProgress.currentLegProgress.upComingStep, let upcomingIntersection = upcomingStep.intersections, let firstUpcomingIntersection = upcomingIntersection.first {
+        if let upcomingStep = routeProgress.currentLegProgress.upcomingStep, let upcomingIntersection = upcomingStep.intersections, let firstUpcomingIntersection = upcomingIntersection.first {
             intersections += [firstUpcomingIntersection]
         }
 
@@ -557,7 +557,7 @@ extension RouteController: CLLocationManagerDelegate {
 
         // Bearings need to normalized so when the `finalHeading` is 359 and the user heading is 1,
         // we count this as within the `RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion`
-        if let upcomingStep = routeProgress.currentLegProgress.upComingStep, let finalHeading = upcomingStep.finalHeading, let initialHeading = upcomingStep.initialHeading {
+        if let upcomingStep = routeProgress.currentLegProgress.upcomingStep, let finalHeading = upcomingStep.finalHeading, let initialHeading = upcomingStep.initialHeading {
             let initialHeadingNormalized = initialHeading.wrap(min: 0, max: 360)
             let finalHeadingNormalized = finalHeading.wrap(min: 0, max: 360)
             let userHeadingNormalized = location.course.wrap(min: 0, max: 360)
@@ -576,7 +576,7 @@ extension RouteController: CLLocationManagerDelegate {
             }
         }
 
-        let step = routeProgress.currentLegProgress.upComingStep?.maneuverLocation ?? routeProgress.currentLegProgress.currentStep.maneuverLocation
+        let step = routeProgress.currentLegProgress.upcomingStep?.maneuverLocation ?? routeProgress.currentLegProgress.currentStep.maneuverLocation
         let userAbsoluteDistance = step.distance(to: location.coordinate)
         let lastKnownUserAbsoluteDistance = routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation
 

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -156,7 +156,7 @@ open class RouteController: NSObject, Router {
      - important: If the rawLocation is outside of the route snapping tolerances, this value is nil.
      */
     var snappedLocation: CLLocation? {
-        return rawLocation?.snapped(to: routeProgress.currentLegProgress)
+        return rawLocation?.snapped(to: routeProgress)
     }
 
     var heading: CLHeading?

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -357,7 +357,12 @@ open class RouteLegProgress: NSObject {
 
      If there is no `upcomingStep`, nil is returned.
      */
+    @available(*, deprecated, renamed: "upcomingStep")
     @objc public var upComingStep: RouteStep? {
+        return upcomingStep
+    }
+    
+    @objc public var upcomingStep: RouteStep? {
         guard stepIndex + 1 < leg.steps.endIndex else {
             return nil
         }
@@ -405,7 +410,7 @@ open class RouteLegProgress: NSObject {
      */
     @objc public var nearbyCoordinates: [CLLocationCoordinate2D] {
         let priorCoords = priorStep?.coordinates ?? []
-        let upcomingCoords = upComingStep?.coordinates ?? []
+        let upcomingCoords = upcomingStep?.coordinates ?? []
         let currentCoords = currentStep.coordinates ?? []
         let nearby = priorCoords + currentCoords + upcomingCoords
         assert(!nearby.isEmpty, "Step must have coordinates")

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -98,6 +98,42 @@ open class RouteProgress: NSObject {
      */
     @objc public var currentLegProgress: RouteLegProgress
 
+    @objc public var nearbyCoordinates: [CLLocationCoordinate2D] {
+        
+        var coords: [CLLocationCoordinate2D] = []
+        
+        //If we're on the first step of a leg, add coords from previous leg.
+        if let firstStep = currentLegProgress.leg.steps.first,
+            currentLegProgress.currentStep == firstStep,
+            legIndex > 0 {
+            
+            let lastLeg = route.legs[legIndex - 1]
+            
+            if let lastStep = lastLeg.steps.last,
+               let priorCoords = lastStep.coordinates {
+                coords += priorCoords
+            }
+        }
+        
+        //Add nearby coordinates from current step.
+        coords += currentLegProgress.nearbyCoordinates
+        
+        //If we're on the last step of a leg, add coordinates from the next leg.
+        if let lastStep = currentLegProgress.leg.steps.last,
+            currentLegProgress.currentStep == lastStep,
+            legIndex < (route.legs.count - 1) {
+            
+            let nextLeg = route.legs[legIndex + 1]
+            
+            if let nextStep = nextLeg.steps.first,
+               let upcomingCoords = nextStep.coordinates {
+                coords += upcomingCoords
+            }
+        }
+        
+        return coords
+    }
+    
     /**
      Tuple containing a `CongestionLevel` and a corresponding `TimeInterval` representing the expected travel time for this segment.
      */

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -133,7 +133,9 @@ open class RouteProgress: NSObject {
     }
     
     /**
-     Returns an array of `CLLocationCoordinate2D` of the prior, current and upcoming step geometry.
+     Returns an array of `CLLocationCoordinate2D` of the coordinates along the current step and any adjacent steps.
+     
+     - important: The adjacent steps may be part of legs other than the current leg.
      */
 
     @objc public var nearbyCoordinates: [CLLocationCoordinate2D] {

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -97,43 +97,50 @@ open class RouteProgress: NSObject {
      Returns the progress along the current `RouteLeg`.
      */
     @objc public var currentLegProgress: RouteLegProgress
+    
+    @objc public var priorLeg: RouteLeg? {
+        return legIndex > 0 ? route.legs[legIndex - 1] : nil
+    }
+    
+    /**
+     Returns the prior `RouteStep`.
+     
+     If there is no `prior`, nil is returned.
+     */
+    
+    @objc public var priorStep: RouteStep? {
+        return currentLegProgress.priorStep ?? priorLeg?.steps.last
+    }
+    
+    /**
+     Returns the upcoming `RouteLeg`.
+     
+     If there is no `upcomingLeg`, nil is returned.
+     */
+    
+    @objc public var upcomingLeg: RouteLeg? {
+        return legIndex + 1 < route.legs.endIndex ? route.legs[legIndex + 1] : nil
+    }
+    
+    /**
+     Returns the upcoming `RouteStep`.
+     
+     If there is no `upcomingStep`, nil is returned.
+     */
+    
+    public var upcomingStep: RouteStep? {
+        return currentLegProgress.upcomingStep ?? upcomingLeg?.steps.first
+    }
+    
+    /**
+     Returns an array of `CLLocationCoordinate2D` of the prior, current and upcoming step geometry.
+     */
 
     @objc public var nearbyCoordinates: [CLLocationCoordinate2D] {
-        
-        var coords: [CLLocationCoordinate2D] = []
-        
-        //If we're on the first step of a leg, add coords from previous leg.
-        if let firstStep = currentLegProgress.leg.steps.first,
-            currentLegProgress.currentStep == firstStep,
-            legIndex > 0 {
-            
-            let lastLeg = route.legs[legIndex - 1]
-            
-            if let lastStep = lastLeg.steps.last,
-               let priorCoords = lastStep.coordinates {
-                coords += priorCoords
-            }
-        }
-        
-        //Add nearby coordinates from current step.
-        coords += currentLegProgress.priorStep?.coordinates ?? []
-        coords += currentLegProgress.currentStep.coordinates ?? []
-        coords += currentLegProgress.upcomingStep?.coordinates ?? []
-        
-        //If we're on the last step of a leg, add coordinates from the next leg.
-        if let lastStep = currentLegProgress.leg.steps.last,
-            currentLegProgress.currentStep == lastStep,
-            legIndex < (route.legs.count - 1) {
-            
-            let nextLeg = route.legs[legIndex + 1]
-            
-            if let nextStep = nextLeg.steps.first,
-               let upcomingCoords = nextStep.coordinates {
-                coords += upcomingCoords
-            }
-        }
-        
-        return coords
+        let priorCoordinates = priorStep?.coordinates?.dropLast() ?? []
+        let currentCoordinates = currentLegProgress.currentStep.coordinates ?? []
+        let upcomingCoordinates = upcomingStep?.coordinates?.dropFirst() ?? []
+        return priorCoordinates + currentCoordinates + upcomingCoordinates
     }
     
     /**

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -103,9 +103,9 @@ open class RouteProgress: NSObject {
     }
     
     /**
-     Returns the prior `RouteStep`.
+     The step prior to the current step along this route.
      
-     If there is no `prior`, nil is returned.
+     The prior step may be part of a different RouteLeg than the current step. If the current step is the first step along the route, this property is set to nil.
      */
     
     @objc public var priorStep: RouteStep? {
@@ -113,19 +113,19 @@ open class RouteProgress: NSObject {
     }
     
     /**
-     Returns the upcoming `RouteLeg`.
+     The leg following the current leg along this route.
      
-     If there is no `upcomingLeg`, nil is returned.
-     */
+     If this leg is the last leg of the route, this property is set to nil.
+    */
     
     @objc public var upcomingLeg: RouteLeg? {
         return legIndex + 1 < route.legs.endIndex ? route.legs[legIndex + 1] : nil
     }
     
     /**
-     Returns the upcoming `RouteStep`.
+     The step following the current step along this route.
      
-     If there is no `upcomingStep`, nil is returned.
+     The upcoming step may be part of a different RouteLeg than the current step. If it is the last step along the route, this property is set to nil.
      */
     
     public var upcomingStep: RouteStep? {

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -116,7 +116,9 @@ open class RouteProgress: NSObject {
         }
         
         //Add nearby coordinates from current step.
-        coords += currentLegProgress.nearbyCoordinates
+        coords += currentLegProgress.priorStep?.coordinates ?? []
+        coords += currentLegProgress.currentStep.coordinates ?? []
+        coords += currentLegProgress.upcomingStep?.coordinates ?? []
         
         //If we're on the last step of a leg, add coordinates from the next leg.
         if let lastStep = currentLegProgress.leg.steps.last,
@@ -403,18 +405,6 @@ open class RouteLegProgress: NSObject {
         self.leg = leg
         self.stepIndex = stepIndex
         currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
-    }
-
-    /**
-     Returns an array of `CLLocationCoordinate2D` of the prior, current and upcoming step geometry.
-     */
-    @objc public var nearbyCoordinates: [CLLocationCoordinate2D] {
-        let priorCoords = priorStep?.coordinates ?? []
-        let upcomingCoords = upcomingStep?.coordinates ?? []
-        let currentCoords = currentStep.coordinates ?? []
-        let nearby = priorCoords + currentCoords + upcomingCoords
-        assert(!nearby.isEmpty, "Step must have coordinates")
-        return nearby
     }
 
     typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -414,6 +414,20 @@ open class RouteLegProgress: NSObject {
         currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
     }
 
+    /**
+     Returns an array of `CLLocationCoordinate2D` of the prior, current and upcoming step geometry.
+     */
+    
+    @available(*, deprecated: 0.1, message: "Use RouteProgress.nearbyCoordinates")
+    @objc public var nearbyCoordinates: [CLLocationCoordinate2D] {
+        let priorCoords = priorStep?.coordinates ?? []
+        let upcomingCoords = upcomingStep?.coordinates ?? []
+        let currentCoords = currentStep.coordinates ?? []
+        let nearby = priorCoords + currentCoords + upcomingCoords
+        assert(!nearby.isEmpty, "Step must have coordinates")
+        return nearby
+    }
+
     typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)
 
     func closestStep(to coordinate: CLLocationCoordinate2D) -> StepIndexDistance? {

--- a/MapboxCoreNavigationTests/LocationTests.swift
+++ b/MapboxCoreNavigationTests/LocationTests.swift
@@ -6,7 +6,7 @@ class LocationTests: XCTestCase {
     
     var setup: (progress: RouteProgress, firstLocation: CLLocation) {
         let progress = RouteProgress(route: route)
-        let firstCoord = progress.currentLegProgress.nearbyCoordinates.first!
+        let firstCoord = progress.nearbyCoordinates.first!
         let firstLocation = CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
         
         return (progress, firstLocation)

--- a/MapboxCoreNavigationTests/LocationTests.swift
+++ b/MapboxCoreNavigationTests/LocationTests.swift
@@ -47,7 +47,7 @@ class LocationTests: XCTestCase {
         let initialHeadingOnFirstStep = progress.currentLegProgress.currentStep.finalHeading!
         let coordinateAlongFirstStep = firstLocation.coordinate.coordinate(at: 100, facing: initialHeadingOnFirstStep)
         let locationAlongFirstStep = CLLocation(latitude: coordinateAlongFirstStep.latitude, longitude: coordinateAlongFirstStep.longitude)
-        guard let snapped = locationAlongFirstStep.snapped(to: progress.currentLegProgress) else {
+        guard let snapped = locationAlongFirstStep.snapped(to: progress) else {
             return XCTFail("Location should have snapped to route")
         }
         

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -26,7 +26,7 @@ class NavigationServiceTests: XCTestCase {
 
         let legProgress: RouteLegProgress = navigationService.router.routeProgress.currentLegProgress
 
-        let firstCoord = legProgress.nearbyCoordinates.first!
+        let firstCoord = navigationService.router.routeProgress.nearbyCoordinates.first!
         let firstLocation = CLLocation(coordinate: firstCoord, altitude: 5, horizontalAccuracy: 10, verticalAccuracy: 5, course: 20, speed: 4, timestamp: Date())
 
         let remainingStepCount = legProgress.remainingSteps.count
@@ -163,7 +163,7 @@ class NavigationServiceTests: XCTestCase {
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertEqual(navigation.router.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
 
-        let futureCoord = Polyline(navigation.router.routeProgress.currentLegProgress.nearbyCoordinates).coordinateFromStart(distance: 100)!
+        let futureCoord = Polyline(navigation.router.routeProgress.nearbyCoordinates).coordinateFromStart(distance: 100)!
         let futureInaccurateLocation = CLLocation(coordinate: futureCoord, altitude: 0, horizontalAccuracy: 1, verticalAccuracy: 200, course: 0, speed: 5, timestamp: Date())
 
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [futureInaccurateLocation])
@@ -181,9 +181,9 @@ class NavigationServiceTests: XCTestCase {
         route.accessToken = "foo"
         let navigation = MapboxNavigationService(route: route, directions: directions)
         let router = navigation.router!
-        let firstCoord = router.routeProgress.currentLegProgress.nearbyCoordinates.first!
+        let firstCoord = router.routeProgress.nearbyCoordinates.first!
         let firstLocation = CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
-        let coordNearStart = Polyline(router.routeProgress.currentLegProgress.nearbyCoordinates).coordinateFromStart(distance: 10)!
+        let coordNearStart = Polyline(router.routeProgress.nearbyCoordinates).coordinateFromStart(distance: 10)!
 
         navigation.locationManager(navigation.locationManager, didUpdateLocations: [firstLocation])
 
@@ -196,7 +196,7 @@ class NavigationServiceTests: XCTestCase {
 
         // The course should not be the interpolated course, rather the raw course.
         XCTAssertEqual(directionToStart, router.location!.course, "The course should be the raw course and not an interpolated course")
-        XCTAssertFalse(facingTowardsStartLocation.shouldSnap(toRouteWith: facingTowardsStartLocation.interpolatedCourse(along: router.routeProgress.currentLegProgress.nearbyCoordinates)!, distanceToFirstCoordinateOnLeg: facingTowardsStartLocation.distance(from: firstLocation)), "Should not snap")
+        XCTAssertFalse(facingTowardsStartLocation.shouldSnap(toRouteWith: facingTowardsStartLocation.interpolatedCourse(along: router.routeProgress.nearbyCoordinates)!, distanceToFirstCoordinateOnLeg: facingTowardsStartLocation.distance(from: firstLocation)), "Should not snap")
     }
 
     //TODO: Broken by PortableRoutecontroller & MBNavigator -- needs team discussion.

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -124,7 +124,7 @@ class NavigationServiceTests: XCTestCase {
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertEqual(navigation.router.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
         
-        let firstCoordinateOnUpcomingStep = navigation.router.routeProgress.currentLegProgress.upComingStep!.coordinates!.first!
+        let firstCoordinateOnUpcomingStep = navigation.router.routeProgress.currentLegProgress.upcomingStep!.coordinates!.first!
         let firstLocationOnNextStepWithNoSpeed = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, course: 10, speed: 0, timestamp: Date())
         
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithNoSpeed])
@@ -144,9 +144,9 @@ class NavigationServiceTests: XCTestCase {
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [firstLocation])
         XCTAssertEqual(navigation.router.location!.coordinate, firstLocation.coordinate, "Check snapped location is working")
         
-        let firstCoordinateOnUpcomingStep = navigation.router.routeProgress.currentLegProgress.upComingStep!.coordinates!.first!
+        let firstCoordinateOnUpcomingStep = navigation.router.routeProgress.currentLegProgress.upcomingStep!.coordinates!.first!
         
-        let finalHeading = navigation.router.routeProgress.currentLegProgress.upComingStep!.finalHeading!
+        let finalHeading = navigation.router.routeProgress.currentLegProgress.upcomingStep!.finalHeading!
         let firstLocationOnNextStepWithDifferentCourse = CLLocation(coordinate: firstCoordinateOnUpcomingStep, altitude: 0, horizontalAccuracy: 30, verticalAccuracy: 10, course: -finalHeading, speed: 5, timestamp: Date())
         
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [firstLocationOnNextStepWithDifferentCourse])

--- a/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -20,7 +20,7 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.fractionTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.stepIndex, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.followOnStep?.description, "Turn left onto Gough Street")
-        XCTAssertEqual(routeProgress.currentLegProgress.upComingStep?.description, "Turn right onto Sacramento Street")
+        XCTAssertEqual(routeProgress.currentLegProgress.upcomingStep?.description, "Turn right onto Sacramento Street")
     }
     
     func testRouteStepProgress() {

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -351,7 +351,7 @@ public class CarPlayNavigationViewController: UIViewController {
                 tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]
             }
             
-            if let upcomingStep = navService.routeProgress.currentLegProgress.upComingStep {
+            if let upcomingStep = navService.routeProgress.currentLegProgress.upcomingStep {
                 let distance = distanceFormatter.measurement(of: upcomingStep.distance)
                 tertiaryManeuver.initialTravelEstimates = CPTravelEstimates(distanceRemaining: distance, timeRemaining: upcomingStep.expectedTravelTime)
             }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -289,7 +289,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
         if UIDevice.current.isPluggedIn {
             preferredFramesPerSecond = FrameIntervalOptions.pluggedInFramesPerSecond
-        } else if let upcomingStep = routeProgress.currentLegProgress.upComingStep,
+        } else if let upcomingStep = routeProgress.currentLegProgress.upcomingStep,
             upcomingStep.maneuverDirection == .straightAhead || upcomingStep.maneuverDirection == .slightLeft || upcomingStep.maneuverDirection == .slightRight {
             preferredFramesPerSecond = shouldPositionCourseViewFrameByFrame ? FrameIntervalOptions.defaultFramesPerSecond : minimumFramesPerSecond
         } else if durationUntilNextManeuver > FrameIntervalOptions.durationUntilNextManeuver &&

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -385,7 +385,7 @@ class RouteMapViewController: UIViewController {
         let defaultAltitude = mapView.defaultAltitude
         let isLongRoad = routeProgress.distanceRemaining >= mapView.longManeuverDistance
         let currentStep = routeProgress.currentLegProgress.currentStep
-        let upComingStep = routeProgress.currentLegProgress.upComingStep
+        let upComingStep = routeProgress.currentLegProgress.upcomingStep
 
         //If the user is at the last turn maneuver, the map should zoom in to the default altitude.
         let currentInstruction = routeProgress.currentLegProgress.currentStepProgress.currentSpokenInstruction
@@ -935,7 +935,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         guard let stepIndex = leg.steps.index(of: step) else { return }
         
         let legProgress = RouteLegProgress(leg: leg, stepIndex: stepIndex)
-        guard let upcomingStep = legProgress.upComingStep else { return }
+        guard let upcomingStep = legProgress.upcomingStep else { return }
         addPreviewInstructions(step: legProgress.currentStep, maneuverStep: upcomingStep, distance: instructionsBannerView.distance)
         
         mapView.enableFrameByFrameCourseViewTracking(for: 1)
@@ -973,7 +973,7 @@ extension RouteMapViewController: StepsViewControllerDelegate {
         
         let legProgress = RouteLegProgress(leg: router.route.legs[legIndex], stepIndex: stepIndex)
         let step = legProgress.currentStep
-        guard let upcomingStep = legProgress.upComingStep else { return }
+        guard let upcomingStep = legProgress.upcomingStep else { return }
 
         currentPreviewInstructionBannerStepIndex = router.routeProgress.remainingSteps.index(of: step)
         

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -31,7 +31,7 @@ extension SpokenInstruction {
     @available(iOS 10.0, *)
     func attributedText(for legProgress: RouteLegProgress) -> NSAttributedString {
         let attributedText = NSMutableAttributedString(string: text)
-        if let step = legProgress.upComingStep,
+        if let step = legProgress.upcomingStep,
             let name = step.names?.first,
             let phoneticName = step.phoneticNames?.first {
             let nameRange = attributedText.mutableString.range(of: name)

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -25,7 +25,7 @@ class NavigationViewControllerTests: XCTestCase {
         
         let navigationService = navigationViewController.navigationService!
         let router = navigationService.router!
-        let firstCoord      = router.routeProgress.currentLegProgress.nearbyCoordinates.first!
+        let firstCoord      = router.routeProgress.nearbyCoordinates.first!
         let firstLocation   = location(at: firstCoord)
         
         var poi = [CLLocation]()

--- a/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -22,7 +22,7 @@ class StepsViewControllerTests: XCTestCase {
         
         let stepsViewController = StepsViewController(routeProgress: routeController.routeProgress)
         
-        let firstCoord = routeController.routeProgress.currentLegProgress.nearbyCoordinates.first!
+        let firstCoord = routeController.routeProgress.nearbyCoordinates.first!
         let firstLocation = CLLocation(coordinate: firstCoord, altitude: 5, horizontalAccuracy: 10, verticalAccuracy: 5, course: 20, speed: 4, timestamp: Date())
         
         let lastCoord = routeController.routeProgress.currentLegProgress.remainingSteps.last!.coordinates!.first!


### PR DESCRIPTION
Fixes #1879. Allows for look-behind when you're on the first step of a leg, and look-ahead when you're on the last step.

/cc @mapbox/navigation-ios 