### PR TITLE
Revert untranslated strings

### DIFF
--- a/MapboxNavigation/Resources/de.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/de.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "RESUME" = "Fortfahren";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %@×";
+"USER_IN_SIMULATION_MODE" = "Navigation bei %@ simulieren.";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, über %2$@";

--- a/MapboxNavigation/Resources/hu.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/hu.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "RESUME" = "Folytatás";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %@×";
+"USER_IN_SIMULATION_MODE" = "Navigáció szimulációja %@× sebességgel";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, ezen keresztül: %2$@";


### PR DESCRIPTION
The new format for `USER_IN_SIMULATION_MODE` caused some strings to fall back to English. I've reverted back to the original and fixed the format here and on Transifex.

cc @1ec5 