### PR TITLE
Map SDK v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Upgraded to Mapbox Maps SDK for iOS v5.0.0. ([#2133](https://github.com/mapbox/mapbox-navigation-ios/pull/2133))
+
 ## v0.33.0
 
 * Restored the compass to `CarPlayNavigationViewController`, now displaying a digital readout of the direction of travel, represented by the `CarPlayCompassView` class. ([#2077](https://github.com/mapbox/mapbox-navigation-ios/pull/2077))

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.3
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.0
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.1.3
 github "mapbox/MapboxDirections.swift" ~> 0.28.0
 github "mapbox/turf-swift" ~> 0.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.11.0"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.0.0"
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "6.2.0"
 github "AndriiDoroshko/SnappyShrimp" "1.6.4"
 github "CedarBDD/Cedar" "v1.0"

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Mapbox-iOS-SDK (4.10.0)
-  - MapboxCoreNavigation (0.31.0):
-    - MapboxDirections.swift (~> 0.27.3)
+  - Mapbox-iOS-SDK (5.0.0)
+  - MapboxCoreNavigation (0.33.0):
+    - MapboxDirections.swift (~> 0.28.0)
     - MapboxMobileEvents (~> 0.9.3)
     - MapboxNavigationNative (~> 6.1.3)
     - Turf (~> 0.3.0)
-  - MapboxDirections.swift (0.27.3):
+  - MapboxDirections.swift (0.28.0):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.9.3)
-  - MapboxNavigation (0.31.0):
-    - Mapbox-iOS-SDK (~> 4.3)
-    - MapboxCoreNavigation (= 0.31.0)
+  - MapboxNavigation (0.33.0):
+    - Mapbox-iOS-SDK (~> 5.0)
+    - MapboxCoreNavigation (= 0.33.0)
     - MapboxSpeech (~> 0.1.0)
     - Solar (~> 2.1)
   - MapboxNavigationNative (6.1.3)
@@ -41,11 +41,11 @@ EXTERNAL SOURCES:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 8b1b777de7de373cdf000994c91af101ef886477
-  MapboxCoreNavigation: ad9a230a2ecd0163154fd0510897702c6573db86
-  MapboxDirections.swift: af3d8bc8cd80ed6e498dd6ed933f3c348799e1e2
+  Mapbox-iOS-SDK: 018266d830ecb6e57d913494c280383b47981590
+  MapboxCoreNavigation: b18785b61517628bcbc8d2d2c287812c71e8bdfe
+  MapboxDirections.swift: bec8771badfbdd55a0194649a4194b2c2cb15b96
   MapboxMobileEvents: dea3b845b1a8528def7150dedf0cedefc6dfe284
-  MapboxNavigation: 188a6e4652da8de68b2e19bf7928a40766e9f3eb
+  MapboxNavigation: 63dbc3c9060e294a620614f46da4973c486d5ed7
   MapboxNavigationNative: c7340cdfcb28f88aa02b6e3896151f4cd897f323
   MapboxSpeech: 59b3984d3f433a443d24acf53097f918c5cc70f9
   Polyline: 0e9890790292741c8186201a536b6bb6a78d02dd
@@ -54,4 +54,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 55ae5a7edbc3dedda5149ba3d58b992ab7327f95
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.6.2

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
 
   s.dependency "MapboxDirections.swift", "~> 0.28.0"
   s.dependency "MapboxGeocoder.swift", "~> 0.10.0"
-  s.dependency "Mapbox-iOS-SDK", "~> 4.3"
+  s.dependency "Mapbox-iOS-SDK", "~> 5.0"
   s.dependency "MapboxMobileEvents", "~> 0.8.1"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.3.0"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "Mapbox-iOS-SDK", "~> 4.3"
+  s.dependency "Mapbox-iOS-SDK", "~> 5.0"
   s.dependency "Solar", "~> 2.1"
   s.dependency "MapboxSpeech", "~> 0.1.0"
 


### PR DESCRIPTION
Upgraded the Carthage Cartfile and CocoaPods podspecs to require [iOS map SDK v5._x_](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.0.0). With this change, developers can take advantage of [the new billing plans](https://blog.mapbox.com/new-pricing-46b7c26166e7) when using the map SDK, instead of being stuck on an older version of the map SDK that only offers an old-style billing plan.

/ref mapbox/ios-sdk-examples#222
/cc @mapbox/navigation-ios @mapbox/maps-ios @coxchapman