### PR TITLE
Silence reroute questioning if reroute is already inflight

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -344,7 +344,7 @@ extension RouteController: CLLocationManagerDelegate {
         updateRouteLegProgress(for: location)
         updateVisualInstructionProgress()
 
-        if !userIsOnRoute(location) && delegate?.router?(self, shouldRerouteFrom: location) ?? DefaultBehavior.shouldRerouteFromLocation {
+        if !isRerouting, !userIsOnRoute(location), delegate?.router?(self, shouldRerouteFrom: location) ?? DefaultBehavior.shouldRerouteFromLocation {
 
             reroute(from: location, along: routeProgress)
             return


### PR DESCRIPTION
Quick fix. Implements #1929. 

/cc @mapbox/navigation-ios 