### PR TITLE
Reword low volume warning to be less passive

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -306,7 +306,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         guard !NavigationSettings.shared.voiceMuted else { return }
         guard AVAudioSession.sharedInstance().outputVolume <= NavigationViewMinimumVolumeForWarning else { return }
         
-        let title = String.localizedStringWithFormat(NSLocalizedString("DEVICE_VOLUME_LOW", bundle: .mapboxNavigation, value: "%@ Volume Low", comment: "Format string for indicating the device volume is low; 1 = device model"), UIDevice.current.model)
+        let title = NSLocalizedString("INAUDIBLE_INSTRUCTIONS_CTA", bundle: .mapboxNavigation, value: "Adjust Volume to Hear Instructions", comment: "Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased")
         showStatus(title: title, spinner: false, duration: 3, animated: true, interactive: false)
     }
     

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Unmute";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volume Low";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Close";
 
@@ -90,6 +87,9 @@
 
 /* Title of view controller for sending feedback */
 "FEEDBACK_TITLE" = "Report Problem";
+
+/* Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased */
+"INAUDIBLE_INSTRUCTIONS_CTA" = "Adjust Volume to Hear Instructions";
 
 /* Format for displaying the first two major ways */
 "LEG_MAJOR_WAYS_FORMAT" = "%1$@ and %2$@";

--- a/MapboxNavigation/Resources/da.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/da.lproj/Localizable.strings
@@ -1,6 +1,3 @@
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volume Low";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Luk";
 

--- a/MapboxNavigation/Resources/de.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/de.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Laut";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Lautstärke leiser";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Schließen";
 

--- a/MapboxNavigation/Resources/es.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/es.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Unmute";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "Volumen de %@ está bajo";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Cerrar";
 

--- a/MapboxNavigation/Resources/fr.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/fr.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Réactiver le son";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volume moins";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Fermer";
 

--- a/MapboxNavigation/Resources/he.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/he.lproj/Localizable.strings
@@ -1,6 +1,3 @@
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volume Low";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "סגור";
 

--- a/MapboxNavigation/Resources/hu.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/hu.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Unmute";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volume Low";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Bezárás";
 

--- a/MapboxNavigation/Resources/ja.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ja.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "音声を出す";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@音量を下げる";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "閉じる";
 

--- a/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Ligar som";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volume Baixo";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Fechar";
 

--- a/MapboxNavigation/Resources/ru.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ru.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Звук";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "Недостаточно места в %@";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Закрыть";
 

--- a/MapboxNavigation/Resources/sv.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/sv.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Ljud på";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volym Låg";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Stäng";
 

--- a/MapboxNavigation/Resources/uk.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/uk.lproj/Localizable.strings
@@ -1,6 +1,3 @@
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Низька гучність";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Закрити";
 

--- a/MapboxNavigation/Resources/vi.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/vi.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Bật Tiếng";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "Âm lượng %@ Đang Thấp";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Đóng";
 

--- a/MapboxNavigation/Resources/yo.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/yo.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Title for unmute button */
 "CARPLAY_UNMUTE" = "Ṣi i";
 
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ didun kekere";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "Pa";
 

--- a/MapboxNavigation/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,6 +1,3 @@
-/* Format string for indicating the device volume is low; 1 = device model */
-"DEVICE_VOLUME_LOW" = "%@ Volume Low";
-
 /* Dismiss button title on the steps view */
 "DISMISS_STEPS_TITLE" = "关闭";
 


### PR DESCRIPTION
Replaced the low volume warning string with a new string that sounds more like a call to action. The new string is no longer a format string, so existing translations are invalid and couldn’t be reused.

Fixes #2205.

/cc @mapbox/navigation-ios