### PR TITLE
Streamline status view toggling and interactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 
 * Upgraded to Mapbox Maps SDK for iOS v5.0.0. ([#2133](https://github.com/mapbox/mapbox-navigation-ios/pull/2133))
+* Deprecated `StatusViewDelegate` in favor of calling the `UIControl.addTarget(_:action:for:)` method on `StatusView`.
+* Fixed an issue where the status view showed a simulated speed factor as an unformatted number.
 
 ## v0.33.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## master
 
 * Upgraded to Mapbox Maps SDK for iOS v5.0.0. ([#2133](https://github.com/mapbox/mapbox-navigation-ios/pull/2133))
-* Deprecated `StatusViewDelegate` in favor of calling the `UIControl.addTarget(_:action:for:)` method on `StatusView`.
-* Fixed an issue where the status view showed a simulated speed factor as an unformatted number.
+* Deprecated `StatusViewDelegate` in favor of calling the `UIControl.addTarget(_:action:for:)` method on `StatusView` for `UIControl.Event.valueChanged`. ([#2136](https://github.com/mapbox/mapbox-navigation-ios/pull/2136))
+* Fixed an issue where the status view showed a simulated speed factor as an unformatted number. ([#2136](https://github.com/mapbox/mapbox-navigation-ios/pull/2136))
 
 ## v0.33.0
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -274,7 +274,6 @@
 		AE5F8771209A082500F58FDB /* route-with-banner-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = AE5F8770209A082500F58FDB /* route-with-banner-instructions.json */; };
 		AE7DE6C421A47A03002653D1 /* CarPlaySearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DE6C321A47A03002653D1 /* CarPlaySearchController.swift */; };
 		AE7DE6C621A47A23002653D1 /* CarPlaySearchController+ CPSearchTemplateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DE6C521A47A23002653D1 /* CarPlaySearchController+ CPSearchTemplateDelegate.swift */; };
-		AE997D2221137B8B00EB0AAB /* String+LocalizedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE997D2121137B8B00EB0AAB /* String+LocalizedConstants.swift */; };
 		AEC3AC9A2106703100A26F34 /* HighwayShield.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC3AC992106703100A26F34 /* HighwayShield.swift */; };
 		C51511D120EAC89D00372A91 /* CPMapTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51511D020EAC89D00372A91 /* CPMapTemplate.swift */; };
 		C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51DF8651F38C31C006C6A15 /* Locale.swift */; };
@@ -844,7 +843,6 @@
 		AE7DE6C321A47A03002653D1 /* CarPlaySearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySearchController.swift; sourceTree = "<group>"; };
 		AE7DE6C521A47A23002653D1 /* CarPlaySearchController+ CPSearchTemplateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CarPlaySearchController+ CPSearchTemplateDelegate.swift"; sourceTree = "<group>"; };
 		AE8B1B96207D2B2B003050F6 /* TunnelAuthorityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelAuthorityTests.swift; sourceTree = "<group>"; };
-		AE997D2121137B8B00EB0AAB /* String+LocalizedConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+LocalizedConstants.swift"; sourceTree = "<group>"; };
 		AEC3AC992106703100A26F34 /* HighwayShield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighwayShield.swift; sourceTree = "<group>"; };
 		AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		AEF2C8F12072B603007B061F /* routeWithTunnels_9thStreetDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithTunnels_9thStreetDC.json; sourceTree = "<group>"; };
@@ -1497,7 +1495,6 @@
 				C58159001EA6D02700FC6C3D /* MGLVectorTileSource.swift */,
 				8D5DFFF0207C04840093765A /* NSAttributedString.swift */,
 				DA0557202154EF4700A1F2AA /* Route.swift */,
-				AE997D2121137B8B00EB0AAB /* String+LocalizedConstants.swift */,
 				35B7837D1F9547B300291F9A /* Transitioning.swift */,
 				359D283B1F9DC14F00FDE9C9 /* UICollectionView.swift */,
 				8D24A2F52040960C0098CBF8 /* UIEdgeInsets.swift */,
@@ -2347,7 +2344,6 @@
 				8D24A2F62040960C0098CBF8 /* UIEdgeInsets.swift in Sources */,
 				353E3C8F20A3501C00FD1789 /* MGLStyle.swift in Sources */,
 				DADAD82F20350849002E25CA /* MBRouteVoiceController.m in Sources */,
-				AE997D2221137B8B00EB0AAB /* String+LocalizedConstants.swift in Sources */,
 				C57491DF1FACC42F006F97BC /* CGPoint.swift in Sources */,
 				16C2A421211526EE00FE6E68 /* CarPlayManager.swift in Sources */,
 				8D53136B20653FA20044891E /* ExitView.swift in Sources */,

--- a/MapboxNavigation/NavigationView.swift
+++ b/MapboxNavigation/NavigationView.swift
@@ -99,7 +99,6 @@ open class NavigationView: UIView {
     lazy var nextBannerView: NextBannerView = .forAutoLayout(hidden: true)
     lazy var statusView: StatusView = {
         let view: StatusView = .forAutoLayout()
-        view.delegate = delegate
         view.isHidden = true
         return view
     }()
@@ -209,10 +208,9 @@ open class NavigationView: UIView {
         instructionsBannerView.delegate = delegate
         instructionsBannerView.instructionDelegate = delegate
         nextBannerView.instructionDelegate = delegate
-        statusView.delegate = delegate
     }
 }
 
-protocol NavigationViewDelegate: NavigationMapViewDelegate, StatusViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
+protocol NavigationViewDelegate: NavigationMapViewDelegate, InstructionsBannerViewDelegate, NavigationMapViewCourseTrackingDelegate, VisualInstructionDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton)
 }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -495,21 +495,14 @@ extension NavigationViewController: NavigationServiceDelegate {
     }
 
     @objc public func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
