### PR TITLE
Preserve via points after rerouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Restored the `RouteController.reroutesProactively` property. By default, `RouteController` and `LegacyRouteController` proactively check for a faster route on an interval defined by `RouteControllerProactiveReroutingInterval`. ([#1986](https://github.com/mapbox/mapbox-navigation-ios/pull/1986))
 * Added a `RouteControllerMinimumDurationRemainingForProactiveRerouting` global variable to customize when `RouteController` stops looking for more optimal routes as the user nears the destination. ([#1986](https://github.com/mapbox/mapbox-navigation-ios/pull/1986))
 * Fixed a bug which would cancel an ongoing reroute request when the request takes longer than one second to complete. ([#1986](https://github.com/mapbox/mapbox-navigation-ios/pull/1986))
+* Fixed an issue where rerouting would ignore any waypoints from the original route options where the `Waypoint.separatesLegs` property was set to `false`. ([#2014](https://github.com/mapbox/mapbox-navigation-ios/pull/2014))
 
 ### CarPlay
 

--- a/MapboxCoreNavigation/RouteLeg.swift
+++ b/MapboxCoreNavigation/RouteLeg.swift
@@ -1,0 +1,8 @@
+import MapboxDirections
+import Turf
+
+extension RouteLeg {
+    var coordinates: [CLLocationCoordinate2D] {
+        return (steps.first?.coordinates ?? []) + steps.dropFirst().flatMap { ($0.coordinates ?? []).dropFirst() }
+    }
+}

--- a/MapboxCoreNavigation/RouteOptions.swift
+++ b/MapboxCoreNavigation/RouteOptions.swift
@@ -23,4 +23,41 @@ extension RouteOptions {
         
         return copy
     }
+    
+    /**
+     Returns a tuple containing the waypoints along the leg at the given index and the waypoints that separate subsequent legs.
+     
+     The first element of the tuple includes the leg’s source but not its destination.
+     */
+    func waypoints(fromLegAt legIndex: Int) -> ([Waypoint], [Waypoint]) {
+        // The first and last waypoints always separate legs. Make exceptions for these waypoints instead of modifying them by side effect.
+        let legSeparators = waypoints.filterKeepingFirstAndLast { $0.separatesLegs }
+        let viaPointsByLeg = waypoints.splitExceptAtStartAndEnd(omittingEmptySubsequences: false) { $0.separatesLegs }
+            .dropFirst() // No leg precedes first separator.
+        
+        let reconstitutedWaypoints = zip(legSeparators, viaPointsByLeg).dropFirst(legIndex).map { [$0.0] + $0.1 }
+        let legWaypoints = reconstitutedWaypoints.first ?? []
+        let subsequentWaypoints = reconstitutedWaypoints.dropFirst()
+        return (legWaypoints, subsequentWaypoints.flatMap { $0 })
+    }
+}
+
+extension Array {
+    /**
+     - seealso: Array.filter(_:)
+     */
+    public func filterKeepingFirstAndLast(_ isIncluded: (Element) throws -> Bool) rethrows -> [Element] {
+        return try enumerated().filter {
+            try isIncluded($0.element) || $0.offset == 0 || $0.offset == indices.last
+        }.map { $0.element }
+    }
+    
+    /**
+     - seealso: Array.split(maxSplits:omittingEmptySubsequences:whereSeparator:)
+     */
+    public func splitExceptAtStartAndEnd(maxSplits: Int = .max, omittingEmptySubsequences: Bool = true, whereSeparator isSeparator: (Element) throws -> Bool) rethrows -> [ArraySlice<Element>] {
+        return try enumerated().split(maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) {
+            try isSeparator($0.element) || $0.offset == 0 || $0.offset == indices.last
+        }.map { $0.map { $0.element }.suffix(from: 0) }
+    }
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -87,10 +87,21 @@ open class RouteProgress: NSObject {
     }
 
     /**
-     Number of waypoints remaining on the current route.
+     The waypoints remaining on the current route.
+     
+     This property does not include waypoints whose `Waypoint.separatesLegs` property is set to `false`.
      */
     @objc public var remainingWaypoints: [Waypoint] {
         return route.legs.suffix(from: legIndex).map { $0.destination }
+    }
+    
+    /**
+     The waypoints remaining on the current route, including any waypoints that do not separate legs.
+     */
+    func remainingWaypointsForCalculatingRoute() -> [Waypoint] {
+        let (currentLegViaPoints, remainingWaypoints) = route.routeOptions.waypoints(fromLegAt: legIndex)
+        let currentLegRemainingViaPoints = currentLegProgress.remainingWaypoints(among: currentLegViaPoints)
+        return currentLegRemainingViaPoints + remainingWaypoints
     }
 
     /**
@@ -253,7 +264,7 @@ open class RouteProgress: NSObject {
             user.heading = current.course
             user.headingAccuracy = RouteProgress.reroutingAccuracy
         }
-        let newWaypoints = [user] + remainingWaypoints
+        let newWaypoints = [user] + remainingWaypointsForCalculatingRoute()
         let newOptions = oldOptions.copy() as! RouteOptions
         newOptions.waypoints = newWaypoints
 
@@ -453,6 +464,33 @@ open class RouteLegProgress: NSObject {
         }
 
         return currentClosest
+    }
+    
+    /**
+     The waypoints remaining on the current leg, not including the leg’s destination.
+     */
+    func remainingWaypoints(among waypoints: [Waypoint]) -> [Waypoint] {
+        guard waypoints.count > 1 else {
+            // The leg has only a source and no via points. Save ourselves a call to RouteLeg.coordinates, which can be expensive.
+            return []
+        }
+        let legPolyline = Polyline(leg.coordinates)
+        guard let userCoordinateIndex = legPolyline.indexedCoordinateFromStart(distance: distanceTraveled)?.index else {
+            // The leg is empty, so none of the waypoints are meaningful.
+            return []
+        }
+        var slice = legPolyline
+        var accumulatedCoordinates = 0
+        return Array(waypoints.drop { (waypoint) -> Bool in
+            var newSlice = slice.sliced(from: waypoint.coordinate)
+            // Work around <https://github.com/mapbox/turf-swift/pull/79>.
+            if newSlice.coordinates.count > 2 && newSlice.coordinates.last == newSlice.coordinates.dropLast().last {
+                newSlice.coordinates.removeLast()
+            }
+            accumulatedCoordinates += slice.coordinates.count - newSlice.coordinates.count
+            slice = newSlice
+            return accumulatedCoordinates <= userCoordinateIndex
+        })
     }
 }
 

--- a/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 import MapboxDirections
+import struct Polyline.Polyline
+import Turf
 @testable import MapboxCoreNavigation
 
 class RouteProgressTests: XCTestCase {
@@ -43,5 +45,190 @@ class RouteProgressTests: XCTestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.fractionTraveled, 0)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.userDistanceToManeuverLocation, Double.infinity)
         XCTAssertEqual(routeProgress.currentLegProgress.currentStepProgress.step.description, "Turn right onto California Street")
+    }
+    
+    func testRemainingWaypointsAlongRoute() {
+        var coordinates = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 2, longitude: 3),
+            CLLocationCoordinate2D(latitude: 4, longitude: 6),
+            CLLocationCoordinate2D(latitude: 6, longitude: 9),
+            CLLocationCoordinate2D(latitude: 8, longitude: 12),
+            CLLocationCoordinate2D(latitude: 10, longitude: 15),
+            CLLocationCoordinate2D(latitude: 12, longitude: 18),
+        ]
+        
+        // Single leg
+        var options = RouteOptions(coordinates: [coordinates.first!, coordinates.last!])
+        var waypoints = options.waypoints(fromLegAt: 0)
+        XCTAssertEqual(waypoints.0.map { $0.coordinate }, [coordinates.first!])
+        XCTAssertEqual(waypoints.1.map { $0.coordinate }, [coordinates.last!])
+        
+        // Two legs
+        options = RouteOptions(coordinates: [coordinates[0], coordinates[1], coordinates.last!])
+        waypoints = options.waypoints(fromLegAt: 0)
+        XCTAssertEqual(waypoints.0.map { $0.coordinate }, [coordinates[0]])
+        XCTAssertEqual(waypoints.1.map { $0.coordinate }, [coordinates[1], coordinates.last!])
+        waypoints = options.waypoints(fromLegAt: 1)
+        XCTAssertEqual(waypoints.0.map { $0.coordinate }, [coordinates[1]])
+        XCTAssertEqual(waypoints.1.map { $0.coordinate }, [coordinates.last!])
+        
+        // Every coordinate is a leg
+        options = RouteOptions(coordinates: coordinates)
+        waypoints = options.waypoints(fromLegAt: 0)
+        XCTAssertEqual(waypoints.0.map { $0.coordinate }, [coordinates.first!])
+        XCTAssertEqual(waypoints.1.map { $0.coordinate }, Array(coordinates.dropFirst()))
+        
+        // Every coordinate is a via point
+        for waypoint in options.waypoints {
+            waypoint.separatesLegs = false
+        }
+        waypoints = options.waypoints(fromLegAt: 0)
+        XCTAssertEqual(waypoints.0.map { $0.coordinate }, Array(coordinates.dropLast()))
+        XCTAssertEqual(waypoints.1.map { $0.coordinate }, [coordinates.last!])
+    }
+    
+    func routeLegProgress(options: RouteOptions, routeCoordinates: [CLLocationCoordinate2D]) -> RouteLegProgress {
+        let source = options.waypoints.first!
+        let destination = options.waypoints.last!
+        options.shapeFormat = .polyline
+        let jsonLeg = [
+            "steps": [
+                [
+                    "maneuver": [
+                        "type": "depart",
+                        "location": [source.coordinate.longitude, source.coordinate.latitude],
+                    ],
+                    "name": "",
+                    "mode": "",
+                    "geometry": Polyline(coordinates: routeCoordinates, precision: 1e5).encodedPolyline,
+                ],
+                [
+                    "maneuver": [
+                        "type": "arrive",
+                        "location": [destination.coordinate.longitude, destination.coordinate.latitude],
+                    ],
+                    "name": "",
+                    "mode": "",
+                ],
+            ],
+            "distance": 0.0,
+            "duration": 0.0,
+            "summary": "",
+        ] as [String: Any]
+        let leg = RouteLeg(json: jsonLeg, source: source, destination: destination, options: options)
+        return RouteLegProgress(leg: leg)
+    }
+    
+    func testRemainingWaypointsAlongLeg() {
+        // Linear leg
+        var coordinates = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 2, longitude: 3),
+            CLLocationCoordinate2D(latitude: 4, longitude: 6),
+            CLLocationCoordinate2D(latitude: 6, longitude: 9),
+            CLLocationCoordinate2D(latitude: 8, longitude: 12),
+            CLLocationCoordinate2D(latitude: 10, longitude: 15),
+            CLLocationCoordinate2D(latitude: 12, longitude: 18),
+        ]
+        
+        // No via points
+        var options = RouteOptions(coordinates: [coordinates.first!, coordinates.last!])
+        var legProgress = routeLegProgress(options: options, routeCoordinates: coordinates)
+        
+        var remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 0,
+                       "With no via points, at the start of the leg, neither the source nor a via point should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = coordinates[0].distance(to: coordinates[1]) / 2.0
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 0,
+                       "With no via points, partway down the leg, neither the source nor a via point should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = coordinates[0].distance(to: coordinates[1])
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 0,
+                       "With no via points, partway down the leg, neither the source nor a via point should remain")
+        
+        // Every coordinate is a via point.
+        options = RouteOptions(coordinates: coordinates)
+        
+        legProgress = routeLegProgress(options: options, routeCoordinates: coordinates)
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, options.waypoints.count - 2,
+                       "At the start of the leg, all but the source should remain")
+        
+        legProgress = routeLegProgress(options: options, routeCoordinates: coordinates)
+        legProgress.currentStepProgress.distanceTraveled = coordinates[0].distance(to: coordinates[1]) / 2.0
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, options.waypoints.count - 2,
+                       "Halfway to the first via point, all but the source should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = coordinates[0].distance(to: coordinates[1])
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, options.waypoints.count - 3,
+                       "At the first via point, all but the source and first via point should remain")
+        
+        // Leg that backtracks
+        coordinates = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 2, longitude: 3),
+            CLLocationCoordinate2D(latitude: 4, longitude: 6),
+            CLLocationCoordinate2D(latitude: 6, longitude: 9), // begin backtracking
+            CLLocationCoordinate2D(latitude: 4, longitude: 6),
+            CLLocationCoordinate2D(latitude: 2, longitude: 3),
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+        ]
+        
+        // No via points.
+        options = RouteOptions(coordinates: [coordinates.first!, coordinates.last!])
+        legProgress = routeLegProgress(options: options, routeCoordinates: coordinates)
+        
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 0,
+                       "With no via points, at the start of a leg that backtracks, neither the source nor a via point should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = coordinates[0].distance(to: coordinates[1])
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 0,
+                       "With no via points, partway down a leg before backtracking, neither the source nor a via point should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = coordinates[0].distance(to: coordinates[3]) + coordinates[3].distance(to: coordinates[4])
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 0,
+                       "With no via points, partway down a leg after backtracking, neither the source nor a via point should remain")
+        
+        // Every coordinate is a via point.
+        options = RouteOptions(coordinates: coordinates)
+        
+        legProgress = routeLegProgress(options: options, routeCoordinates: coordinates)
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 5,
+                       "At the start of a leg that backtracks, all but the source should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = coordinates[0].distance(to: coordinates[1])
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 4,
+                       "At the first via point before backtracking, all but the source and first via point should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = LineString(coordinates).distance() / 2.0
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 2,
+                       "At the via point where the leg backtracks, only the via points after backtracking should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = LineString(coordinates).distance() / 2.0 + coordinates[3].distance(to: coordinates[4]) / 2.0
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 2,
+                       "Halfway to the via point where the leg backtracks, only the via points after backtracking should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = LineString(coordinates).distance() / 2.0 + coordinates[3].distance(to: coordinates[4])
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 1,
+                       "At the first via point after backtracking, all but one of the via points after backtracking should remain")
+        
+        legProgress.currentStepProgress.distanceTraveled = LineString(coordinates).distance()
+        remainingWaypoints = legProgress.remainingWaypoints(among: Array(options.waypoints.dropLast()))
+        XCTAssertEqual(remainingWaypoints.count, 0,
+                       "At the last via point after backtracking, nothing should remain")
     }
 }

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 		DADAD82F20350849002E25CA /* MBRouteVoiceController.m in Sources */ = {isa = PBXBuildFile; fileRef = DADAD82D20350849002E25CA /* MBRouteVoiceController.m */; };
 		DADD82802161EC0300B8B47D /* UIViewAnimationOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADD827F2161EC0300B8B47D /* UIViewAnimationOptionsTests.swift */; };
 		DAE22A2921C9DEDA00CA269D /* MGLVectorTileSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE22A2821C9DEDA00CA269D /* MGLVectorTileSourceTests.swift */; };
