### PR TITLE
Fix infinite recursion when failing to download shield image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * The `NavigationSettings.shared` property is now accessible in Objective-C code as `MBNavigationSettings.sharedSettings`. ([#1882](https://github.com/mapbox/mapbox-navigation-ios/pull/1882))
 * Fixed spurious rerouting on multi-leg routes. ([#1884](https://github.com/mapbox/mapbox-navigation-ios/pull/1884))
+* Fixed a hang that occurred when failing to fetch a route shield image for display in a visual instruction banner. ([#1888](https://github.com/mapbox/mapbox-navigation-ios/pull/1888))
 * Adding property `RouteController.nearbyCoordinates`, which offers similar behavior to `RouteLegProgress.nearbyCoordinates`, which the addition of step lookahead/lookbehind in multi-leg routes. ([#1883](https://github.com/mapbox/mapbox-navigation-ios/pull/1883))
 
 ## v0.25.0 (November 22, 2018)

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -237,6 +237,7 @@ class InstructionPresenter {
     }
     
     private func completeShieldDownload(_ image: UIImage?) {
+        guard image != nil else { return }
         //We *must* be on main thread here, because attributedText() looks at object properties only accessible on main thread.
         DispatchQueue.main.async {
             self.onShieldDownload?(self.attributedText()) //FIXME: Can we work with the image directly?


### PR DESCRIPTION
If there’s no image after the shield downloading operation completes, then there’s no reason to regenerate the attributed text that would embed that image. Bailing instead of regenerating the attributed text heads off infinite recursion that results whenever the shield image URL can’t be reached for some reason, such as the situation described in mapbox/MapboxDirections.swift#322.

Fixes #1887.

/cc @mapbox/navigation-ios @kevinkreiser