### PR TITLE
Uniformise events between route controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Fixed a bug where proactive route updates where not reported as such. ([#2086](https://github.com/mapbox/mapbox-navigation-ios/pull/2086))
+* Uniformise events between `RouteController` and `LegacyRouteController`. `LegacyRouteController` was missing a call to `MapboxNavigationService.router(_:didPassSpokenInstructionPoint:routeProgress:)` and was not passing the `RouteControllerNotificationUserInfoKey.spokenInstructionKey` in `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notification ([#2089](https://github.com/mapbox/mapbox-navigation-ios/pull/2089))
 
 ## v0.31.0
 

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -478,8 +478,11 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         for voiceInstruction in spokenInstructions {
             if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep || firstInstructionOnFirstStep {
 
+                let currentSpokenInstruction = routeProgress.currentLegProgress.currentStepProgress.currentSpokenInstruction!
+                delegate?.router?(self, didPassSpokenInstructionPoint: currentSpokenInstruction, routeProgress: routeProgress)
                 NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
-                    RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress
+                    RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress,
+                    RouteControllerNotificationUserInfoKey.spokenInstructionKey: currentSpokenInstruction
                 ])
 
                 routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex += 1

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -475,14 +475,13 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         // Always give the first voice announcement when beginning a leg.
         let firstInstructionOnFirstStep = routeProgress.currentLegProgress.stepIndex == 0 && routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex == 0
 
-        for voiceInstruction in spokenInstructions {
-            if userSnapToStepDistanceFromManeuver <= voiceInstruction.distanceAlongStep || firstInstructionOnFirstStep {
+        for spokenInstruction in spokenInstructions {
+            if userSnapToStepDistanceFromManeuver <= spokenInstruction.distanceAlongStep || firstInstructionOnFirstStep {
 
-                let currentSpokenInstruction = routeProgress.currentLegProgress.currentStepProgress.currentSpokenInstruction!
-                delegate?.router?(self, didPassSpokenInstructionPoint: currentSpokenInstruction, routeProgress: routeProgress)
+                delegate?.router?(self, didPassSpokenInstructionPoint: spokenInstruction, routeProgress: routeProgress)
                 NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
                     RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress,
-                    RouteControllerNotificationUserInfoKey.spokenInstructionKey: currentSpokenInstruction
+                    RouteControllerNotificationUserInfoKey.spokenInstructionKey: spokenInstruction
                 ])
 
                 routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex += 1
@@ -498,11 +497,10 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         
         for visualInstruction in visualInstructions {
             if userSnapToStepDistanceFromManeuver <= visualInstruction.distanceAlongStep || isFirstLocation {
-                let currentVisualInstruction = currentStepProgress.currentVisualInstruction!
-                delegate?.router?(self, didPassVisualInstructionPoint: currentVisualInstruction, routeProgress: routeProgress)
+                delegate?.router?(self, didPassVisualInstructionPoint: visualInstruction, routeProgress: routeProgress)
                 NotificationCenter.default.post(name: .routeControllerDidPassVisualInstructionPoint, object: self, userInfo: [
                     RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress,
-                    RouteControllerNotificationUserInfoKey.visualInstructionKey: currentVisualInstruction,
+                    RouteControllerNotificationUserInfoKey.visualInstructionKey: visualInstruction,
                 ])
                 currentStepProgress.visualInstructionIndex += 1
                 return

--- a/MapboxCoreNavigation/MBRouteController.h
+++ b/MapboxCoreNavigation/MBRouteController.h
@@ -65,7 +65,7 @@ extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteController
 extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerVisualInstructionKey;
 
 /**
- A key in the user info dictionary of a `MBRouteControllerDidPassSpokenInstructionPointNotification` notification. The corresponding value is an `MBVisualInstruction` object representing the current visual instruction.
+ A key in the user info dictionary of a `MBRouteControllerDidPassSpokenInstructionPointNotification` notification. The corresponding value is an `MBSpokenInstruction` object representing the current visual instruction.
  */
 extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerSpokenInstructionKey;
 


### PR DESCRIPTION
Fixes #2088

Done:
- Add call to `router(_ router: Router, didPassSpokenInstructionPoint...)` in LegacyRouteController
- Add missing object to `routeControllerDidPassVisualInstructionPoint` in LegacyRouteController
- Minor code documentation fix.