### PR TITLE
[WIP] Fix route preview broken on first render in CarPlay

### DIFF
--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -478,7 +478,9 @@ extension CarPlayManager {
 
         let traitCollection = (self.carWindow?.rootViewController as! CarPlayMapViewController).traitCollection
         let previewMapTemplate = mapTemplateProvider.mapTemplate(forPreviewing: trip, traitCollection: traitCollection, mapDelegate: self)
-
+        
+        carPlayMapViewController?.mapView.routes = routes
+        
         previewMapTemplate.showTripPreviews([trip], textConfiguration: previewText)
         
         guard let interfaceController = interfaceController else {

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -212,7 +212,7 @@ public class CarPlayMapViewController: UIViewController {
         }
         
         if isOverviewingRoutes {
-            mapView.fit(to: active, animated: false)
+            mapView.fit(to: active, for: mapView.camera, animated: false)
         }
     }
 }

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -189,7 +189,7 @@ public class CarPlayNavigationViewController: UIViewController {
         
         if !tracksUserCourse {
             mapView.setContentInset(overviewContentInsets(), animated: false)
-            mapView.fit(to: navigationService.route, facing: 0, padding: .zero, animated: false)
+            mapView.fit(to: navigationService.route, for: mapView.camera, facing: 0, padding: .zero, animated: false)
         }
     }
     

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -438,17 +438,24 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         showRoutes(routes)
         showWaypoints(active)
         
-        fit(to: active, facing: 0, padding: padding, animated: animated)
+        let topDownCamera = camera
+        topDownCamera.pitch = 0
+        
+        fit(to: active, for: topDownCamera, facing: 0, padding: padding, animated: animated)
     }
     
-    func fit(to route: Route, facing direction:CLLocationDirection = 0, padding: UIEdgeInsets = NavigationMapView.defaultPadding, animated: Bool = false) {
+    func fit(to route: Route, for camera: MGLMapCamera, facing direction:CLLocationDirection = 0, padding: UIEdgeInsets = NavigationMapView.defaultPadding, animated: Bool = false) {
         guard let coords = route.coordinates, !coords.isEmpty else { return }
       
         setUserTrackingMode(.none, animated: false)
         let line = MGLPolyline(coordinates: coords, count: UInt(coords.count))
-        let camera = cameraThatFitsShape(line, direction: direction, edgePadding: padding)
         
-        setCamera(camera, animated: animated)
+        let customCamera = camera
+        customCamera.heading = direction
+        
+        let fittedCamera = self.camera(customCamera, fitting: line, edgePadding: padding)
+        
+        setCamera(fittedCamera, animated: animated)
     }
     
     /**


### PR DESCRIPTION
Background: When a device is connected to CarPlay, the route preview on first render displays on the head unit display. (Note - the simulator doesn't exhibit this buggy experience.) 

Issues addressed:
- [ ] The `CarPlayMapViewController`'s map view wasn't updated after a successful `MapboxDirections` service request. 
- [ ] The race condition of fitting the camera prematurely before the camera pitch was set has been addressed. 
- [ ] Mapview camera zooming into the wrong location coordinates after directions route(s) for preview is returned by the `MapboxDirections` service request.

/cc @1ec5 @mapbox/navigation-ios 
