### PR TITLE
Can certain conditional CarPlay compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 
 * Fixed an issue where InstructionsBannerView remained the same color after switching to a day or night style. ([#2178](https://github.com/mapbox/mapbox-navigation-ios/pull/2178))
+* Designables no longer crash and fail to render in Interface Builder when the application target links to this SDK via CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))
+* Fixed a crash that could occur when statically initializing a `Style` if the SDK was installed using CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))   
 
 ## v0.35.0
 

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -1,9 +1,6 @@
 import Foundation
 import MapboxDirections
 import Turf
-#if canImport(CarPlay)
-import CarPlay
-#endif
 
 /**
  `RouteProgress` stores the user’s progress along a route.

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -4,9 +4,6 @@ import MapboxDirections
 import MapboxSpeech
 import AVFoundation
 import Mapbox
-#if canImport(CarPlay)
-import CarPlay
-#endif
 
 /**
  A ContainerViewController is any UIViewController that conforms to the NavigationComponent messaging protocol.

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -36,19 +36,10 @@ open class Style: NSObject {
      */
     @objc open var mapStyleURL: URL = MGLStyle.navigationGuidanceDayStyleURL
     
-    #if canImport(CarPlay)
     /**
-     URL of the style to display on the map when previewing a route, for example on CarPlay.
+     URL of the style to display on the map when previewing a route, for example on CarPlay or your own route preview map.
      */
     @objc open var previewMapStyleURL = MGLStyle.navigationPreviewDayStyleURL
-    #else
-    /**
-     URL of the style to display on the map when previewing a route.
-     
-     This property is currently unused by default, but you can use it to present your own route preview map.
-     */
-    @objc open var previewMapStyleURL = MGLStyle.navigationPreviewDayStyleURL
-    #endif
     
     /**
      Applies the style for all changed properties.


### PR DESCRIPTION
Removed some unnecessary `#if canImport(CarPlay)` statements. It’s possible that the conditional compilation of `Style.previewMapStyleURL` – added for no other reason than to clarify the documentation comment! – causes Style to have incorrect Swift class metadata after unused symbols are stripped from the static, CocoaPods-generated Pods library. This would explain why whole module optimization has been observed to work around the issue.

This is a speculative fix for #2170. It needs to be tested in Interface Builder or a CocoaPods environment.

/cc @mapbox/navigation-ios @avi-c