### PR TITLE
Fix progress updates order of execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Core Navigation
 
+* Fixed an issue where the wrong instruction could be announced or a crash could occur in some situations when using a RouteController. ([#2029](https://github.com/mapbox/mapbox-navigation-ios/pull/2029))
 * Restored the `RouteController.reroutesProactively` property. By default, `RouteController` and `LegacyRouteController` proactively check for a faster route on an interval defined by `RouteControllerProactiveReroutingInterval`. ([#1986](https://github.com/mapbox/mapbox-navigation-ios/pull/1986))
 * Added a `RouteControllerMinimumDurationRemainingForProactiveRerouting` global variable to customize when `RouteController` stops looking for more optimal routes as the user nears the destination. ([#1986](https://github.com/mapbox/mapbox-navigation-ios/pull/1986))
 * Fixed a bug which would cancel an ongoing reroute request when the request takes longer than one second to complete. ([#1986](https://github.com/mapbox/mapbox-navigation-ios/pull/1986))

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -181,9 +181,9 @@ open class RouteController: NSObject {
         let willReroute = !userIsOnRoute(location) && delegate?.router?(self, shouldRerouteFrom: location)
                           ?? DefaultBehavior.shouldRerouteFromLocation
         
-        updateSpokenInstructionProgress(status: status, willReRoute: willReroute)
         updateRouteStepProgress(status: status)
         updateRouteLegProgress(status: status)
+        updateSpokenInstructionProgress(status: status, willReRoute: willReroute)
         updateVisualInstructionProgress(status: status)
         
         if willReroute {

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -301,6 +301,24 @@ class MapboxCoreNavigationTests: XCTestCase {
         XCTAssertEqual(points[3].visualInstructionIndex, 0)
         XCTAssertEqual(points[3].spokenInstructionIndex, 0)
         XCTAssertEqual(points[3].type, .spoken)
+        
+        // Make sure we never have unsynced indexes or move backward in time by comparing previous to current instruction point
+        let zippedPoints = zip(points, points.suffix(from: 1))
+        
+        for seq in zippedPoints {
+            let previous = seq.0
+            let current = seq.1
+            
+            let sameStepAndLeg = previous.legIndex == current.legIndex && previous.stepIndex == current.stepIndex
+            
+            if sameStepAndLeg {
+                XCTAssert(current.visualInstructionIndex >= previous.visualInstructionIndex)
+                XCTAssert(current.spokenInstructionIndex >= previous.spokenInstructionIndex)
+            } else {
+                XCTAssert(current.visualInstructionIndex == 0)
+                XCTAssert(current.spokenInstructionIndex == 0)
+            }
+        }
     }
     
     func testFailToReroute() {


### PR DESCRIPTION
`updateSpokenInstructionProgress(status:willReRoute:)` must happen after step progress and leg progress has been updated to keep the indexes in sync.

cc @1ec5 @JThramer 