### PR TITLE
Require map SDK v5.2.x

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.1
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.2
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 6.2.1
 github "mapbox/MapboxDirections.swift" ~> 0.30.0
 github "mapbox/turf-swift" ~> 0.3

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.9.5)
   - MapboxNavigation (0.36.0):
-    - Mapbox-iOS-SDK (~> 5.1)
+    - Mapbox-iOS-SDK (~> 5.2)
     - MapboxCoreNavigation (= 0.36.0)
     - MapboxSpeech (~> 0.1.0)
     - Solar (~> 2.1)
@@ -45,7 +45,7 @@ SPEC CHECKSUMS:
   MapboxCoreNavigation: 41f550b9e22bf92c0adff2784881441d363ffb1c
   MapboxDirections.swift: 1c6df988c24b753888ebd9976d7c98632501a413
   MapboxMobileEvents: f6c21b2e59066c5c7093585de7c15adae3b63da0
-  MapboxNavigation: 76b39a959d8213b81a88267f086393ab4166d098
+  MapboxNavigation: d34ca18d915c3b3caefccaca5ceb7261c5e2be11
   MapboxNavigationNative: 11dc22140f4698d3f26989f2b6379dc81ef0d4c1
   MapboxSpeech: 59b3984d3f433a443d24acf53097f918c5cc70f9
   Polyline: 0e9890790292741c8186201a536b6bb6a78d02dd

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
 
   s.dependency "MapboxDirections.swift", "~> 0.30.0"
   s.dependency "MapboxGeocoder.swift", "~> 0.10.0"
-  s.dependency "Mapbox-iOS-SDK", "~> 5.1"
+  s.dependency "Mapbox-iOS-SDK", "~> 5.2"
   s.dependency "MapboxMobileEvents", "~> 0.9.5"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.3.0"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "Mapbox-iOS-SDK", "~> 5.1"
+  s.dependency "Mapbox-iOS-SDK", "~> 5.2"
   s.dependency "Solar", "~> 2.1"
   s.dependency "MapboxSpeech", "~> 0.1.0"
 


### PR DESCRIPTION
#2192 fixed the deprecation warnings arising from mapbox/mapbox-gl-native#14959 but introduced an implicit dependency on map SDK v5.2.0. This change makes the dependency on v5.2.0 explicit, so that developers don’t accidentally wind up with a broken build because of an existing copy of v5.1._x_.

/ref #2189
/cc @mapbox/navigation-ios @friedbunny @d-prukop