-        switch service.simulationMode {
-        case .always:
-            let localized = String.Localized.simulationStatus(speed: 1)
-            mapViewController?.statusView.show(localized, showSpinner: false, interactive: true)
-        default:
-            return
+        if service.simulationMode == .always {
+            mapViewController?.showSimulationStatus(speed: 1)
         }
     }
     
     @objc public func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
-        switch service.simulationMode {
-        case .always:
-            mapViewController?.statusView.hide(delay: 0, animated: true)
-        default:
-            return
+        if service.simulationMode == .always {
+            mapViewController?.hideStatus()
         }
     }
     

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "RESUME" = "Resume";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %d×";
+"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";

--- a/MapboxNavigation/Resources/bg.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/bg.lproj/Localizable.strings
@@ -50,7 +50,7 @@
 "RESUME" = "Поднови";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %d×";
+"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, през %2$@";

--- a/MapboxNavigation/Resources/da.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/da.lproj/Localizable.strings
@@ -74,7 +74,7 @@
 "RESUME" = "Genoptag";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulerer navigation ved %d×";
+"USER_IN_SIMULATION_MODE" = "Simulerer navigation ved %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";

--- a/MapboxNavigation/Resources/es.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/es.lproj/Localizable.strings
@@ -74,7 +74,7 @@
 "RESUME" = "Continuar";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulando navegación a velocidad %d×";
+"USER_IN_SIMULATION_MODE" = "Simulando navegación a velocidad %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@ por %2$@";

--- a/MapboxNavigation/Resources/fr.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/fr.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "RESUME" = "Reprendre";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulation de navigation à %d×";
+"USER_IN_SIMULATION_MODE" = "Simulation de navigation à %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, par %2$@";

--- a/MapboxNavigation/Resources/hu.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/hu.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "RESUME" = "Folytatás";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Navigáció szimulációja %d× sebességgel";
+"USER_IN_SIMULATION_MODE" = "Navigáció szimulációja %@× sebességgel";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, ezen keresztül: %2$@";

