### PR TITLE
Simplify anchor point calculation and puck centering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * This library now requires a minimum deployment target of iOS 10.0 or above. iOS 9._x_ is no longer supported. ([#2206](https://github.com/mapbox/mapbox-navigation-ios/pull/2206))
+* Fixed an issue where the user puck appeared farther up the screen than the actual user location even while the camera pivoted around the user location at turns. ([#2211](https://github.com/mapbox/mapbox-navigation-ios/pull/2211))
 * Lock screen notifications are presented more reliably and more closely resemble instruction banners. ([#2206](https://github.com/mapbox/mapbox-navigation-ios/pull/2206))
 * Fixed an issue where manually incrementing `RouteProgress.legIndex` could lead to undefined behavior. ([#2229](https://github.com/mapbox/mapbox-navigation-ios/pull/2229))
 * `DistanceFormatter` now inherits directly from `Formatter` rather than `LengthFormatter`. ([#2206](https://github.com/mapbox/mapbox-navigation-ios/pull/2206))

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -620,17 +620,6 @@ extension CarPlayManager: CPMapTemplateDelegate {
     }
 
     public func mapTemplate(_ mapTemplate: CPMapTemplate, didUpdatePanGestureWithTranslation translation: CGPoint, velocity: CGPoint) {
-        let mapView: NavigationMapView
-        if let navigationViewController = currentNavigator, mapTemplate == navigationViewController.mapTemplate {
-            mapView = navigationViewController.mapView!
-        } else if let carPlayMapViewController = carPlayMapViewController {
-            mapView = carPlayMapViewController.mapView
-        } else {
-            return
-        }
-        
-        // Make sure the content inset is always up to date in case the safe area changes during a gesture.
-        mapView.setContentInset(mapView.safeArea, animated: false, completionHandler: nil)
         updatePan(by: translation, mapTemplate: mapTemplate, animated: false)
     }
     
@@ -649,7 +638,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
     }
 
     func coordinate(of offset: CGPoint, in mapView: NavigationMapView) -> CLLocationCoordinate2D {
-        let contentFrame = mapView.bounds.inset(by: mapView.safeArea)
+        let contentFrame = mapView.bounds.inset(by: mapView.contentInset)
         let centerPoint = CGPoint(x: contentFrame.midX, y: contentFrame.midY)
         let endCameraPoint = CGPoint(x: centerPoint.x - offset.x, y: centerPoint.y - offset.y)
 
@@ -663,7 +652,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
 
         // Determine the screen distance to pan by based on the distance from the visual center to the closest side.
         let mapView = carPlayMapViewController.mapView
-        let contentFrame = mapView.bounds.inset(by: mapView.safeArea)
+        let contentFrame = mapView.bounds.inset(by: mapView.contentInset)
         let increment = min(mapView.bounds.width, mapView.bounds.height) / 2.0
         
         // Calculate the distance in physical units from the visual center to where it would be after panning downwards.

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -29,7 +29,13 @@ public class CarPlayMapViewController: UIViewController {
         return coarseLocationManager
     }()
     
-    var isOverviewingRoutes: Bool = false
+    var isOverviewingRoutes: Bool = false {
+        didSet {
+            // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/15574
+            // In overview mode, content insets are set to .zero, avoid getting them changed.
+            automaticallyAdjustsScrollViewInsets = !isOverviewingRoutes
+        }
+    }
     
     var mapView: NavigationMapView {
         get {
@@ -194,18 +200,6 @@ public class CarPlayMapViewController: UIViewController {
     
     override public func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
-        
-        var edgePadding = view.safeArea
-        edgePadding += NavigationMapView.defaultPadding
-        
-        if let userCourseView = mapView.userCourseView {
-            let midX = userCourseView.bounds.midX
-            let midY = userCourseView.bounds.midY
-            edgePadding += UIEdgeInsets(top: midY, left: midX, bottom: midY, right: midX)
-        }
-        
-        mapView.setContentInset(edgePadding, animated: false, completionHandler: nil)
-        
         guard let active = mapView.routes?.first else {
             mapView.setUserTrackingMode(.followWithCourse, animated: true, completionHandler: nil)
             return

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -184,11 +184,34 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
         guard let mapView = mapView else { return }
         
         mapView.enableFrameByFrameCourseViewTracking(for: 1)
-        
-        mapView.setContentInset(view.safeArea, animated: true) { [weak self] in
-            guard let self = self, self.tracksUserCourse else { return }
-            mapView.fit(to: self.navigationService.route, facing: 0, animated: true)
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if (isOverviewingRoutes) { return } // Don't move content when overlays change.
+        guard let mapView = mapView else { return }
+        mapView.contentInset = contentInset(forOverviewing: false)
+    }
+
+    func contentInset(forOverviewing overviewing: Bool) -> UIEdgeInsets {
+        guard let mapView = mapView else { return .zero }
+        var insets = mapView.safeArea
+        if !overviewing {
+            // Puck position calculation - position it just above the bottom of the content area.
+            var contentFrame = mapView.bounds.inset(by: insets)
+
+            // Avoid letting the puck go partially off-screen, and add a comfortable padding beyond that.
+            let courseViewBounds = mapView.userCourseView?.bounds ?? .zero
+            // If it is not possible to position it right above the content area, center it at the remaining space.
+            contentFrame = contentFrame.insetBy(dx: min(NavigationMapView.courseViewMinimumInsets.left + courseViewBounds.width / 2.0, contentFrame.width / 2.0),
+                                                dy: min(NavigationMapView.courseViewMinimumInsets.top + courseViewBounds.height / 2.0, contentFrame.height / 2.0))
+            assert(!contentFrame.isInfinite)
+
+            let y = contentFrame.maxY
+            let height = mapView.bounds.height
+            insets.top = height - insets.bottom - 2 * (height - insets.bottom - y)
         }
+        return insets;
     }
     
     /**
@@ -233,27 +256,38 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
         set {
             let progress = navigationService.routeProgress
             if !tracksUserCourse && newValue {
-                
+                isOverviewingRoutes = false;
                 mapView?.recenterMap()
                 mapView?.addArrow(route: progress.route,
                                  legIndex: progress.legIndex,
                                  stepIndex: progress.currentLegProgress.stepIndex + 1)
+                mapView?.setContentInset(contentInset(forOverviewing: false), animated: true, completionHandler: nil)
             } else if tracksUserCourse && !newValue {
-                
+                isOverviewingRoutes = !isPanningAway;
                 guard let userLocation = self.navigationService.router.location?.coordinate,
                 let coordinates = navigationService.route.coordinates else {
                     return
                 }
                 mapView?.enableFrameByFrameCourseViewTracking(for: 1)
-                mapView?.setOverheadCameraView(from: userLocation, along: coordinates, for: .zero)
+                mapView?.contentInset = contentInset(forOverviewing: isOverviewingRoutes)
+                if (isOverviewingRoutes) {
+                    mapView?.setOverheadCameraView(from: userLocation, along: coordinates, for: contentInset(forOverviewing: true))
+                }
             }
         }
     }
+
+    // Tracks if tracksUserCourse was set to false from overview button
+    // or panned away.
+    var isPanningAway = false;
+    var isOverviewingRoutes = false;
     
     public func beginPanGesture() {
+        isPanningAway = true;
         tracksUserCourse = false
         mapView?.tracksUserCourse = false
         mapView?.enableFrameByFrameCourseViewTracking(for: 1)
+        isPanningAway = false;
     }
     
     @objc func visualInstructionDidChange(_ notification: NSNotification) {

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -211,7 +211,7 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
             let height = mapView.bounds.height
             insets.top = height - insets.bottom - 2 * (height - insets.bottom - y)
         }
-        return insets;
+        return insets
     }
     
     /**
@@ -256,14 +256,14 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
         set {
             let progress = navigationService.routeProgress
             if !tracksUserCourse && newValue {
-                isOverviewingRoutes = false;
+                isOverviewingRoutes = false
                 mapView?.recenterMap()
                 mapView?.addArrow(route: progress.route,
                                  legIndex: progress.legIndex,
                                  stepIndex: progress.currentLegProgress.stepIndex + 1)
                 mapView?.setContentInset(contentInset(forOverviewing: false), animated: true, completionHandler: nil)
             } else if tracksUserCourse && !newValue {
-                isOverviewingRoutes = !isPanningAway;
+                isOverviewingRoutes = !isPanningAway
                 guard let userLocation = self.navigationService.router.location?.coordinate,
                 let coordinates = navigationService.route.coordinates else {
                     return
@@ -279,15 +279,15 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
 
     // Tracks if tracksUserCourse was set to false from overview button
     // or panned away.
-    var isPanningAway = false;
-    var isOverviewingRoutes = false;
+    var isPanningAway = false
+    var isOverviewingRoutes = false
     
     public func beginPanGesture() {
-        isPanningAway = true;
+        isPanningAway = true
         tracksUserCourse = false
         mapView?.tracksUserCourse = false
         mapView?.enableFrameByFrameCourseViewTracking(for: 1)
-        isPanningAway = false;
+        isPanningAway = false
     }
     
     @objc func visualInstructionDidChange(_ notification: NSNotification) {

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -148,19 +148,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         if let anchorPoint = navigationMapViewDelegate?.navigationMapViewUserAnchorPoint?(self), anchorPoint != .zero {
             return anchorPoint
         }
-        
-        // Inset by the safe area to avoid notches.
-        // Inset by the content inset to avoid application-defined content.
-        var contentFrame = bounds.inset(by: safeArea).inset(by: contentInset)
-        
-        // Avoid letting the puck go partially off-screen, and add a comfortable padding beyond that.
-        let courseViewBounds = userCourseView?.bounds ?? .zero
-        contentFrame = contentFrame.insetBy(dx: min(NavigationMapView.courseViewMinimumInsets.left + courseViewBounds.width / 2.0, contentFrame.width / 2.0),
-                                            dy: min(NavigationMapView.courseViewMinimumInsets.top + courseViewBounds.height / 2.0, contentFrame.height / 2.0))
-        
-        // Get the bottom-center of the remaining frame.
-        assert(!contentFrame.isInfinite)
-        return CGPoint(x: contentFrame.midX, y: contentFrame.maxY)
+        let contentFrame = bounds.inset(by: contentInset)
+        return CGPoint(x: contentFrame.midX, y: contentFrame.midY)
     }
     
     /**
@@ -194,8 +183,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             if let userCourseView = userCourseView {
                 if let location = userLocationForCourseTracking {
                     updateCourseTracking(location: location, animated: false)
-                } else {
-                    userCourseView.center = userAnchorPoint
                 }
                 addSubview(userCourseView)
             }
@@ -337,10 +324,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         if tracksUserCourse {
             let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, altitude: altitude, pitch: 45, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: .linear) : nil
-            let point = userAnchorPoint
-            let padding = UIEdgeInsets(top: point.y, left: point.x, bottom: bounds.height - point.y, right: bounds.width - point.x)
-            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, edgePadding: padding, completionHandler: nil)
-            userCourseView?.center = userAnchorPoint
+            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, completionHandler: nil)
         } else {
             // Animate course view updates in overview mode
             UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: { [weak self] in

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -429,8 +429,11 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
       
         setUserTrackingMode(.none, animated: false, completionHandler: nil)
         let line = MGLPolyline(coordinates: coords, count: UInt(coords.count))
-        let camera = cameraThatFitsShape(line, direction: direction, edgePadding: .zero)
         
+        // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/15574
+        // Set content insets .zero, before cameraThatFitsShape + setCamera.
+        contentInset = .zero
+        let camera = cameraThatFitsShape(line, direction: direction, edgePadding: safeArea + NavigationMapView.defaultPadding)
         setCamera(camera, animated: animated)
     }
     
@@ -1085,7 +1088,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let currentCamera = self.camera
         currentCamera.pitch = 0
         currentCamera.heading = 0
-        
+
+        // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/15574
+        // Set content insets .zero, before cameraThatFitsShape + setCamera.
+        contentInset = .zero
         let newCamera = camera(currentCamera, fitting: line, edgePadding: padding)
         
         setCamera(newCamera, withDuration: 1, animationTimingFunction: nil) { [weak self] in

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -333,7 +333,7 @@ class RouteMapViewController: UIViewController {
         super.viewDidLayoutSubviews()
         if (mapView.showsUserLocation && !mapView.tracksUserCourse) {
             // Don't move mapView content on rotation or when e.g. top banner expands.
-            return;
+            return
         }
         mapView.setContentInset(contentInset(forOverviewing: isInOverviewMode), animated: true, completionHandler: nil)
         mapView.setNeedsUpdateConstraints()

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -302,7 +302,7 @@ class RouteMapViewController: UIViewController {
         if let coordinates = router.route.coordinates,
             let userLocation = router.location?.coordinate {
             mapView.contentInset = contentInset(forOverviewing: true)
-            mapView.setOverheadCameraView(from: userLocation, along: coordinates, for: .zero)
+            mapView.setOverheadCameraView(from: userLocation, along: coordinates, for: contentInset(forOverviewing: true))
         }
         isInOverviewMode = true
     }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -331,6 +331,10 @@ class RouteMapViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        if (mapView.showsUserLocation && !mapView.tracksUserCourse) {
+            // Don't move mapView content on rotation or when e.g. top banner expands.
+            return;
+        }
         mapView.setContentInset(contentInset(forOverviewing: isInOverviewMode), animated: true, completionHandler: nil)
         mapView.setNeedsUpdateConstraints()
     }


### PR DESCRIPTION
Decouple dependency content insets -> anchor point -> padding/content insets broken after https://github.com/mapbox/mapbox-gl-native/pull/14664 introduced animated interpolation for padding change.

Remove the need to specify center for puck view - use the approach where content inset is keeping it centered.

Take safeArea into account when calculating contentInsets.

[Link to video showing current state.](https://www.dropbox.com/s/wori62tfhp69feg/RPReplay_Final1565767435.mp4?dl=0) 

EDIT 9/9/2019:
Work around mapbox-gl-native/15574. Panning fix.

Fix CarPlay puck positioning, panning away from navigation, navigation -> overview transitions.
Remove syncing safeArea to contentInset, contentInset is to be used to position puck and this causes map position sudden change when panning.

Work around mapbox-gl-native/15574: should be future proof as the mapbox/mapbox-gl-native#15574 exists only with MGLMapView.contentInset.

Addresses: https://github.com/mapbox/mapbox-gl-native/issues/15232, https://github.com/mapbox/mapbox-gl-native/issues/15233

Related to: https://github.com/mapbox/mapbox-navigation-ios/issues/2165,

Fixes: https://github.com/mapbox/mapbox-navigation-ios/issues/2145, #2190