### PR TITLE
Always reset rerouting flag even if request fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed an issue where `RouteControllerNotificationUserInfoKey.isProactiveKey` was not set to `true` in `Notification.Name.routeControllerDidReroute` notifications after proactively rerouting the user. ([#2086](https://github.com/mapbox/mapbox-navigation-ios/pull/2086))
 * Fixed an issue where `LegacyRouteController` failed to call `NavigationServiceDelegate.navigationService(_:didPassSpokenInstructionPoint:routeProgress:)` and omitted `RouteControllerNotificationUserInfoKey.spokenInstructionKey` from `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notifications. ([#2089](https://github.com/mapbox/mapbox-navigation-ios/pull/2089))
 * `NavigationMatchOptions.shapeFormat` now defaults to `RouteShapeFormat.polyline6` for consistency with `NavigationRouteOptions` and compatibility with the `RouteController`. ([#2084](https://github.com/mapbox/mapbox-navigation-ios/pull/2084))
+* Fixed an issue where no more route could be requested in case a re-routing request failed when using `LegacyRouteController`. ([#2093](https://github.com/mapbox/mapbox-navigation-ios/pull/2093))
 
 ## v0.31.0
 

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -364,6 +364,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                 return
             }
 
+			strongSelf.isRerouting = false
             if let error = error {
                 strongSelf.delegate?.router?(strongSelf, didFailToRerouteWith: error)
                 NotificationCenter.default.post(name: .routeControllerDidFailToReroute, object: self, userInfo: [
@@ -373,7 +374,6 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             }
 
             guard let route = route else { return }
-            strongSelf.isRerouting = false
             strongSelf._routeProgress = RouteProgress(route: route, legIndex: 0)
             strongSelf._routeProgress.currentLegProgress.stepIndex = 0
             strongSelf.announce(reroute: route, at: location, proactive: false)


### PR DESCRIPTION
In `LegacyRouteController`, if the re-routing request fails the `isRerouting` flag isn't reset as it is the case in `RouteController` for off-route rerouting and `Router` for proactive rerouting.

If that happens then no subsequent request can be sent by `LegacyRouterController` and the user becomes stuck with an outdated and irrelevant route.