### PR TITLE
Correct Local Variable Typo

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -733,7 +733,7 @@ extension RouteMapViewController: NavigationViewDelegate {
 
      - parameter location: The user’s current location.
      */
-    func labelCurrentRoad(at rawLocation: CLLocation, for snappedLoction: CLLocation? = nil) {
+    func labelCurrentRoad(at rawLocation: CLLocation, for snappedLocation: CLLocation? = nil) {
 
         guard navigationView.resumeButton.isHidden else {
                 return
@@ -755,7 +755,7 @@ extension RouteMapViewController: NavigationViewDelegate {
             return
         }
 
-        let location = snappedLoction ?? rawLocation
+        let location = snappedLocation ?? rawLocation
 
         labelCurrentRoadFeature(at: location)
 


### PR DESCRIPTION
Fixes #1958 

Minor change to two local uses of the `snappedLocation` variable in `RouteMapViewController`'s `labelCurrentRoad` function.

More of an aesthetic change than anything else, so feel free to reject if it poses too much of a headache for `semver` conversations.