### PR TITLE
Do not use invalid location course in step advancement heuristic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue where the turn banner remained blank and  `RouterDelegate.router(_:didPassVisualInstructionPoint:routeProgress:)` was never called if `MapboxNavigationService` was created with a `LegacyRouteController` router. ([#1983](https://github.com/mapbox/mapbox-navigation-ios/pull/1983))
 * Fixed an issue preventing `CarPlayMapViewController` and `CarPlayNavigationViewController` from applying custom map styles. ([#1985](https://github.com/mapbox/mapbox-navigation-ios/pull/1985))
 * Renamed `-[MBStyleManagerDelegate styleManager:didApply:]` to `-[MBStyleManagerDelegate styleManager:didApplyStyle:]` in Objective-C. If your `StyleManagerDelegate`-conforming class is written in Swift, make sure its methods match `StyleManagerDelegate`’s method signatures, including `@objc` annotations. ([#1985](https://github.com/mapbox/mapbox-navigation-ios/pull/1985))
+* Fixed an issue causing `LegacyRouteController` to prematurely advance to the next step when receiving an unreliable course from Core Location. ([#1989](https://github.com/mapbox/mapbox-navigation-ios/pull/1989))
 
 ## v0.29.0
 

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -526,7 +526,6 @@ open class LegacyRouteController: NSObject, Router, CLLocationManagerDelegate {
         if let upcomingStep = routeProgress.currentLegProgress.upcomingStep, let finalHeading = upcomingStep.finalHeading, let initialHeading = upcomingStep.initialHeading {
             let initialHeadingNormalized = initialHeading.wrap(min: 0, max: 360)
             let finalHeadingNormalized = finalHeading.wrap(min: 0, max: 360)
-            let userHeadingNormalized = location.course.wrap(min: 0, max: 360)
             let expectedTurningAngle = initialHeadingNormalized.difference(from: finalHeadingNormalized)
 
             // If the upcoming maneuver is fairly straight,
@@ -537,7 +536,8 @@ open class LegacyRouteController: NSObject, Router, CLLocationManagerDelegate {
             // Once this distance is zero, they are at more moving away from the maneuver location
             if expectedTurningAngle <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion {
                 courseMatchesManeuverFinalHeading = userSnapToStepDistanceFromManeuver == 0
-            } else {
+            } else if location.course.isQualified {
+                let userHeadingNormalized = location.course.wrap(min: 0, max: 360)
                 courseMatchesManeuverFinalHeading = finalHeadingNormalized.difference(from: userHeadingNormalized) <= RouteControllerMaximumAllowedDegreeOffsetForTurnCompletion
             }
         }


### PR DESCRIPTION
I noticed a while ago a minor edge case in the step advancement heuristic that I fixed in our fork but never took time to contribute back, so here it is.

Basically if the user doesn't have a valid course, the wrap of the value gives **359**, which is then used as a valid value to compare against the maneuver final heading.

This can lead to advancing the step too early.
I guess it is better to let the fallback mechanism kick in in this case (user moving away from the maneuver location) to trigger the step advancement.