### PR TITLE
Fixed Xcode build error

### DIFF
--- a/MapboxCoreNavigation/MBRouteController.h
+++ b/MapboxCoreNavigation/MBRouteController.h
@@ -7,7 +7,7 @@
  
  :nodoc:
  */
-extern const NSNotificationName MBRouteControllerProgressDidChangeNotification;
+extern const _Nonnull NSNotificationName MBRouteControllerProgressDidChangeNotification;
 
 /**
  Posted after the user diverges from the expected route, just before `MBRouteController` attempts to calculate a new route.
@@ -16,7 +16,7 @@ extern const NSNotificationName MBRouteControllerProgressDidChangeNotification;
  
  :nodoc:
  */
-extern const NSNotificationName MBRouteControllerWillRerouteNotification;
+extern const _Nonnull NSNotificationName MBRouteControllerWillRerouteNotification;
 
 /**
  Posted when `MBRouteController` obtains a new route in response to the user diverging from a previous route.
@@ -25,7 +25,7 @@ extern const NSNotificationName MBRouteControllerWillRerouteNotification;
  
  :nodoc:
  */
-extern const NSNotificationName MBRouteControllerDidRerouteNotification;
+extern const _Nonnull NSNotificationName MBRouteControllerDidRerouteNotification;
 
 /**
  Posted when `MBRouteController` fails to reroute the user after the user diverges from the expected route.
@@ -34,7 +34,7 @@ extern const NSNotificationName MBRouteControllerDidRerouteNotification;
  
  :nodoc:
  */
-extern const NSNotificationName MBRouteControllerDidFailToRerouteNotification;
+extern const _Nonnull NSNotificationName MBRouteControllerDidFailToRerouteNotification;
 
 /**
  Posted when `MBRouteController` detects that the user has passed an ideal point for saying an instruction aloud.
@@ -43,9 +43,9 @@ extern const NSNotificationName MBRouteControllerDidFailToRerouteNotification;
  
  :nodoc:
  */
-extern const NSNotificationName MBRouteControllerDidPassSpokenInstructionPointNotification;
+extern const _Nonnull NSNotificationName MBRouteControllerDidPassSpokenInstructionPointNotification;
 
-extern const NSNotificationName MBRouteControllerDidPassVisualInstructionPointNotification;
+extern const _Nonnull NSNotificationName MBRouteControllerDidPassVisualInstructionPointNotification;
 
 /**
  Keys in the user info dictionaries of various notifications posted by instances of `MBRouteController`.
@@ -57,37 +57,37 @@ typedef NSString *MBRouteControllerNotificationUserInfoKey NS_EXTENSIBLE_STRING_
 /**
  A key in the user info dictionary of a `MBRouteControllerProgressDidChangeNotification`, `MBRouteControllerDidPassVisualInstructionPointNotification`, or `MBRouteControllerDidPassVisualInstructionPointNotification` notification. The corresponding value is a `RouteProgress` object representing the current route progress.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProgressKey;
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProgressKey;
 
 /**
  A key in the user info dictionary of an `MBRouteControllerDidPassVisualInstructionPointNotification`. The corresponding value is an `MBVisualInstruction` object representing the current visual instruction.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerVisualInstructionKey;
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerVisualInstructionKey;
 
 /**
  A key in the user info dictionary of a `MBRouteControllerDidPassSpokenInstructionPointNotification` notification. The corresponding value is an `MBVisualInstruction` object representing the current visual instruction.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerSpokenInstructionKey;
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerSpokenInstructionKey;
 
 /**
  A key in the user info dictionary of a `MBRouteControllerProgressDidChangeNotification` or `MBRouteControllerWillRerouteNotification` notification. The corresponding value is a `CLLocation` object representing the current idealized user location.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey;
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey;
 
 /**
  A key in the user info dictionary of a `MBRouteControllerProgressDidChangeNotification` or `MBRouteControllerWillRerouteNotification` notification. The corresponding value is a `CLLocation` object representing the current raw user location.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocationKey;
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocationKey;
 
 /**
  A key in the user info dictionary of a `MBRouteControllerDidFailToRerouteNotification` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey;
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey;
 
 /**
  A key in the user info dictionary of a `MBRouteControllerDidRerouteNotification` notification. The corresponding value is an `NSNumber` instance containing a Boolean value indicating whether `RouteController` proactively rerouted the user onto a faster route.
  */
-extern const MBRouteControllerNotificationUserInfoKey MBRouteControllerIsProactiveKey;
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerIsProactiveKey;
 
 @interface NSString (MD5)
 - (NSString * _Nonnull)md5;


### PR DESCRIPTION
Xcode 10.2 started to complain about the missing _Nonnull modifiers