### PR TITLE
Location Simulator Reroute Report

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.7.1"
-binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "3.4.11"
+binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "3.4.12"
 github "CedarBDD/Cedar" "v1.0"
 github "Quick/Nimble" "v7.3.1"
 github "Quick/Quick" "v1.3.2"

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -298,7 +298,7 @@ public class MapboxNavigationService: NSObject, NavigationService, DefaultInterf
     
     private func endSimulation(intent: SimulationIntent = .manual) {
         guard isSimulating else { return }
-        let progress = simulatedLocationSource?.routeProgress ?? router.routeProgress
+        let progress = router.routeProgress
         delegate?.navigationService?(self, willEndSimulating: progress, becauseOf: intent)
         simulatedLocationSource?.stopUpdatingLocation()
         simulatedLocationSource?.stopUpdatingHeading()

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -435,6 +435,9 @@ extension MapboxNavigationService: RouterDelegate {
         //notify the events manager that the route has changed
         eventsManager.reportReroute(progress: router.routeProgress, proactive: proactive)
         
+        //update the route progress model of the simulated location manager, if applicable.
+        simulatedLocationSource?.route = router.route
+        
         //notify our consumer
         delegate?.navigationService?(self, didRerouteAlong: route, at: location, proactive: proactive)
     }

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -27,6 +27,7 @@ fileprivate class SimulatedLocation: CLLocation {
  
  The route will be replaced upon a `RouteControllerDidReroute` notification.
  */
+
 @objc(MBSimulatedLocationManager)
 open class SimulatedLocationManager: NavigationLocationManager {
     internal var currentDistance: CLLocationDistance = 0
@@ -104,7 +105,6 @@ open class SimulatedLocationManager: NavigationLocationManager {
             self?.tick()
         }
         
-        NotificationCenter.default.addObserver(self, selector: #selector(didReroute(_:)), name: .routeControllerDidReroute, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(progressDidChange(_:)), name: .routeControllerProgressDidChange, object: nil)
     }
     
@@ -123,16 +123,8 @@ open class SimulatedLocationManager: NavigationLocationManager {
         routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
     }
     
-    @objc private func didReroute(_ notification: Notification) {
-        guard let routeController = notification.object as? RouteController else {
-            return
-        }
-        
-        route = routeController.routeProgress.route
-    }
     
     deinit {
-        NotificationCenter.default.removeObserver(self, name: .routeControllerDidReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: .routeControllerProgressDidChange, object: nil)
     }
     

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -70,7 +70,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
         return copy
     }
     
-    var routeProgress: RouteProgress?
+    private var routeProgress: RouteProgress?
     
     /**
      Initalizes a new `SimulatedLocationManager` with the given route.

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -228,6 +228,22 @@ class NavigationServiceTests: XCTestCase {
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: MMEEventTypeAppUserTurnstile))
     }
 
+    func testReroutingFromLocationUpdatesSimulatedLocationSource() {
+        let navigationService = MapboxNavigationService(route: initialRoute, directions: directionsClientSpy, eventsManagerType: NavigationEventsManagerSpy.self, simulating: .always)
+        navigationService.delegate = delegate
+        let router = navigationService.router!
+        
+        navigationService.eventsManager.delaysEventFlushing = false
+        navigationService.start()
+        
+        router.route = alternateRoute
+        
+        let simulatedLocationManager = navigationService.locationManager as! SimulatedLocationManager
+        
+        XCTAssert(simulatedLocationManager.route == alternateRoute, "Simulated Location Manager should be updated with new route progress model")
+    }
+    
+    
     func testReroutingFromALocationSendsEvents() {
         let navigationService = dependencies.navigationService
         let router = navigationService.router!


### PR DESCRIPTION
Fixes #1922. Updates route model of simulator when reroute occurs. 

/cc @mapbox/navigation-ios 