### PR TITLE
Clean up CarPlay route preview pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
 * Fixed a regression where the puck could float around when standing still or moving backwards. ([#2109](https://github.com/mapbox/mapbox-navigation-ios/pull/2109))
 
 ### CarPlay
+
 * Fixed issue where, during turn-by-turn navigation, the Leg estimates (ETA, Distance Remaining, Time Remaining) were showing on CarPlay instead of Route estimates, as intended.([#2119](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
 * Deprecated `CarPlayManager.overviewButton` in favor of `CarPlayManager.userTrackingButton` which now updates the icon correctly when panning out of tracking state. ([#2100](https://github.com/mapbox/mapbox-navigation-ios/pull/2100))
+* By default, the destination waypoint name is no longer displayed a second time when previewing a route. To add a subtitle to the preview, implement the `CarPlayManagerDelegate.carPlayManager(_:willPreview:)` method; create an `MKMapItem` whose `MKPlacemark` has the `Street` key in its address dictionary. ([#2120](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
 
 ## v0.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Fixed issue where, during turn-by-turn navigation, the Leg estimates (ETA, Distance Remaining, Time Remaining) were showing on CarPlay instead of Route estimates, as intended.([#2119](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
 * Deprecated `CarPlayManager.overviewButton` in favor of `CarPlayManager.userTrackingButton` which now updates the icon correctly when panning out of tracking state. ([#2100](https://github.com/mapbox/mapbox-navigation-ios/pull/2100))
+* When previewing a route, the distance and estimated travel time are displayed at the bottom of the window. ([#2120](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
 * By default, the destination waypoint name is no longer displayed a second time when previewing a route. To add a subtitle to the preview, implement the `CarPlayManagerDelegate.carPlayManager(_:willPreview:)` method; create an `MKMapItem` whose `MKPlacemark` has the `Street` key in its address dictionary. ([#2120](https://github.com/mapbox/mapbox-navigation-ios/pull/2119))
 
 ## v0.31.0

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		DA303CAA21B7A93400F921DC /* ResizableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529FCF121A5C5B300AEA9AA /* ResizableView.swift */; };
 		DA303CAB21B7A93B00F921DC /* OfflineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529FCF921A5C63A00AEA9AA /* OfflineViewController.swift */; };
 		DA3525702010A5210048DDFC /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DA35256E2010A5200048DDFC /* Localizable.stringsdict */; };
+		DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA443DDD2278C90E00ED1307 /* CPTrip.swift */; };
 		DAA96D18215A961D00BEF703 /* route-doubling-back.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA96D17215A961D00BEF703 /* route-doubling-back.json */; };
 		DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DAAE5F321EAE4C4700832871 /* Localizable.strings */; };
 		DAD17202214DB12B009C8161 /* CPMapTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD17201214DB12B009C8161 /* CPMapTemplateTests.swift */; };
@@ -915,6 +916,7 @@
 		DA3525712011435E0048DDFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Main.strings; sourceTree = "<group>"; };
 		DA352572201143BA0048DDFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Navigation.strings; sourceTree = "<group>"; };
 		DA352573201143D30048DDFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DA443DDD2278C90E00ED1307 /* CPTrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPTrip.swift; sourceTree = "<group>"; };
 		DA545ABA1FA993DF0090908E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
 		DA545ABC1FA9941F0090908E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA545ABE1FA9A1370090908E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Main.strings; sourceTree = "<group>"; };
@@ -1474,6 +1476,7 @@
 				8D24A2F720409A890098CBF8 /* CGSize.swift */,
 				C5F4D21820DC468B0059FABF /* CongestionLevel.swift */,
 				C51511D020EAC89D00372A91 /* CPMapTemplate.swift */,
+				DA443DDD2278C90E00ED1307 /* CPTrip.swift */,
 				35BF8CA31F28EBD8003F6125 /* String.swift */,
 				8D24A2F920449B430098CBF8 /* Dictionary.swift */,
 				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
@@ -2292,6 +2295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				351BEBF11E5BCC63006FE110 /* MGLMapView.swift in Sources */,
+				DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */,
 				35D825FC1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m in Sources */,
 				8D3322252200E149001D44AA /* NavigationViewController+Obsolete.swift in Sources */,
 				C51511D120EAC89D00372A91 /* CPMapTemplate.swift in Sources */,

--- a/MapboxNavigation/CPTrip.swift
+++ b/MapboxNavigation/CPTrip.swift
@@ -1,0 +1,52 @@
+import MapboxDirections
+#if canImport(CarPlay)
+import CarPlay
+#endif
+
+@available(iOS 12.0, *)
+extension CPTrip {
+    static let fullDateComponentsFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.day, .hour, .minute]
+        return formatter
+    }()
+    
+    static let shortDateComponentsFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .short
+        formatter.allowedUnits = [.day, .hour, .minute]
+        return formatter
+    }()
+    
+    static let briefDateComponentsFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .brief
+        formatter.allowedUnits = [.day, .hour, .minute]
+        return formatter
+    }()
+    
+    convenience init(routes: [Route], routeOptions: RouteOptions, waypoints: [Waypoint]) {
+        let routeChoices = routes.map { (route) -> CPRouteChoice in
+            let summaryVariants = [
+                CPTrip.fullDateComponentsFormatter.string(from: route.expectedTravelTime)!,
+                CPTrip.shortDateComponentsFormatter.string(from: route.expectedTravelTime)!,
+                CPTrip.briefDateComponentsFormatter.string(from: route.expectedTravelTime)!
+            ]
+            let routeChoice = CPRouteChoice(summaryVariants: summaryVariants,
+                                            additionalInformationVariants: [route.description],
+                                            selectionSummaryVariants: [route.description])
+            routeChoice.userInfo = route
+            return routeChoice
+        }
+        
+        let waypoints = routeOptions.waypoints
+        let origin = MKMapItem(placemark: MKPlacemark(coordinate: waypoints.first!.coordinate))
+        origin.name = waypoints.first?.name
+        let destination = MKMapItem(placemark: MKPlacemark(coordinate: waypoints.last!.coordinate))
+        destination.name = waypoints.last?.name
+        
+        self.init(origin: origin, destination: destination, routeChoices: routeChoices)
+        userInfo = routeOptions
+    }
+}

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -550,6 +550,11 @@ extension CarPlayManager: CPMapTemplateDelegate {
         carPlayMapViewController.isOverviewingRoutes = true
         let mapView = carPlayMapViewController.mapView
         let route = routeChoice.userInfo as! Route
+        
+        let distanceFormatter = DistanceFormatter(approximate: true)
+        let estimates = CPTravelEstimates(distanceRemaining: distanceFormatter.measurement(of: route.distance),
+                                          timeRemaining: route.expectedTravelTime)
+        mapTemplate.updateEstimates(estimates, for: trip)
 
         //FIXME: Unable to tilt map during route selection -- https://github.com/mapbox/mapbox-gl-native/issues/2259
         let topDownCamera = mapView.camera

--- a/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -111,6 +111,8 @@ public protocol CarPlayManagerDelegate {
     /**
      Offers the delegate the opportunity to customize a trip before it is presented to the user to preview.
      
+     To customize the destination’s title, which is displayed when a route is selected, set the `MKMapItem.name` property of the `CPTrip.destination` property. To add a subtitle, create a new `MKMapItem` whose `MKPlacemark` has the `Street` key in its address dictionary.
+     
      - parameter carPlayManager: The CarPlay manager instance.
      - parameter trip: The trip that will be previewed.
      - returns: The actual trip to be previewed. This can be the same trip or a new/alternate trip if desired.


### PR DESCRIPTION
Removed the “street address” from the CarPlay route preview pane; it was set redundantly to the destination waypoint’s name. For consistency, call `CarPlayManagerDelegate.carPlayManager(_:willPreview:)` also when programmatically starting a new route in CarPlay. Show statistics like the distance and estimated travel time when previewing a selected route.

<img src="https://user-images.githubusercontent.com/1231218/56985647-acee8280-6b3d-11e9-90ee-ed3644fa5db5.png" width="400" alt="preview-single">
<img src="https://user-images.githubusercontent.com/1231218/56985663-b677ea80-6b3d-11e9-8e6c-99b3996d8d42.png" width="400" alt="preview-multi">
<img src="https://user-images.githubusercontent.com/1231218/56985679-bd9ef880-6b3d-11e9-8321-746be0551fc9.png" width="400" alt="choose-multi">

Fixes #2090.

/cc @mapbox/navigation-ios