### PR TITLE
List downloaded offline packs

### DIFF
--- a/MapboxCoreNavigationTests/BridgingTests.m
+++ b/MapboxCoreNavigationTests/BridgingTests.m
@@ -75,6 +75,16 @@
         
     }];
 }
+
+- (void)testDownloadedVersions {
+    NSBundle *bundle = [NSBundle mapboxCoreNavigation];
+    NSArray<NSString *> *versions = [MBNavigationDirections downloadedVersionsInBundle:bundle error:NULL];
+    
+    NSString *version = versions.firstObject;
+    
+    XCTAssert(versions.count == 1);
+    XCTAssert([version isEqualToString:@"2018_12_18-20_59_05"]);
+}
     
 @end
 

--- a/MapboxCoreNavigationTests/OfflineRoutingTests.swift
+++ b/MapboxCoreNavigationTests/OfflineRoutingTests.swift
@@ -118,4 +118,10 @@ class OfflineRoutingTests: XCTestCase {
         
         wait(for: [configureExpectation], timeout: 60)
     }
+    
+    func testDownloadedVersions() {
+        let versions = try! NavigationDirections.downloadedVersions()
+        XCTAssert(versions.count == 1)
+        XCTAssert(versions[0] == "2018_12_18-20_59_05")
+    }
 }


### PR DESCRIPTION
To find an already downloaded offline routing pack, you have to scan for directories in a bundle, filter out relevant versions and verify the integrity of that folder or make an API call to `fetchAvailableOfflineVersions(completionHandler:)` and then check for available tiles in the corresponding version’s directory.

I added a helper method to simplify these steps.

cc @mapbox/navigation-ios 