### PR TITLE
Fix blank banner

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -259,6 +259,7 @@ class RouteMapViewController: UIViewController {
         navigationView.resumeButton.addTarget(self, action: Actions.recenter, for: .touchUpInside)
         resumeNotifications()
         notifyUserAboutLowVolume()
+        updateInstructionBanners(visualInstructionBanner: router.routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction)
     }
 
     deinit {
@@ -267,7 +268,6 @@ class RouteMapViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
 
         navigationView.muteButton.isSelected = NavigationSettings.shared.voiceMuted
         mapView.compassView.isHidden = true
@@ -405,10 +405,14 @@ class RouteMapViewController: UIViewController {
         
         // only update banner with the current step if we are not previewing our route
         if currentPreviewInstructionBannerStepIndex == nil {
-            instructionsBannerView.update(for: routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction)
-            lanesView.update(for: routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction)
-            nextBannerView.update(for: routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction)
+            updateInstructionBanners(visualInstructionBanner: routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction)
         }
+    }
+    
+    func updateInstructionBanners(visualInstructionBanner: VisualInstructionBanner?) {
+        instructionsBannerView.update(for: visualInstructionBanner)
+        lanesView.update(for: visualInstructionBanner)
+        nextBannerView.update(for: visualInstructionBanner)
     }
 
     func updateMapOverlays(for routeProgress: RouteProgress) {

--- a/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -224,6 +224,22 @@ class NavigationViewControllerTests: XCTestCase {
         
     }
     
+    func testBlankBanner() {
+        let window = UIApplication.shared.keyWindow!
+        let viewController = window.rootViewController!
+        
+        let route = Fixture.route(from: "DCA-Arboretum")
+        let navigationViewController = NavigationViewController(for: route)
+        
+        viewController.present(navigationViewController, animated: false, completion: nil)
+        
+        let firstInstruction = route.legs[0].steps[0].instructionsDisplayedAlongStep!.first
+        let instructionsBannerView = navigationViewController.mapViewController!.instructionsBannerView
+        
+        XCTAssertNotNil(instructionsBannerView.primaryLabel.text)
+        XCTAssertEqual(instructionsBannerView.primaryLabel.text, firstInstruction?.primaryInstruction.text)
+    }
+    
     private func annotationFilter(matching coordinate: CLLocationCoordinate2D) -> ((MGLAnnotation) -> Bool) {
         let filter = { (annotation: MGLAnnotation) -> Bool in
             guard let pointAnno = annotation as? MGLPointAnnotation else { return false }


### PR DESCRIPTION
Fixes #1995 

nav-native needs three location updates to fully initialize so we don't have an instructions banner at the very beginning.

This PR fixes that by using the first instruction initially.

cc @1ec5 @JThramer 