+		DAE9ED522233097C00C01291 /* RouteLeg.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9ED512233097C00C01291 /* RouteLeg.swift */; };
 		DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */; };
 /* End PBXBuildFile section */
 
@@ -986,6 +987,7 @@
 		DAE26B2820647A82001D6E1F /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = he; path = Resources/he.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DAE7114C1F22E94E009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE7114E1F22E977009AED76 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Navigation.strings; sourceTree = "<group>"; };
+		DAE9ED512233097C00C01291 /* RouteLeg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteLeg.swift; sourceTree = "<group>"; };
 		DAF257122017C1E800367EF5 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sv; path = Resources/sv.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DAFEB36A2093A0D800A86A83 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Navigation.strings; sourceTree = "<group>"; };
 		DAFEB36D2093A11F00A86A83 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1566,6 +1568,7 @@
 				C5381F01204E03B600A5493E /* UIDevice.swift */,
 				C5F2DC9F206DBF5E002F99F6 /* Sequence.swift */,
 				35C98732212E037900808B82 /* MBNavigator.swift */,
+				DAE9ED512233097C00C01291 /* RouteLeg.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2600,6 +2603,7 @@
 				C58D6BAD1DDCF2AE00387F53 /* CoreConstants.swift in Sources */,
 				35C77F621FE8219900338416 /* NavigationSettings.swift in Sources */,
 				C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */,
+				DAE9ED522233097C00C01291 /* RouteLeg.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Fixed an issue where rerouting would ignore any waypoints from the original route options where the `Waypoint.separatesLegs` property was set to `false`.

~~This is still a work in progress – some test cases fail because the algorithm doesn’t adequately account for edge cases when backtracking.~~

Fixes #2003.

/cc @mapbox/navigation-ios