### PR TITLE
Add common attributes to congestionless route polylines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Fixed an issue where InstructionsBannerView remained the same color after switching to a day or night style. ([#2178](https://github.com/mapbox/mapbox-navigation-ios/pull/2178))
+* Fixed an issue where `NavigationMapView` showed routes without congestion attributes, such as `MBDirectionsProfileIdentifier.walking` routes, as translucent lines, even if the route had only one leg. ([#2193](https://github.com/mapbox/mapbox-navigation-ios/pull/2193))
 * Fixed an issue where the “iPhone Volume Low” banner would persist until replaced by another banner about simulation or rerouting. ([#2183](https://github.com/mapbox/mapbox-navigation-ios/pull/2183))
 * Designables no longer crash and fail to render in Interface Builder when the application target links to this SDK via CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))
 * Fixed a crash that could occur when statically initializing a `Style` if the SDK was installed using CocoaPods. ([#2179](https://github.com/mapbox/mapbox-navigation-ios/pull/2179))

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -816,32 +816,36 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         var linesPerLeg: [MGLPolylineFeature] = []
         
         for (index, leg) in route.legs.enumerated() {
+            let lines: [MGLPolylineFeature]
             // If there is no congestion, don't try and add it
-            guard let legCongestion = leg.segmentCongestionLevels, legCongestion.count < coordinates.count else {
-                return [MGLPolylineFeature(coordinates: route.coordinates!, count: UInt(route.coordinates!.count))]
-            }
-            
-            // The last coord of the preceding step, is shared with the first coord of the next step, we don't need both.
-            let legCoordinates: [CLLocationCoordinate2D] = leg.steps.enumerated().reduce([]) { allCoordinates, current in
-                let index = current.offset
-                let step = current.element
-                let stepCoordinates = step.coordinates!
-                
-                return index == 0 ? stepCoordinates : allCoordinates + stepCoordinates.suffix(from: 1)
-            }
-            
-            let mergedCongestionSegments = combine(legCoordinates, with: legCongestion)
-            
-            let lines: [MGLPolylineFeature] = mergedCongestionSegments.map { (congestionSegment: CongestionSegment) -> MGLPolylineFeature in
-                let polyline = MGLPolylineFeature(coordinates: congestionSegment.0, count: UInt(congestionSegment.0.count))
-                polyline.attributes[MBCongestionAttribute] = String(describing: congestionSegment.1)
-                polyline.attributes["isAlternateRoute"] = false
-                if let legIndex = legIndex {
-                    polyline.attributes[MBCurrentLegAttribute] = index == legIndex
-                } else {
-                    polyline.attributes[MBCurrentLegAttribute] = index == 0
+            if let legCongestion = leg.segmentCongestionLevels, legCongestion.count < coordinates.count {
+                // The last coord of the preceding step, is shared with the first coord of the next step, we don't need both.
+                let legCoordinates: [CLLocationCoordinate2D] = leg.steps.enumerated().reduce([]) { allCoordinates, current in
+                    let index = current.offset
+                    let step = current.element
+                    let stepCoordinates = step.coordinates!
+                    
+                    return index == 0 ? stepCoordinates : allCoordinates + stepCoordinates.suffix(from: 1)
                 }
-                return polyline
+                
+                let mergedCongestionSegments = combine(legCoordinates, with: legCongestion)
+                
+                lines = mergedCongestionSegments.map { (congestionSegment: CongestionSegment) -> MGLPolylineFeature in
+                    let polyline = MGLPolylineFeature(coordinates: congestionSegment.0, count: UInt(congestionSegment.0.count))
+                    polyline.attributes[MBCongestionAttribute] = String(describing: congestionSegment.1)
+                    return polyline
+                }
+            } else {
+                lines = [MGLPolylineFeature(coordinates: route.coordinates!, count: UInt(route.coordinates!.count))]
+            }
+            
+            for line in lines {
+                line.attributes["isAlternateRoute"] = false
+                if let legIndex = legIndex {
+                    line.attributes[MBCurrentLegAttribute] = index == legIndex
+                } else {
+                    line.attributes[MBCurrentLegAttribute] = index == 0
+                }
             }
             
             linesPerLeg.append(contentsOf: lines)


### PR DESCRIPTION
Fixed an issue where NavigationMapView showed routes without congestion attributes, such as walking routes, as translucent lines, even if the route had only one leg.

Even if a polyline represents a route that has no congestion attributes, if should still have attributes indicating whether it’s the alternative route and/or current leg so that the style can choose the appropriate opacity.

Here’s a before and after:

<img src="https://user-images.githubusercontent.com/1231218/61988370-3692dc80-afd5-11e9-9f28-c5fd3a54f390.png" width="300" alt="walking before"> <img src="https://user-images.githubusercontent.com/1231218/61988381-43173500-afd5-11e9-8eee-ee7f5f6d5e8c.png" width="300" alt="walking after">

Meanwhile, traffic congestion and subsequent legs are still styled correctly for traffic-avoiding driving routes:

<img src="https://user-images.githubusercontent.com/1231218/61988397-71951000-afd5-11e9-85f0-ac3c4096ea8d.png" width="300" alt="driving after">

/cc @mapbox/navigation-ios @friedbunny