### PR TITLE
update nav native dependency to 6.2.1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Upgraded to Mapbox Maps SDK for iOS v5.0.0. ([#2133](https://github.com/mapbox/mapbox-navigation-ios/pull/2133))
 * Deprecated `StatusViewDelegate` in favor of calling the `UIControl.addTarget(_:action:for:)` method on `StatusView` for `UIControl.Event.valueChanged`. ([#2136](https://github.com/mapbox/mapbox-navigation-ios/pull/2136))
 * Fixed an issue where the status view showed a simulated speed factor as an unformatted number. ([#2136](https://github.com/mapbox/mapbox-navigation-ios/pull/2136))
+* Offline router now respects `walkway_bias`, `walking_speed` and `alley_bias` request parameters. ([#2142](https://github.com/mapbox/mapbox-navigation-ios/pull/2142))
 
 ## v0.33.0
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.0
-binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.1.3
+binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.2.1
 github "mapbox/MapboxDirections.swift" ~> 0.28.0
 github "mapbox/turf-swift" ~> 0.3
 github "mapbox/mapbox-events-ios" ~> 0.9.3

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 6.1.3"
+  s.dependency "MapboxNavigationNative", "~> 6.2.1"
   s.dependency "MapboxDirections.swift", "~> 0.28.0"    # Always pin to a patch release if pre-1.0
   s.dependency "MapboxMobileEvents", "~> 0.9.3"         # Always pin to a patch release if pre-1.0
   s.dependency "Turf", "~> 0.3.0"                       # Always pin to a patch release if pre-1.0

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - MapboxCoreNavigation (0.33.0):
     - MapboxDirections.swift (~> 0.28.0)
     - MapboxMobileEvents (~> 0.9.3)
-    - MapboxNavigationNative (~> 6.1.3)
+    - MapboxNavigationNative (~> 6.2.1)
     - Turf (~> 0.3.0)
   - MapboxDirections.swift (0.28.0):
     - Polyline (~> 4.2)
@@ -13,7 +13,7 @@ PODS:
     - MapboxCoreNavigation (= 0.33.0)
     - MapboxSpeech (~> 0.1.0)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (6.1.3)
+  - MapboxNavigationNative (6.2.1)
   - MapboxSpeech (0.1.1)
   - Polyline (4.2.1)
   - Solar (2.1.0)


### PR DESCRIPTION
just as the title and changelog say: updating the native dependency to the latest to get support for walking parameters in the offline router.