### PR TITLE
Carplay Route Failure Delegate Messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### CarPlay
 
-* The `CarPlayManager` will now notify its delegate if the route request fails, and provides the option to present an alert on the map template.  ([#1981](https://github.com/mapbox/mapbox-navigation-ios/pull/1981))
+* The `CarPlayManager` will now notify its delegate if the route request fails and provide the option to present an alert on the map template.  ([#1981](https://github.com/mapbox/mapbox-navigation-ios/pull/1981))
 * You can now customize the control layer of the map template comprising of the navigation bar's leading and trailing buttons and the map buttons. ([#1962](https://github.com/mapbox/mapbox-navigation-ios/pull/1962))
 * Added new map buttons in the `CarPlayManager` and the `CarPlayMapViewController`. You can now access map buttons that perform built-in actions on the map by accessing read-only properties such as: `CarPlayManager.exitButton`, `CarPlayManager.muteButton`, `CarPlayManager.showFeedbackButton`, `CarPlayManager.overviewButton`, `CarPlayMapViewController.recenterButton`, `CarPlayMapViewController.zoomInButton`, `CarPlayMapViewController.zoomOutButton`, `CarPlayMapViewController.panningInterfaceDisplayButton(for:)`, `CarPlayMapViewController.panningInterfaceDismissalButton(for:)`. ([#1962](https://github.com/mapbox/mapbox-navigation-ios/pull/1962))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### CarPlay
 
+* The `CarPlayManager` will now notify its delegate if the route request fails, and provides the option to present an alert on the map template.  ([#1981](https://github.com/mapbox/mapbox-navigation-ios/pull/1981))
 * You can now customize the control layer of the map template comprising of the navigation bar's leading and trailing buttons and the map buttons. ([#1962](https://github.com/mapbox/mapbox-navigation-ios/pull/1962))
 * Added new map buttons in the `CarPlayManager` and the `CarPlayMapViewController`. You can now access map buttons that perform built-in actions on the map by accessing read-only properties such as: `CarPlayManager.exitButton`, `CarPlayManager.muteButton`, `CarPlayManager.showFeedbackButton`, `CarPlayManager.overviewButton`, `CarPlayMapViewController.recenterButton`, `CarPlayMapViewController.zoomInButton`, `CarPlayMapViewController.zoomOutButton`, `CarPlayMapViewController.panningInterfaceDisplayButton(for:)`, `CarPlayMapViewController.panningInterfaceDismissalButton(for:)`. ([#1962](https://github.com/mapbox/mapbox-navigation-ios/pull/1962))
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -77,6 +77,18 @@ extension AppDelegate: CarPlayManagerDelegate {
         }
     }
     
+    func carPlayManager(_ carPlayManager: CarPlayManager, didFailToFetchRouteBetween waypoints: [Waypoint]?, options: RouteOptions, error: NSError) -> CPNavigationAlert? {
+        let okTitle = NSLocalizedString("CARPLAY_OK", bundle: .main, value: "OK", comment: "CPAlertTemplate OK button title")
+        let action = CPAlertAction(title: okTitle, style: .default, handler: {_ in })
+        let alert = CPNavigationAlert(titleVariants: [error.localizedDescription],
+                                      subtitleVariants: [error.localizedFailureReason ?? ""],
+                                      imageSet: nil,
+                                      primaryAction: action,
+                                      secondaryAction: nil,
+                                      duration: 5)
+        return alert
+    }
+    
     func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in template: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]? {
         
         switch activity {

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -400,10 +400,7 @@ extension CarPlayManager: CPListTemplateDelegate {
             completionHandler()
         }
         
-        guard let interfaceController = interfaceController,
-              let mapTemplate = interfaceController.rootTemplate as? CPMapTemplate else {
-                return
-        }
+
         
         if let error = error {
             guard let delegate = delegate,
@@ -411,8 +408,10 @@ extension CarPlayManager: CPListTemplateDelegate {
                     return
             }
 
-            interfaceController.popToRootTemplate(animated: true)
-            mapTemplate.present(navigationAlert: alert, animated: true)
+            let mapTemplate = interfaceController?.rootTemplate as? CPMapTemplate
+            interfaceController?.popToRootTemplate(animated: true)
+            mapTemplate?.present(navigationAlert: alert, animated: true)
+            return
         }
         
         guard let waypoints = waypoints, let routes = routes else {
@@ -448,7 +447,10 @@ extension CarPlayManager: CPListTemplateDelegate {
         let previewMapTemplate = mapTemplateProvider.mapTemplate(forPreviewing: trip, traitCollection: traitCollection, mapDelegate: self)
 
         previewMapTemplate.showTripPreviews([trip], textConfiguration: previewText)
-
+        
+        guard let interfaceController = interfaceController else {
+                return
+        }
         interfaceController.pushTemplate(previewMapTemplate, animated: true)
     }
 

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -395,7 +395,7 @@ extension CarPlayManager: CPListTemplateDelegate {
     }
     
     
-    internal func didCalculate(_ routes: [Route]?, for routeOptions: RouteOptions, between waypoints: [Waypoint]?, error: NSError?, completionHandler: @escaping () -> Void) {
+    internal func didCalculate(_ routes: [Route]?, for routeOptions: RouteOptions, between waypoints: [Waypoint]?, error: NSError?, completionHandler: CompletionHandler) {
         defer {
             completionHandler()
         }
@@ -406,16 +406,12 @@ extension CarPlayManager: CPListTemplateDelegate {
         }
         
         if let error = error {
-            let okTitle = NSLocalizedString("CARPLAY_OK", bundle: .mapboxNavigation, value: "OK", comment: "CPNavigationAlert OK button title")
-            let okAction = CPAlertAction(title: okTitle, style: .default) { _ in
-                interfaceController.popToRootTemplate(animated: true)
+            guard let delegate = delegate,
+                  let alert = delegate.carplayManager?(self, didFailToFetchRouteBetweenWaypoints: waypoints, options: routeOptions, error: error) else {
+                    return
             }
-            let alert = CPNavigationAlert(titleVariants: [error.localizedDescription],
-                                          subtitleVariants: [error.localizedFailureReason ?? ""],
-                                          imageSet: nil,
-                                          primaryAction: okAction,
-                                          secondaryAction: nil,
-                                          duration: 0)
+
+            interfaceController.popToRootTemplate(animated: true)
             mapTemplate.present(navigationAlert: alert, animated: true)
         }
         

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -402,12 +402,12 @@ extension CarPlayManager: CPListTemplateDelegate {
         
         guard let interfaceController = interfaceController,
               let mapTemplate = interfaceController.rootTemplate as? CPMapTemplate else {
-            return
+                return
         }
         
         if let error = error {
             guard let delegate = delegate,
-                  let alert = delegate.carplayManager?(self, didFailToFetchRouteBetweenWaypoints: waypoints, options: routeOptions, error: error) else {
+                  let alert = delegate.carPlayManager?(self, didFailToFetchRouteBetween: waypoints, options: routeOptions, error: error) else {
                     return
             }
 

--- a/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -18,7 +18,7 @@ public protocol CarPlayManagerDelegate {
      
      These buttons' tap handlers encapsulate the action to be taken, so it is up to the developer to ensure the hierarchy of templates is adequately navigable.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
      - parameter template: The template into which the returned bar buttons will be inserted.
      - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
@@ -32,7 +32,7 @@ public protocol CarPlayManagerDelegate {
      
      These buttons' tap handlers encapsulate the action to be taken, so it is up to the developer to ensure the hierarchy of templates is adequately navigable.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
      - parameter template: The template into which the returned bar buttons will be inserted.
      - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
@@ -47,7 +47,7 @@ public protocol CarPlayManagerDelegate {
      These buttons handle the gestures on the map view, so it is up to the developer to ensure the map template is interactive.
      If this method is not implemented, or if nil is returned, a default set of zoom and pan buttons declared in the `CarPlayMapViewController` will be provided.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter traitCollection: The trait collection of the view controller being shown in the CarPlay window.
      - parameter template: The template into which the returned map buttons will be inserted.
      - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
@@ -59,7 +59,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Offers the delegate an opportunity to provide an alternate navigation service, otherwise a default built-in MapboxNavigationService will be created and used.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter route: The route for which the returned route controller will manage location updates.
      - returns: A navigation service that manages location updates along `route`.
      */
@@ -70,7 +70,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Offers the delegate an opportunity to react to updates in the search text.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter searchTemplate: The search template currently accepting user input.
      - parameter searchText: The updated search text in `searchTemplate`.
      - parameter completionHandler: Called when the search is complete. Accepts a list of search results.
@@ -83,7 +83,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Offers the delegate an opportunity to react to selection of a search result.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter searchTemplate: The search template currently accepting user input.
      - parameter item: The search result the user has selected.
      - parameter completionHandler: Called when the delegate is done responding to the selection.
@@ -95,7 +95,7 @@ public protocol CarPlayManagerDelegate {
     
     /**
      Called when the CarPlay manager fails to fetch a route.
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter waypoints: the waypoints for which a route could not be retrieved.
      - parameter options: The route options that were attached to the route request.
      - parameter error: The error returned from the directions API.
@@ -108,7 +108,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Offers the delegate the opportunity to customize a trip before it is presented to the user to preview.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter trip: The trip that will be previewed.
      - returns: The actual trip to be previewed. This can be the same trip or a new/alternate trip if desired.
      */
@@ -118,7 +118,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Offers the delegate the opportunity to customize a trip preview text configuration for a given trip.
 
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter trip: The trip that will be previewed.
      - parameter previewTextConfiguration: The trip preview text configuration that will be presented alongside the trip.
      - returns: The actual preview text configuration to be presented alongside the trip.
@@ -129,7 +129,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Offers the delegate the opportunity to react to selection of a trip. Certain trips may have alternate route(s).
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter trip: The trip to begin navigating along.
      - parameter routeChoice: The possible route for the chosen trip.
      */
@@ -139,7 +139,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Called when navigation begins so that the containing app can update accordingly.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - parameter service: The navigation service that has begun managing location updates for a navigation session.
      */
     @objc(carPlayManager:didBeginNavigationWithNavigationService:)
@@ -148,7 +148,7 @@ public protocol CarPlayManagerDelegate {
     /**
      Called when navigation ends so that the containing app can update accordingly.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      */
     @objc func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) -> ()
     
@@ -157,7 +157,7 @@ public protocol CarPlayManagerDelegate {
      
      Implementing this method will allow developers to change whether idle timer is disabled when carplay is connected and the vice-versa when disconnected.
      
-     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter carPlayManager: The CarPlay manager instance.
      - returns: A Boolean value indicating whether to disable idle timer when carplay is connected and enable when disconnected.
      */
     @objc optional func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool

--- a/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -103,7 +103,7 @@ public protocol CarPlayManagerDelegate {
      - returns Optionally, a CPNavigationAlert to present to the user. If an alert is returned, Carplay will transition back to the map template and display the alert. If `nil` is returned, nothing is done.
      */
     @objc(carPlayManager:didFailToFetchRouteBetweenWaypoints:withOptions:becauseOfError:)
-    optional func carplayManager(_ carPlayManager: CarPlayManager, didFailToFetchRouteBetweenWaypoints waypoints: [Waypoint]?, options: RouteOptions, error: NSError) -> CPNavigationAlert?
+    optional func carPlayManager(_ carPlayManager: CarPlayManager, didFailToFetchRouteBetween waypoints: [Waypoint]?, options: RouteOptions, error: NSError) -> CPNavigationAlert?
     
     /**
      Offers the delegate the opportunity to customize a trip before it is presented to the user to preview.

--- a/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -94,6 +94,18 @@ public protocol CarPlayManagerDelegate {
     optional func carPlayManager(_ carPlayManager: CarPlayManager, searchTemplate: CPSearchTemplate, selectedResult item: CPListItem, completionHandler: @escaping () -> Void)
     
     /**
+     Called when the CarPlay manager fails to fetch a route.
+     - parameter carPlayManager: The shared CarPlay manager.
+     - parameter waypoints: the waypoints for which a route could not be retrieved.
+     - parameter options: The route options that were attached to the route request.
+     - parameter error: The error returned from the directions API.
+     
+     - returns Optionally, a CPNavigationAlert to present to the user. If an alert is returned, Carplay will transition back to the map template and display the alert. If `nil` is returned, nothing is done.
+     */
+    @objc(carPlayManager:didFailToFetchRouteBetweenWaypoints:withOptions:becauseOfError:)
+    optional func carplayManager(_ carPlayManager: CarPlayManager, didFailToFetchRouteBetweenWaypoints waypoints: [Waypoint]?, options: RouteOptions, error: NSError) -> CPNavigationAlert?
+    
+    /**
      Offers the delegate the opportunity to customize a trip before it is presented to the user to preview.
      
      - parameter carPlayManager: The shared CarPlay manager.

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -213,6 +213,21 @@ class CarPlayManagerTests: XCTestCase {
         XCTAssertTrue(exampleDelegate.navigationEnded, "The CarPlayManagerDelegate should have been told that navigation ended.")
     }
     
+    func testRouteFailure() {
+        
+        let manager = CarPlayManager()
+        
+        let spy = CarPlayManagerFailureDelegateSpy()
+        let testError = NSError(domain: "com.mapbox.test", code: 42, userInfo: nil)
+        let locOne = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let fakeOptions = RouteOptions(coordinates: [locOne])
+        manager.delegate = spy
+        manager.didCalculate(nil, for: fakeOptions, between: nil, error: testError, completionHandler: { })
+        XCTAssert(spy.recievedError == testError, "Delegate should have receieved error")
+        
+    }
+    
+    
     func testDirectionsOverride() {
         
         class DirectionsInvocationSpy: Directions {
@@ -428,6 +443,25 @@ func simulateCarPlayConnection(_ manager: CarPlayManager) {
     let fakeWindow = CPWindow()
     
     manager.application(UIApplication.shared, didConnectCarInterfaceController: fakeInterfaceController, to: fakeWindow)
+}
+
+@available(iOS 12.0, *)
+class CarPlayManagerFailureDelegateSpy: CarPlayManagerDelegate {
+    private(set) var recievedError: NSError?
+    
+    @available(iOS 12.0, *)
+    func carPlayManager(_ carPlayManager: CarPlayManager, didFailToFetchRouteBetween waypoints: [Waypoint]?, options: RouteOptions, error: NSError) -> CPNavigationAlert? {
+        recievedError = error
+        return nil
+    }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith service: NavigationService) {
+        fatalError("This is an empty stub.")
+    }
+    
+    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+        fatalError("This is an empty stub.")
+    }
 }
 
 //MARK: Test Objects / Classes.


### PR DESCRIPTION
![Epic fail.](https://thumbs.gfycat.com/QuarrelsomeWebbedDoe-size_restricted.gif)

Adding a delegate message notifying the developer of a route-fetch failure. Developer can optionally return an alert which will be presented to the user.

To-Do: 
- [x] Default Implementation in Example App
- [x] ~~use `CPAlertTemplate` instead of navigation alert~~ (only `CPNavigationAlert` is possible)
- [x] Tests
- [x] Changelog Entry

/cc @mapbox/navigation-ios 