### PR TITLE
Fix status view when rerouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Upgraded to Mapbox Maps SDK for iOS v5.0.0. ([#2133](https://github.com/mapbox/mapbox-navigation-ios/pull/2133))
 * Deprecated `StatusViewDelegate` in favor of calling the `UIControl.addTarget(_:action:for:)` method on `StatusView` for `UIControl.Event.valueChanged`. ([#2136](https://github.com/mapbox/mapbox-navigation-ios/pull/2136))
 * Fixed an issue where the status view showed a simulated speed factor as an unformatted number. ([#2136](https://github.com/mapbox/mapbox-navigation-ios/pull/2136))
+* Fixed an issue preventing the status view from appearing while rerouting. ([#2137](https://github.com/mapbox/mapbox-navigation-ios/pull/2137))
 * The `RouteOptions.alleyPriority`, `RouteOptions.walkwayPriority`, and `RouteOptions.speed` properties now work when calculating walking routes offline. ([#2142](https://github.com/mapbox/mapbox-navigation-ios/pull/2142))
 
 ## v0.33.0

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -399,10 +399,16 @@ extension NavigationViewController: RouteMapViewControllerDelegate {
 extension NavigationViewController: NavigationServiceDelegate {
     
     @objc public func navigationService(_ service: NavigationService, shouldRerouteFrom location: CLLocation) -> Bool {
-        return delegate?.navigationViewController?(self, shouldRerouteFrom: location) ?? true
+        let defaultBehavior = RouteController.DefaultBehavior.shouldRerouteFromLocation
+        let componentsWantReroute = navigationComponents.allSatisfy { $0.navigationService?(service, shouldRerouteFrom: location) ?? defaultBehavior }
+        return componentsWantReroute && (delegate?.navigationViewController?(self, shouldRerouteFrom: location) ?? defaultBehavior)
     }
     
     @objc public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
+        for component in navigationComponents {
+            component.navigationService?(service, willRerouteFrom: location)
+        }
+        
         delegate?.navigationViewController?(self, willRerouteFrom: location)
     }
     
@@ -423,7 +429,9 @@ extension NavigationViewController: NavigationServiceDelegate {
     }
     
     @objc public func navigationService(_ service: NavigationService, shouldDiscard location: CLLocation) -> Bool {
-        return delegate?.navigationViewController?(self, shouldDiscard: location) ?? true
+        let defaultBehavior = RouteController.DefaultBehavior.shouldDiscardLocation
+        let componentsWantToDiscard = navigationComponents.allSatisfy { $0.navigationService?(service, shouldDiscard: location) ?? defaultBehavior }
+        return componentsWantToDiscard && (delegate?.navigationViewController?(self, shouldDiscard: location) ?? defaultBehavior)
     }
     
     @objc public func navigationService(_ service: NavigationService, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
@@ -459,7 +467,9 @@ extension NavigationViewController: NavigationServiceDelegate {
     }
     
     @objc public func navigationService(_ service: NavigationService, didPassSpokenInstructionPoint instruction: SpokenInstruction, routeProgress: RouteProgress) {
-        navigationComponents.forEach { $0.navigationService?(service, didPassSpokenInstructionPoint: instruction, routeProgress: routeProgress) }
+        for component in navigationComponents {
+            component.navigationService?(service, didPassSpokenInstructionPoint: instruction, routeProgress: routeProgress)
+        }
         
         clearStaleNotifications()
         
@@ -469,24 +479,28 @@ extension NavigationViewController: NavigationServiceDelegate {
     }
     
     @objc public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
-        navigationComponents.forEach { $0.navigationService?(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress) }
+        for component in navigationComponents {
+            component.navigationService?(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress)
+        }
     }
     
-    
-    
-    
     @objc public func navigationService(_ service: NavigationService, willArriveAt waypoint: Waypoint, after remainingTimeInterval: TimeInterval, distance: CLLocationDistance) {
+        for component in navigationComponents {
+            component.navigationService?(service, willArriveAt: waypoint, after: remainingTimeInterval, distance: distance)
+        }
+        
         delegate?.navigationViewController?(self, willArriveAt: waypoint, after: remainingTimeInterval, distance: distance)
     }
     
     @objc public func navigationService(_ service: NavigationService, didArriveAt waypoint: Waypoint) -> Bool {
-        let advancesToNextLeg = delegate?.navigationViewController?(self, didArriveAt: waypoint) ?? true
+        let defaultBehavior = RouteController.DefaultBehavior.didArriveAtWaypoint
+        let componentsWantAdvance = navigationComponents.allSatisfy { $0.navigationService?(service, didArriveAt: waypoint) ?? defaultBehavior }
+        let advancesToNextLeg = componentsWantAdvance && (delegate?.navigationViewController?(self, didArriveAt: waypoint) ?? defaultBehavior)
         
         if service.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
             showEndOfRouteFeedback()
         }
         return advancesToNextLeg
-
     }
     
     @objc public func showEndOfRouteFeedback(duration: TimeInterval = 1.0, completionHandler: ((Bool) -> Void)? = nil) {
@@ -495,14 +509,26 @@ extension NavigationViewController: NavigationServiceDelegate {
     }
 
     @objc public func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
-        if service.simulationMode == .always {
-            mapViewController?.showSimulationStatus(speed: 1)
+        for component in navigationComponents {
+            component.navigationService?(service, willBeginSimulating: progress, becauseOf: reason)
+        }
+    }
+    
+    public func navigationService(_ service: NavigationService, didBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
+        for component in navigationComponents {
+            component.navigationService?(service, didBeginSimulating: progress, becauseOf: reason)
         }
     }
     
     @objc public func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
-        if service.simulationMode == .always {
-            mapViewController?.hideStatus()
+        for component in navigationComponents {
+            component.navigationService?(service, willEndSimulating: progress, becauseOf: reason)
+        }
+    }
+    
+    public func navigationService(_ service: NavigationService, didEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
+        for component in navigationComponents {
+            component.navigationService?(service, didEndSimulating: progress, becauseOf: reason)
         }
     }
     
@@ -518,6 +544,16 @@ extension NavigationViewController: NavigationServiceDelegate {
             traversingTunnel = false
             styleManager.timeOfDayChanged()
         }
+    }
+    
+    public func navigationService(_ service: NavigationService, shouldPreventReroutesWhenArrivingAt waypoint: Waypoint) -> Bool {
+        let defaultBehavior = RouteController.DefaultBehavior.shouldPreventReroutesWhenArrivingAtWaypoint
+        return navigationComponents.allSatisfy { $0.navigationService?(service, shouldPreventReroutesWhenArrivingAt: waypoint) ?? defaultBehavior }
+    }
+    
+    public func navigationServiceShouldDisableBatteryMonitoring(_ service: NavigationService) -> Bool {
+        let defaultBehavior = RouteController.DefaultBehavior.shouldDisableBatteryMonitoring
+        return navigationComponents.allSatisfy { $0.navigationServiceShouldDisableBatteryMonitoring?(service) ?? defaultBehavior }
     }
 }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -48,6 +48,18 @@ extension RouteMapViewController: NavigationComponent {
         navigationComponents.forEach {$0.navigationService?(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress)}
     }
     
+    func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
+        if service.simulationMode == .always {
+            showSimulationStatus(speed: 1)
+        }
+    }
+    
+    func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
+        if service.simulationMode == .always {
+            hideStatus()
+        }
+    }
+    
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()


### PR DESCRIPTION
Fixed an issue preventing the status view from appearing while rerouting. NavigationViewController was only forwarding a few selected NavigationServiceDelegate methods to its components, whereas the components conform to the NavigationServiceDelegate protocol and should expect any NavigationServiceDelegate method to be forwarded to them. In this case, RouteMapViewController was responsible for showing the status view while rerouting and hiding it after a failed reroute.

<img src="https://user-images.githubusercontent.com/1231218/58296874-61b93f80-7d8a-11e9-9877-d405246975da.png" width="300" alt="rerouting">

Unfortunately, we don’t have a good mechanism to automatically ensure that all NavigationServiceDelegate methods are forwarded to the components, so we’ll have to stay vigilant as we continue to add more methods to the protocol.

Depends on #2136.

/cc @mapbox/navigation-ios