### PR TITLE
Update the offline tile downloading example

### DIFF
--- a/Example/Base.lproj/Localizable.strings
+++ b/Example/Base.lproj/Localizable.strings
@@ -4,14 +4,29 @@
 /* Title of button that downloads an offline region */
 "OFFLINE_ITEM_DOWNLOAD" = "Download";
 
+/* Message to display when the user needs to obtain an enterprise token */
+"OFFLINE_MESSAGE_ENTERPRISE_TOKEN_NEEDED" = "Before you can fetch routing tiles you must obtain an enterprise access token. Please contact us at support@mapbox.com";
+
+/* Message to display when the user needs to select a smaller bounding box */
+"OFFLINE_MESSAGE_USE_SMALLER_BOUNDING_BOX" = "The bounding box you have specified is too large. Please select a smaller box and try again.";
+
+/* Error message to display when no routing tile versions are available */
+"OFFLINE_MESSAGE_VERSION_FETCHING_FAILED" = "No routing tile versions are available for download. Please try again later.";
+
 /* Status item while downloading an offline region */
 "OFFLINE_TITLE_DOWNLOADING_TILES" = "Downloading Tiles…";
 
 /* Status item while downloading an offline region */
 "OFFLINE_TITLE_FETCHING_VERSIONS" = "Fetching Versions…";
 
+/* Title to display when tile downloading fails */
+"OFFLINE_TITLE_TILE_DOWNLOAD_FAILED" = "Unable to fetch tiles";
+
 /* Status item while downloading an offline region; 1 = percentage complete */
 "OFFLINE_TITLE_UNPACKING_FMT" = "Unpacking… (%@)";
+
+/* Error title to display when no routing tile versions are available */
+"OFFLINE_TITLE_VERSION_FETCHING_FAILED" = "Unable to fetch available routing tile versions";
 
 /* Title of action for dismissing waypoint removal confirmation sheet */
 "REMOVE_WAYPOINT_CONFIRM_CANCEL" = "Cancel";

--- a/Example/OfflineViewController.swift
+++ b/Example/OfflineViewController.swift
@@ -3,7 +3,7 @@ import Mapbox
 import MapboxDirections
 import MapboxCoreNavigation
 
-class OfflineViewController: UIViewController {
+class OfflineViewController: UIViewController, MGLMapViewDelegate {
     
     var mapView: MGLMapView!
     var resizableView: ResizableView!
@@ -13,6 +13,8 @@ class OfflineViewController: UIViewController {
         super.viewDidLoad()
         
         mapView = MGLMapView(frame: view.bounds)
+        mapView.delegate = self
+
         view.addSubview(mapView)
         
         backgroundLayer.frame = view.bounds
@@ -26,27 +28,69 @@ class OfflineViewController: UIViewController {
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("OFFLINE_ITEM_DOWNLOAD", value: "Download", comment: "Title of button that downloads an offline region"), style: .done, target: self, action: #selector(downloadRegion))
     }
+
+    func mapViewDidFinishLoadingMap(_ mapView: MGLMapView) {
+        mapView.setUserTrackingMode(.follow, animated: false)
+        mapView.setZoomLevel(8, animated: false)
+    }
+    
+    func disableUserInterface() {
+        updateTitle(NSLocalizedString("OFFLINE_TITLE_FETCHING_VERSIONS", value: "Fetching Versions…", comment: "Status item while downloading an offline region"))
+        navigationItem.rightBarButtonItem?.isEnabled = false
+        view.isUserInteractionEnabled = false
+    }
+    
+    func enableUserInterface() {
+        navigationItem.rightBarButtonItem?.isEnabled = true
+        navigationItem.title = nil
+        view.isUserInteractionEnabled = true
+    }
     
     @objc func downloadRegion() {
         
-        // Hide the download button so we can't download the same region twice
-        navigationItem.rightBarButtonItem = nil
-        
         let northWest = mapView.convert(resizableView.frame.minXY, toCoordinateFrom: nil)
         let southEast = mapView.convert(resizableView.frame.maxXY, toCoordinateFrom: nil)
-        
         let coordinateBounds = CoordinateBounds([northWest, southEast])
         
-        updateTitle(NSLocalizedString("OFFLINE_TITLE_FETCHING_VERSIONS", value: "Fetching Versions…", comment: "Status item while downloading an offline region"))
+        disableUserInterface()
         
         Directions.shared.fetchAvailableOfflineVersions { [weak self] (versions, error) in
             
-            guard let version = versions?.first(where: { !$0.isEmpty } ) else { return }
+            guard let version = versions?.first(where: { !$0.isEmpty } ) else {
+                let title = NSLocalizedString("OFFLINE_TITLE_VERSION_FETCHING_FAILED", value:"Unable to fetch available routing tile versions", comment: "Error title to display when no routing tile versions are available")
+                let message = NSLocalizedString("OFFLINE_MESSAGE_VERSION_FETCHING_FAILED", value:"No routing tile versions are available for download. Please try again later.", comment: "Error message to display when no routing tile versions are available")
+                self?.presentAlert(title, message: message)
+                return
+            }
             
             self?.updateTitle(NSLocalizedString("OFFLINE_TITLE_DOWNLOADING_TILES", value: "Downloading Tiles…", comment: "Status item while downloading an offline region"))
             
             Directions.shared.downloadTiles(in: coordinateBounds, version: version, completionHandler: { (url, response, error) in
                 guard let url = url else { return assert(false, "Unable to locate temporary file") }
+                
+                if let response = response as? HTTPURLResponse {
+                    // if 402, need to upgrade the token
+                    if response.statusCode == 402 {
+                        DispatchQueue.main.async { [weak self] in
+                            let title = NSLocalizedString("OFFLINE_TITLE_TILE_DOWNLOAD_FAILED", value: "Unable to fetch tiles", comment: "Title to display when tile downloading fails")
+                            let message = NSLocalizedString("OFFLINE_MESSAGE_ENTERPRISE_TOKEN_NEEDED", value: "Before you can fetch routing tiles you must obtain an enterprise access token. Please contact us at support@mapbox.com", comment: "Message to display when the user needs to obtain an enterprise token")
+                            self?.presentAlert(title, message: message)
+                            self?.enableUserInterface()
+                        }
+                        return
+                    }
+
+                    // if 422, too many tiles were requested
+                    if response.statusCode == 422 {
+                        DispatchQueue.main.async { [weak self] in
+                            let title = NSLocalizedString("OFFLINE_TITLE_TILE_DOWNLOAD_FAILED", value: "Unable to fetch tiles", comment: "Title to display when tile downloading fails")
+                            let message = NSLocalizedString("OFFLINE_MESSAGE_USE_SMALLER_BOUNDING_BOX", value: "The bounding box you have specified is too large. Please select a smaller box and try again.", comment: "Message to display when the user needs to select a smaller bounding box")
+                            self?.presentAlert(title, message: message)
+                            self?.enableUserInterface()
+                        }
+                        return
+                    }
+                }
                 
                 let outputDirectoryURL = Bundle.mapboxCoreNavigation.suggestedTileURL(version: version)
                 outputDirectoryURL?.ensureDirectoryExists()


### PR DESCRIPTION
Provides reasonable error messages to the user when tile downloads fail due to access token or bounding box issues.

Centers the map on the user since they probably want to download routing tiles and generate a route near their location.