### PR TITLE
Upgrade to Mapbox Streets source v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * The `NavigationDirections.unpackTilePack(at:outputDirectoryURL:progressHandler:completionHandler:)` method is now available to Objective-C code as `-[MBNavigationDirections unpackTilePackAtURL:outputDirectoryURL:progressHandler:completionHandler:]`. ([#1891](https://github.com/mapbox/mapbox-navigation-ios/pull/1891))
+* Added support for styles powered by [version 8 of the Mapbox Streets source](https://www.mapbox.com/vector-tiles/mapbox-streets-v8/). ([#1909](https://github.com/mapbox/mapbox-navigation-ios/pull/1909))
 
 ## v0.26.0
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		DADAD82E20350849002E25CA /* MBRouteVoiceController.h in Headers */ = {isa = PBXBuildFile; fileRef = DADAD82C20350849002E25CA /* MBRouteVoiceController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DADAD82F20350849002E25CA /* MBRouteVoiceController.m in Sources */ = {isa = PBXBuildFile; fileRef = DADAD82D20350849002E25CA /* MBRouteVoiceController.m */; };
 		DADD82802161EC0300B8B47D /* UIViewAnimationOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADD827F2161EC0300B8B47D /* UIViewAnimationOptionsTests.swift */; };
+		DAE22A2921C9DEDA00CA269D /* MGLVectorTileSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE22A2821C9DEDA00CA269D /* MGLVectorTileSourceTests.swift */; };
 		DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */; };
 /* End PBXBuildFile section */
 
@@ -941,6 +942,7 @@
 		DADAD82C20350849002E25CA /* MBRouteVoiceController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBRouteVoiceController.h; sourceTree = "<group>"; };
 		DADAD82D20350849002E25CA /* MBRouteVoiceController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBRouteVoiceController.m; sourceTree = "<group>"; };
 		DADD827F2161EC0300B8B47D /* UIViewAnimationOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewAnimationOptionsTests.swift; sourceTree = "<group>"; };
+		DAE22A2821C9DEDA00CA269D /* MGLVectorTileSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLVectorTileSourceTests.swift; sourceTree = "<group>"; };
 		DAE26B1A20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE26B1C20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Navigation.strings; sourceTree = "<group>"; };
 		DAE26B1F2064407D001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1106,6 +1108,7 @@
 				DAD17201214DB12B009C8161 /* CPMapTemplateTests.swift */,
 				DA0557242155040700A1F2AA /* RouteTests.swift */,
 				DADD827F2161EC0300B8B47D /* UIViewAnimationOptionsTests.swift */,
+				DAE22A2821C9DEDA00CA269D /* MGLVectorTileSourceTests.swift */,
 			);
 			name = "Extensions and Categories";
 			sourceTree = "<group>";
@@ -2382,6 +2385,7 @@
 				3510300F1F54B67000E3B7E7 /* LaneTests.swift in Sources */,
 				160A4A712127A46C0028B070 /* CPBarButton+MBTestable.m in Sources */,
 				169A970A216440820082A6A0 /* NavigationViewControllerTestDoubles.swift in Sources */,
+				DAE22A2921C9DEDA00CA269D /* MGLVectorTileSourceTests.swift in Sources */,
 				3573EA71215A5A9F009899D7 /* RouteControllerSnapshotTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxNavigation/MGLVectorTileSource.swift
+++ b/MapboxNavigation/MGLVectorTileSource.swift
@@ -2,10 +2,39 @@ import Foundation
 import Mapbox
 
 extension MGLVectorTileSource {
-    var isMapboxStreets: Bool {
-        guard let configurationURL = configurationURL else {
-            return false
+    /**
+     The identifiers of the tile sets that make up this source.
+     
+     This array contains multiple entries for a composited source. This property is set to `nil` for non-Mapbox-hosted tile sets.
+     */
+    var tileSetIdentifiers: [String]? {
+        guard let configurationURL = configurationURL, configurationURL.scheme == "mapbox" else {
+            return nil
         }
-        return configurationURL.scheme == "mapbox" && configurationURL.host!.components(separatedBy: ",").contains("mapbox.mapbox-streets-v7")
+        return configurationURL.host!.components(separatedBy: ",")
+    }
+    
+    /**
+     A Boolean value indicating whether the tile source is a supported version of the Mapbox Streets source.
+     */
+    var isMapboxStreets: Bool {
+        let tileSetIdentifiers = self.tileSetIdentifiers
+        return tileSetIdentifiers?.contains("mapbox.mapbox-streets-v8") ?? false ||
+            tileSetIdentifiers?.contains("mapbox.mapbox-streets-v7") ?? false
+    }
+    
+    /**
+     A dictionary associating known tile set identifiers with identifiers of source layers that contain road names.
+     */
+    static var roadLabelLayerIdentifiersByTileSetIdentifier = [
+        "mapbox.mapbox-streets-v8": "road",
+        "mapbox.mapbox-streets-v7": "road_label",
+    ]
+    
+    /**
+     The identifier of a layer in this source that contains road names.
+     */
+    var roadLabelLayerIdentifier: String? {
+        return tileSetIdentifiers?.compactMap { MGLVectorTileSource.roadLabelLayerIdentifiersByTileSetIdentifier[$0] }.first
     }
 }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1006,7 +1006,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             }
             
             // Road labels should match road signage.
