### PR TITLE
Always hide compass on CarPlay during navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * `CarPlayNavigationDelegate.carPlayNavigationViewControllerDidDismiss(_:byCanceling:)` is now optional. ([#2005](https://github.com/mapbox/mapbox-navigation-ios/pull/2005))
 * Removed the `CarPlayNavigationDelegate.carPlayNavigationViewControllerDidArrive(_:)` method in favor of `NavigationServiceDelegate.navigationService(_:didArriveAt:)`. ([#2005](https://github.com/mapbox/mapbox-navigation-ios/pull/2005), [#2025](https://github.com/mapbox/mapbox-navigation-ios/pull/2025))
 * Fixed an issue where the camera would sometimes not animate properly when returning to the free-drive map screen. [#2022](https://github.com/mapbox/mapbox-navigation-ios/pull/2022))
-* Fixed an issue where compass would remain visible while the navigation bar is visible. ([#2023](https://github.com/mapbox/mapbox-navigation-ios/pull/2023))
+* Removed the compass from `CarPlayNavigationViewController`. ([#2051](https://github.com/mapbox/mapbox-navigation-ios/pull/2051))
 
 ### Other changes
 

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -174,9 +174,6 @@ public class CarPlayNavigationViewController: UIViewController {
     public override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         
-        let navigationBarIsOpen = view.safeAreaInsets.top > 0
-        mapView?.compassView.isHidden = navigationBarIsOpen
-        
         // Adjust the map’s vanishing point to counterbalance the side maneuver panels by extending the view off beyond the other side of the screen.
         if let mapView = mapView {
             mapViewRightSafeAreaBalancingConstraint?.constant = -mapView.safeArea.right


### PR DESCRIPTION
Always hide the compass on CarPlay during the navigation activity (in other words, in CarPlayNavigationViewController’s map view). Otherwise, the compass would appear in an odd position to the left of the column of map buttons. Also, the compass has an analog design more appropriate for the browsing activity but not for the navigation activity.

The analog compass remains in the browsing activity. A digital compass will be added as part of #1217 for parity with other CarPlay navigation applications.

/cc @mapbox/navigation-ios