### PR TITLE
Exclude Twitter reachability test from CocoaPods installation test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
       - when:
           condition: << parameters.lint >>
           steps:
+            - run: find . -path '*.podspec' -exec perl -pi -e 's/.+\.social_media_url.+//' {} \;
             - run: pod lib lint MapboxCoreNavigation.podspec
             - run: pod lib lint MapboxNavigation.podspec
       - *save-cache-podmaster


### PR DESCRIPTION
Before linting the podspecs as part of the CocoaPods installation test, remove [@mapbox](https://twitter.com/mapbox) from the podspecs, keeping CocoaPods from checking whether Twitter is reachable. (It is, trust me.)

Fixes #2187.

/cc @mapbox/navigation-ios