### PR TITLE
Tell delegate when passing visual instruction point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixed an issue where the turn banner remained blank and  `RouterDelegate.router(_:didPassVisualInstructionPoint:routeProgress:)` was never called if `MapboxNavigationService` was created with a `LegacyRouteController` router. ([#1983](https://github.com/mapbox/mapbox-navigation-ios/pull/1983))
+
 ## v0.29.0
 
 ### Core Navigation


### PR DESCRIPTION
In addition to posting a notification, LegacyRouteController now tells its delegate when the user passes a visual instruction point, for consistency with RouteController.

Fixes #1972.

/cc @JThramer @frederoni