### PR TITLE
Fix depart and arrive event

### DIFF
--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -59,7 +59,6 @@ struct NavigationEventDetails: EventDetails {
     let batteryLevel: Int = UIDevice.current.batteryLevel >= 0 ? Int(UIDevice.current.batteryLevel * 100) : -1
     let batteryPluggedIn: Bool = [.charging, .full].contains(UIDevice.current.batteryState)
     let coordinate: CLLocationCoordinate2D?
-    let created: Date = Date()
     let device: String = UIDevice.current.machine
     let distance: CLLocationDistance?
     let distanceCompleted: CLLocationDistance
@@ -96,6 +95,7 @@ struct NavigationEventDetails: EventDetails {
     let legCount: Int
     let totalStepCount: Int
     
+    var created: Date = Date()
     var event: String?
     var arrivalTimestamp: Date?
     var rating: Int?

--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -110,7 +110,7 @@ struct NavigationEventDetails: EventDetails {
     var newGeometry: String?
     
     init(dataSource: EventsManagerDataSource, session: SessionState, defaultInterface: Bool) {
-        coordinate = dataSource.location?.coordinate
+        coordinate = dataSource.router.rawLocation?.coordinate
         startTimestamp = session.departureTimestamp ?? nil
         sdkIdentifier = defaultInterface ? "mapbox-navigation-ui-ios" : "mapbox-navigation-ios"
         profile = dataSource.routeProgress.route.routeOptions.profileIdentifier.rawValue
@@ -120,7 +120,7 @@ struct NavigationEventDetails: EventDetails {
         originalRequestIdentifier = session.originalRoute.routeIdentifier
         requestIdentifier = dataSource.routeProgress.route.routeIdentifier
                 
-        if let location = dataSource.location,
+        if let location = dataSource.router.rawLocation,
            let coordinates = dataSource.routeProgress.route.coordinates,
            let lastCoord = coordinates.last {
             userAbsoluteDistanceToDestination = location.distance(from: CLLocation(latitude: lastCoord.latitude, longitude: lastCoord.longitude))

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -47,7 +47,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                 delegate?.router?(self, willRerouteFrom: location)
             }
             _routeProgress = newValue
-            announce(reroute: routeProgress.route, at: dataSource.location, proactive: didFindFasterRoute)
+            announce(reroute: routeProgress.route, at: location, proactive: didFindFasterRoute)
         }
     }
     
@@ -129,7 +129,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
      The most recently received user location.
      - note: This is a raw location received from `locationManager`. To obtain an idealized location, use the `location` property.
      */
-    var rawLocation: CLLocation? {
+    public var rawLocation: CLLocation? {
         didSet {
             if isFirstLocation == true {
                 isFirstLocation = false

--- a/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -173,6 +173,7 @@ open class NavigationEventsManager: NSObject {
         
         var event = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = eventType
+        event.created = timestamp
         
         if let lastRerouteDate = sessionState.lastRerouteDate {
             event.secondsSinceLastReroute = round(timestamp.timeIntervalSince(lastRerouteDate))

--- a/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -9,7 +9,7 @@ let NavigationEventTypeRouteRetrieval = "mobile.performance_trace"
  */
 @objc public protocol EventsManagerDataSource: class {
     var routeProgress: RouteProgress { get }
-    var location: CLLocation? { get }
+    var router: Router! { get }
     var desiredAccuracy: CLLocationAccuracy { get }
     var locationProvider: NavigationLocationManager.Type { get }
 }
@@ -139,7 +139,7 @@ open class NavigationEventsManager: NSObject {
         var event = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = MMEEventTypeNavigationArrive
         
-        event.arrivalTimestamp = dataSource.location?.timestamp ?? Date()
+        event.arrivalTimestamp = dataSource.router.rawLocation?.timestamp ?? Date()
         return event
     }
     
@@ -169,7 +169,7 @@ open class NavigationEventsManager: NSObject {
     func navigationRerouteEvent(eventType: String = MMEEventTypeNavigationReroute) -> NavigationEventDetails? {
         guard let dataSource = dataSource, let sessionState = sessionState else { return nil }
 
-        let timestamp = dataSource.location?.timestamp ?? Date()
+        let timestamp = dataSource.router.rawLocation?.timestamp ?? Date()
         
         var event = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: usesDefaultUserInterface)
         event.event = eventType
@@ -250,7 +250,7 @@ open class NavigationEventsManager: NSObject {
 
     func enqueueRerouteEvent() {
         guard let eventDictionary = try? navigationRerouteEvent()?.asDictionary() else { return }
-        let timestamp = dataSource?.location?.timestamp ?? Date()
+        let timestamp = dataSource?.router.location?.timestamp ?? Date()
         
         sessionState?.lastRerouteDate = timestamp
         sessionState?.numberOfReroutes += 1
@@ -377,14 +377,14 @@ open class NavigationEventsManager: NSObject {
         
         if sessionState?.arrivalTimestamp == nil,
             progress.currentLegProgress.userHasArrivedAtWaypoint {
-            sessionState?.arrivalTimestamp = dataSource?.location?.timestamp ?? Date()
+            sessionState?.arrivalTimestamp = dataSource?.router.location?.timestamp ?? Date()
             sendArriveEvent()
             
             return
         }
         
         if sessionState?.departureTimestamp == nil {
-            sessionState?.departureTimestamp = dataSource?.location?.timestamp ?? Date()
+            sessionState?.departureTimestamp = dataSource?.router.location?.timestamp ?? Date()
             sendDepartEvent()
         }
     }

--- a/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -268,7 +268,7 @@ open class NavigationEventsManager: NSObject {
     }
 
     func enqueueFoundFasterRouteEvent() {
-        guard let eventDictionary = try? navigationRerouteEvent()?.asDictionary() else { return }
+        guard let eventDictionary = try? navigationRerouteEvent(eventType: FasterRouteFoundEvent)?.asDictionary() else { return }
 
         let timestamp = Date()
         sessionState?.lastRerouteDate = timestamp

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -504,10 +504,6 @@ extension MapboxNavigationService {
         return self.router.routeProgress
     }
     
-    public var location: CLLocation? {
-        return self.router.location
-    }
-    
     public var desiredAccuracy: CLLocationAccuracy {
         return self.locationManager.desiredAccuracy
     }

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -505,7 +505,7 @@ extension MapboxNavigationService {
     }
     
     public var location: CLLocation? {
-        return self.locationManager.location
+        return self.router.location
     }
     
     public var desiredAccuracy: CLLocationAccuracy {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -200,8 +200,9 @@ open class RouteController: NSObject {
             routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex = Int(voiceInstructionIndex)
             
             // Don't annouce spoken instruction if we are going to reroute
-            if !willReRoute {
-                announcePassage(of: routeProgress.currentLegProgress.currentStepProgress.currentSpokenInstruction!, routeProgress: routeProgress)
+            if !willReRoute,
+                let spokenInstruction = routeProgress.currentLegProgress.currentStepProgress.currentSpokenInstruction {
+                announcePassage(of: spokenInstruction, routeProgress: routeProgress)
             }
         }
     }

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -80,7 +80,7 @@ open class RouteController: NSObject {
                 delegate?.router?(self, willRerouteFrom: location)
             }
             _routeProgress = newValue
-            announce(reroute: routeProgress.route, at: dataSource.location, proactive: didFindFasterRoute)
+            announce(reroute: routeProgress.route, at: rawLocation, proactive: didFindFasterRoute)
         }
     }
     
@@ -102,7 +102,7 @@ open class RouteController: NSObject {
      The most recently received user location.
      - note: This is a raw location received from `locationManager`. To obtain an idealized location, use the `location` property.
      */
-    var rawLocation: CLLocation? {
+    public var rawLocation: CLLocation? {
         didSet {
             if isFirstLocation == true {
                 isFirstLocation = false

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -4,7 +4,6 @@ import MapboxDirections
 
 @objc (MBRouterDataSource)
 public protocol RouterDataSource {
-    var location: CLLocation? { get }
     var locationProvider: NavigationLocationManager.Type { get }
 }
 
@@ -49,6 +48,13 @@ public protocol RouterDataSource {
      The idealized user location. Snapped to the route line, if applicable, otherwise raw or nil.
      */
     @objc var location: CLLocation? { get }
+    
+    /**
+     The most recently received user location.
+     - note: This is a raw location received from `locationManager`. To obtain an idealized location, use the `location` property.
+     */
+    @objc var rawLocation: CLLocation? { get }
+    
     
     /**
      If true, the `RouteController` attempts to calculate a more optimal route for the user on an interval defined by `RouteControllerProactiveReroutingInterval`.
@@ -176,7 +182,7 @@ extension InternalRouter where Self: Router {
         }
         userInfo[.isProactiveKey] = didFindFasterRoute
         NotificationCenter.default.post(name: .routeControllerDidReroute, object: self, userInfo: userInfo)
-        delegate?.router?(self, didRerouteAlong: routeProgress.route, at: dataSource.location, proactive: didFindFasterRoute)
+        delegate?.router?(self, didRerouteAlong: routeProgress.route, at: location, proactive: didFindFasterRoute)
     }
 }
 

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -53,6 +53,8 @@ class NavigationEventsManagerTests: XCTestCase {
         let durationBetweenRerouteAndArrive = arriveEvent.arrivalTimestamp!.timeIntervalSince(rerouteEvent.startTimestamp!)
         
         XCTAssertTrue(durationBetweenDepartAndArrive > 1040, "Duration between depart and arrive should be greater than 1040 seconds")
+        XCTAssertEqual(arriveEvent.rerouteCount, 1)
+        
         // TODO: Figure out what timestamp to use for reroute and enable this test.
         //XCTAssertTrue(durationBetweenDepartAndReroute > 0, "Duration between depart and reroute should be greater than 0 seconds")
         // TODO: Figure out what timestamp to use for reroute and enable this test.

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -49,15 +49,12 @@ class NavigationEventsManagerTests: XCTestCase {
         let arriveEvent = events.filter { $0.event == MMEEventTypeNavigationArrive }.first!
         
         let durationBetweenDepartAndArrive = arriveEvent.arrivalTimestamp!.timeIntervalSince(departEvent.startTimestamp!)
-        let durationBetweenDepartAndReroute = rerouteEvent.startTimestamp!.timeIntervalSince(departEvent.startTimestamp!)
-        let durationBetweenRerouteAndArrive = arriveEvent.arrivalTimestamp!.timeIntervalSince(rerouteEvent.startTimestamp!)
+        let durationBetweenDepartAndReroute = rerouteEvent.created.timeIntervalSince(departEvent.startTimestamp!)
+        let durationBetweenRerouteAndArrive = arriveEvent.arrivalTimestamp!.timeIntervalSince(rerouteEvent.created)
         
-        XCTAssertTrue(durationBetweenDepartAndArrive > 1040, "Duration between depart and arrive should be greater than 1040 seconds")
+        XCTAssertEqual(Int(round(durationBetweenDepartAndArrive)), 1041)
+        XCTAssertEqual(Int(round(durationBetweenDepartAndReroute)), 225)
+        XCTAssertEqual(Int(round(durationBetweenRerouteAndArrive)), 816)
         XCTAssertEqual(arriveEvent.rerouteCount, 1)
-        
-        // TODO: Figure out what timestamp to use for reroute and enable this test.
-        //XCTAssertTrue(durationBetweenDepartAndReroute > 0, "Duration between depart and reroute should be greater than 0 seconds")
-        // TODO: Figure out what timestamp to use for reroute and enable this test.
-        //XCTAssertEqual(durationBetweenRerouteAndArrive > 0, "Duration between reroute and arrive should be greater than 0 seconds")
     }
 }

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -19,7 +19,7 @@ class NavigationEventsManagerTests: XCTestCase {
         let secondRoute = Fixture.route(from: "PipeFittersUnion-FourSeasonsBoston")
         
         let firstTrace = Array<CLLocation>(Fixture.generateTrace(for: firstRoute).prefix(upTo: firstRoute.coordinates!.count / 2)).shiftedToPresent().qualified()
-        let secondTrace = Fixture.generateTrace(for: secondRoute).shiftedTo(firstTrace.last!.timestamp + 1).qualified()
+        let secondTrace = Fixture.generateTrace(for: secondRoute).shifted(to: firstTrace.last!.timestamp + 1).qualified()
         
         let locationManager = NavigationLocationManager()
         let service = MapboxNavigationService(route: firstRoute,

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -40,16 +40,22 @@ class NavigationEventsManagerTests: XCTestCase {
         }
         
         let eventsManager = service.eventsManager as! NavigationEventsManagerSpy
+        let events = eventsManager.debuggableEvents
         
-        let departEvents = eventsManager.debuggableEvents.filter { $0.event == MMEEventTypeNavigationDepart }
+        XCTAssertEqual(events.count, 3, "There should be one depart, one reroute, and one arrive event.")
         
-        XCTAssertTrue(departEvents.count == 2, "There should be two depart events")
+        let departEvent = events.filter { $0.event == MMEEventTypeNavigationDepart }.first!
+        let rerouteEvent = events.filter { $0.event == MMEEventTypeNavigationReroute }.first!
+        let arriveEvent = events.filter { $0.event == MMEEventTypeNavigationArrive }.first!
         
-        let firstDepartEvent = departEvents.sorted(by: { $0.startTimestamp! < $1.startTimestamp! }).first!
-        let secondDepartEvent = departEvents.sorted(by: { $0.startTimestamp! > $1.startTimestamp! }).first!
+        let durationBetweenDepartAndArrive = arriveEvent.arrivalTimestamp!.timeIntervalSince(departEvent.startTimestamp!)
+        let durationBetweenDepartAndReroute = rerouteEvent.startTimestamp!.timeIntervalSince(departEvent.startTimestamp!)
+        let durationBetweenRerouteAndArrive = arriveEvent.arrivalTimestamp!.timeIntervalSince(rerouteEvent.startTimestamp!)
         
-        let durationBetweenDepartures = secondDepartEvent.startTimestamp!.timeIntervalSince(firstDepartEvent.startTimestamp!)
-        
-        XCTAssertTrue(durationBetweenDepartures > 1040, "Second departure should be more than 1040 seconds later than the first departure")
+        XCTAssertTrue(durationBetweenDepartAndArrive > 1040, "Duration between depart and arrive should be greater than 1040 seconds")
+        // TODO: Figure out what timestamp to use for reroute and enable this test.
+        //XCTAssertTrue(durationBetweenDepartAndReroute > 0, "Duration between depart and reroute should be greater than 0 seconds")
+        // TODO: Figure out what timestamp to use for reroute and enable this test.
+        //XCTAssertEqual(durationBetweenRerouteAndArrive > 0, "Duration between reroute and arrive should be greater than 0 seconds")
     }
 }

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MapboxMobileEvents
 @testable import TestHelper
 @testable import MapboxCoreNavigation
 
@@ -10,5 +11,45 @@ class NavigationEventsManagerTests: XCTestCase {
         let _ = NavigationEventsManager(dataSource: nil, accessToken: "example token", mobileEventsManager: mobileEventsManagerSpy)
 
         XCTAssertEqual(mobileEventsManagerSpy.accessToken, "example token")
+    }
+    
+    func testDepartRerouteArrive() {
+        
+        let firstRoute = Fixture.route(from: "DCA-Arboretum")
+        let secondRoute = Fixture.route(from: "PipeFittersUnion-FourSeasonsBoston")
+        
+        let firstTrace = Array<CLLocation>(Fixture.generateTrace(for: firstRoute).prefix(upTo: firstRoute.coordinates!.count / 2)).shiftedToPresent().qualified()
+        let secondTrace = Fixture.generateTrace(for: secondRoute).shiftedTo(firstTrace.last!.timestamp + 1).qualified()
+        
+        let locationManager = NavigationLocationManager()
+        let service = MapboxNavigationService(route: firstRoute,
+                                              directions: nil,
+                                              locationSource: locationManager,
+                                              eventsManagerType: NavigationEventsManagerSpy.self,
+                                              simulating: .always)
+        service.start()
+        
+        for location in firstTrace {
+            service.router.locationManager!(locationManager, didUpdateLocations: [location])
+        }
+        
+        service.route = secondRoute
+        
+        for location in secondTrace {
+            service.router.locationManager!(locationManager, didUpdateLocations: [location])
+        }
+        
+        let eventsManager = service.eventsManager as! NavigationEventsManagerSpy
+        
+        let departEvents = eventsManager.debuggableEvents.filter { $0.event == MMEEventTypeNavigationDepart }
+        
+        XCTAssertTrue(departEvents.count == 2, "There should be two depart events")
+        
+        let firstDepartEvent = departEvents.sorted(by: { $0.startTimestamp! < $1.startTimestamp! }).first!
+        let secondDepartEvent = departEvents.sorted(by: { $0.startTimestamp! > $1.startTimestamp! }).first!
+        
+        let durationBetweenDepartures = secondDepartEvent.startTimestamp!.timeIntervalSince(firstDepartEvent.startTimestamp!)
+        
+        XCTAssertTrue(durationBetweenDepartures > 1040, "Second departure should be more than 1040 seconds later than the first departure")
     }
 }

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -227,7 +227,7 @@ public class CarPlayNavigationViewController: UIViewController {
                                  legIndex: progress.legIndex,
                                  stepIndex: progress.currentLegProgress.stepIndex + 1)
             } else if tracksUserCourse && !newValue {
-                guard let userLocation = self.navigationService.location?.coordinate else {
+                guard let userLocation = self.navigationService.router.location?.coordinate else {
                     return
                 }
                 mapView?.enableFrameByFrameCourseViewTracking(for: 3)

--- a/TestHelper/CoreLocation.swift
+++ b/TestHelper/CoreLocation.swift
@@ -136,11 +136,11 @@ extension Array where Element == CLLocation {
     
     // Shifts the [CLLocation]’s first location to now and offsets the remaining locations by one second after the prior.
     public func shiftedToPresent() -> [CLLocation] {
-        return shiftedTo(Date())
+        return shifted(to: Date())
     }
     
     // Shifts the [CLLocation]’s first location to the given timestamp and offsets the  remaining locations by one second after the prior.
-    public func shiftedTo(_ timestamp: Date) -> [CLLocation] {
+    public func shifted(to timestamp: Date) -> [CLLocation] {
         return enumerated().map { CLLocation(coordinate: $0.element.coordinate,
                                              altitude: $0.element.altitude,
                                              horizontalAccuracy: $0.element.horizontalAccuracy,

--- a/TestHelper/CoreLocation.swift
+++ b/TestHelper/CoreLocation.swift
@@ -136,14 +136,18 @@ extension Array where Element == CLLocation {
     
     // Shifts the [CLLocation]’s first location to now and offsets the remaining locations by one second after the prior.
     public func shiftedToPresent() -> [CLLocation] {
-        let now = Date()
+        return shiftedTo(Date())
+    }
+    
+    // Shifts the [CLLocation]’s first location to the given timestamp and offsets the  remaining locations by one second after the prior.
+    public func shiftedTo(_ timestamp: Date) -> [CLLocation] {
         return enumerated().map { CLLocation(coordinate: $0.element.coordinate,
                                              altitude: $0.element.altitude,
                                              horizontalAccuracy: $0.element.horizontalAccuracy,
                                              verticalAccuracy: $0.element.verticalAccuracy,
                                              course: $0.element.course,
                                              speed: $0.element.speed,
-                                             timestamp: now + $0.offset) }
+                                             timestamp: timestamp + $0.offset) }
     }
     
     // Returns a [CLLocation] with course and accuracies qualified for navigation native.

--- a/TestHelper/NavigationEventsManagerTestDoubles.swift
+++ b/TestHelper/NavigationEventsManagerTestDoubles.swift
@@ -5,7 +5,17 @@ import MapboxDirections
 
 public class NavigationEventsManagerSpy: NavigationEventsManager {
 
-    private var mobileEventsManagerSpy: MMEEventsManagerSpy!
+    var mobileEventsManagerSpy: MMEEventsManagerSpy!
+    
+    var _enqueuedEvents: [FakeTelemetryEvent] {
+        return mobileEventsManagerSpy.enqueuedEvents
+    }
+    
+    var _flushedEvents: [FakeTelemetryEvent] {
+        return mobileEventsManagerSpy.flushedEvents
+    }
+    
+    var debuggableEvents = [NavigationEventDetails]()
 
     required public init() {
         mobileEventsManagerSpy = MMEEventsManagerSpy()
@@ -35,14 +45,38 @@ public class NavigationEventsManagerSpy: NavigationEventsManager {
     func flushedEventCount(with eventName: String) -> Int {
         return mobileEventsManagerSpy.flushedEventCount(with: eventName)
     }
+    
+    override public func navigationDepartEvent() -> NavigationEventDetails? {
+        if let event = super.navigationDepartEvent() {
+            debuggableEvents.append(event)
+            return event
+        }
+        return nil
+    }
+    
+    override public func navigationArriveEvent() -> NavigationEventDetails? {
+        if let event = super.navigationArriveEvent() {
+            debuggableEvents.append(event)
+            return event
+        }
+        return nil
+    }
+    
+    override public func navigationRerouteEvent(eventType: String = MMEEventTypeNavigationReroute) -> NavigationEventDetails? {
+        if let event = super.navigationRerouteEvent() {
+            debuggableEvents.append(event)
+            return event
+        }
+        return nil
+    }
 }
 
 typealias FakeTelemetryEvent = (name: String, attributes: [String: Any])
 
 class MMEEventsManagerSpy: MMEEventsManager {
 
-    private var enqueuedEvents = [FakeTelemetryEvent]()
-    private var flushedEvents = [FakeTelemetryEvent]()
+    var enqueuedEvents = [FakeTelemetryEvent]()
+    var flushedEvents = [FakeTelemetryEvent]()
 
     public func reset() {
         enqueuedEvents.removeAll()


### PR DESCRIPTION
- [x] Make events agnostic to real-time so we can speed up the tests
- [x] Avoid duplicated depart event (your assumption was correct here @akitchen)
- [x] Set reroute timestamp

Regarding the reroute timestamp, `NavigationEventDetails.created` is now mutable to support the reroute case.

cc @mapbox/navigation-ios 