### PR TITLE
Top Banner Swipe Gesture Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+* Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
+
 ## v0.36.0
 
 * Fixed an issue where InstructionsBannerView remained the same color after switching to a day or night style. ([#2178](https://github.com/mapbox/mapbox-navigation-ios/pull/2178))

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -638,21 +638,20 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
     public func topBanner(_ banner: TopBannerViewController, didSwipeInDirection direction: UISwipeGestureRecognizer.Direction) {
         let progress = navigationService.routeProgress
         let route = progress.route
+        switch direction {
         
-        if direction == .down {
+        case .up where banner.isDisplayingSteps:
+            banner.dismissStepsTable()
+        
+        case .down where !banner.isDisplayingSteps:
             banner.displayStepsTable()
             
             
             if banner.isDisplayingPreviewInstructions {
                 mapViewController?.recenter(self)
             }
-            
-        } else if direction == .right {
-            // prevent swiping when step list is visible
-            if banner.isDisplayingSteps {
-                return
-            }
-            
+        
+        case .right where !banner.isDisplayingSteps:
             guard let currentStepIndex = banner.currentPreviewStep?.1 else { return }
             let remainingSteps = progress.remainingSteps
             let prevStepIndex = currentStepIndex.advanced(by: -1)
@@ -660,12 +659,8 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
             
             let prevStep = remainingSteps[prevStepIndex]
             preview(step: prevStep, in: banner, remaining: remainingSteps, route: route)
-        } else if direction == .left {
-            // prevent swiping when step list is visible
-            if banner.isDisplayingSteps {
-                return
-            }
             
+        case .left where !banner.isDisplayingSteps:
             let remainingSteps = navigationService.router.routeProgress.remainingSteps
             let currentStepIndex = banner.currentPreviewStep?.1
             let nextStepIndex = currentStepIndex?.advanced(by: 1) ?? 0
@@ -673,6 +668,9 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
             
             let nextStep = remainingSteps[nextStepIndex]
             preview(step: nextStep, in: banner, remaining: remainingSteps, route: route)
+            
+        default:
+            return
         }
     }
     


### PR DESCRIPTION
Fixes #2195.

* Fixing issue where "swipe down" gesture on top banner could be triggered after banner already displays

/cc @navigation-ios