### PR TITLE
Carplay Natural End Navigation

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -423,7 +423,6 @@ extension ViewController: NavigationViewControllerDelegate {
         
         //If we're not in a "Multiple Stops" demo, show the normal EORVC
         if navigationViewController.navigationService.router.routeProgress.isFinalLeg {
-            endCarplayNavigation(canceled: false)
             return true
         }
         
@@ -440,11 +439,11 @@ extension ViewController: NavigationViewControllerDelegate {
     // Called when the user hits the exit button.
     // If implemented, you are responsible for also dismissing the UI.
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
-        endCarplayNavigation(canceled: canceled)
+        endCarPlayNavigation(canceled: canceled)
         navigationViewController.dismiss(animated: true, completion: nil)
     }
     
-    private func endCarplayNavigation(canceled: Bool) {
+    private func endCarPlayNavigation(canceled: Bool) {
         if #available(iOS 12.0, *), let delegate = UIApplication.shared.delegate as? AppDelegate {
             delegate.carPlayManager.currentNavigator?.exitNavigation(byCanceling: canceled)
         }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -423,6 +423,7 @@ extension ViewController: NavigationViewControllerDelegate {
         
         //If we're not in a "Multiple Stops" demo, show the normal EORVC
         if navigationViewController.navigationService.router.routeProgress.isFinalLeg {
+            endCarplayNavigation(canceled: false)
             return true
         }
         
@@ -439,10 +440,14 @@ extension ViewController: NavigationViewControllerDelegate {
     // Called when the user hits the exit button.
     // If implemented, you are responsible for also dismissing the UI.
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
+        endCarplayNavigation(canceled: canceled)
+        navigationViewController.dismiss(animated: true, completion: nil)
+    }
+    
+    private func endCarplayNavigation(canceled: Bool) {
         if #available(iOS 12.0, *), let delegate = UIApplication.shared.delegate as? AppDelegate {
             delegate.carPlayManager.currentNavigator?.exitNavigation(byCanceling: canceled)
         }
-        navigationViewController.dismiss(animated: true, completion: nil)
     }
 }
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -519,8 +519,7 @@ extension NavigationViewController: NavigationServiceDelegate {
     @objc public func navigationService(_ service: NavigationService, didArriveAt waypoint: Waypoint) -> Bool {
         let advancesToNextLeg = delegate?.navigationViewController?(self, didArriveAt: waypoint) ?? true
         
-        if !isConnectedToCarPlay, // CarPlayManager shows rating on CarPlay if it's connected
-            service.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
+        if service.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
             showEndOfRouteFeedback()
         }
         return advancesToNextLeg


### PR DESCRIPTION
Fixing issue where CarPlay would not end navigation gracefully when phone was connected, due to an assumption made in code that was no-longer true. 

/cc @mapbox/navigation-ios 