### PR TITLE
Silence `willReroute` when changing route via property.

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -69,9 +69,6 @@ open class RouteController: NSObject, Router {
             return _routeProgress
         }
         set {
-            if let location = self.location {
-                delegate?.router?(self, willRerouteFrom: location)
-            }
             _routeProgress = newValue
             announce(reroute: routeProgress.route, at: dataSource.location, proactive: didFindFasterRoute)
         }


### PR DESCRIPTION
Another Quick Fix. Implements #1927.

/cc @mapbox/navigation-ios 