--- a/MapboxNavigation/Resources/ko.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ko.lproj/Localizable.strings
@@ -71,7 +71,7 @@
 "RESUME" = "재시작";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "네비게이션을 %d×에서 시뮬레이션합니다.";
+"USER_IN_SIMULATION_MODE" = "네비게이션을 %@×에서 시뮬레이션합니다.";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, 통한 %2$@";

--- a/MapboxNavigation/Resources/nl.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/nl.lproj/Localizable.strings
@@ -50,7 +50,7 @@
 "RESUME" = "Doorgaan";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %d×";
+"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";

--- a/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "RESUME" = "Continuar";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulando Navegação em %d×";
+"USER_IN_SIMULATION_MODE" = "Simulando Navegação em %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";

--- a/MapboxNavigation/Resources/ru.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ru.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "RESUME" = "Возобновить";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Ускорение маршрута %d×";
+"USER_IN_SIMULATION_MODE" = "Ускорение маршрута %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@ через %2$@";

--- a/MapboxNavigation/Resources/sv.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/sv.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "RESUME" = "Återuppta";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulerar Navigation i %d×";
+"USER_IN_SIMULATION_MODE" = "Simulerar Navigation i %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";

--- a/MapboxNavigation/Resources/uk.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/uk.lproj/Localizable.strings
@@ -74,7 +74,7 @@
 "RESUME" = "Продовжити";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Імітація навігації %d×";
+"USER_IN_SIMULATION_MODE" = "Імітація навігації %@×";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, через %2$@";

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -51,7 +51,7 @@ extension RouteMapViewController: NavigationComponent {
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
-        statusView.show(title, showSpinner: true)
+        showStatus(title: title, withSpinner: true, for: .infinity)
     }
     
     func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
@@ -88,10 +88,9 @@ extension RouteMapViewController: NavigationComponent {
         }
         
         if let locationManager = navService.locationManager as? SimulatedLocationManager {
-            let localized = String.Localized.simulationStatus(speed: Int(locationManager.speedMultiplier))
-            showStatus(title: localized, for: .infinity, interactive: true)
+            showSimulationStatus(speed: Int(locationManager.speedMultiplier))
         } else {
-            statusView.hide(delay: 2, animated: true)
+            hideStatus(after: 2)
         }
         
         if proactive {
@@ -101,7 +100,7 @@ extension RouteMapViewController: NavigationComponent {
     }
     
     func navigationService(_ service: NavigationService, didFailToRerouteWith error: Error) {
-        statusView.hide()
+        hideStatus()
     }
 }
 
@@ -397,8 +396,7 @@ class RouteMapViewController: UIViewController {
         guard AVAudioSession.sharedInstance().outputVolume <= NavigationViewMinimumVolumeForWarning else { return }
 
         let title = String.localizedStringWithFormat(NSLocalizedString("DEVICE_VOLUME_LOW", bundle: .mapboxNavigation, value: "%@ Volume Low", comment: "Format string for indicating the device volume is low; 1 = device model"), UIDevice.current.model)
-        statusView.show(title, showSpinner: false)
-        statusView.hide(delay: 3, animated: true)
+        showStatus(title: title, withSpinner: false, for: 3)
     }
 
 
@@ -448,10 +446,21 @@ class RouteMapViewController: UIViewController {
         }
     }
 
