### PR TITLE
Locking down the navigationService after initialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Restored “Declaration” and “Parameters” sections throughout the API reference. ([#1952](https://github.com/mapbox/mapbox-navigation-ios/pull/1952))
 * Removed the deprecated `NavigationViewController.routeController`, `NavigationViewController.eventsManager`, and `NavigationViewController.locationManager` properties. ([#1904](https://github.com/mapbox/mapbox-navigation-ios/pull/1904))
 * Fixed audio ducking issues. ([#1915](https://github.com/mapbox/mapbox-navigation-ios/pull/1915))
+* The `NavigationViewController.navigationService` property is now read-only. ([#1965](https://github.com/mapbox/mapbox-navigation-ios/pull/1965]))
 
 ## v0.28.0 (January 23, 2018)
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -75,7 +75,7 @@ open class NavigationViewController: UIViewController {
 
      See `NavigationService` for more information.
      */
-    @objc public var navigationService: NavigationService! {
+    @objc private(set) public var navigationService: NavigationService! {
         didSet {
             mapViewController?.navService = navigationService
         }


### PR DESCRIPTION
Another quick fix. Locking down the `navigationService` so it can't be mutated after init.

/cc @mapbox/navigation-ios 