### PR TITLE
Depend on map SDK v5.0.x specifically

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.0
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.0.0
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.2.1
 github "mapbox/MapboxDirections.swift" ~> 0.28.0
 github "mapbox/turf-swift" ~> 0.3

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
@@ -231,6 +231,8 @@
 				"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-frameworks.sh",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/CD548FF3-ECB4-31D0-8E4F-AE55F70E287F.bcsymbolmap",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/70E1902C-569B-3192-A297-3622F9745C20.bcsymbolmap",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxDirections.swift/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
@@ -246,6 +248,8 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/CD548FF3-ECB4-31D0-8E4F-AE55F70E287F.bcsymbolmap",
+				"${BUILT_PRODUCTS_DIR}/70E1902C-569B-3192-A297-3622F9745C20.bcsymbolmap",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.9.3)
   - MapboxNavigation (0.33.0):
-    - Mapbox-iOS-SDK (~> 5.0)
+    - Mapbox-iOS-SDK (~> 5.0.0)
     - MapboxCoreNavigation (= 0.33.0)
     - MapboxSpeech (~> 0.1.0)
     - Solar (~> 2.1)
@@ -42,11 +42,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 018266d830ecb6e57d913494c280383b47981590
-  MapboxCoreNavigation: b18785b61517628bcbc8d2d2c287812c71e8bdfe
+  MapboxCoreNavigation: 27b8b66cb8886b747583e275f680a7ee171645c0
   MapboxDirections.swift: bec8771badfbdd55a0194649a4194b2c2cb15b96
   MapboxMobileEvents: dea3b845b1a8528def7150dedf0cedefc6dfe284
-  MapboxNavigation: 63dbc3c9060e294a620614f46da4973c486d5ed7
-  MapboxNavigationNative: c7340cdfcb28f88aa02b6e3896151f4cd897f323
+  MapboxNavigation: 7c6906cd311660eb988524ef2b5beb677380048c
+  MapboxNavigationNative: 11dc22140f4698d3f26989f2b6379dc81ef0d4c1
   MapboxSpeech: 59b3984d3f433a443d24acf53097f918c5cc70f9
   Polyline: 0e9890790292741c8186201a536b6bb6a78d02dd
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
@@ -54,4 +54,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 55ae5a7edbc3dedda5149ba3d58b992ab7327f95
 
-COCOAPODS: 1.6.2
+COCOAPODS: 1.7.0

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
 
   s.dependency "MapboxDirections.swift", "~> 0.28.0"
   s.dependency "MapboxGeocoder.swift", "~> 0.10.0"
-  s.dependency "Mapbox-iOS-SDK", "~> 5.0"
+  s.dependency "Mapbox-iOS-SDK", "~> 5.0.0"
   s.dependency "MapboxMobileEvents", "~> 0.8.1"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.3.0"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "Mapbox-iOS-SDK", "~> 5.0"
+  s.dependency "Mapbox-iOS-SDK", "~> 5.0.0"
   s.dependency "Solar", "~> 2.1"
   s.dependency "MapboxSpeech", "~> 0.1.0"
 


### PR DESCRIPTION
mapbox/mapbox-gl-native#14664 will introduce a significant change in rendering behavior in map SDK v5.1.0, obviating the workaround in #1845. As of #2133, the navigation SDK depends on v5._x_, which means `pod install` and `carthage bootstrap` will automatically pull in v5.1.0. The workaround will clash with the upstream fix, resulting in an unusable map on CarPlay and other situations where there’s a large left or right content inset.

This change tightens the dependency to v5.0._x_, allowing only patch releases, to avoid surprises when installing the SDK. Once map SDK v5.1.0 comes out, we’ll land #2134 to remove our workaround. This assumes mapbox/mapbox-gl-native#12818 is fixed either in v5.1.0 or deferred until v6.0.0. Otherwise, if that issue is fixed in another minor release of v5._x_, the navigation SDK will be prevented from upgrading beyond v5.0._x_.

/cc @mapbox/navigation-ios @mapbox/maps-ios @coxchapman @andrewychen