### PR TITLE
Do not use invalid location course in step advancement heuristic.

### DIFF
--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -396,6 +396,8 @@ open class LegacyRouteController: NSObject, Router, CLLocationManagerDelegate {
         }
         let durationRemaining = routeProgress.durationRemaining
 
+        self.lastLocationDate = nil
+
         getDirections(from: location, along: routeProgress) { [weak self] (route, error) in
             guard let strongSelf = self else {
                 return
@@ -404,8 +406,6 @@ open class LegacyRouteController: NSObject, Router, CLLocationManagerDelegate {
             guard let route = route else {
                 return
             }
-
-            strongSelf.lastLocationDate = nil
 
             guard let firstLeg = route.legs.first, let firstStep = firstLeg.steps.first else {
                 return

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -526,7 +526,6 @@ open class LegacyRouteController: NSObject, Router, CLLocationManagerDelegate {
         if let upcomingStep = routeProgress.currentLegProgress.upcomingStep, let finalHeading = upcomingStep.finalHeading, let initialHeading = upcomingStep.initialHeading {
             let initialHeadingNormalized = initialHeading.wrap(min: 0, max: 360)
             let finalHeadingNormalized = finalHeading.wrap(min: 0, max: 360)
-            let userHeadingNormalized = location.course.wrap(min: 0, max: 360)
             let expectedTurningAngle = initialHeadingNormalized.difference(from: finalHeadingNormalized)
 
             // If the upcoming maneuver is fairly straight,
@@ -537,7 +536,8 @@ open class LegacyRouteController: NSObject, Router, CLLocationManagerDelegate {
             // Once this distance is zero, they are at more moving away from the maneuver location
             if expectedTurningAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion {
                 courseMatchesManeuverFinalHeading = userSnapToStepDistanceFromManeuver == 0
-            } else {
+            } else if location.course.isQualified {
+                let userHeadingNormalized = location.course.wrap(min: 0, max: 360)
                 courseMatchesManeuverFinalHeading = finalHeadingNormalized.difference(from: userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
             }
         }


### PR DESCRIPTION
I noticed a while ago a minor edge case in the step advancement heuristic that I fixed in our fork but never took time to contribute back, so here it is.

Basically if the user doesn't have a valid course, the wrap of the value gives **359**, which is then used as a valid value to compare against the maneuver final heading.

This can lead to advancing the step too early.
I guess it is better to let the fallback mechanism kick in in this case (user moving away from the maneuver location) to trigger the step advancement.