### PR TITLE
Fix crash presenting NavigationViewController on iOS 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added the ability to define a custom view controller for the top banner via `NavigationOptions.topBanner`. ([#2121](https://github.com/mapbox/mapbox-navigation-ios/pull/2121))
 * StyleManager now posts a `StyleManagerDidApplyStyleNotification` when a style gets applied due to a change of day of time, or when entering or exiting a tunnel. ([#2148](https://github.com/mapbox/mapbox-navigation-ios/pull/2148))
-
+* Fixed a crash when presenting `NavigationViewController` on iOS 13.0. ([#2156](https://github.com/mapbox/mapbox-navigation-ios/pull/2156))
 
 ## v0.34.0
 

--- a/MapboxCoreNavigation/NavigationSettings.swift
+++ b/MapboxCoreNavigation/NavigationSettings.swift
@@ -60,7 +60,7 @@ public class NavigationSettings: NSObject {
         let properties = Mirror(reflecting: self).children
         return properties.filter({ (child) -> Bool in
             if let label = child.label {
-                return label != "properties.storage"
+                return label != "properties.storage" && label != "$__lazy_storage_$_properties"
             }
             return false
         })


### PR DESCRIPTION
Ignore the `$__lazy_storage_$_properties` key on NavigationSettings.

Fixes #2154.

/cc @mapbox/navigation-ios