### PR TITLE
Fix compiler warning about deprecated delegate method

### DIFF
--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -28,6 +28,11 @@ public protocol InstructionsBannerViewDelegate: class {
     @objc optional func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizerDirection)
 }
 
+@objc private protocol InstructionsBannerViewDelegateDeprecations {
+    @objc(didDragInstructionsBanner:)
+    optional func didDragInstructionsBanner(_ sender: BaseInstructionsBannerView)
+}
+
 /// :nodoc:
 @IBDesignable
 @objc(MBInstructionsBannerView)
@@ -141,7 +146,7 @@ open class BaseInstructionsBannerView: UIControl {
             
             if let delegate = delegate {
                 delegate.didSwipeInstructionsBanner?(self, swipeDirection: .down)
-                delegate.didDragInstructionsBanner?(self)
+                (delegate as? InstructionsBannerViewDelegateDeprecations)?.didDragInstructionsBanner?(self)
             }
         }
     }


### PR DESCRIPTION
This won’t quite streamline CocoaPods trunk-pushing, due to #1966, but it’s better than nothing.

Fixes #1758.

/cc @JThramer