### PR TITLE
Deprecate BottomBannerViewController(delegate:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Fixed an issue where the turn banner stayed blank when using a `RouteController`. ([#1996](https://github.com/mapbox/mapbox-navigation-ios/pull/1996))
 * The `BottomBannerViewController` now accounts for the safe area inset if present. ([#1982](https://github.com/mapbox/mapbox-navigation-ios/pull/1982))
+* Deprecated `BottomBannerViewController(delegate:)`. Set the `BottomBannerViewController.delegate` property separately after initializing a `BottomBannerViewController`. ([#2027](https://github.com/mapbox/mapbox-navigation-ios/pull/2027))
 * The map now pans when the user drags a `UserCourseView`. ([#2012](https://github.com/mapbox/mapbox-navigation-ios/pull/2012))
 
 ## v0.29.1

--- a/MapboxNavigation/BottomBannerViewController.swift
+++ b/MapboxNavigation/BottomBannerViewController.swift
@@ -99,6 +99,7 @@ open class BottomBannerViewController: UIViewController, NavigationComponent {
      
      - parameter delegate: A delegate to recieve BottomBannerViewControllerDelegate messages.
      */
+    @available(*, deprecated, message: "Set the delegate property separately after initializing this object.")
     public convenience init(delegate: BottomBannerViewControllerDelegate?) {
         self.init(nibName: nil, bundle: nil)
         self.delegate = delegate

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -216,7 +216,11 @@ open class NavigationViewController: UIViewController {
 
         NavigationSettings.shared.distanceUnit = route.routeOptions.locale.usesMetric ? .kilometer : .mile
         
-        let bottomBanner = options?.bottomBanner ?? BottomBannerViewController(delegate: self)
+        let bottomBanner = options?.bottomBanner ?? {
+            let viewController = BottomBannerViewController()
+            viewController.delegate = self
+            return viewController
+        }()
         bottomViewController = bottomBanner
 
         let mapViewController = RouteMapViewController(navigationService: self.navigationService, delegate: self, bottomBanner: bottomBanner)


### PR DESCRIPTION
Deprecated `BottomBannerViewController(delegate:)` in favor of setting the `BottomBannerViewController.delegate` property separately after initializing a `BottomBannerViewController`.

Fixes #1968.