-            let locale = layer.sourceLayerIdentifier == "road_label" ? Locale(identifier: "mul") : nil
+            let isLabelLayer = MGLVectorTileSource.roadLabelLayerIdentifiersByTileSetIdentifier.values.contains(layer.sourceLayerIdentifier ?? "")
+            let locale = isLabelLayer ? Locale(identifier: "mul") : nil
             
             let localizedText = text.mgl_expressionLocalized(into: locale)
             if localizedText != text {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -776,14 +776,14 @@ extension RouteMapViewController: NavigationViewDelegate {
 
         // Add Mapbox Streets if the map does not already have it
         if streetsSources.isEmpty {
-            let source = MGLVectorTileSource(identifier: "mapboxStreetsv7", configurationURL: URL(string: "mapbox://mapbox.mapbox-streets-v7")!)
+            let source = MGLVectorTileSource(identifier: "com.mapbox.MapboxStreets", configurationURL: URL(string: "mapbox://mapbox.mapbox-streets-v8")!)
             style.addSource(source)
             streetsSources.append(source)
         }
 
-        if let mapboxSteetsSource = streetsSources.first, style.layer(withIdentifier: roadLabelLayerIdentifier) == nil {
-            let streetLabelLayer = MGLLineStyleLayer(identifier: roadLabelLayerIdentifier, source: mapboxSteetsSource)
-            streetLabelLayer.sourceLayerIdentifier = "road_label"
+        if let mapboxStreetsSource = streetsSources.first, style.layer(withIdentifier: roadLabelLayerIdentifier) == nil {
+            let streetLabelLayer = MGLLineStyleLayer(identifier: roadLabelLayerIdentifier, source: mapboxStreetsSource)
+            streetLabelLayer.sourceLayerIdentifier = mapboxStreetsSource.roadLabelLayerIdentifier
             streetLabelLayer.lineOpacity = NSExpression(forConstantValue: 1)
             streetLabelLayer.lineWidth = NSExpression(forConstantValue: 20)
             streetLabelLayer.lineColor = NSExpression(forConstantValue: UIColor.white)

--- a/MapboxNavigationTests/MGLVectorTileSourceTests.swift
+++ b/MapboxNavigationTests/MGLVectorTileSourceTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import MapboxNavigation
+
+class MGLVectorTileSourceTests: XCTestCase {
+    func testMapboxStreets() {
+        let v8 = MGLVectorTileSource(identifier: "com.mapbox.MapboxStreets", configurationURL: URL(string: "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v1")!)
+        XCTAssertTrue(v8.isMapboxStreets)
+        XCTAssertEqual(v8.tileSetIdentifiers, ["mapbox.mapbox-streets-v8", "mapbox.mapbox-terrain-v1"])
+        XCTAssertEqual(v8.roadLabelLayerIdentifier, "road")
+        
+        let v7 = MGLVectorTileSource(identifier: "com.mapbox.MapboxStreets", configurationURL: URL(string: "mapbox://mapbox.mapbox-terrain-v1,mapbox.mapbox-streets-v7")!)
+        XCTAssertTrue(v7.isMapboxStreets)
+        XCTAssertEqual(v7.tileSetIdentifiers, ["mapbox.mapbox-terrain-v1", "mapbox.mapbox-streets-v7"])
+        XCTAssertEqual(v7.roadLabelLayerIdentifier, "road_label")
+        
+        let v6 = MGLVectorTileSource(identifier: "com.mapbox.MapboxStreets", configurationURL: URL(string: "mapbox://mapbox.mapbox-streets-v6")!)
+        XCTAssertFalse(v6.isMapboxStreets)
+        XCTAssertEqual(v6.tileSetIdentifiers, ["mapbox.mapbox-streets-v6"])
+        XCTAssertNil(v6.roadLabelLayerIdentifier)
+    }
+}


### PR DESCRIPTION
Both label localization and feature querying for the current road name label now support styles powered by Mapbox Streets source v8. If the current style doesn’t use the Streets source, version 8 is now added automatically instead of v7.

Fixes #1896.

/cc @frederoni @JThramer