### PR TITLE
Incrementing navigator index for multi-leg routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 
 ### Other changes
 
-* This release includes a possible fix for spurious rerouting when passing an intermediate waypoint. ([#1869](https://github.com/mapbox/mapbox-navigation-ios/pull/1869))
 * The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
+* Fixing issue where the native-navigator may not declare off-route status for subsequent legs of a multi-leg route. 
 
 ## v0.25.0 (November 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Other changes
 
 * The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
-* Fixing issue where the native-navigator may not declare off-route status for subsequent legs of a multi-leg route. 
+* Fixing issue where the native-navigator may not declare off-route status for subsequent legs of a multi-leg route. ([#1884](https://github.com/mapbox/mapbox-navigation-ios/pull/1884))
 
 ## v0.25.0 (November 22, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Other changes
 
 * The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
-* Fixing issue where the native-navigator may not declare off-route status for subsequent legs of a multi-leg route. ([#1884](https://github.com/mapbox/mapbox-navigation-ios/pull/1884))
+* Fixed spurious rerouting on multi-leg routes. ([#1884](https://github.com/mapbox/mapbox-navigation-ios/pull/1884))
 
 ## v0.25.0 (November 22, 2018)
 

--- a/MapboxCoreNavigation/PortableRouteController.swift
+++ b/MapboxCoreNavigation/PortableRouteController.swift
@@ -67,6 +67,22 @@ open class PortableRouteController: RouteController {
         return !offRoute
     }
     
+    /**
+     Advances the leg index. This override also advances the leg index of the native navigator.
+     
+     This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
+     */
+    override public func advanceLegIndex(location: CLLocation) {
+        super.advanceLegIndex(location: location)
+        
+        let status = navigator.getStatusForTimestamp(location.timestamp)
+        let legIndex = status.legIndex
+        let routeIndex = status.routeIndex
+
+        //The first route is the active one in the navigator.
+        navigator.changeRouteLeg(forRoute: routeIndex, leg: legIndex + 1)
+    }
+    
     public func enableLocationRecording() {
         navigator.toggleHistoryFor(onOff: true)
     }

--- a/MapboxCoreNavigation/PortableRouteController.swift
+++ b/MapboxCoreNavigation/PortableRouteController.swift
@@ -73,6 +73,8 @@ open class PortableRouteController: RouteController {
      This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
      */
     override public func advanceLegIndex(location: CLLocation) {
+        precondition(!routeProgress.isFinalLeg, "Can not increment leg index beyond final leg.")
+        
         super.advanceLegIndex(location: location)
         
         let status = navigator.getStatusForTimestamp(location.timestamp)

--- a/MapboxCoreNavigation/PortableRouteController.swift
+++ b/MapboxCoreNavigation/PortableRouteController.swift
@@ -82,7 +82,7 @@ open class PortableRouteController: RouteController {
         let routeIndex = status.routeIndex
 
         //The first route is the active one in the navigator.
-        navigator.changeRouteLeg(forRoute: routeIndex, leg: legIndex + 1)
+        navigator.changeRouteLeg(forRoute: routeIndex, leg: routeProgress.legIndex)
     }
     
     public func enableLocationRecording() {

--- a/MapboxCoreNavigation/PortableRouteController.swift
+++ b/MapboxCoreNavigation/PortableRouteController.swift
@@ -73,16 +73,13 @@ open class PortableRouteController: RouteController {
      This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
      */
     override public func advanceLegIndex(location: CLLocation) {
-        precondition(!routeProgress.isFinalLeg, "Can not increment leg index beyond final leg.")
-        
         super.advanceLegIndex(location: location)
         
         let status = navigator.getStatusForTimestamp(location.timestamp)
-        let legIndex = status.legIndex
         let routeIndex = status.routeIndex
 
         //The first route is the active one in the navigator.
-        navigator.changeRouteLeg(forRoute: routeIndex, leg: routeProgress.legIndex)
+        navigator.changeRouteLeg(forRoute: routeIndex, leg: UInt32(routeProgress.legIndex))
     }
     
     public func enableLocationRecording() {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -289,6 +289,7 @@ open class RouteController: NSObject, Router {
      This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
      */
     public func advanceLegIndex(location: CLLocation) {
+        precondition(!routeProgress.isFinalLeg, "Can not increment leg index beyond final leg.")
         routeProgress.legIndex += 1
     }
     

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -288,6 +288,7 @@ open class RouteController: NSObject, Router {
      
      This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
      */
+    @objc(advanceLegIndexWithLocation:)
     public func advanceLegIndex(location: CLLocation) {
         precondition(!routeProgress.isFinalLeg, "Can not increment leg index beyond final leg.")
         routeProgress.legIndex += 1

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -282,6 +282,16 @@ open class RouteController: NSObject, Router {
         let isCloseToCurrentStep = location.isWithin(radius, of: routeProgress.currentLegProgress.currentStep)
         return isCloseToCurrentStep
     }
+    
+    /**
+     Advances the leg index.
+     
+     This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
+     */
+    public func advanceLegIndex(location: CLLocation) {
+        routeProgress.legIndex += 1
+    }
+    
 }
 
 extension RouteController: CLLocationManagerDelegate {
@@ -411,7 +421,7 @@ extension RouteController: CLLocationManagerDelegate {
                 let advancesToNextLeg = delegate?.router?(self, didArriveAt: currentDestination) ?? DefaultBehavior.didArriveAtWaypoint
                 
                 guard !routeProgress.isFinalLeg && advancesToNextLeg else { return }
-                routeProgress.legIndex += 1
+                advanceLegIndex(location: location)
                 updateDistanceToManeuver()
                 
             } else { //we are approaching the destination
@@ -419,6 +429,8 @@ extension RouteController: CLLocationManagerDelegate {
             }
         }
     }
+    
+
     
     func checkForFasterRoute(from location: CLLocation) {
         guard let currentUpcomingManeuver = routeProgress.currentLegProgress.upComingStep else {

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -21,6 +21,8 @@ public protocol RouterDataSource {
     @objc func reroute(from: CLLocation, along: RouteProgress)
     @objc var location: CLLocation? { get }
     
+    @objc func advanceLegIndex(location: CLLocation)
+    
     @objc optional func enableLocationRecording()
     @objc optional func disableLocationRecording()
     @objc optional func locationHistory() -> String


### PR DESCRIPTION
Fixes #1878, where the navigator can get out-of-sync with the route controller when navigating multi-leg routes. This could potentially cause a situation where the navigator always reports you as on-route for any leg other than the first.

/cc @mapbox/navigation-ios 