### PR TITLE
Fix CarPlay compass visibility

### DIFF
--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -119,7 +119,6 @@ public class CarPlayMapViewController: UIViewController {
     
     override public func loadView() {
         let mapView = NavigationMapView()
-//        mapView.navigationMapDelegate = self
         mapView.logoView.isHidden = true
         mapView.attributionButton.isHidden = true
         

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -42,7 +42,6 @@ public class CarPlayNavigationViewController: UIViewController {
     var mapTemplate: CPMapTemplate
     var carFeedbackTemplate: CPGridTemplate!
     var carInterfaceController: CPInterfaceController
-    var previousSafeAreaInsets: UIEdgeInsets?
     var styleManager: StyleManager?
     
     /**
@@ -167,12 +166,8 @@ public class CarPlayNavigationViewController: UIViewController {
     public override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         
-        if let previousSafeAreaInsets = previousSafeAreaInsets {
-            let navigationBarIsOpen = view.safeAreaInsets > previousSafeAreaInsets
-            mapView?.compassView.isHidden = navigationBarIsOpen
-        }
-        
-        previousSafeAreaInsets = view.safeAreaInsets
+        let navigationBarIsOpen = view.safeAreaInsets.top > 0
+        mapView?.compassView.isHidden = navigationBarIsOpen
         
         // Adjust the map’s vanishing point to counterbalance the side maneuver panels by extending the view off beyond the other side of the screen.
         if let mapView = mapView {

--- a/MapboxNavigation/UIEdgeInsets.swift
+++ b/MapboxNavigation/UIEdgeInsets.swift
@@ -9,11 +9,6 @@ public extension UIEdgeInsets {
                             bottom: left.bottom + right.bottom,
                             right: left.right + right.right )
     }
-    
-    static func >(lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> Bool {
-        return (lhs.top + lhs.left + lhs.bottom + lhs.right)
-            > (rhs.top + rhs.left + rhs.bottom + rhs.right)
-    }
 }
 
 extension UIEdgeInsets: ExpressibleByFloatLiteral {


### PR DESCRIPTION
This PR attempts to fix the compass visibility in the CarPlayNavigationViewController

It still goes out of bounds along with the map view when the correct content inset is applied after the first time the navigation bar is toggled.

cc @1ec5 