### PR TITLE
Guard against missing speed limit data when speed limit is queried for

### DIFF
--- a/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -83,10 +83,9 @@ open class NavigationMatchOptions: MatchOptions {
         includesSteps = true
         routeShapeResolution = .full
         shapeFormat = .polyline6
-        if profileIdentifier == .walking {
-            attributeOptions = [.congestionLevel, .expectedTravelTime]
-        } else {
-            attributeOptions = [.congestionLevel, .expectedTravelTime, .maximumSpeedLimit]
+        attributeOptions = [.congestionLevel, .expectedTravelTime]
+        if profileIdentifier == .automobile || profileIdentifier == .automobileAvoidingTraffic {
+            attributeOptions.insert(.maximumSpeedLimit)
         }
         includesSpokenInstructions = true
         locale = Locale.nationalizedCurrent

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -258,7 +258,7 @@ open class RouteProgress: NSObject {
      Returns the SpeedLimit for the current position along the route. Returns SpeedLimit.invalid if the speed limit is unknown or missing.
      */
     public var currentSpeedLimit: SpeedLimit {
-
+        guard legIndex < positionedSpeedLimitsByStep.count, currentLegProgress.stepIndex < positionedSpeedLimitsByStep[legIndex].count else { return .invalid }
         let speedLimits = positionedSpeedLimitsByStep[legIndex][currentLegProgress.stepIndex]
         let lastSpeedLimitTuple = speedLimits.last { $0.1 <= currentLegProgress.currentStepProgress.distanceTraveled }
         if let lastSpeedLimitTuple = lastSpeedLimitTuple {


### PR DESCRIPTION
If speed limit annotations were not requested then we need to guard against attempting to look them up should the client request the current speed limit.

We should return SpeedLimit.invalid in these cases.