-    private func showStatus(title: String, withSpinner spin: Bool = false, for time: TimeInterval, animated: Bool = true, interactive: Bool = false) {
+    private func showStatus(title: String, withSpinner spin: Bool = false, for duration: TimeInterval, interactive: Bool = false) {
         statusView.show(title, showSpinner: spin, interactive: interactive)
-        guard time < .infinity else { return }
-        statusView.hide(delay: time, animated: animated)
+        if !duration.isInfinite {
+            hideStatus(after: duration)
+        }
+    }
+    
+    func showSimulationStatus(speed: Int) {
+        let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %@×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
+        let title = String.localizedStringWithFormat(format, NumberFormatter.localizedString(from: speed as NSNumber, number: .decimal))
+        showStatus(title: title, for: .infinity, interactive: true)
+    }
+    
+    func hideStatus(after delay: TimeInterval = 0) {
+        statusView.hide(delay: delay, animated: true)
     }
 
     private func setCamera(altitude: Double) {
@@ -994,8 +1003,7 @@ extension RouteMapViewController: StepsViewControllerDelegate {
 
     func statusView(_ statusView: StatusView, valueChangedTo value: Double) {
         let displayValue = 1+min(Int(9 * value), 8)
-        let title = String.Localized.simulationStatus(speed: displayValue)
-        showStatus(title: title, for: .infinity, interactive: true)
+        showSimulationStatus(speed: displayValue)
         
         if let locationManager = navService.locationManager as? SimulatedLocationManager {
             locationManager.speedMultiplier = Double(displayValue)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -174,7 +174,7 @@ class RouteMapViewController: UIViewController {
     weak var delegate: RouteMapViewControllerDelegate?
     var navService: NavigationService! {
         didSet {
-            navigationView.statusView.canChangeValue = navService.locationManager is SimulatedLocationManager
+            statusView.isEnabled = navService.locationManager is SimulatedLocationManager
             guard let destination = route.legs.last?.destination else { return }
             populateName(for: destination, populated: { self.destination = $0 })
         }
@@ -256,6 +256,7 @@ class RouteMapViewController: UIViewController {
         navigationView.muteButton.addTarget(self, action: Actions.mute, for: .touchUpInside)
         navigationView.reportButton.addTarget(self, action: Actions.feedback, for: .touchUpInside)
         navigationView.resumeButton.addTarget(self, action: Actions.recenter, for: .touchUpInside)
+        statusView.addTarget(self, action: #selector(didChangeSpeed(_:)), for: .valueChanged)
         resumeNotifications()
         notifyUserAboutLowVolume()
         updateInstructionBanners(visualInstructionBanner: router.routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction)
@@ -1001,8 +1002,8 @@ extension RouteMapViewController: StepsViewControllerDelegate {
         }
     }
 
-    func statusView(_ statusView: StatusView, valueChangedTo value: Double) {
-        let displayValue = 1+min(Int(9 * value), 8)
+    @objc func didChangeSpeed(_ sender: StatusView) {
+        let displayValue = 1+min(Int(9 * sender.value), 8)
         showSimulationStatus(speed: displayValue)
         
         if let locationManager = navService.locationManager as? SimulatedLocationManager {

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -46,7 +46,6 @@ public class StatusView: UIView {
         
         let textLabel = UILabel()
         textLabel.contentMode = .bottom
-        textLabel.text = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         textLabel.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         textLabel.textColor = .white

--- a/MapboxNavigation/String+LocalizedConstants.swift
+++ b/MapboxNavigation/String+LocalizedConstants.swift
@@ -1,8 +1,0 @@
-extension String {
-    enum Localized {
-        static func simulationStatus(speed: Int) -> String {
-            let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %d×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
-            return String.localizedStringWithFormat(format, speed)
-        }
-    }
-}


### PR DESCRIPTION
StatusView is now a subclass of UIControl, since it can be interactive. StatusViewDelegate is deprecated in favor of calling the `UIControl.addTarget(_:action:for:)` method on `StatusView` for `UIControl.Event.valueChanged`.

Fixed an issue where the status view showed a simulated speed factor as an unformatted number. Refactored a bunch of call sites for showing and hiding StatusView to go through a bottleneck in RouteMapViewController, making the String extension unnecessary.

<details>
<summary>Blooper</summary>

<img src="https://user-images.githubusercontent.com/1231218/58296893-77c70000-7d8a-11e9-9f47-833af2465a54.png" width="300" alt="speed">

</details>

/ref #2135
/cc @mapbox/navigation-ios