### PR TITLE
Bump nav-native to 6.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed an issue where `LegacyRouteController` failed to call `NavigationServiceDelegate.navigationService(_:didPassSpokenInstructionPoint:routeProgress:)` and omitted `RouteControllerNotificationUserInfoKey.spokenInstructionKey` from `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notifications. ([#2089](https://github.com/mapbox/mapbox-navigation-ios/pull/2089))
 * Fixed an issue where `SimulatedLocationManager` would not update its current distance when updating the Router's route. As a result the user puck was being snapped at an invalid location on the new route ([#2096](https://github.com/mapbox/mapbox-navigation-ios/pull/2096))
 * `NavigationMatchOptions.shapeFormat` now defaults to `RouteShapeFormat.polyline6` for consistency with `NavigationRouteOptions` and compatibility with the `RouteController`. ([#2084](https://github.com/mapbox/mapbox-navigation-ios/pull/2084))
+* Fixed a regression where the puck could float around when standing still or moving backwards. ([#2109](https://github.com/mapbox/mapbox-navigation-ios/pull/2109))
 
 ## v0.31.0
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.3
-binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.1.1
+binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.1.3
 github "mapbox/MapboxDirections.swift" ~> 0.27.3
 github "mapbox/turf-swift" ~> 0.3
 github "mapbox/mapbox-events-ios" ~> 0.8.1

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 6.1.1"
+  s.dependency "MapboxNavigationNative", "~> 6.1.3"
   s.dependency "MapboxDirections.swift", "~> 0.27.3"    # Always pin to a patch release if pre-1.0
   s.dependency "MapboxMobileEvents", "~> 0.8.1"         # Always pin to a patch release if pre-1.0
   s.dependency "Turf", "~> 0.3.0"                       # Always pin to a patch release if pre-1.0

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
@@ -230,7 +230,6 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-frameworks.sh",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
-				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxDirections.swift/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
@@ -245,7 +244,6 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - Mapbox-iOS-SDK (4.9.0)
-  - MapboxCoreNavigation (0.30.0):
+  - MapboxCoreNavigation (0.31.0):
     - MapboxDirections.swift (~> 0.27.3)
     - MapboxMobileEvents (~> 0.8.1)
-    - MapboxNavigationNative (~> 6.1.1)
+    - MapboxNavigationNative (~> 6.1.3)
     - Turf (~> 0.3.0)
   - MapboxDirections.swift (0.27.3):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.8.1)
-  - MapboxNavigation (0.30.0):
+  - MapboxNavigation (0.31.0):
     - Mapbox-iOS-SDK (~> 4.3)
-    - MapboxCoreNavigation (= 0.30.0)
+    - MapboxCoreNavigation (= 0.31.0)
     - MapboxSpeech (~> 0.1.0)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (6.1.1)
+  - MapboxNavigationNative (6.1.3)
   - MapboxSpeech (0.1.1)
   - Polyline (4.2.0)
   - Solar (2.1.0)
@@ -42,11 +42,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 225036950837cbe408e6b333e51cd6001c122499
-  MapboxCoreNavigation: bca953c7a8e5d0169d53a8478030ee17b53f3eca
+  MapboxCoreNavigation: d6436bd0a018f0bc7a0d97fd5e075dddf2ddffb6
   MapboxDirections.swift: af3d8bc8cd80ed6e498dd6ed933f3c348799e1e2
   MapboxMobileEvents: 0f30fe39687f26fd8f255335053023ba039a0392
-  MapboxNavigation: 31d1bd3076da438fbd7cfaaa34ea1f41b9c1723c
-  MapboxNavigationNative: 4b3c0d38c57f43ba525283dab6abdead0558b2bc
+  MapboxNavigation: 188a6e4652da8de68b2e19bf7928a40766e9f3eb
+  MapboxNavigationNative: c7340cdfcb28f88aa02b6e3896151f4cd897f323
   MapboxSpeech: 59b3984d3f433a443d24acf53097f918c5cc70f9
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24


### PR DESCRIPTION
Bumped nav-native to 6.1.3 - Fixes a regression where the puck didn't always snap when standing still or slowly moving backwards.

@mapbox/navigation-ios 