### PR TITLE
Fix multi-waypoint selection in example application

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -139,7 +139,7 @@ class ViewController: UIViewController {
         }
 
         if waypoints.count > 1 {
-            waypoints = Array(waypoints.suffix(1))
+            waypoints = Array(waypoints.dropFirst())
         }
         
         let coordinates = mapView.convert(tap.location(in: mapView), toCoordinateFrom: mapView)


### PR DESCRIPTION
Fixed an issue where the example application wouldn’t allow the user to select multiple destinations by long-pressing on the map view. The first destination would be selected just fine, but long-pressing again would delete the first destination in favor of the second, and so on.

This line was intended to retain all but the first element of the array, which would represent the user’s location from the last Directions API request. However, it called `Array.suffix(_:)` instead of `Array.suffix(from:)`. `Array.suffix(_:)` takes a maximum length, not a minimum index. `ViewController.waypoints` got truncated, preventing it from ever holding more than one destination at a time. This change fixes the issue but goes one further by calling `Array.dropFirst()`, which requires a little less mental gymnastics.

Fixes #1321.

/cc @mapbox/navigation-ios