### PR TITLE
Fix Interface Builder designable compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Deprecated `BottomBannerViewController(delegate:)`. Set the `BottomBannerViewController.delegate` property separately after initializing a `BottomBannerViewController`. ([#2027](https://github.com/mapbox/mapbox-navigation-ios/pull/2027))
 * The map now pans when the user drags a `UserCourseView`. ([#2012](https://github.com/mapbox/mapbox-navigation-ios/pull/2012))
 * Added a Japanese localization. ([#2032](https://github.com/mapbox/mapbox-navigation-ios/pull/2032))
+* Fixed a compiler error when rendering a `NavigationViewController` designable inside an Interface Builder storyboard. ([#2039](https://github.com/mapbox/mapbox-navigation-ios/pull/2039))
 
 ## v0.29.1
 

--- a/MapboxNavigation/LaneView.swift
+++ b/MapboxNavigation/LaneView.swift
@@ -165,7 +165,7 @@ open class LaneView: UIView {
         
         #if TARGET_INTERFACE_BUILDER
             isValid = true
-            LanesStyleKit.drawLane_right_only(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
+            LanesStyleKit.drawLaneRightOnly(primaryColor: appropriatePrimaryColor, secondaryColor: secondaryColor)
         #endif
     }
 }


### PR DESCRIPTION
Updated a method call to reflect the renaming that occurred in #1910. This code path only runs inside Interface Builder, so the outdated call site didn’t get caught by CI.

Fixes #2038.

/cc @mapbox/navigation-ios