### PR TITLE
Document various Core Navigation classes

### DIFF
--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -38,10 +38,13 @@ public protocol DefaultInterfaceFlag {
 }
 
 /**
- A `NavigationService` is the entry-point protocol for MapboxCoreNavigation.
-    It contains all the dependencies needed by the `MapboxNavigation` UI SDK, as well as dependencies for its child objects.
-    `MapboxNavigationService` is the default implementation.
-    If you would like to implement your own core-navigation stack, be sure to conform to this protocol.
+ A navigation service coordinates various nonvisual components that track the user as they navigate along a predetermined route. You use `MapboxNavigationService`, which conforms to this protocol, either as part of `NavigationViewController` or by itself as part of a custom user interface. A navigation service calls methods on its `delegate`, which conforms to the `NavigationServiceDelegate` protocol, whenever significant events or decision points occur along the route.
+ 
+ A navigation service controls a `NavigationLocationManager` for determining the user’s location, a `Router` that tracks the user’s progress along the route, a `Directions` service for calculating new routes (only used when rerouting), and a `NavigationEventsManager` for sending telemetry events related to navigation or user feedback.
+ 
+ `NavigationViewController` comes with a `MapboxNavigationService` by default. You may override it to customize the `Directions` service or simulation mode. After creating the navigation service, pass it into `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:)`, then pass that object into `NavigationViewController(for:options:)`.
+ 
+ If you use a navigation service by itself, outside of `NavigationViewController`, call `start()` when the user is ready to begin navigating along the route.
  */
 @objc(MBNavigationService)
 public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, EventsManagerDataSource, DefaultInterfaceFlag {
@@ -56,7 +59,7 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
     var directions: Directions { get }
     
     /**
-     The active router, responsible for all route-following.
+     The router object that tracks the user’s progress as they travel along a predetermined route.
      */
     var router: Router! { get }
     
@@ -86,7 +89,9 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
     var poorGPSPatience: Double { get set }
     
     /**
-     The `NavigationService` delegate. Wraps `RouterDelegate` messages.
+     The navigation service’s delegate, which is informed of significant events and decision points along the route.
+     
+     To synchronize your application’s state with the turn-by-turn navigation experience, set this property before starting the navigation session.
      */
     weak var delegate: NavigationServiceDelegate? { get set }
 
@@ -113,7 +118,11 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
 }
 
 /**
- A `NavigationService` is the entry-point interface into MapboxCoreNavigation. This service manages a `locationManager` (which feeds it location updates), a `Directions` service (for rerouting), a `Router` (for route-following), a `NavigationEventsManager` (for telemetry), and a simulation engine for use during poor GPS conditions.
+ A concrete implementation of the `NavigationService` protocol.
+ 
+ `NavigationViewController` comes with a `MapboxNavigationService` by default. You may override it to customize the `Directions` service or simulation mode. After creating the navigation service, pass it into `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:)`, then pass that object into `NavigationViewController(for:options:)`.
+ 
+ If you use a navigation service by itself, outside of `NavigationViewController`, call `start()` when the user is ready to begin navigating along the route.
  */
 @objc(MBNavigationService)
 public class MapboxNavigationService: NSObject, NavigationService, DefaultInterfaceFlag {

--- a/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -12,9 +12,9 @@ import MapboxDirections
  * Customize visual / spoken instructions that are presented to the user
  * Decide if battery monitoring should be disabled
  * Decide if the SDK should pause navigation when the user reaches an intermediate destination (for example, to show a interstitial modal UI)
- * Be told when the SDK fails to fetch a new route
- * Be told when the SDK is beginning or ending route-simulation
- * Be told when the user is about to arrive, or has arrived at their destination
+ * Be informed when the SDK fails to fetch a new route
+ * Be informed when the SDK is beginning or ending route-simulation
+ * Be informed when the user is about to arrive, or has arrived at their destination
  */
 @objc public protocol NavigationServiceDelegate {
     /**
@@ -82,7 +82,6 @@ import MapboxDirections
      - parameter location: the guaranteed location, possibly snapped, associated with the progress update.
      - parameter rawLocation: the raw location, from the location manager, associated with the progress update.
      */
-    
     @objc(navigationService:didUpdateProgress:withLocation:rawLocation:)
     optional func navigationService(_ service: NavigationService, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation)
     

--- a/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -14,7 +14,7 @@ import MapboxDirections
  * Decide if the SDK should pause navigation when the user reaches an intermediate destination (for example, to show a interstitial modal UI)
  * Be informed when the SDK fails to fetch a new route
  * Be informed when the SDK is beginning or ending route-simulation
- * Be informed when the user is about to arrive, or has arrived at their destination
+ * Be informed when the user is approaching or has arrived at their destination
  */
 @objc public protocol NavigationServiceDelegate {
     /**

--- a/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -2,6 +2,20 @@ import Foundation
 import CoreLocation
 import MapboxDirections
 
+/**
+ NavigationServiceDelegate is the main delegation protocol in MapboxCoreNavigation. It's purpose is to delegate the operational parameters of the core navigation engine. See discussion for use-case examples.
+
+ You can use this protocol to:
+ * Recieve navigation progress updates
+ * Decide when to reroute the user
+ * Decide what location updates are considered 'qualified'
+ * Customize visual / spoken instructions that are presented to the user
+ * Decide if battery monitoring should be disabled
+ * Decide if the SDK should pause navigation when the user reaches an intermediate destination (for example, to show a interstitial modal UI)
+ * Be told when the SDK fails to fetch a new route
+ * Be told when the SDK is beginning or ending route-simulation
+ * Be told when the user is about to arrive, or has arrived at their destination
+ */
 @objc public protocol NavigationServiceDelegate {
     /**
      Returns whether the navigation service should be allowed to calculate a new route.

--- a/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -3,18 +3,16 @@ import CoreLocation
 import MapboxDirections
 
 /**
- NavigationServiceDelegate is the main delegation protocol in MapboxCoreNavigation. It's purpose is to delegate the operational parameters of the core navigation engine. See discussion for use-case examples.
-
- You can use this protocol to:
- * Recieve navigation progress updates
- * Decide when to reroute the user
- * Decide what location updates are considered 'qualified'
- * Customize visual / spoken instructions that are presented to the user
- * Decide if battery monitoring should be disabled
- * Decide if the SDK should pause navigation when the user reaches an intermediate destination (for example, to show a interstitial modal UI)
- * Be informed when the SDK fails to fetch a new route
- * Be informed when the SDK is beginning or ending route-simulation
- * Be informed when the user is approaching or has arrived at their destination
+ A navigation service delegate interacts with one or more `NavigationService` instances (such as `MapboxNavigationService` objects) during turn-by-turn navigation. This protocol is the main way that your application can synchronize its state with the SDK’s location-related functionality. Each of the protocol’s methods is optional.
+ 
+ As the user progresses along a route, a navigation service informs its delegate about significant events as they occur, and the delegate has opportunities to influence the route and its presentation. For example, when the navigation service reports that the user has arrived at the destination, your delegate implementation could present information about the destination. It could also customize individual visual or spoken instructions along the route by returning modified instruction objects.
+ 
+ Assign a `NavigationServiceDelegate` instance to the `NavigationService.delegate` property of the navigation service before you start the service.
+ 
+ The `RouterDelegate` protocol defines corresponding methods so that a `Router` instance can interact with an object that is both a router delegate and a navigation service, which in turn interacts with a navigation service delegate. Additionally, several location-related methods in this protocol have corresponding methods in the `NavigationViewControllerDelegate` protocol, which can be convenient if you are using the navigation service in conjunction with a `NavigationViewController`. Normally, you would either implement methods in `NavigationServiceDelegate` or `NavigationViewControllerDelegate` but not `RouterDelegate`.
+ 
+ - seealso: NavigationViewControllerDelegate
+ - seealso: RouterDelegate
  */
 @objc public protocol NavigationServiceDelegate {
     /**

--- a/MapboxCoreNavigation/NavigationSettings.swift
+++ b/MapboxCoreNavigation/NavigationSettings.swift
@@ -10,9 +10,11 @@ extension Notification.Name {
 }
 
 /**
- `NavigationSettings` provides a wrapper for UserDefaults.
+ A wrapper for the `UserDefaults` class for navigation-specific settings.
  
- Properties are prefixed and before they are stored in UserDefaults.standard.
+ Properties are prefixed before they are stored in `UserDefaults.standard`.
+ 
+ To specify criteria when calculating routes, use the `NavigationRouteOptions` class. To customize the user experience during a particular turn-by-turn navigation session, use the `NavigationOptions` class when initializing a `NavigationViewController`.
  */
 @objc(MBNavigationSettings)
 public class NavigationSettings: NSObject {

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -6,11 +6,16 @@ import MapboxDirections
 public protocol RouterDataSource {
     
     /**
-    The location Provider for the `Router.` This class is designated as the object that will provide location updates when requested.
+    The location provider for the `Router.` This class is designated as the object that will provide location updates when requested.
     */
     var locationProvider: NavigationLocationManager.Type { get }
 }
 
+/**
+ A class conforming to the `Router` protocol tracks the user’s progress as they travel along a predetermined route. It calls methods on its `delegate`, which conforms to the `RouterDelegate` protocol, whenever significant events or decision points occur along the route. Despite its name, this protocol does not define the interface of a routing engine.
+ 
+ There are two concrete implementations of the `Router` protocol. `RouteController`, the default implementation, is capable of client-side routing and depends on the Mapbox Navigation Native framework. `LegacyRouteController` is an alternative implementation that does not have this dependency but must be used in conjunction with the Mapbox Directions API over a network connection.
+ */
 @objc public protocol Router: class, CLLocationManagerDelegate {
     
     /**

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -4,6 +4,10 @@ import MapboxDirections
 
 @objc (MBRouterDataSource)
 public protocol RouterDataSource {
+    
+    /**
+    The location Provider for the `Router.` This class is designated as the object that will provide location updates when requested.
+    */
     var locationProvider: NavigationLocationManager.Type { get }
 }
 

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -2,6 +2,9 @@ import Foundation
 import CoreLocation
 import MapboxDirections
 
+/**
+ A router data source, also known as a location manager, supplies location data to a `Router` instance. For example, a `MapboxNavigationService` supplies location data to a `RouteController` or `LegacyRouteController`.
+ */
 @objc (MBRouterDataSource)
 public protocol RouterDataSource {
     

--- a/MapboxCoreNavigation/RouterDelegate.swift
+++ b/MapboxCoreNavigation/RouterDelegate.swift
@@ -16,7 +16,7 @@ import MapboxDirections
  * Decide if the SDK should pause navigation when the user reaches an intermediate destination (for example, to show a interstitial modal UI)
  * Be informed when the SDK fails to fetch a new route
  * Be informed when the SDK is beginning or ending route-simulation
- * Be informed when the user is about to arrive, or has arrived at their destination
+ * Be informed when the user is approaching or has arrived at their destination
  - seealso: NavigationServiceDelegate
  */
 @objc(MBRouterDelegate)

--- a/MapboxCoreNavigation/RouterDelegate.swift
+++ b/MapboxCoreNavigation/RouterDelegate.swift
@@ -4,43 +4,156 @@ import MapboxDirections
 
 
 
-//:nodoc: See NavigationServiceDelegate.
+/**
+ RouterDelegate is a mid-level delegate that defines the messaging architechture between the NavigationService and its router. Developers generally shouldn't have to concern themselves with this class unless a custom core-navigation engine (conforming to NavigationService) is being written.
+ 
+ You can use this protocol to:
+ * Recieve navigation progress updates
+ * Decide when to reroute the user
+ * Decide what location updates are considered 'qualified'
+ * Customize visual / spoken instructions that are presented to the user
+ * Decide if battery monitoring should be disabled
+ * Decide if the SDK should pause navigation when the user reaches an intermediate destination (for example, to show a interstitial modal UI)
+ * Be informed when the SDK fails to fetch a new route
+ * Be informed when the SDK is beginning or ending route-simulation
+ * Be informed when the user is about to arrive, or has arrived at their destination
+ - seealso: NavigationServiceDelegate
+ */
 @objc(MBRouterDelegate)
 public protocol RouterDelegate: class {
     
+    /**
+     Returns whether the router should be allowed to calculate a new route.
+     
+     If implemented, this method is called as soon as the router detects that the user is off the predetermined route. Implement this method to conditionally prevent rerouting. If this method returns `true`, `router(_:willRerouteFrom:)` will be called immediately afterwards.
+     
+     - parameter router: The router that has detected the need to calculate a new route.
+     - parameter location: The user’s current location.
+     - returns: True to allow the router to calculate a new route; false to keep tracking the current route.
+     */
     @objc(router:shouldRerouteFromLocation:)
     optional func router(_ router: Router, shouldRerouteFrom location: CLLocation) -> Bool
 
+    /**
+     Called immediately before the router calculates a new route.
+     
+     This method is called after `router(_:shouldRerouteFrom:)` is called, and before `router(_:didRerouteAlong:)` is called.
+     
+     - parameter router: The router that will calculate a new route.
+     - parameter location: The user’s current location.
+     */
     @objc(router:willRerouteFromLocation:)
     optional func router(_ router: Router, willRerouteFrom location: CLLocation)
     
+    /**
+     Called when a location has been identified as unqualified to navigate on.
+     
+     See `CLLocation.isQualified` for more information about what qualifies a location.
+     
+     - parameter router: The router that discarded the location.
+     - parameter location: The location that will be discarded.
+     - return: If `true`, the location is discarded and the `Router` will not consider it. If `false`, the location will not be thrown out.
+     */
     @objc(router:shouldDiscardLocation:)
     optional func router(_ router: Router, shouldDiscard location: CLLocation) -> Bool
 
+    /**
+     Called immediately after the router receives a new route.
+     
+     This method is called after `router(_:willRerouteFrom:)` method is called.
+     
+     - parameter router: The router that has calculated a new route.
+     - parameter route: The new route.
+     */
     @objc(router:didRerouteAlongRoute:at:proactive:)
     optional func router(_ router: Router, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool)
 
+    /**
+     Called when the router fails to receive a new route.
+     
+     This method is called after `router(_:willRerouteFrom:)`.
+     
+     - parameter router: The router that has calculated a new route.
+     - parameter error: An error raised during the process of obtaining a new route.
+     */
     @objc(router:didFailToRerouteWithError:)
     optional func router(_ router: Router, didFailToRerouteWith error: Error)
     
+    /**
+     Called when the router updates the route progress model.
+     
+     - parameter router: The router that received the new locations.
+     - parameter progress: the RouteProgress model that was updated.
+     - parameter location: the guaranteed location, possibly snapped, associated with the progress update.
+     - parameter rawLocation: the raw location, from the location manager, associated with the progress update.
+     */
     @objc(router:didUpdateProgress:withLocation:rawLocation:)
     optional func router(_ router: Router, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation)
     
+    /**
+     Called when the router detects that the user has passed a point at which an instruction should be displayed.
+     - parameter router: The router that passed the instruction point.
+     - parameter instruction: The instruction to be presented.
+     - parameter routeProgress: The route progress object that the router is updating.
+     */
     @objc(router:didPassVisualInstructionPoint:routeProgress:)
     optional func router(_ router: Router, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress)
     
+    /**
+     Called when the router detects that the user has passed a point at which an instruction should be spoken.
+     - parameter router: The router that passed the instruction point.
+     - parameter instruction: The instruction to be spoken.
+     - parameter routeProgress: The route progress object that the router is updating.
+     */
     @objc(router:didPassSpokenInstructionPoint:routeProgress:)
     optional func router(_ router: Router, didPassSpokenInstructionPoint instruction: SpokenInstruction, routeProgress: RouteProgress)
     
+    /**
+     Called as the router approaches a waypoint.
+     
+     This message is sent, once per progress update, as the user is approaching a waypoint. You can use this to cue UI, to do network pre-loading, etc.
+     - parameter router: The router that is detecting the destination approach.
+     - parameter waypoint: The waypoint that the service is arriving at.
+     - parameter remainingTimeInterval: The estimated number of seconds until arrival.
+     - parameter distance: The current distance from the waypoint, in meters.
+     - important: This method will likely be called several times as you approach a destination. If only one consumption of this method is desired, then usage of an internal flag is recommended.
+     */
     @objc(router:willArriveAtWaypoint:in:distance:)
     optional func router(_ router: Router, willArriveAt waypoint: Waypoint, after remainingTimeInterval:TimeInterval, distance: CLLocationDistance)
     
+    /**
+     Called when the router arrives at a waypoint.
+     
+     You can implement this method to prevent the router from automatically advancing to the next leg. For example, you can and show an interstitial sheet upon arrival and pause navigation by returning `false`, then continue the route when the user dismisses the sheet. If this method is unimplemented, the router automatically advances to the next leg when arriving at a waypoint.
+     
+     - postcondition: If you return false, you must manually advance to the next leg: obtain the value of the `routeProgress` property, then increment the `RouteProgress.legIndex` property.
+     - parameter router: The router that has arrived at a waypoint.
+     - parameter waypoint: The waypoint that the controller has arrived at.
+     - returns: True to advance to the next leg, if any, or false to remain on the completed leg.
+     */
     @objc(router:didArriveAtWaypoint:)
     optional func router(_ router: Router, didArriveAt waypoint: Waypoint) -> Bool
     
+    /**
+     Called when the router arrives at a waypoint.
+     
+     You can implement this method to allow the router to continue check and reroute the user if needed. By default, the user will not be rerouted when arriving at a waypoint.
+     
+     - parameter router: The router that has arrived at a waypoint.
+     - parameter waypoint: The waypoint that the controller has arrived at.
+     - returns: True to prevent the router from checking if the user should be rerouted.
+     */
     @objc(router:shouldPreventReroutesWhenArrivingAtWaypoint:)
     optional func router(_ router: Router, shouldPreventReroutesWhenArrivingAt waypoint: Waypoint) -> Bool
 
+    /**
+     Called when the router will disable battery monitoring.
+     
+     Implementing this method will allow developers to change whether battery monitoring is disabled when the `Router` is deinited.
+     
+     - parameter router: The router that will change the state of battery monitoring.
+     - returns: A bool indicating whether to disable battery monitoring when the RouteController is deinited.
+     */
     @objc(routerShouldDisableBatteryMonitoring:)
     optional func routerShouldDisableBatteryMonitoring(_ router: Router) -> Bool
 }

--- a/MapboxCoreNavigation/RouterDelegate.swift
+++ b/MapboxCoreNavigation/RouterDelegate.swift
@@ -5,18 +5,11 @@ import MapboxDirections
 
 
 /**
- RouterDelegate is a mid-level delegate that defines the messaging architechture between the NavigationService and its router. Developers generally shouldn't have to concern themselves with this class unless a custom core-navigation engine (conforming to NavigationService) is being written.
+ A router delegate interacts with one or more `Router` instances, such as `RouteController` objects, during turn-by-turn navigation. This protocol is similar to `NavigationServiceDelegate`, which is the main way that your application can synchronize its state with the SDK’s location-related functionality. Normally, you should not need to make a class conform to the `RouterDelegate` protocol or call any of its methods directly, but you would need to call this protocol’s methods if you implement a custom `Router` class.
  
- You can use this protocol to:
- * Recieve navigation progress updates
- * Decide when to reroute the user
- * Decide what location updates are considered 'qualified'
- * Customize visual / spoken instructions that are presented to the user
- * Decide if battery monitoring should be disabled
- * Decide if the SDK should pause navigation when the user reaches an intermediate destination (for example, to show a interstitial modal UI)
- * Be informed when the SDK fails to fetch a new route
- * Be informed when the SDK is beginning or ending route-simulation
- * Be informed when the user is approaching or has arrived at their destination
+ `MapboxNavigationService` is the only concrete implementation of a router delegate. Implement the `NavigationServiceDelegate` protocol instead to be notified when various significant events occur along the route tracked by a `NavigationService`.
+ 
+ - seealso: MapboxNavigationService
  - seealso: NavigationServiceDelegate
  */
 @objc(MBRouterDelegate)

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -6,9 +6,15 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 /**
- `MapboxVoiceController` extends the default `RouteVoiceController` by providing a more robust speech synthesizer via the Mapbox Speech API. `RouteVoiceController` will be used as a fallback during poor network conditions.
+ The Mapbox voice controller plays spoken instructions using the [MapboxSpeech](https://github.com/mapbox/mapbox-speech-swift/) framework.
  
- If you need text-to-speech functionality without NavigationService, use SpeechSynthesizer directly.
+ You initialize a voice controller using a `NavigationService` instance. The voice controller observes when the navigation service hints that the user has passed a _spoken instruction point_ and responds by converting the contents of a `SpokenInstruction` object into audio and playing the audio.
+ 
+ The MapboxSpeech framework requires a network connection to connect to the Mapbox Voice API, but it produces superior speech output in several languages including English. If the voice controller is unable to connect to the Voice API, it falls back to the Speech Synthesis framework as implemented by the superclass, `RouteVoiceController`. To mitigate network latency over a cell connection, `MapboxVoiceController` prefetches and caches synthesized audio.
+ 
+ If you need to supply a third-party speech synthesizer that requires a network connection, define a subclass of `MapboxVoiceController` that overrides the `speak(_:)` method. If the third-party speech synthesizer does not require a network connection, you can instead subclass `RouteVoiceController`.
+ 
+ The Mapbox Voice API is optimized for spoken instructions provided by the Mapbox Directions API via the MapboxDirections.swift framework. If you need text-to-speech functionality outside the context of a navigation service, use the Speech Synthesis framework’s `AVSpeechSynthesizer` class directly.
  */
 @objc(MBMapboxVoiceController)
 open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {

--- a/MapboxNavigation/NavigationOptions.swift
+++ b/MapboxNavigation/NavigationOptions.swift
@@ -6,7 +6,7 @@ import MapboxCoreNavigation
  
  A navigation options object is where you place customized components that the navigation view controller uses during its lifetime, such as styles or voice controllers. You would likely use this class if you need to specify a Mapbox access token programmatically instead of in the Info.plist file.
  
- - note: `NavigationOptions` is designed to be used with the `NavigationViewController` class to customize the user experience. To specify criteria when calculating routes, use the `NavigationRouteOptions` class.
+ - note: `NavigationOptions` is designed to be used with the `NavigationViewController` class to customize the user experience. To specify criteria when calculating routes, use the `NavigationRouteOptions` class. To modify user preferences that persist across navigation sessions, use the `NavigationSettings` class.
  */
 
 @objc(MBNavigationOptions)
@@ -48,6 +48,15 @@ open class NavigationOptions: NSObject, NavigationCustomizable {
         super.init()
     }
     
+    /**
+     Initializes an object that configures a `NavigationViewController`.
+     
+     - parameter styles: The user interface styles that are available for display.
+     - parameter navigationService: The navigation service that coordinates the view controller’s nonvisual components, tracking the user’s location as they proceed along the route.
+     - parameter voiceController: The voice controller that vocalizes spoken instructions along the route at the appropriate times.
+     - parameter topBanner: The container view controller that presents the top banner.
+     - parameter bottomBanner: The container view controller that presents the bottom banner.
+     */
     @objc public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil) {
         self.init()
         self.styles = styles
@@ -58,7 +67,7 @@ open class NavigationOptions: NSObject, NavigationCustomizable {
     }
     
     /**
-     Convienence factory-method for convenient bridging to OBJ-C.
+     Convienence factory-method for convenient bridging to Objective-C.
      */
     @objc public class func navigationOptions() -> Self {
         return self.init()

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -6,19 +6,19 @@ import AVFoundation
 import Mapbox
 
 /**
- A ContainerViewController is any UIViewController that conforms to the NavigationComponent messaging protocol.
- - seealso: NavigationComponent
+ A container view controller is a view controller that behaves as a navigation component; that is, it responds as the user progresses along a route according to the `NavigationServiceDelegate` protocol.
  */
 public typealias ContainerViewController = UIViewController & NavigationComponent
 
 /**
- `NavigationViewController` is a fully-featured turn-by-turn navigation UI.
+ `NavigationViewController` is a fully-featured user interface for turn-by-turn navigation. Do not confuse it with the `NavigationController` class in UIKit.
  
- It provides step by step instructions, an overview of all steps for the given route and support for basic styling.
+ You initialize a navigation view controller based on a predefined `Route` and `NavigationOptions`. As the user progresses along the route, the navigation view controller shows their surroundings and the route line on a map. Banners above and below the map display key information pertaining to the route. A list of steps and a feedback mechanism are accessible via the navigation view controller.
  
- - seealso: CarPlayNavigationViewController
+ To be informed of significant events and decision points as the user progresses along the route, set the `NavigationService.delegate` property of the `NavigationService` that you provide when creating the navigation options.
+ 
+ `CarPlayNavigationViewController` manages the corresponding user interface on a CarPlay screen.
  */
-
 @objc(MBNavigationViewController)
 open class NavigationViewController: UIViewController, NavigationStatusPresenter {
     
@@ -62,16 +62,12 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     @objc public weak var delegate: NavigationViewControllerDelegate?
     
     /**
-     Provides access to various speech synthesizer options.
-     
-     See `RouteVoiceController` for more information.
+     The voice controller that vocalizes spoken instructions along the route at the appropriate times.
      */
     @objc public var voiceController: RouteVoiceController!
     
     /**
-     Provides all routing logic for the user.
-
-     See `NavigationService` for more information.
+     The navigation service that coordinates the view controller’s nonvisual components, tracking the user’s location as they proceed along the route.
      */
     @objc private(set) public var navigationService: NavigationService! {
         didSet {
@@ -188,12 +184,12 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     private var traversingTunnel = false
     
     /**
-     Initializes a `NavigationViewController` that provides turn by turn navigation for the given route. A optional `direction` object is needed for  potential rerouting.
+     Initializes a navigation view controller that presents the user interface for following a predefined route based on the given options.
 
-     See [Mapbox Directions](https://mapbox.github.io/mapbox-navigation-ios/directions/) for further information.
+     The route may come directly from the completion handler of the [MapboxDirections.swift](https://mapbox.github.io/mapbox-navigation-ios/directions/) framework’s `Directions.calculate(_:completionHandler:)` method, or it may be unarchived or created from a JSON object.
      
      - parameter route: The route to navigate along.
-     - parameter options: The navigation options to use for the navigation session. See `NavigationOptions`.
+     - parameter options: The navigation options to use for the navigation session.
      */
     @objc(initWithRoute:options:)
     required public init(for route: Route,

--- a/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -3,6 +3,8 @@ import MapboxDirections
 
 /**
  The `NavigationViewControllerDelegate` protocol provides methods for configuring the map view shown by a `NavigationViewController` and responding to the cancellation of a navigation session.
+ 
+ For convenience, several location-related methods in the `NavigationServiceDelegate` protocol have corresponding methods in this protocol.
  */
 @objc(MBNavigationViewControllerDelegate)
 public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -49,7 +49,13 @@ extension SpokenInstruction {
 }
 
 /**
- The `RouteVoiceController` class provides voice guidance.
+ A route voice controller plays spoken instructions as audio using the Speech Synthesis framework, also known as VoiceOver.
+ 
+ You initialize a voice controller using a `NavigationService` instance. The voice controller observes when the navigation service hints that the user has passed a _spoken instruction point_ and responds by reading aloud the contents of a `SpokenInstruction` object using an `AVSpeechSynthesizer` object.
+ 
+ The Speech Synthesis framework does not require a network connection, but the speech quality may be limited in some languages including English. By default, a `NavigationViewController` plays spoken instruction susing a subclass, `MapboxVoiceController`, that is powered by the [MapboxSpeech](https://github.com/mapbox/mapbox-speech-swift/) framework instead of the Speech Synthesis framework.
+ 
+ If you need to supply a third-party speech synthesizer, define a subclass of `RouteVoiceController` that overrides the `speak(_:)` method. If the third-party speech synthesizer requires a network connection, you can instead subclass `MapboxVoiceController` to take advantage of its prefetching functionality.
  */
 @objc(MBRouteVoiceController)
 open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {


### PR DESCRIPTION
![Documetation!](https://areyoumyspiritanimal.files.wordpress.com/2015/10/documentation.gif)

Fixes #2010.

To-Do:
- [x] `NavigationService` documentation
- [x] `Router` Documentation
- [x] `RouterDelegate` Documentation.
- [x] `NavigationServiceDelegate` documentation
- [ ] `RouterDataSource` documentation

/cc @mapbox/navigation-ios 