### PR TITLE
Fix auto-hiding status view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Fixed an issue where InstructionsBannerView remained the same color after switching to a day or night style. ([#2178](https://github.com/mapbox/mapbox-navigation-ios/pull/2178))
+* Fixed an issue where the “iPhone Volume Low” banner would persist until replaced by another banner about simulation or rerouting. ([#2183](https://github.com/mapbox/mapbox-navigation-ios/pull/2183))
 * Designables no longer crash and fail to render in Interface Builder when the application target links to this SDK via CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))
 * Fixed a crash that could occur when statically initializing a `Style` if the SDK was installed using CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))   
 

--- a/MapboxNavigation/StatusView.swift
+++ b/MapboxNavigation/StatusView.swift
@@ -176,10 +176,10 @@ public class StatusView: UIControl {
         }
         
         let animate = {
-            guard !self.isHidden, self.isCurrentlyVisible else { return }
-            
             let fireTime = DispatchTime.now() + delay
             DispatchQueue.main.asyncAfter(deadline: fireTime, execute: {
+                guard !self.isHidden, self.isCurrentlyVisible else { return }
+                
                 self.activityIndicatorView.stopAnimating()
                 UIView.defaultAnimation(0.3, delay: 0, animations: hide, completion: { _ in
                     self.isCurrentlyVisible = false
@@ -187,6 +187,10 @@ public class StatusView: UIControl {
             })
         }
         
-        animated ? animate() : hide()
+        if animated {
+            animate()
+        } else {
+            hide()
+        }
     }
 }


### PR DESCRIPTION
Fixed an issue where the “iPhone Volume Low” banner would persist until replaced by another banner about simulation or rerouting. Also expanded some code golf.

Fixes #2180. Thanks to @imaginaris for the fix!

/cc @JThramer