### PR TITLE
Fix coordinate bounds in offline region downloads

### DIFF
--- a/Example/OfflineViewController.swift
+++ b/Example/OfflineViewController.swift
@@ -48,9 +48,8 @@ class OfflineViewController: UIViewController, MGLMapViewDelegate {
     
     @objc func downloadRegion() {
         
-        let northWest = mapView.convert(resizableView.frame.minXY, toCoordinateFrom: nil)
-        let southEast = mapView.convert(resizableView.frame.maxXY, toCoordinateFrom: nil)
-        let coordinateBounds = CoordinateBounds(northWest: northWest, southEast: southEast)
+        let mapCoordinateBounds = mapView.convert(resizableView.frame, toCoordinateBoundsFrom: nil)
+        let coordinateBounds = CoordinateBounds(coordinates: [mapCoordinateBounds.sw, mapCoordinateBounds.ne])
         
         disableUserInterface()
         


### PR DESCRIPTION
This is a temporary workaround for mapbox/MapboxDirections.swift#349. mapbox/MapboxDirections.swift#348 surfaced in mapbox/mapbox-navigation-ios#1913, when I optimistically switched to the more strongly typed CoordinateBounds initializer, unaware that it was backwards.

/cc @mapbox/navigation-ios