### PR TITLE
Marking Invalid Values as Omitted

### DIFF
--- a/MapboxCoreNavigation/CLLocation.swift
+++ b/MapboxCoreNavigation/CLLocation.swift
@@ -30,10 +30,10 @@ extension CLLocation {
     convenience init(_ location: MBFixLocation) {
         self.init(coordinate: location.coordinate,
                   altitude: location.altitude?.doubleValue ?? 0,
-                  horizontalAccuracy: location.accuracyHorizontal?.doubleValue ?? 0,
+                  horizontalAccuracy: location.accuracyHorizontal?.doubleValue ?? -1,
                   verticalAccuracy: 0,
-                  course: location.bearing?.doubleValue ?? 0,
-                  speed: location.speed?.doubleValue ?? 0,
+                  course: location.bearing?.doubleValue ?? -1,
+                  speed: location.speed?.doubleValue ?? -1,
                   timestamp: location.time)
     }
     
@@ -157,12 +157,5 @@ extension CLLocation {
     
     func shifted(to newTimestamp: Date) -> CLLocation {
         return CLLocation(coordinate: coordinate, altitude: altitude, horizontalAccuracy: horizontalAccuracy, verticalAccuracy: verticalAccuracy, course: course, speed: speed, timestamp: newTimestamp)
-    }
-    
-    convenience init(fixLocation: MBFixLocation) {
-        self.init(coordinate: fixLocation.coordinate, altitude: 0,
-                  horizontalAccuracy: fixLocation.accuracyHorizontal?.doubleValue ?? 0,
-                  verticalAccuracy: 0, course: fixLocation.bearing?.doubleValue ?? 0,
-                  speed: fixLocation.speed?.doubleValue ?? 0, timestamp: fixLocation.time)
     }
 }

--- a/MapboxCoreNavigation/MBNavigator.swift
+++ b/MapboxCoreNavigation/MBNavigator.swift
@@ -7,10 +7,10 @@ extension MBFixLocation {
     convenience init(_ location: CLLocation) {
         self.init(coordinate: location.coordinate,
                   time: location.timestamp,
-                  speed: location.speed as NSNumber,
-                  bearing: location.course as NSNumber,
+                  speed: location.speed >= 0 ? location.speed as NSNumber : nil,
+                  bearing: location.course >= 0 ? location.course as NSNumber : nil,
                   altitude: location.altitude as NSNumber,
-                  accuracyHorizontal: location.horizontalAccuracy as NSNumber,
+                  accuracyHorizontal: location.horizontalAccuracy >= 0 ? location.horizontalAccuracy as NSNumber : nil,
                   provider: nil)
     }
 }

--- a/MapboxCoreNavigationTests/CLLocationTests.swift
+++ b/MapboxCoreNavigationTests/CLLocationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import CoreLocation
 @testable import MapboxCoreNavigation
-import MapboxNavigationNative
+@testable import MapboxNavigationNative
 
 class CLLocationTests: XCTestCase {
     
@@ -35,6 +35,50 @@ class CLLocationTests: XCTestCase {
                                   timestamp: Date())
         
         XCTAssertEqual(location.timestamp, location.shifted(to: location.timestamp).timestamp)
+    }
+    
+    func testCLLocationToMBFixLocation() {
+        let coordinate = CLLocationCoordinate2D(latitude: 1, longitude: 2)
+        let now = Date()
+        
+        let location = CLLocation(coordinate: coordinate,
+                                  altitude: -1,
+                                  horizontalAccuracy: -1,
+                                  verticalAccuracy: 0,
+                                  course: -1,
+                                  speed: -1,
+                                  timestamp: now)
+        
+        let fixLocation = MBFixLocation(location)
+        
+        XCTAssertEqual(fixLocation.coordinate.latitude, coordinate.latitude)
+        XCTAssertEqual(fixLocation.coordinate.longitude, coordinate.longitude)
+        XCTAssertEqual(fixLocation.altitude, -1)
+        XCTAssertEqual(fixLocation.bearing, nil)
+        XCTAssertEqual(fixLocation.accuracyHorizontal, nil)
+        XCTAssertEqual(fixLocation.speed, nil)
+        XCTAssertEqual(fixLocation.time, now)
+    }
+    
+    func testMBFixLocationToCLLocation() {
+        let coordinate = CLLocationCoordinate2D(latitude: 1, longitude: 2)
+        let now = Date()
+        let fixLocation = MBFixLocation(coordinate: coordinate,
+                                        time: now,
+                                        speed: nil,
+                                        bearing: nil,
+                                        altitude: -1,
+                                        accuracyHorizontal: nil, provider: "default")
+        
+        let location = CLLocation(fixLocation)
+        
+        XCTAssertEqual(location.coordinate.latitude, 1)
+        XCTAssertEqual(location.coordinate.longitude, 2)
+        XCTAssertEqual(location.timestamp, now)
+        XCTAssertEqual(location.speed, -1)
+        XCTAssertEqual(location.course, -1)
+        XCTAssertEqual(location.altitude, -1)
+        XCTAssertEqual(location.horizontalAccuracy, -1)
     }
 }
 


### PR DESCRIPTION
`speed` , `course` and `horizontalAccuracy` can all hold invalid values. `MBFixLocation` uses `nil` to communicate the omission of an optional value.

Interestingly an invalid `horizontalAccuracy` also means that the `CLLocationCoordinate2D` will also be bunk, but I've not taken any measures there as that is a required parameter by `MBFixLocation`

I've also made the changes in the other direction as well and marked omitted values from `MBFixLocation` as invalid in the constructed `CLLocation`