### PR TITLE
CarPlay - Show route estimates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * `NavigationMatchOptions.shapeFormat` now defaults to `RouteShapeFormat.polyline6` for consistency with `NavigationRouteOptions` and compatibility with the `RouteController`. ([#2084](https://github.com/mapbox/mapbox-navigation-ios/pull/2084))
 * Fixed an issue where no more route could be requested in case a re-routing request failed when using `LegacyRouteController`. ([#2093](https://github.com/mapbox/mapbox-navigation-ios/pull/2093))
 * Fixed a regression where the puck could float around when standing still or moving backwards. ([#2109](https://github.com/mapbox/mapbox-navigation-ios/pull/2109))
+
+### CarPlay
+* Fixed issue where the Leg estimates (ETA, Distance Remaining, Time Remaining) were showing on CarPlay instead of Route estimates, as intended.
 * Deprecated `CarPlayManager.overviewButton` in favor of `CarPlayManager.userTrackingButton` which now updates the icon correctly when panning out of tracking state. ([#2100](https://github.com/mapbox/mapbox-navigation-ios/pull/2100))
 
 ## v0.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fixed a regression where the puck could float around when standing still or moving backwards. ([#2109](https://github.com/mapbox/mapbox-navigation-ios/pull/2109))
 
 ### CarPlay
-* Fixed issue where the Leg estimates (ETA, Distance Remaining, Time Remaining) were showing on CarPlay instead of Route estimates, as intended.([#2119](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
+* Fixed issue where, during turn-by-turn navigation, the Leg estimates (ETA, Distance Remaining, Time Remaining) were showing on CarPlay instead of Route estimates, as intended.([#2119](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
 * Deprecated `CarPlayManager.overviewButton` in favor of `CarPlayManager.userTrackingButton` which now updates the icon correctly when panning out of tracking state. ([#2100](https://github.com/mapbox/mapbox-navigation-ios/pull/2100))
 
 ## v0.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fixed a regression where the puck could float around when standing still or moving backwards. ([#2109](https://github.com/mapbox/mapbox-navigation-ios/pull/2109))
 
 ### CarPlay
-* Fixed issue where the Leg estimates (ETA, Distance Remaining, Time Remaining) were showing on CarPlay instead of Route estimates, as intended.
+* Fixed issue where the Leg estimates (ETA, Distance Remaining, Time Remaining) were showing on CarPlay instead of Route estimates, as intended.([#2119](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
 * Deprecated `CarPlayManager.overviewButton` in favor of `CarPlayManager.userTrackingButton` which now updates the icon correctly when panning out of tracking state. ([#2100](https://github.com/mapbox/mapbox-navigation-ios/pull/2100))
 
 ## v0.31.0

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -302,12 +302,11 @@ public class CarPlayNavigationViewController: UIViewController {
         let congestionLevel = routeProgress.averageCongestionLevelRemainingOnLeg ?? .unknown
         guard let maneuver = carSession.upcomingManeuvers.first else { return }
         
-        let legProgress = routeProgress.currentLegProgress
-        let legDistance = distanceFormatter.measurement(of: legProgress.distanceRemaining)
-        let legEstimates = CPTravelEstimates(distanceRemaining: legDistance, timeRemaining: legProgress.durationRemaining)
-        mapTemplate.update(legEstimates, for: carSession.trip, with: congestionLevel.asCPTimeRemainingColor)
+        let routeDistance = distanceFormatter.measurement(of: routeProgress.distanceRemaining)
+        let routeEstimates = CPTravelEstimates(distanceRemaining: routeDistance, timeRemaining: routeProgress.durationRemaining)
+        mapTemplate.update(routeEstimates, for: carSession.trip, with: congestionLevel.asCPTimeRemainingColor)
         
-        let stepProgress = legProgress.currentStepProgress
+        let stepProgress = routeProgress.currentLegProgress.currentStepProgress
         let stepDistance = distanceFormatter.measurement(of: stepProgress.distanceRemaining)
         let stepEstimates = CPTravelEstimates(distanceRemaining: stepDistance, timeRemaining: stepProgress.durationRemaining)
         carSession.updateEstimates(stepEstimates, for: maneuver)

--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -569,15 +569,27 @@ class TestCarPlaySearchControllerDelegate: CarPlaySearchControllerDelegate {
 class MapTemplateSpy: CPMapTemplate {
     private(set) var currentTripPreviews: [CPTrip]?
     private(set) var currentPreviewTextConfiguration: CPTripPreviewTextConfiguration?
+    
+    private(set) var estimatesUpdate: (CPTravelEstimates, CPTrip, CPTimeRemainingColor)?
+    
+    var fakeSession:  CPNavigationSession!
 
     override func showTripPreviews(_ tripPreviews: [CPTrip], textConfiguration: CPTripPreviewTextConfiguration?) {
         currentTripPreviews = tripPreviews
         currentPreviewTextConfiguration = textConfiguration
     }
     
+    override func update(_ estimates: CPTravelEstimates, for trip: CPTrip, with timeRemainingColor: CPTimeRemainingColor) {
+        estimatesUpdate = (estimates, trip, timeRemainingColor)
+    }
+    
     override func hideTripPreviews() {
         currentTripPreviews = nil
         currentPreviewTextConfiguration = nil
+    }
+    
+    override func startNavigationSession(for trip: CPTrip) -> CPNavigationSession {
+        return fakeSession
     }
 }
 

--- a/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
@@ -13,5 +13,81 @@ fileprivate class CarPlayNavigationDelegateSpy: NSObject, CarPlayNavigationDeleg
     init(_ didArriveExpectation: XCTestExpectation) {
         self.didArriveExpectation = didArriveExpectation
     }
+}
+
+@available(iOS 12.0, *)
+fileprivate class CPManeuverFake: CPManeuver {
+    override init() {
+        super.init()
+    }
     
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@available(iOS 12.0, *)
+fileprivate class CPNavigationSessionFake: CPNavigationSession {
+     init(maneuvers: [CPManeuver]) {
+        fakeManeuvers = maneuvers
+        
+    }
+    
+    override var upcomingManeuvers: [CPManeuver] {
+        get {
+            return fakeManeuvers
+        }
+        set {
+            fatalError()
+        }
+    }
+    
+    private(set) var fakeManeuvers: [CPManeuver]
+}
+
+@available(iOS 12.0, *)
+fileprivate class CarPlayNavigationViewControllerTests: XCTestCase {
+    func testCarplayDisplaysCorrectEstimates() {
+        
+        //set up the litany of dependancies
+        let directions = Directions(accessToken: "fafedeadbeef")
+        let manager = CarPlayManager(directions: directions)
+        let route = Fixture.route(from: "multileg-route")
+        let navService = MapboxNavigationService(route: route)
+        let interface = FakeCPInterfaceController("test estimates display")
+        let mapSpy = MapTemplateSpy()
+        let trip = CPTrip(origin: MKMapItem(), destination: MKMapItem(), routeChoices: [])
+        let fakeManeuver = CPManeuverFake()
+        let fakeSession = CPNavigationSessionFake(maneuvers: [fakeManeuver])
+        mapSpy.fakeSession = fakeSession
+        let progress = navService.routeProgress
+        let firstCoordinate = progress.currentLeg.coordinates.first!
+        let location = CLLocation(latitude: firstCoordinate.latitude, longitude: firstCoordinate.longitude)
+        
+        //create the subject and notification
+        let subject = CarPlayNavigationViewController(navigationService: navService, mapTemplate: mapSpy, interfaceController: interface, manager: manager)
+        subject.startNavigationSession(for: trip)
+        let payload: [RouteControllerNotificationUserInfoKey:Any] = [.routeProgressKey : navService.routeProgress,
+             .locationKey: location]
+        let fakeNotication = NSNotification(name: .routeControllerProgressDidChange, object: navService.router, userInfo: payload)
+        
+        //fire the fake notification
+        subject.progressDidChange(fakeNotication)
+        
+        //retreieve the update
+        guard let update = mapSpy.estimatesUpdate else {
+            XCTFail("The CPNVC needs to update the map template with new estimates when it recieves a progress update.")
+            return
+        }
+        
+        // establish a point of truth and fetch the answer from the update
+        let distanceTruth = subject.distanceFormatter.measurement(of: progress.distanceRemaining)
+        let estimateTruth = CPTravelEstimates(distanceRemaining: distanceTruth, timeRemaining: progress.durationRemaining)
+        let answer = update.0
+        
+        //verify answer is correct
+        let distanceEqual = answer.distanceRemaining.value == estimateTruth.distanceRemaining.value
+        let timeEqual = answer.timeRemaining.doubleValue == estimateTruth.timeRemaining.doubleValue
+        XCTAssert(distanceEqual && timeEqual, "The subject should update the CP Map Template based upon CPTravelEstimates derived from the entire route progress.")
+    }
 }


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/887225/56930362-a6a6ca80-6a99-11e9-80f3-930b9eca38bb.png)

Fixes #2118.

* Fixing issue where leg estimates were being shown instead of route estimates

/cc @mapbox/navigation-ios 