### PR TITLE
Fixed simulation not stopped when simulation mode is set to onPoorGPS bug

### DIFF
--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -342,7 +342,7 @@ public class MapboxNavigationService: NSObject, NavigationService, DefaultInterf
         nativeLocationSource.stopUpdatingHeading()
         nativeLocationSource.stopUpdatingLocation()
         
-        if simulationMode == .always {
+        if [.always, .onPoorGPS].contains(simulationMode) {
             endSimulation()
         }
         


### PR DESCRIPTION
Modified navigation service to ensure we stop simulation for both `.always` and `.onPoorGPS` modes.

/cc @mapbox/navigation-ios 