### PR TITLE
Make reroutesProactively mutable on Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added the ability to define a custom view controller for the top banner via `NavigationOptions.topBanner`. ([#2121](https://github.com/mapbox/mapbox-navigation-ios/pull/2121))
 * StyleManager now posts a `StyleManagerDidApplyStyleNotification` when a style gets applied due to a change of day of time, or when entering or exiting a tunnel. ([#2148](https://github.com/mapbox/mapbox-navigation-ios/pull/2148))
 * Fixed a crash when presenting `NavigationViewController` on iOS 13.0. ([#2156](https://github.com/mapbox/mapbox-navigation-ios/pull/2156))
+* Added a setter to the `Router.reroutesProactively` property. ([#2157](https://github.com/mapbox/mapbox-navigation-ios/pull/2157))
 
 ## v0.34.0
 

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -59,7 +59,7 @@ public protocol RouterDataSource {
     /**
      If true, the `RouteController` attempts to calculate a more optimal route for the user on an interval defined by `RouteControllerProactiveReroutingInterval`.
      */
-    @objc var reroutesProactively: Bool { get }
+    @objc var reroutesProactively: Bool { get set }
     
     /**
      Advances the leg index.


### PR DESCRIPTION
Fixes #2153 

The `Router` protocol declares `reroutesProactively` non-mutable, but both `RouteController` and `LegacyRouteController` defines the variable mutable. Making this mutable on the protocol prevents excessive casting.

cc @1ec5 