### PR TITLE
Update MapboxVoiceController.swift

### DIFF
--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -55,7 +55,7 @@ open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {
                 do {
                     try strongSelf.unDuckAudio()
                 } catch {
-                    strongSelf.voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
+                    strongSelf.voiceControllerDelegate?.voiceController?(strongSelf, spokenInstructionsDidFailWith: error)
                 }
             }
         }

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -51,11 +51,11 @@ open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {
             if settings.voiceMuted {
                 self?.audioPlayer?.stop()
              
-                guard let self = self else { return }
+                guard let strongSelf = self else { return }
                 do {
-                    try self.unDuckAudio()
+                    try strongSelf.unDuckAudio()
                 } catch {
-                    self.voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
+                    strongSelf.voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
                 }
             }
         }

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -50,12 +50,24 @@ open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {
         muteToken = NavigationSettings.shared.observe(\.voiceMuted) { [weak self] (settings, change) in
             if settings.voiceMuted {
                 self?.audioPlayer?.stop()
+             
+                guard let self = self else { return }
+                do {
+                    try self.unDuckAudio()
+                } catch {
+                    self.voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
+                }
             }
         }
     }
     
     deinit {
         audioPlayer?.stop()
+        do {
+            try unDuckAudio()
+        } catch {
+            voiceControllerDelegate?.voiceController?(self, spokenInstructionsDidFailWith: error)
+        }
         audioPlayer?.delegate = nil
     }
     


### PR DESCRIPTION
In two below scenarios:
1 - Music in another application is playing -> In driving mode when we change the value of the voiceMuted variable to true (while the audio player is playing), we need to call unDuckAudio()
2 - Music in another application is playing -> When we close the navigation controller (driving mode) by tapping on the cancel button, deinit method of MapboxVoiceController will be called, after that, we need to call unDuckAudio()