### PR TITLE
Correct Signature Obsoletion for CarPlay

### DIFF
--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -709,10 +709,6 @@ extension CarPlayManager: CPMapTemplateDelegate {
 // MARK: CarPlayNavigationDelegate
 @available(iOS 12.0, *)
 extension CarPlayManager: CarPlayNavigationDelegate {
-    public func carPlayNavigationViewControllerDidArrive(_: CarPlayNavigationViewController) {
-        delegate?.carPlayManagerDidEndNavigation(self)
-    }
-
     public func carPlayNavigationViewControllerDidDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController, byCanceling canceled: Bool) {
         if let mainMapTemplate = mainMapTemplate {
             interfaceController?.setRootTemplate(mainMapTemplate, animated: true)

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -502,7 +502,6 @@ public protocol CarPlayNavigationDelegate {
     //MARK: - Deprecated.
     
     @available(*, obsoleted: 0.1, message: "Use NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:) or  NavigationServiceDelegate.navigationService(_:didArriveAt:) instead.")
-    @objc(carPlayNavigationViewController:didArriveAtWaypoint:)
-    optional func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
+    @objc optional func carPlayNavigationViewControllerDidArrive(_ carPlayNavigationViewController: CarPlayNavigationViewController)
 }
 #endif

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -208,7 +208,7 @@ class CarPlayManagerTests: XCTestCase {
         // the CarPlayNavigationDelegate is notified
         XCTAssertTrue(exampleDelegate.navigationInitiated, "The CarPlayManagerDelegate should have been told that navigation was initiated.")
 
-        manager.carPlayNavigationViewControllerDidArrive(manager.currentNavigator!)
+        manager.currentNavigator!.exitNavigation(byCanceling: true)
 
         XCTAssertTrue(exampleDelegate.navigationEnded, "The CarPlayManagerDelegate should have been told that navigation ended.")
     }


### PR DESCRIPTION
Fixing issue where the signature we obsoleted was never released.

/cc @mapbox/navigation-ios 