### PR TITLE
Expose offline routing functionality to Obj-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* The `NavigationDirections.unpackTilePack(at:outputDirectoryURL:progressHandler:completionHandler:)` method is now available to Objective-C code as `-[MBNavigationDirections unpackTilePackAtURL:outputDirectoryURL:progressHandler:completionHandler:]`. ([#1891](https://github.com/mapbox/mapbox-navigation-ios/pull/1891))
+
 ## v0.26.0
 
 ### Client-side routing

--- a/MapboxCoreNavigation/OfflineDirections.swift
+++ b/MapboxCoreNavigation/OfflineDirections.swift
@@ -56,7 +56,7 @@ public typealias UnpackCompletionHandler = (_ numberOfTiles: UInt64, _ error: Er
 @objc(MBNavigationDirections)
 public class NavigationDirections: Directions {
     
-    public override init(accessToken: String? = nil, host: String? = nil) {
+    @objc public override init(accessToken: String? = nil, host: String? = nil) {
         super.init(accessToken: accessToken, host: host)
     }
     
@@ -67,7 +67,7 @@ public class NavigationDirections: Directions {
      - parameter translationsURL: The location where the translations has been downloaded to.
      - parameter completionHandler: A block that is called when the router is completely configured.
      */
-    public func configureRouter(tilesURL: URL, translationsURL: URL? = nil, completionHandler: @escaping NavigationDirectionsCompletionHandler) {
+    @objc public func configureRouter(tilesURL: URL, translationsURL: URL? = nil, completionHandler: @escaping NavigationDirectionsCompletionHandler) {
         
         NavigationDirectionsConstants.offlineSerialQueue.sync {
             // Translations files bundled within navigation native
@@ -89,7 +89,7 @@ public class NavigationDirections: Directions {
      - parameter progressHandler: Unpacking reports progress every 500ms.
      - parameter completionHandler: Called when unpacking completed.
      */
-    public class func unpackTilePack(at filePathURL: URL, outputDirectoryURL: URL, progressHandler: UnpackProgressHandler?, completionHandler: UnpackCompletionHandler?) {
+    @objc public class func unpackTilePack(at filePathURL: URL, outputDirectoryURL: URL, progressHandler: UnpackProgressHandler?, completionHandler: UnpackCompletionHandler?) {
         
         NavigationDirectionsConstants.offlineSerialQueue.sync {
             
@@ -134,6 +134,7 @@ public class NavigationDirections: Directions {
      - parameter offline: Determines whether to calculate the route offline or online.
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
      */
+    @objc(calculateDirectionsWithOptions:offline:completionHandler:)
     public func calculate(_ options: RouteOptions, offline: Bool = true, completionHandler: @escaping Directions.RouteCompletionHandler) {
         
         guard offline == true else {

--- a/MapboxCoreNavigation/OfflineDirections.swift
+++ b/MapboxCoreNavigation/OfflineDirections.swift
@@ -89,7 +89,8 @@ public class NavigationDirections: Directions {
      - parameter progressHandler: Unpacking reports progress every 500ms.
      - parameter completionHandler: Called when unpacking completed.
      */
-    @objc public class func unpackTilePack(at filePathURL: URL, outputDirectoryURL: URL, progressHandler: UnpackProgressHandler?, completionHandler: UnpackCompletionHandler?) {
+    @objc(unpackTilePackAtURL:outputDirectoryURL:progressHandler:completionHandler:)
+    public class func unpackTilePack(at filePathURL: URL, outputDirectoryURL: URL, progressHandler: UnpackProgressHandler?, completionHandler: UnpackCompletionHandler?) {
         
         NavigationDirectionsConstants.offlineSerialQueue.sync {
             

--- a/MapboxCoreNavigationTests/BridgingTests.m
+++ b/MapboxCoreNavigationTests/BridgingTests.m
@@ -57,7 +57,7 @@
             
             NSURL *outputDirectoryURL = [[NSBundle mapboxCoreNavigation] suggestedTileURLWithVersion:versions.firstObject];
             
-            [MBNavigationDirections unpackTilePackAt:url outputDirectoryURL:outputDirectoryURL progressHandler:^(uint64_t totalBytes, uint64_t bytesRemaining) {
+            [MBNavigationDirections unpackTilePackAtURL:url outputDirectoryURL:outputDirectoryURL progressHandler:^(uint64_t totalBytes, uint64_t bytesRemaining) {
                 // Show unpacking progress
             } completionHandler:^(uint64_t numberOfTiles, NSError * _Nullable error) {
                 // Dismiss UI

--- a/MapboxCoreNavigationTests/BridgingTests.m
+++ b/MapboxCoreNavigationTests/BridgingTests.m
@@ -4,6 +4,7 @@
 @import MapboxCoreNavigation;
 @import MapboxDirections;
 @import TestHelper;
+@import MapKit;
 
 @interface BridgingTests : XCTestCase
 @property (nonatomic) MBRouteController *routeController;
@@ -40,6 +41,43 @@
     
     _routeController.routeProgress = [[MBRouteProgress alloc] initWithRoute:route legIndex:0 spokenInstructionIndex:0];
     [self waitForExpectations:@[expectation] timeout:5];
+}
+
+// This test is excluded from the test suite. We are just verifying that offline routing bridges to Obj-C at compile time.
+- (void)testOfflineRouting {
+    [[[MBDirections sharedDirections] fetchAvailableOfflineVersionsWithCompletionHandler:^(NSArray<NSString *> * _Nullable versions, NSError * _Nullable error) {
+        
+        NSArray <NSValue *> *coordinates = nil;
+        coordinates = @[[NSValue valueWithMKCoordinate:CLLocationCoordinate2DMake(0, 0)],
+                        [NSValue valueWithMKCoordinate:CLLocationCoordinate2DMake(1, 1)]];
+        
+        MBCoordinateBounds *bounds = [[MBCoordinateBounds alloc] init:coordinates];
+        
+        [[[MBDirections sharedDirections] downloadTilesIn:bounds version:versions.firstObject session:nil completionHandler:^(NSURL * _Nullable url, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+            
+            NSURL *outputDirectoryURL = [[NSBundle mapboxCoreNavigation] suggestedTileURLWithVersion:versions.firstObject];
+            
+            [MBNavigationDirections unpackTilePackAt:url outputDirectoryURL:outputDirectoryURL progressHandler:^(uint64_t totalBytes, uint64_t bytesRemaining) {
+                // Show unpacking progress
+            } completionHandler:^(uint64_t numberOfTiles, NSError * _Nullable error) {
+                // Dismiss UI
+            }];
+            
+        }] resume];
+    }] resume];
+    
+    MBNavigationRouteOptions *options = [[MBNavigationRouteOptions alloc] initWithLocations:@[] profileIdentifier:MBDirectionsProfileIdentifierCycling];
+    
+    MBNavigationDirections *directions = nil;
+    
+    [directions calculateDirectionsWithOptions:options offline:YES completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error) {
+        
+    }];
+    
+    NSURL *url = [NSURL URLWithString:@""];
+    [directions configureRouterWithTilesURL:url translationsURL:url completionHandler:^(uint64_t numberOfTiles) {
+        
+    }];
 }
     
 @end

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
@@ -49,6 +49,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "BridgingTests/testOfflineRouting">
+               </Test>
+               <Test
                   Identifier = "MapboxNavigationTests/testLowAlert()">
                </Test>
             </SkippedTests>


### PR DESCRIPTION
Tail work from https://github.com/mapbox/mapbox-navigation-ios/pull/1808 , offline routing now bridges to Obj-C.

cc @1ec5 @JThramer 
