### PR TITLE
Show lane guidance in CarPlay guidance panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Search functionality on CarPlay is now managed by `CarPlaySearchController`. Added the `CarPlayManagerDelegate.carPlayManager(_:selectedPreviewFor:using:)` method for any additional customization after a trip is selected on CarPlay. ([#1846](https://github.com/mapbox/mapbox-navigation-ios/pull/1846))
+* The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
 * Added the `NavigationViewController.showEndOfRouteFeedback(duration:completionHandler:)` method for showing the end-of-route feedback UI after manually ending a navigation session. ([#1932](https://github.com/mapbox/mapbox-navigation-ios/pull/1932))
 * Fixed an issue where setting `Router.route` did not update `SimulatedLocationManager.route`. ([#1928](https://github.com/mapbox/mapbox-navigation-ios/pull/1928))
 * Programmatically setting `Router.route` no longer causes `NavigationViewControllerDelegate.navigationViewController(_:shouldRerouteFrom:)` or `RouterDelegate.router(_:shouldRerouteFrom:)` to be called. ([#1931](https://github.com/mapbox/mapbox-navigation-ios/pull/1931))

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -624,7 +624,13 @@ extension CarPlayManager: CPMapTemplateDelegate {
         let shiftedCenterCoordinate = mapView.centerCoordinate.coordinate(at: distance, facing: shiftedDirection)
         mapView.setCenter(shiftedCenterCoordinate, animated: true)
     }
-
+    
+    public func mapTemplate(_ mapTemplate: CPMapTemplate, displayStyleFor maneuver: CPManeuver) -> CPManeuverDisplayStyle {
+        if let visualInstruction = maneuver.userInfo as? VisualInstruction, visualInstruction.containsLaneIndications {
+            return .symbolOnly
+        }
+        return []
+    }
 }
 
 // MARK: CarPlayNavigationDelegate

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -337,23 +337,30 @@ public class CarPlayNavigationViewController: UIViewController {
         
         var maneuvers: [CPManeuver] = [primaryManeuver]
         
-        // Add tertiary text if available. TODO: handle lanes.
-        if let tertiaryInstruction = visualInstruction.tertiaryInstruction, !tertiaryInstruction.containsLaneIndications {
+        if let tertiaryInstruction = visualInstruction.tertiaryInstruction {
             let tertiaryManeuver = CPManeuver()
-            tertiaryManeuver.symbolSet = tertiaryInstruction.maneuverImageSet(side: visualInstruction.drivingSide)
-            
-            if let text = tertiaryInstruction.text {
-                tertiaryManeuver.instructionVariants = [text]
-            }
-            if let attributedTertiary = tertiaryInstruction.carPlayManeuverLabelAttributedText(bounds: bounds, shieldHeight: shieldHeight, window: carPlayManager.carWindow) {
-                let attributedTertiary = NSMutableAttributedString(attributedString: attributedTertiary)
-                attributedTertiary.canonicalizeAttachments(maximumImageSize: maximumImageSize, imageRendererFormat: imageRendererFormat)
-                tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]
-            }
-            
-            if let upcomingStep = navService.routeProgress.currentLegProgress.upcomingStep {
-                let distance = distanceFormatter.measurement(of: upcomingStep.distance)
-                tertiaryManeuver.initialTravelEstimates = CPTravelEstimates(distanceRemaining: distance, timeRemaining: upcomingStep.expectedTravelTime)
+            if tertiaryInstruction.containsLaneIndications {
+                // Add lanes if available.
+                tertiaryManeuver.userInfo = tertiaryInstruction
+                let symbolSize = bounds().intersection(CGRect(x: 0, y: 0, width: 120, height: 18)).size
+                tertiaryManeuver.symbolSet = visualInstruction.lanesImageSet(size: symbolSize, window: carPlayManager.carWindow)
+            } else {
+                // Add tertiary text if available.
+                tertiaryManeuver.symbolSet = tertiaryInstruction.maneuverImageSet(side: visualInstruction.drivingSide)
+                
+                if let text = tertiaryInstruction.text {
+                    tertiaryManeuver.instructionVariants = [text]
+                }
+                if let attributedTertiary = tertiaryInstruction.carPlayManeuverLabelAttributedText(bounds: bounds, shieldHeight: shieldHeight, window: carPlayManager.carWindow) {
+                    let attributedTertiary = NSMutableAttributedString(attributedString: attributedTertiary)
+                    attributedTertiary.canonicalizeAttachments(maximumImageSize: maximumImageSize, imageRendererFormat: imageRendererFormat)
+                    tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]
+                }
+                
+                if let upcomingStep = navService.routeProgress.currentLegProgress.upcomingStep {
+                    let distance = distanceFormatter.measurement(of: upcomingStep.distance)
+                    tertiaryManeuver.initialTravelEstimates = CPTravelEstimates(distanceRemaining: distance, timeRemaining: upcomingStep.expectedTravelTime)
+                }
             }
             
             maneuvers.append(tertiaryManeuver)

--- a/MapboxNavigation/UIView.swift
+++ b/MapboxNavigation/UIView.swift
@@ -139,7 +139,7 @@ extension UIView {
     
     var imageRepresentation: UIImage? {
         let size = CGSize(width: frame.size.width, height: frame.size.height)
-        UIGraphicsBeginImageContextWithOptions(size, false, UIScreen.main.scale)
+        UIGraphicsBeginImageContextWithOptions(size, false, (window?.screen ?? UIScreen.main).scale)
         guard let currentContext = UIGraphicsGetCurrentContext() else { return nil }
         layer.render(in:currentContext)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/MapboxNavigation/UIView.swift
+++ b/MapboxNavigation/UIView.swift
@@ -141,7 +141,7 @@ extension UIView {
         let size = CGSize(width: frame.size.width, height: frame.size.height)
         UIGraphicsBeginImageContextWithOptions(size, false, (window?.screen ?? UIScreen.main).scale)
         guard let currentContext = UIGraphicsGetCurrentContext() else { return nil }
-        layer.render(in:currentContext)
+        layer.render(in: currentContext)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return image

--- a/MapboxNavigation/VisualInstruction.swift
+++ b/MapboxNavigation/VisualInstruction.swift
@@ -10,6 +10,7 @@ extension VisualInstructionBanner {
         let colors: [UIColor] = [.black, .white]
         let blackAndWhiteLaneIcons: [UIImage] = colors.compactMap { (color) in
             let lanesView = LanesView(frame: CGRect(origin: .zero, size: size))
+            lanesView.widthAnchor.constraint(equalToConstant: size.width).isActive = true
             
             // Temporarily add the view to the view hierarchy for UIAppearance to work its magic.
             if let carWindow = window {
@@ -19,6 +20,9 @@ extension VisualInstructionBanner {
             } else {
                 lanesView.update(for: self)
             }
+            
+            lanesView.show(animated: false)
+            lanesView.layoutIfNeeded()
             
             lanesView.backgroundColor = .clear
             return lanesView.imageRepresentation

--- a/MapboxNavigation/VisualInstruction.swift
+++ b/MapboxNavigation/VisualInstruction.swift
@@ -3,6 +3,32 @@ import MapboxDirections
 import CarPlay
 #endif
 
+extension VisualInstructionBanner {
+    #if canImport(CarPlay)
+    @available(iOS 12.0, *)
+    public func lanesImageSet(size: CGSize, window: UIWindow?) -> CPImageSet? {
+        let colors: [UIColor] = [.black, .white]
+        let blackAndWhiteLaneIcons: [UIImage] = colors.compactMap { (color) in
+            let lanesView = LanesView(frame: CGRect(origin: .zero, size: size))
+            
+            // Temporarily add the view to the view hierarchy for UIAppearance to work its magic.
+            if let carWindow = window {
+                carWindow.addSubview(lanesView)
+                lanesView.update(for: self)
+                lanesView.removeFromSuperview()
+            } else {
+                lanesView.update(for: self)
+            }
+            
+            lanesView.backgroundColor = .clear
+            return lanesView.imageRepresentation
+        }
+        guard blackAndWhiteLaneIcons.count == 2 else { return nil }
+        return CPImageSet(lightContentImage: blackAndWhiteLaneIcons[1], darkContentImage: blackAndWhiteLaneIcons[0])
+    }
+    #endif
+}
+
 extension VisualInstruction {
     
     /// Returns true if `VisualInstruction.components` contains any `LaneIndicationComponent`.


### PR DESCRIPTION
CarPlayNavigationViewController now snapshots a LanesView for display in the CarPlay guidance panel. The layout needs work: currently all the LaneViews are smooshed up against the upper-left corner of the LanesView, and they’re shown at full scale but cropped.

![lanes](https://user-images.githubusercontent.com/1231218/49503576-a711a100-f82c-11e8-86e1-856cc9761b18.png)

LanesView is the right size, but the stack view inside it seems to be missing constraints:

<img width="120" alt="lanesview" src="https://user-images.githubusercontent.com/1231218/49504320-42efdc80-f82e-11e8-89c6-944d68c56c6d.png">

Additionally, LaneView will need to be modified to accept alternative dimensions for the arrows.

Fixes #1858.

/cc @JThramer @frederoni