### PR TITLE
Car Play Quick Fixes: Data Race Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### CarPlay
 
+* Fixing issue where a data-race could cause CarPlay to create it's own NavigationService, resulting in unexpected behavior. ([#2041](https://github.com/mapbox/mapbox-navigation-ios/pull/2041)
+* Fixing issue where data-race could unexpectedly cause a NavigationViewController to be created and presented on-screen.  ([#2041](https://github.com/mapbox/mapbox-navigation-ios/pull/2041)
 * Added the `CarPlayManager.beginNavigationWithCarPlay(_:navigationService:)` method. Use this method to programmatically start navigation in CarPlay if CarPlay is being connected while turn-by-turn navigation is already underway on the iOS device. ([#2021](https://github.com/mapbox/mapbox-navigation-ios/pull/2021))
 * Renamed the `CarPlayManagerDelegate.carPlayManager(_:navigationServiceAlong:)` method to `CarPlayManagerDelegate.carPlayManager(_:navigationServiceAlong:desiredSimulationMode:)`. `CarPlayManagerDelegate` implementations are now required to implement this method. ([#2018](https://github.com/mapbox/mapbox-navigation-ios/pull/2018), [#2021](https://github.com/mapbox/mapbox-navigation-ios/pull/2021))
 * Renamed the `MapboxVoiceController(speechClient:dataCache:audioPlayerType:)` initializer to `MapboxVoiceController(navigationService:speechClient:dataCache:audioPlayerType:)` and the `RouteVoiceController()` initializer to `RouteVoiceController(navigationService:)`. ([#2018](https://github.com/mapbox/mapbox-navigation-ios/pull/2018))

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -258,11 +258,14 @@ class ViewController: UIViewController {
     func presentAndRemoveMapview(_ navigationViewController: NavigationViewController) {
         let delegate = UIApplication.shared.delegate as? AppDelegate
         
-        if #available(iOS 12.0, *), let service = navigationViewController.navigationService, let location = service.router.location {
-            delegate?.carPlayManager.beginNavigationWithCarPlay(using: location.coordinate, navigationService: service)
-        }
-        
         present(navigationViewController, animated: true) {
+            if #available(iOS 12.0, *),
+                let service = navigationViewController.navigationService,
+                let location = service.router.location {
+                delegate?.carPlayManager.beginNavigationWithCarPlay(using: location.coordinate,
+                                                                    navigationService: service)
+            }
+            
             self.mapView?.removeFromSuperview()
             self.mapView = nil
         }

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -216,6 +216,7 @@ public class CarPlayManager: NSObject {
      
      - parameter currentLocation: The current location of the user. This will be used to initally draw the current location icon.
      - parameter navigationService: The service with which to navigation. CarPlayNavigationViewController will observe the progress updates from this service.
+     - precondition: The NavigationViewController must be fully presented at the time of this call.
      */
     public func beginNavigationWithCarPlay(using currentLocation: CLLocationCoordinate2D, navigationService: NavigationService) {
         let route = navigationService.route
@@ -508,20 +509,14 @@ extension CarPlayManager: CPMapTemplateDelegate {
         mapTemplate.hideTripPreviews()
 
         let route = routeChoice.userInfo as! Route
-        var service: NavigationService
         
         let desiredSimulationMode: SimulationMode = simulatesLocations ? .always : .onPoorGPS
-        if let navService = navigationService {
-            service = navService
-        } else {
-            if let override = delegate?.carPlayManager(self, navigationServiceAlong: route, desiredSimulationMode: desiredSimulationMode) {
-                service = override
-            } else {
-                service = MapboxNavigationService(route: route, simulating: desiredSimulationMode)
-            }
-            navigationService = service
-        }
-
+        
+        let service = navigationService ??
+            delegate?.carPlayManager(self, navigationServiceAlong: route, desiredSimulationMode: desiredSimulationMode) ??
+            MapboxNavigationService(route: route, simulating: desiredSimulationMode)
+        
+        navigationService = service //store the service it was newly created/fetched
 
         if simulatesLocations == true {
             service.simulationSpeedMultiplier = simulatedSpeedMultiplier

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -502,7 +502,7 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
             return route
         }()
         let directionsClientSpy = DirectionsSpy(accessToken: "garbage", host: nil)
-        let service = MapboxNavigationService(route: initialRoute, directions: directionsClientSpy, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
+        let service = MapboxNavigationService(route: initialRoute, directions: directionsClientSpy, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self, simulating: desiredSimulationMode)
         return service
     }
 


### PR DESCRIPTION
![Data Race!](https://media.giphy.com/media/6Z3D5t31ZdoNW/200.gif)

Fixes #2035 and #2034.

* Fixing race-condition bug by waiting until presentation completion to trigger carplay nav
* also changing trip-starting logic to not ask for a NavigationService if the user has already provided one

To-Do: 
- [x] Drive-test this to make sure things are fixed in the way we expect
- [x] Fix test

/cc @mapbox/navigation-ios 