### PR TITLE
Publicly exposing the EORVC presentation in the NVC

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -684,12 +684,17 @@ extension NavigationViewController: NavigationServiceDelegate {
         
         if !isConnectedToCarPlay, // CarPlayManager shows rating on CarPlay if it's connected
             service.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
-            self.mapViewController?.showEndOfRoute { _ in }
+            showEndOfRoute()
         }
         return advancesToNextLeg
 
     }
     
+    @objc public func showEndOfRoute(duration: TimeInterval = 1.0, completion: ((Bool) -> Void)? = nil) {
+        guard let mapController = mapViewController else { return }
+        mapController.showEndOfRoute(duration: duration, completion: completion)
+    }
+
     @objc public func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
         switch service.simulationMode {
         case .always:


### PR DESCRIPTION
Quick fix the third. Fixes #1926. Turns out that you can already [end navigation manually](https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxCoreNavigation/NavigationService.swift#L106) through the `NavigationService`.

/cc @mapbox/navigation-ios 