### PR TITLE
Carplay Arrival UI - Removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## master
 
 * The `BottomBannerViewController` now accounts for the safe-area inset correctly, if applicable. ([#1982](https://github.com/mapbox/mapbox-navigation-ios/pull/1982))
+
+### CarPlay
+
+* `CarPlayNavigationViewController` now exposes the `navigationService`. ([#2005](https://github.com/mapbox/mapbox-navigation-ios/pull/2005))
+* `CarPlayNavigationViewControllerDelegate` now has a message for when a user arrives at a waypoint. ([#2005](https://github.com/mapbox/mapbox-navigation-ios/pull/2005))
 * `CarPlayManager` will now notify its delegate if the route request fails and provide the option to present an alert on the map template. ([#1981](https://github.com/mapbox/mapbox-navigation-ios/pull/1981))
 
 ## v0.29.1

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		8DDBFCA32205016E0064DEBB /* NavigationCustomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDBFCA22205016E0064DEBB /* NavigationCustomizable.swift */; };
 		8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE879651FBB9980002F06C0 /* EndOfRouteViewController.swift */; };
 		8DEB4066220CE596008BAAB4 /* NavigationMapViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEB4065220CE596008BAAB4 /* NavigationMapViewDelegate.swift */; };
+		8DEDBCA9222F442900DA2618 /* CarPlayNavigationViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEDBCA7222F433700DA2618 /* CarPlayNavigationViewControllerTests.swift */; };
 		8DEDEF3421E3FBE80049E114 /* NavigationViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEDEF3321E3FBE80049E114 /* NavigationViewControllerDelegate.swift */; };
 		8DF399B21FB257B30034904C /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF399B11FB257B30034904C /* UIGestureRecognizer.swift */; };
 		8DFD949E221F66BE00152F45 /* BottomBannerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DFD949D221F66BE00152F45 /* BottomBannerSnapshotTests.swift */; };
@@ -823,6 +824,7 @@
 		8DDBFCA22205016E0064DEBB /* NavigationCustomizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCustomizable.swift; sourceTree = "<group>"; };
 		8DE879651FBB9980002F06C0 /* EndOfRouteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfRouteViewController.swift; sourceTree = "<group>"; };
 		8DEB4065220CE596008BAAB4 /* NavigationMapViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationMapViewDelegate.swift; sourceTree = "<group>"; };
+		8DEDBCA7222F433700DA2618 /* CarPlayNavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayNavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		8DEDEF3321E3FBE80049E114 /* NavigationViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerDelegate.swift; sourceTree = "<group>"; };
 		8DF399B11FB257B30034904C /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
 		8DF8E4DE2202696800B29FEF /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
@@ -1318,6 +1320,7 @@
 				3527D2B61EC45FBD00C07FC9 /* Fixtures.xcassets */,
 				16E3625A2012656C00DF0592 /* Support */,
 				16EF6C1D21193A9600AA580B /* CarPlayManagerTests.swift */,
+				8DEDBCA7222F433700DA2618 /* CarPlayNavigationViewControllerTests.swift */,
 				35022319205BC94E00E1449A /* Constants.swift */,
 				160D827A2059973C00D278D6 /* DataCacheTests.swift */,
 				1662244A2029059C00EA4824 /* ImageCacheTests.swift */,
@@ -2472,6 +2475,7 @@
 				3597ABD021553B6F00C12785 /* SimulatedLocationManagerTests.swift in Sources */,
 				35F1F5931FD57EFD00F8E502 /* StyleManagerTests.swift in Sources */,
 				AE00A73A209A2C38006A3DC7 /* StepsViewControllerTests.swift in Sources */,
+				8DEDBCA9222F442900DA2618 /* CarPlayNavigationViewControllerTests.swift in Sources */,
 				35B1AEBC20AD9B3C00C8544E /* LeaksSpec.swift in Sources */,
 				16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */,
 				8D86AE8B21C31CC80064A304 /* ManeuverArrowTests.swift in Sources */,

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -518,7 +518,7 @@ public protocol CarPlayNavigationDelegate {
      - parameter waypoint: The waypoint that the user has arrived at.
      - returns: True to automatically advance to the next leg, or false to remain on the now completed leg.
      */
-    @objc(carPlaynavigationViewController:didArriveAtWaypoint:)
-    optional func carPlaynavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
+    @objc(carPlayNavigationViewController:didArriveAtWaypoint:)
+    optional func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
 }
 #endif

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -487,7 +487,7 @@ extension CarPlayNavigationViewController: StyleManagerDelegate {
 @available(iOS 12.0, *)
 extension CarPlayNavigationViewController: NavigationServiceDelegate {
     public func navigationService(_ service: NavigationService, didArriveAt waypoint: Waypoint) -> Bool {
-        let advancesToNextLeg = carPlayNavigationDelegate?.carPlaynavigationViewController?(self, didArriveAt: waypoint) ?? true
+        let advancesToNextLeg = carPlayNavigationDelegate?.carPlayNavigationViewController?(self, didArriveAt: waypoint) ?? true
         
         return advancesToNextLeg
     }

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -21,6 +21,12 @@ public class CarPlayNavigationViewController: UIViewController {
     
     @objc public var drivingSide: DrivingSide = .right
     
+    
+    /**
+     Provides all routing logic for the user.
+     
+     See `NavigationService` for more information.
+     */
     @objc public var navigationService: NavigationService
     
     /**

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -200,7 +200,7 @@ public class CarPlayNavigationViewController: UIViewController {
     public func exitNavigation(byCanceling canceled: Bool = false) {
         carSession.finishTrip()
         dismiss(animated: true, completion: nil)
-        carPlayNavigationDelegate?.carPlayNavigationViewControllerDidDismiss(self, byCanceling: canceled)
+        carPlayNavigationDelegate?.carPlayNavigationViewControllerDidDismiss?(self, byCanceling: canceled)
     }
     
     /**
@@ -506,14 +506,7 @@ public protocol CarPlayNavigationDelegate {
      - parameter canceled: True if the user dismissed the CarPlay navigation view controller by tapping the Cancel button; false if the navigation view controller dismissed by some other means.
      */
     @objc(carPlayNavigationViewControllerDidDismiss:byCanceling:)
-    func carPlayNavigationViewControllerDidDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController, byCanceling canceled: Bool)
-
-    /**
-     Called when the CarPlay navigation view controller detects an arrival.
-
-     - parameter carPlayNavigationViewController: The CarPlay navigation view controller that was dismissed.
-     */
-    @objc func carPlayNavigationViewControllerDidArrive(_ carPlayNavigationViewController: CarPlayNavigationViewController)
+    optional func carPlayNavigationViewControllerDidDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController, byCanceling canceled: Bool)
     
     /**
      Called when the user arrives at the destination waypoint for a route leg.

--- a/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
@@ -14,7 +14,7 @@ fileprivate class CarPlayNavigationDelegateSpy: NSObject, CarPlayNavigationDeleg
         self.didArriveExpectation = didArriveExpectation
     }
     
-    func carPlaynavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
+    func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
     {
         self.didArriveExpectation.fulfill()
         return true

--- a/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
@@ -1,0 +1,46 @@
+@testable import MapboxNavigation
+@testable import MapboxCoreNavigation
+import MapboxDirections
+import XCTest
+import Foundation
+import TestHelper
+
+
+@available(iOS 12.0, *)
+fileprivate class CarPlayNavigationDelegateSpy: NSObject, CarPlayNavigationDelegate {
+    var didArriveExpectation: XCTestExpectation!
+    
+    init(_ didArriveExpectation: XCTestExpectation) {
+        self.didArriveExpectation = didArriveExpectation
+    }
+    
+    func carPlaynavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
+    {
+        self.didArriveExpectation.fulfill()
+        return true
+    }
+}
+
+@available(iOS 12.0, *)
+class CarPlayNavigationViewControllerTests: XCTestCase {
+    
+    
+    
+    func testArrive() {
+        let expectation = XCTestExpectation(description: "The delegate should of recieved the didArrive message")
+        let spy = CarPlayNavigationDelegateSpy(expectation)
+        
+        let route = Fixture.route(from: "routeWithInstructions")
+        let serviceFake = MapboxNavigationService(route: route)
+        let fakeTemplate = CPMapTemplate()
+        let fakeManager = CarPlayManager(styles: nil, directions: nil, eventsManager: nil)
+        simulateCarPlayConnection(fakeManager)
+        let subject = CarPlayNavigationViewController(navigationService: serviceFake, mapTemplate: fakeTemplate, interfaceController: fakeManager.interfaceController!, manager: fakeManager)
+        subject.carPlayNavigationDelegate = spy
+        let answer = subject.navigationService(serviceFake, didArriveAt: route.routeOptions.waypoints.last!)
+        
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssert(answer == true, "Boolean response not respected in didArrive: delegate call")
+    }
+
+}


### PR DESCRIPTION
Implements #2000. 

![The arrival... get it?](https://hips.hearstapps.com/pop.h-cdn.co/assets/17/08/1487623674-ezgif-2-8b28b07fc8.gif)

* Removing CarPlay arrival UI. 
* Creating delegate method for arrival event. 
* Also renaming navService -> navigationService and taking it public.

To-do: 
- [x] Write a test?

/cc @mapbox/navigation-ios 