### PR TITLE
Include docset title and version in masthead

### DIFF
--- a/docs/theme/templates/header.mustache
+++ b/docs/theme/templates/header.mustache
@@ -4,7 +4,7 @@
     <p class="header-col header-col--primary">
       <a class="header-link" href="{{path_to_root}}index.html">
         <img style="height: 25px;"  class="header-icon" src="{{path_to_root}}img/mapbox.svg" alt="{{module_name}} Docs"/>
-        <span class='header-tag'>BRANDLESS_DOCSET_TITLE Reference</span>
+        <span class='header-tag'>{{docs_title}} Reference ({{module_version}})</span>
       </a>
       {{#doc_coverage}} ({{doc_coverage}}% documented){{/doc_coverage}}
     </p>

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -63,6 +63,7 @@ jazzy \
     --output ${OUTPUT} \
     --module_version ${RELEASE_VERSION}
 
+REPLACE_REGEXP='s/MapboxNavigation\s+(Docs|Reference)/Mapbox Navigation SDK for iOS $1/, '
 REPLACE_REGEXP+="s/<span class=\"kt\">(${DIRECTIONS_SYMBOLS})<\/span>/<span class=\"kt\"><a href=\"${BASE_URL//\//\\/}\/directions\/${DIRECTIONS_VERSION}\/Classes\/\$1.html\">\$1<\/a><\/span>/, "
 
 find ${OUTPUT} -name *.html -exec \


### PR DESCRIPTION
Reprised mapbox/jazzy-theme#9 in this repository’s copy of the Mapbox jazzy theme.

Fixes #2199.

/cc @mapbox/navigation-ios @captainbarbosa