### PR TITLE
Fix pod linter and compiler warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ jobs:
       xcode:
         type: string
         default: "10.2.0"
+      lint:
+        type: boolean
+        default: false
     macos:
       xcode: << parameters.xcode >>
     environment:
@@ -90,6 +93,11 @@ jobs:
           steps:
             - run: cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall && pod install --repo-update
       - run: cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall && xcodebuild -workspace PodInstall.xcworkspace -scheme PodInstall -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=iPhone 6 Plus' clean build | xcpretty
+      - when:
+          condition: << parameters.lint >>
+          steps:
+            - run: pod lib lint MapboxCoreNavigation.podspec
+            - run: pod lib lint MapboxNavigation.podspec
       - *save-cache-podmaster
       - *save-cache-cocoapods
 
@@ -187,4 +195,5 @@ workflows:
           update: true
           xcode: "10.2.0"
           iOS: "12.2"
+          lint: true
       - xcode-10-examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,9 @@ jobs:
       - run:
           name: Install prerequisites
           command: if [ $(xcversion simulators | grep -cF "iOS << parameters.iOS >> Simulator (installed)") -eq 0 ]; then xcversion simulators --install="iOS << parameters.iOS >>" || true; fi
+      - run:
+          name: pre-start simulator
+          command: xcrun instruments -w "<< parameters.device >> (<< parameters.iOS >>) [" || true
       - *verify-missing-localizable-strings
       - run:
           name: MapboxCoreNavigation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Fixed a bug where proactive route updates where not reported as such. ([#2086](https://github.com/mapbox/mapbox-navigation-ios/pull/2086))
+* Fixed compiler warnings in Xcode 10.2 when installing the SDK using CocoaPods. ([#2087](https://github.com/mapbox/mapbox-navigation-ios/pull/2087))
 
 ## v0.31.0
 

--- a/MapboxCoreNavigation/CoreFeedbackEvent.swift
+++ b/MapboxCoreNavigation/CoreFeedbackEvent.swift
@@ -14,10 +14,8 @@ class CoreFeedbackEvent: Hashable {
         self.eventDictionary = eventDictionary
     }
     
-    var hashValue: Int {
-        get {
-            return id.hashValue
-        }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id.hashValue)
     }
     
     static func ==(lhs: CoreFeedbackEvent, rhs: CoreFeedbackEvent) -> Bool {

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -529,14 +529,14 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     
     // MARK: Obsolete methods
     
-    @available(*, obsoleted: 0.1, message: "MapboxNavigationService is now the point-of-entry to MapboxCoreNavigation. Direct use of RouteController is no longer reccomended. See MapboxNavigationService for more information.")
+    @available(*, deprecated, message: "MapboxNavigationService is now the point-of-entry to MapboxCoreNavigation. Direct use of RouteController is no longer reccomended. See MapboxNavigationService for more information.")
     /// :nodoc: Obsoleted method.
     @objc(initWithRoute:directions:dataSource:eventsManager:)
     public convenience init(along route: Route, directions: Directions = Directions.shared, dataSource: NavigationLocationManager = NavigationLocationManager(), eventsManager: NavigationEventsManager) {
         fatalError()
     }
     
-    @available(*, obsoleted: 0.1, message: "RouteController no longer manages a location manager directly. Instead, the Router protocol conforms to CLLocationManagerDelegate, and RouteControllerDataSource provides access to synchronous location requests.")
+    @available(*, deprecated, message: "RouteController no longer manages a location manager directly. Instead, the Router protocol conforms to CLLocationManagerDelegate, and RouteControllerDataSource provides access to synchronous location requests.")
     /// :nodoc: obsoleted
     @objc public final var locationManager: NavigationLocationManager! {
         get {
@@ -546,7 +546,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             fatalError()
         }
     }
-    @available(*, obsoleted: 0.1, renamed: "NavigationService.locationManager", message: "NavigationViewController no longer directly manages an NavigationLocationManager. See MapboxNavigationService, which contains a reference to the locationManager, for more information.")
+    @available(*, deprecated, renamed: "NavigationService.locationManager", message: "NavigationViewController no longer directly manages an NavigationLocationManager. See MapboxNavigationService, which contains a reference to the locationManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var tunnelIntersectionManager: Any! {
         get {
@@ -556,7 +556,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             fatalError()
         }
     }
-    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no longer directly manages a NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
+    @available(*, deprecated, renamed: "navigationService.eventsManager", message: "NavigationViewController no longer directly manages a NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var eventsManager: NavigationEventsManager! {
         get {

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -542,7 +542,7 @@ public protocol CarPlayNavigationDelegate {
     
     //MARK: - Deprecated.
     
-    @available(*, obsoleted: 0.1, message: "Use NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:) or  NavigationServiceDelegate.navigationService(_:didArriveAt:) instead.")
+    @available(*, deprecated, message: "Use NavigationViewControllerDelegate.navigationViewController(_:didArriveAt:) or  NavigationServiceDelegate.navigationService(_:didArriveAt:) instead.")
     @objc optional func carPlayNavigationViewControllerDidArrive(_ carPlayNavigationViewController: CarPlayNavigationViewController)
 }
 #endif

--- a/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -105,11 +105,11 @@ public protocol NavigationMapViewDelegate: class {
     
     //MARK: Obsolete
     
-    @available(*, obsoleted: 0.1, message: "The NavigationMapView no longer forwards MGLMapViewDelegate messages. Use MGLMapViewDelegate.mapView(_:imageFor:) instead.")
+    @available(*, deprecated, message: "The NavigationMapView no longer forwards MGLMapViewDelegate messages. Use MGLMapViewDelegate.mapView(_:imageFor:) instead.")
     @objc(navigationMapView:imageForAnnotation:)
     optional func navigationMapView(_ mapView: MGLMapView, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
     
-    @available(*, obsoleted: 0.1, message: "The NavigationMapView no longer forwards MGLMapViewDelegate messages. Use MGLMapViewDelegate.mapView(_:viewFor:) instead.")
+    @available(*, deprecated, message: "The NavigationMapView no longer forwards MGLMapViewDelegate messages. Use MGLMapViewDelegate.mapView(_:viewFor:) instead.")
     @objc(navigationMapView:viewForAnnotation:)
     optional func navigationMapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
 }

--- a/MapboxNavigation/NavigationViewController+Obsolete.swift
+++ b/MapboxNavigation/NavigationViewController+Obsolete.swift
@@ -4,8 +4,8 @@ import MapboxDirections
 
 //MARK: - Obsoleted Interfaces
 
-public extension NavigationViewController {
-    @available(*, deprecated: 0.1, message: "Use the new init(route:options:) initalizer.")
+extension NavigationViewController {
+    @available(*, deprecated, message: "Use the new init(route:options:) initalizer.")
     @objc(initWithRoute:styles:navigationService:voiceController:)
     public convenience init(for route: Route,
                          styles: [Style]? = nil,
@@ -19,7 +19,7 @@ public extension NavigationViewController {
         self.init(for: route, options: bridge)
     }
     
-    @available(*, obsoleted: 0.1, renamed: "navigationService", message: "NavigationViewController no longer directly manages a RouteController. See MapboxNavigationService, which contains a protocol-bound reference to the RouteController, for more information.")
+    @available(*, deprecated, renamed: "navigationService", message: "NavigationViewController no longer directly manages a RouteController. See MapboxNavigationService, which contains a protocol-bound reference to the RouteController, for more information.")
     /// :nodoc: obsoleted
     @objc public final var routeController: RouteController! {
         get {
@@ -30,7 +30,7 @@ public extension NavigationViewController {
         }
     }
     
-    @available(*, obsoleted: 0.1, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages a NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
+    @available(*, deprecated, renamed: "navigationService.eventsManager", message: "NavigationViewController no-longer directly manages a NavigationEventsManager. See MapboxNavigationService, which contains a reference to the eventsManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var eventsManager: NavigationEventsManager! {
         get {
@@ -41,7 +41,7 @@ public extension NavigationViewController {
         }
     }
     
-    @available(*, obsoleted: 0.1, renamed: "navigationService.locationManager", message: "NavigationViewController no-longer directly manages an NavigationLocationManager. See MapboxNavigationService, which contains a reference to the locationManager, for more information.")
+    @available(*, deprecated, renamed: "navigationService.locationManager", message: "NavigationViewController no-longer directly manages an NavigationLocationManager. See MapboxNavigationService, which contains a reference to the locationManager, for more information.")
     /// :nodoc: obsoleted
     @objc public final var locationManager: NavigationLocationManager! {
         get {
@@ -52,7 +52,7 @@ public extension NavigationViewController {
         }
     }
     
-    @available(*, obsoleted: 0.1, renamed: "init(for:styles:navigationService:voiceController:)", message: "Intializing a NavigationViewController directly with a RouteController is no longer supported. Use a NavigationService instead.")
+    @available(*, deprecated, renamed: "init(for:styles:navigationService:voiceController:)", message: "Intializing a NavigationViewController directly with a RouteController is no longer supported. Use a NavigationService instead.")
     /// :nodoc: Obsoleted method.
     @objc(initWithRoute:directions:styles:routeController:locationManager:voiceController:eventsManager:)
     public convenience init(for route: Route,

--- a/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -177,11 +177,11 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     
     //MARK: Obsolete
     
-    @available(*, obsoleted: 0.1, message: "Use MGLMapViewDelegate.mapView(_:imageFor:) instead.")
+    @available(*, deprecated, message: "Use MGLMapViewDelegate.mapView(_:imageFor:) instead.")
     @objc(navigationViewController:imageForAnnotation:)
     optional func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage?
     
-    @available(*, obsoleted: 0.1, message: "Use MGLMapViewDelegate.mapView(_:viewFor:) instead.")
+    @available(*, deprecated, message: "Use MGLMapViewDelegate.mapView(_:viewFor:) instead.")
     @objc(navigationViewController:viewForAnnotation:)
     optional func navigationViewController(_ navigationViewController: NavigationViewController, viewFor annotation: MGLAnnotation) -> MGLAnnotationView?
 }

--- a/MapboxNavigation/UIEdgeInsets.swift
+++ b/MapboxNavigation/UIEdgeInsets.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import MapboxDirections
 
-public extension UIEdgeInsets {
+extension UIEdgeInsets {
     public static func +(left: UIEdgeInsets, right: UIEdgeInsets) -> UIEdgeInsets {
         return UIEdgeInsets(top: left.top + right.top,
                             left: left.left + right.left,


### PR DESCRIPTION
Fixes #2081 

- Remove deprecated usage of `Hashable`
- Run pod linter on CI

The pod linter will fail until we bring in #2086 

cc @mapbox/navigation-ios 