### PR TITLE
Fixing broken UIAppearance on InstructionsBannerView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixed an issue where InstructionsBannerView remained the same color after switching to a day or night style. ([#2178](https://github.com/mapbox/mapbox-navigation-ios/pull/2178))
+
 ## v0.35.0
 
 * Upgraded to [Mapbox Maps SDK for iOS v5.1.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.1.0). ([#2134](https://github.com/mapbox/mapbox-navigation-ios/pull/2134))

--- a/MapboxNavigation/InstructionsBannerViewLayout.swift
+++ b/MapboxNavigation/InstructionsBannerViewLayout.swift
@@ -7,7 +7,6 @@ extension BaseInstructionsBannerView {
     static let stepListIndicatorViewSize = CGSize(width: 30, height: 5)
     
     func setupViews() {
-        backgroundColor = .clear
         
         let maneuverView = ManeuverView()
         maneuverView.backgroundColor = .clear

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -292,7 +292,6 @@ import MapboxDirections
         let instructionsView = StepInstructionsView(frame: instructionsBannerView.frame)
         instructionsView.heightAnchor.constraint(equalToConstant: instructionsBannerHeight).isActive = true
         
-        refreshAppearance(view: instructionsView, padding: topPaddingView)
         instructionsView.delegate = self
         instructionsView.distance = distance
         instructionsView.swipeable = true
@@ -323,17 +322,9 @@ import MapboxDirections
         }
     }
     
-    private func refreshAppearance(view: UIView, padding: UIView?) {
-        let viewType = type(of: view)
-        
-        let themedBackgroundColor = viewType.appearance().backgroundColor
-        view.backgroundColor = themedBackgroundColor
-        padding?.backgroundColor = themedBackgroundColor
-    }
     
     private func addInstructionsBanner() {
         informationStackView.insertArrangedSubview(instructionsBannerView, at: 0)
-        refreshAppearance(view: instructionsBannerView, padding: topPaddingView)
         instructionsBannerView.delegate = self
         instructionsBannerView.swipeable = true
     }


### PR DESCRIPTION
Fixes #2166.

* Fixing issue where manual background color set at view setup time breaks UIAppearance proxy behavior.

Screencapture: 
![Screen-Recording-2019-07-10-at-4 38 09-PM](https://user-images.githubusercontent.com/887225/61010091-2cfd4980-a332-11e9-85f1-53fd16a39133.gif)

/cc @mapbox/navigation-ios 
