### PR TITLE
Update StyleManagerDelegate method signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 
 * Fixed an issue where the turn banner remained blank and  `RouterDelegate.router(_:didPassVisualInstructionPoint:routeProgress:)` was never called if `MapboxNavigationService` was created with a `LegacyRouteController` router. ([#1983](https://github.com/mapbox/mapbox-navigation-ios/pull/1983))
+* Fixed an issue preventing `CarPlayMapViewController` and `CarPlayNavigationViewController` from applying custom map styles. ([#1985](https://github.com/mapbox/mapbox-navigation-ios/pull/1985))
+* Renamed `-[MBStyleManagerDelegate styleManager:didApply:]` to `-[MBStyleManagerDelegate styleManager:didApplyStyle:]` in Objective-C. If your `StyleManagerDelegate`-conforming class is written in Swift, make sure its methods match `StyleManagerDelegate`’s method signatures, including `@objc` annotations. ([#1985](https://github.com/mapbox/mapbox-navigation-ios/pull/1985))
 
 ## v0.29.0
 

--- a/Example/CustomStyles.swift
+++ b/Example/CustomStyles.swift
@@ -10,6 +10,7 @@ class CustomDayStyle: DayStyle {
     required init() {
         super.init()
         mapStyleURL = URL(string: "mapbox://styles/mapbox/satellite-streets-v9")!
+        previewMapStyleURL = mapStyleURL
         styleType = .day
     }
     
@@ -25,6 +26,7 @@ class CustomNightStyle: NightStyle {
     required init() {
         super.init()
         mapStyleURL = URL(string: "mapbox://styles/mapbox/satellite-streets-v9")!
+        previewMapStyleURL = mapStyleURL
         styleType = .night
     }
     

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -215,11 +215,13 @@ public class CarPlayMapViewController: UIViewController {
 
 @available(iOS 12.0, *)
 extension CarPlayMapViewController: StyleManagerDelegate {
+    @objc(locationForStyleManager:)
     public func location(for styleManager: StyleManager) -> CLLocation? {
         return mapView.userLocationForCourseTracking ?? mapView.userLocation?.location ?? coarseLocationManager.location
     }
     
-    func styleManager(_ styleManager: StyleManager, didApply style: Style) {
+    @objc(styleManager:didApplyStyle:)
+    public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         let styleURL = style.previewMapStyleURL
         if mapView.styleURL != styleURL {
             mapView.style?.transition = MGLTransition(duration: 0.5, delay: 0)
@@ -227,7 +229,7 @@ extension CarPlayMapViewController: StyleManagerDelegate {
         }
     }
     
-    func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
+    @objc public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
         mapView.reloadStyle(self)
     }
 }

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -471,6 +471,7 @@ extension CarPlayNavigationViewController: NavigationMapViewDelegate {
 
 @available(iOS 12.0, *)
 extension CarPlayNavigationViewController: StyleManagerDelegate {
+    @objc(locationForStyleManager:)
     public func location(for styleManager: StyleManager) -> CLLocation? {
         if let location = navService.router.location {
             return location
@@ -481,6 +482,7 @@ extension CarPlayNavigationViewController: StyleManagerDelegate {
         }
     }
     
+    @objc(styleManager:didApplyStyle:)
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         if mapView?.styleURL != style.mapStyleURL {
             mapView?.style?.transition = MGLTransition(duration: 0.5, delay: 0)
@@ -488,7 +490,7 @@ extension CarPlayNavigationViewController: StyleManagerDelegate {
         }
     }
     
-    public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
+    @objc public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
         mapView?.reloadStyle(self)
     }
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -571,7 +571,7 @@ extension NavigationViewController: NavigationServiceDelegate {
 // MARK: - StyleManagerDelegate
 
 extension NavigationViewController: StyleManagerDelegate {
-    
+    @objc(locationForStyleManager:)
     public func location(for styleManager: StyleManager) -> CLLocation? {
         if let location = navigationService.router.location {
             return location
@@ -582,6 +582,7 @@ extension NavigationViewController: StyleManagerDelegate {
         }
     }
     
+    @objc(styleManager:didApplyStyle:)
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         if mapView?.styleURL != style.mapStyleURL {
             mapView?.style?.transition = MGLTransition(duration: 0.5, delay: 0)
@@ -592,7 +593,7 @@ extension NavigationViewController: StyleManagerDelegate {
         setNeedsStatusBarAppearanceUpdate()
     }
     
-    public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
+    @objc public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
         mapView?.reloadStyle(self)
     }
 }

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -15,7 +15,8 @@ public protocol StyleManagerDelegate: NSObjectProtocol {
     /**
      Informs the delegate that a style was applied.
      */
-    @objc optional func styleManager(_ styleManager: StyleManager, didApply style: Style)
+    @objc(styleManager:didApplyStyle:)
+    optional func styleManager(_ styleManager: StyleManager, didApply style: Style)
     
     /**
      Informs the delegate that the manager forcefully refreshed UIAppearance.

--- a/MapboxNavigationTests/StyleManagerTests.swift
+++ b/MapboxNavigationTests/StyleManagerTests.swift
@@ -127,10 +127,12 @@ class StyleManagerTests: XCTestCase {
 }
 
 extension StyleManagerTests: StyleManagerDelegate {
-    func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) { }
-    func styleManager(_ styleManager: StyleManager, didApply style: Style) { }
+    @objc public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) { }
+    @objc(styleManager:didApplyStyle:)
+    public func styleManager(_ styleManager: StyleManager, didApply style: Style) { }
     
-    func location(for styleManager: StyleManager) -> CLLocation? {
+    @objc(locationForStyleManager:)
+    public func location(for styleManager: StyleManager) -> CLLocation? {
         return location
     }
 }


### PR DESCRIPTION
Fixed an issue where custom styles weren’t getting applied. Fixed compiler warnings about mismatched StyleManagerDelegate methods.

Fixes #1970.

/cc @mapbox/navigation-ios