### PR TITLE
Declare supported Swift version in podspecs

### DIFF
--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -45,4 +45,6 @@ Pod::Spec.new do |s|
   s.dependency "MapboxMobileEvents", "~> 0.8.1"         # Always pin to a patch release if pre-1.0
   s.dependency "Turf", "~> 0.3.0"                       # Always pin to a patch release if pre-1.0
 
+  s.swift_version = "4.2"
+
 end

--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -374,9 +374,6 @@ extension AVAudioSession {
         if currentRoute.outputs.contains(where: { [.builtInSpeaker, .builtInReceiver].contains($0.portType) }) {
             return "speaker"
         }
-//        if currentRoute.outputs.contains(where: { [.builtInMic, .headsetMic, .lineIn].contains($0.portType) }) {
-//            return "microphone"
-//        }
         return "unknown"
     }
 }

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -42,10 +42,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 225036950837cbe408e6b333e51cd6001c122499
-  MapboxCoreNavigation: 0934533a1d1306d74c53ed709e3ca6a1bc73c1ca
+  MapboxCoreNavigation: a05f5ea6f903d32f52e9aa08f2357852164a90cc
   MapboxDirections.swift: b67d0b0bd0ac46906642baba38f4be777c50d68e
   MapboxMobileEvents: 0f30fe39687f26fd8f255335053023ba039a0392
-  MapboxNavigation: 9b2371167b4e1234cd66c4e29f43ce69a0512d92
+  MapboxNavigation: 31d1bd3076da438fbd7cfaaa34ea1f41b9c1723c
   MapboxNavigationNative: bb220f45f93123adae2c05dfb74080773af128f3
   MapboxSpeech: 59b3984d3f433a443d24acf53097f918c5cc70f9
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -53,4 +53,6 @@ Pod::Spec.new do |s|
   s.dependency "Turf", "~> 0.3.0"
   s.dependency "MapboxSpeech", "~> 0.1"
 
+  s.swift_version = "4.2"
+
 end

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -48,4 +48,6 @@ Pod::Spec.new do |s|
   s.dependency "Solar", "~> 2.1"
   s.dependency "MapboxSpeech", "~> 0.1.0"
 
+  s.swift_version = "4.2"
+
 end


### PR DESCRIPTION
#2058 was a bit overzealous in removing the [`swift_version`](https://guides.cocoapods.org/syntax/podspec.html#swift_versions) specifier instead of bumping it to 4.2, as this PR does.

/cc @mapbox/navigation-ios @friedbunny