### PR TITLE
Moving navigation service stop into deinit method.

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -417,6 +417,7 @@ open class NavigationViewController: UIViewController {
     }
     
     deinit {
+        navigationService.stop()
         suspendNotifications()
     }
     
@@ -445,7 +446,6 @@ open class NavigationViewController: UIViewController {
             UIApplication.shared.isIdleTimerDisabled = false
         }
         
-        navigationService.stop()
     }
     
     // MARK: Route controller notifications


### PR DESCRIPTION
![Can't stop](https://media.giphy.com/media/xfR4J1y61nDnW/giphy.gif)

Fixes #1899.

I really spent some time here looking for a better interface into `NavigationViewController`, but I just couldn't really find one that made sense. Stop is normally called when the navigation service receives a `endNavigation(feedback:)` call, which happens at the EORVC. We could expose an `endNavigation` mechanism to the UI SDK, but that brings along its' own considerations.

/cc @mapbox/navigation-ios 