### PR TITLE
Voice Controller Stops After Rerouting

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -136,11 +136,11 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     }
     
     @objc func pauseSpeechAndPlayReroutingDing(notification: NSNotification) {
-        speechSynth.stopSpeaking(at: .word)
-        
         guard playRerouteSound && !NavigationSettings.shared.voiceMuted else {
             return
         }
+        
+        speechSynth.stopSpeaking(at: .word)
         
         do {
             try mixAudio()


### PR DESCRIPTION
In RouteVoiceController class in pauseSpeechAndPlayReroutingDing method, you stop speechSynth at first and then check if playRerouteSound is true or not. I changed the order of the first lines of this method to solve the problem.