### PR TITLE
Fixing issue where steps controller grows from .zero when presented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Fixed an issue where InstructionsBannerView remained the same color after switching to a day or night style. ([#2178](https://github.com/mapbox/mapbox-navigation-ios/pull/2178))
 * Fixed an issue where the “iPhone Volume Low” banner would persist until replaced by another banner about simulation or rerouting. ([#2183](https://github.com/mapbox/mapbox-navigation-ios/pull/2183))
 * Designables no longer crash and fail to render in Interface Builder when the application target links to this SDK via CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))
-* Fixed a crash that could occur when statically initializing a `Style` if the SDK was installed using CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))   
+* Fixed a crash that could occur when statically initializing a `Style` if the SDK was installed using CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))
+* Fixed incorrect animation of instruction labels when presenting the step list. ([#2185](https://github.com/mapbox/mapbox-navigation-ios/pull/2185))
 
 ## v0.35.0
 

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -158,20 +158,27 @@ import MapboxDirections
             return
         }
         
+        var stepsHeightConstraint: [NSLayoutConstraint] = []
+
         
         let controller = StepsViewController(routeProgress: progress)
         controller.delegate = self
-        let topHeight = view.bounds.height
-        let stepsTableExtent = UIScreen.main.bounds.height - topHeight
-        
+
         delegate?.topBanner?(self, willDisplayStepsController: controller)
         embed(controller, in: stepsContainer) { (parent, child) -> [NSLayoutConstraint] in
             child.view.translatesAutoresizingMaskIntoConstraints = false
+            
             let pinningConstraints = child.view.constraintsForPinning(to: self.stepsContainer)
             let hideConstraints = self.stepsContainerHideConstraints
-            let stepsHeight = child.view.heightAnchor.constraint(equalToConstant: stepsTableExtent)
+
             
-            return pinningConstraints + hideConstraints + self.stepsContainerConstraints + [stepsHeight]
+            if let bannerHostHeight = self.view.superview?.superview?.frame.height { 
+                print("Super: \(self.view.superview!.superview!)")
+                let inset = self.instructionsBannerHeight + self.view.safeArea.top
+                stepsHeightConstraint = [child.view.heightAnchor.constraint(equalToConstant: bannerHostHeight - inset)]
+            }
+            
+            return pinningConstraints + hideConstraints + self.stepsContainerConstraints + stepsHeightConstraint
         }
         stepsViewController = controller
         isDisplayingSteps = true
@@ -180,7 +187,7 @@ import MapboxDirections
         view.isUserInteractionEnabled = false
         
         let stepsInAnimation = {
-            NSLayoutConstraint.deactivate(self.stepsContainerHideConstraints)
+            NSLayoutConstraint.deactivate(self.stepsContainerHideConstraints + stepsHeightConstraint)
             NSLayoutConstraint.activate(self.stepsContainerShowConstraints)
             
             

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -161,14 +161,17 @@ import MapboxDirections
         
         let controller = StepsViewController(routeProgress: progress)
         controller.delegate = self
+        let topHeight = view.bounds.height
+        let stepsTableExtent = UIScreen.main.bounds.height - topHeight
         
         delegate?.topBanner?(self, willDisplayStepsController: controller)
         embed(controller, in: stepsContainer) { (parent, child) -> [NSLayoutConstraint] in
             child.view.translatesAutoresizingMaskIntoConstraints = false
             let pinningConstraints = child.view.constraintsForPinning(to: self.stepsContainer)
             let hideConstraints = self.stepsContainerHideConstraints
+            let stepsHeight = child.view.heightAnchor.constraint(equalToConstant: stepsTableExtent)
             
-            return pinningConstraints + hideConstraints + self.stepsContainerConstraints
+            return pinningConstraints + hideConstraints + self.stepsContainerConstraints + [stepsHeight]
         }
         stepsViewController = controller
         isDisplayingSteps = true

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -158,12 +158,11 @@ import MapboxDirections
             return
         }
         
-        var stepsHeightConstraint: [NSLayoutConstraint] = []
-
-        
         let controller = StepsViewController(routeProgress: progress)
         controller.delegate = self
 
+        var stepsHeightPresizingConstraint: NSLayoutConstraint? = nil
+        
         delegate?.topBanner?(self, willDisplayStepsController: controller)
         embed(controller, in: stepsContainer) { (parent, child) -> [NSLayoutConstraint] in
             child.view.translatesAutoresizingMaskIntoConstraints = false
@@ -171,14 +170,15 @@ import MapboxDirections
             let pinningConstraints = child.view.constraintsForPinning(to: self.stepsContainer)
             let hideConstraints = self.stepsContainerHideConstraints
 
+            var constraints = pinningConstraints + hideConstraints + self.stepsContainerConstraints
             
             if let bannerHostHeight = self.view.superview?.superview?.frame.height { 
-                print("Super: \(self.view.superview!.superview!)")
                 let inset = self.instructionsBannerHeight + self.view.safeArea.top
-                stepsHeightConstraint = [child.view.heightAnchor.constraint(equalToConstant: bannerHostHeight - inset)]
+                stepsHeightPresizingConstraint = (child.view.heightAnchor.constraint(equalToConstant: bannerHostHeight - inset))
+                constraints.append(stepsHeightPresizingConstraint!)
             }
             
-            return pinningConstraints + hideConstraints + self.stepsContainerConstraints + stepsHeightConstraint
+            return constraints
         }
         stepsViewController = controller
         isDisplayingSteps = true
@@ -187,7 +187,8 @@ import MapboxDirections
         view.isUserInteractionEnabled = false
         
         let stepsInAnimation = {
-            NSLayoutConstraint.deactivate(self.stepsContainerHideConstraints + stepsHeightConstraint)
+            NSLayoutConstraint.deactivate(self.stepsContainerHideConstraints)
+            stepsHeightPresizingConstraint?.isActive = false
             NSLayoutConstraint.activate(self.stepsContainerShowConstraints)
             
             


### PR DESCRIPTION
Fixes #2165. Sizes the steps table container before presentation so it does not grow during animation

/cc @mapbox/navigation-ios 