### PR TITLE
End CarPlay when Phone Cancels Nav

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -440,7 +440,7 @@ extension ViewController: NavigationViewControllerDelegate {
     // If implemented, you are responsible for also dismissing the UI.
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
         if let delegate = UIApplication.shared.delegate as? AppDelegate {
-            delegate.carPlayManager.currentNavigator?.exitNavigation(byCanceling: true)
+            delegate.carPlayManager.currentNavigator?.exitNavigation(byCanceling: canceled)
         }
         navigationViewController.dismiss(animated: true, completion: nil)
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -439,6 +439,9 @@ extension ViewController: NavigationViewControllerDelegate {
     // Called when the user hits the exit button.
     // If implemented, you are responsible for also dismissing the UI.
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            delegate.carPlayManager.currentNavigator?.exitNavigation(byCanceling: true)
+        }
         navigationViewController.dismiss(animated: true, completion: nil)
     }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -439,7 +439,7 @@ extension ViewController: NavigationViewControllerDelegate {
     // Called when the user hits the exit button.
     // If implemented, you are responsible for also dismissing the UI.
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
-        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+        if #available(iOS 12.0, *), let delegate = UIApplication.shared.delegate as? AppDelegate {
             delegate.carPlayManager.currentNavigator?.exitNavigation(byCanceling: canceled)
         }
         navigationViewController.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
Like it says on the box.

Ending the CarPlay navigation session when the session is cancelled on the device.

/cc @mapbox/navigation-ios 