### PR TITLE
Add speed limit data returned by MapboxDirections.swift to the RouteProgress object

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,7 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.3
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.1.1
-# github "https://github.com/avi-c/mapbox/MapboxDirections.swift.git"
-# git "https://github.com/avi-c/MapboxDirections.swift" "maxspeedAnnotations"
 github "mapbox/MapboxDirections.swift" "maxspeedAnnotations"
 github "mapbox/turf-swift" ~> 0.3
 github "mapbox/mapbox-events-ios" ~> 0.8.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,8 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.3
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.1.1
-github "mapbox/MapboxDirections.swift" ~> 0.27.3
+# github "https://github.com/avi-c/mapbox/MapboxDirections.swift.git"
+# git "https://github.com/avi-c/MapboxDirections.swift" "maxspeedAnnotations"
+github "mapbox/MapboxDirections.swift" "maxspeedAnnotations"
 github "mapbox/turf-swift" ~> 0.3
 github "mapbox/mapbox-events-ios" ~> 0.8.1
 github "ceeK/Solar" ~> 2.1.0

--- a/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -25,7 +25,7 @@ open class NavigationRouteOptions: RouteOptions {
         shapeFormat = .polyline6
         includesSteps = true
         routeShapeResolution = .full
-        attributeOptions = [.congestionLevel, .expectedTravelTime]
+        attributeOptions = [.congestionLevel, .expectedTravelTime, .maximumSpeedLimit]
         includesSpokenInstructions = true
         locale = Locale.nationalizedCurrent
         distanceMeasurementSystem = Locale.current.usesMetricSystem ? .metric : .imperial
@@ -79,7 +79,7 @@ open class NavigationMatchOptions: MatchOptions {
         includesSteps = true
         routeShapeResolution = .full
         shapeFormat = .polyline6
-        attributeOptions = [.congestionLevel, .expectedTravelTime]
+        attributeOptions = [.congestionLevel, .expectedTravelTime, .maximumSpeedLimit]
         includesSpokenInstructions = true
         locale = Locale.nationalizedCurrent
         distanceMeasurementSystem = Locale.current.usesMetricSystem ? .metric : .imperial

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -172,6 +172,11 @@ open class RouteProgress: NSObject {
     public var congestionTimesPerStep: [[[CongestionLevel: TimeInterval]]]  = [[[:]]]
 
     /**
+     An array containing speed limits on the route broken up by leg and then step.
+     */
+    public var maximumSpeedLimitsByLeg: [[[SpeedLimit]]] = []
+
+    /**
      Intializes a new `RouteProgress`.
 
      - parameter route: The route to follow.
@@ -184,6 +189,7 @@ open class RouteProgress: NSObject {
         super.init()
 
         for (legIndex, leg) in route.legs.enumerated() {
+            var maximumSpeedLimitsByStep: [[SpeedLimit]] = []
             var maneuverCoordinateIndex = 0
 
             congestionTimesPerStep.append([])
@@ -217,7 +223,38 @@ open class RouteProgress: NSObject {
             }
 
             congestionTravelTimesSegmentsByStep.append(congestionTravelTimesSegmentsByLeg)
+
+            maneuverCoordinateIndex = 0
+            if let segmentMaximumSpeedLimits = leg.segmentMaximumSpeedLimits {
+                for step in leg.steps {
+                    guard let coordinates = step.coordinates else { continue }
+                    let stepCoordinateCount = step.maneuverType == .arrive ? Int(step.coordinateCount) : coordinates.dropLast().count
+                    let nextManeuverCoordinateIndex = maneuverCoordinateIndex + stepCoordinateCount - 1
+
+                    guard nextManeuverCoordinateIndex < segmentMaximumSpeedLimits.count else { continue }
+
+                    let stepSegmentMaximumSpeedLimits = Array(segmentMaximumSpeedLimits[maneuverCoordinateIndex..<nextManeuverCoordinateIndex])
+                    maneuverCoordinateIndex = nextManeuverCoordinateIndex
+                    maximumSpeedLimitsByStep.append(stepSegmentMaximumSpeedLimits)
+                }
+            }
+
+            maximumSpeedLimitsByLeg.append(maximumSpeedLimitsByStep)
         }
+    }
+
+    public var currentSpeedLimit: SpeedLimit {
+        let coordinatesLeftOnStepCount = Int(floor((Double(currentLegProgress.currentStepProgress.step.coordinateCount)) * currentLegProgress.currentStepProgress.fractionTraveled))
+
+        guard coordinatesLeftOnStepCount >= 0, legIndex < maximumSpeedLimitsByLeg.count, currentLegProgress.stepIndex < maximumSpeedLimitsByLeg[legIndex].count, let coordinates = currentLegProgress.currentStepProgress.step.coordinates else { return SpeedLimit.invalid }
+
+        let indexedCoordinate = LineString(coordinates).indexedCoordinateFromStart(distance: currentLegProgress.currentStepProgress.distanceTraveled)
+
+        guard let index = indexedCoordinate?.index, index < maximumSpeedLimitsByLeg[legIndex][currentLegProgress.stepIndex].count else { return SpeedLimit.invalid }
+
+        let speedLimit = maximumSpeedLimitsByLeg[legIndex][currentLegProgress.stepIndex][index]
+
+        return speedLimit
     }
 
     public var averageCongestionLevelRemainingOnLeg: CongestionLevel? {
@@ -414,27 +451,6 @@ open class RouteLegProgress: NSObject {
      Returns the progress along the current `RouteStep`.
      */
     @objc public var currentStepProgress: RouteStepProgress
-
-    /**
-     Returns the SpeedLimit object for the current step
-     */
-    @objc public var currentSpeedLimit: SpeedLimit? {
-        return leg.segmentMaximumSpeedLimits?[stepIndex]
-    }
-
-    @objc public var priorSpeedLimit: SpeedLimit? {
-        guard stepIndex - 1 >= 0 else {
-            return nil
-        }
-        return leg.segmentMaximumSpeedLimits?[stepIndex - 1]
-    }
-
-    @objc public var upcomingSpeedLimit: SpeedLimit? {
-        guard stepIndex + 1 < leg.steps.endIndex else {
-            return nil
-        }
-        return leg.segmentMaximumSpeedLimits?[stepIndex + 1]
-    }
 
     /**
      Intializes a new `RouteLegProgress`.

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -416,6 +416,27 @@ open class RouteLegProgress: NSObject {
     @objc public var currentStepProgress: RouteStepProgress
 
     /**
+     Returns the SpeedLimit object for the current step
+     */
+    @objc public var currentSpeedLimit: SpeedLimit? {
+        return leg.segmentMaximumSpeedLimits?[stepIndex]
+    }
+
+    @objc public var priorSpeedLimit: SpeedLimit? {
+        guard stepIndex - 1 >= 0 else {
+            return nil
+        }
+        return leg.segmentMaximumSpeedLimits?[stepIndex - 1]
+    }
+
+    @objc public var upcomingSpeedLimit: SpeedLimit? {
+        guard stepIndex + 1 < leg.steps.endIndex else {
+            return nil
+        }
+        return leg.segmentMaximumSpeedLimits?[stepIndex + 1]
+    }
+
+    /**
      Intializes a new `RouteLegProgress`.
 
      - parameter leg: Leg on a `Route`.

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -243,6 +243,9 @@ open class RouteProgress: NSObject {
         }
     }
 
+    /**
+     Returns the SpeedLimit for the current position along the route. Returns SpeedLimit.invalid if the speed limit is unknown or missing.
+     */
     public var currentSpeedLimit: SpeedLimit {
         let coordinatesLeftOnStepCount = Int(floor((Double(currentLegProgress.currentStepProgress.step.coordinateCount)) * currentLegProgress.currentStepProgress.fractionTraveled))
 


### PR DESCRIPTION
Incorporate the new maxspeed annotations on the RouteLeg object from MapboxDirections.swift. Provide this data to Navigation SDK clients via the maximumSpeedLimitsByLeg array on the RouteProgress object.