### PR TITLE
Respect heading while walking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 * Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
+* If the user walks away from the route, they may be rerouted onto a route that initially travels in the opposite direction. This is only the case along steps that require walking on foot. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
 
 ## v0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 * Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
 * If the user walks away from the route, they may be rerouted onto a route that initially travels in the opposite direction. This is only the case along steps that require walking on foot. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
+* Added `RouteControllerNotificationUserInfoKey.headingKey` to the user info dictionary of `Notification.Name.routeControllerWillReroute`, `Notification.Name.routeControllerDidReroute`, and `Notification.Name.routeControllerProgressDidChange` notifications. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
 * Added a `Router.heading` property that may contain a heading from the location manager. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
 
 ## v0.36.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 * Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
 * If the user walks away from the route, they may be rerouted onto a route that initially travels in the opposite direction. This is only the case along steps that require walking on foot. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
+* While the user is walking, the map rotates according to the user’s heading instead of their course. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
+* Added the `NavigationMapView.updateCourseTracking(location:heading:camera:animated:)` method for manually forcing the map view and user course view to update according to a location or heading. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
 * Added `RouteControllerNotificationUserInfoKey.headingKey` to the user info dictionary of `Notification.Name.routeControllerWillReroute`, `Notification.Name.routeControllerDidReroute`, and `Notification.Name.routeControllerProgressDidChange` notifications. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
 * Added a `Router.heading` property that may contain a heading from the location manager. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 * Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
 * If the user walks away from the route, they may be rerouted onto a route that initially travels in the opposite direction. This is only the case along steps that require walking on foot. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
+* Added a `Router.heading` property that may contain a heading from the location manager. ([#2215](https://github.com/mapbox/mapbox-navigation-ios/pull/2215))
 
 ## v0.36.0
 

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -91,6 +91,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         
         let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
         let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
+        let heading = notification.userInfo![RouteControllerNotificationUserInfoKey.headingKey] as? CLHeading
         
         // Add maneuver arrow
         if routeProgress.currentLegProgress.followOnStep != nil {
@@ -104,7 +105,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         instructionsBannerView.isHidden = false
         
         // Update the user puck
-        mapView.updateCourseTracking(location: location, animated: true)
+        mapView.updateCourseTracking(location: location, heading: heading, animated: true)
     }
     
     @objc func updateInstructionsBanner(notification: NSNotification) {

--- a/MapboxCoreNavigation/CoreConstants.swift
+++ b/MapboxCoreNavigation/CoreConstants.swift
@@ -136,21 +136,21 @@ extension Notification.Name {
     /**
      Posted after the user diverges from the expected route, just before `RouteController` attempts to calculate a new route.
      
-     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.locationKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.locationKey` and `RouteControllerNotificationUserInfoKey.headingKey`.
      */
     public static let routeControllerWillReroute = MBRouteControllerWillReroute
     
     /**
      Posted when `RouteController` obtains a new route in response to the user diverging from a previous route.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.locationKey` and `RouteControllerNotificationUserInfoKey.isProactiveKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.locationKey`, `RouteControllerNotificationUserInfoKey.headingKey`, and `RouteControllerNotificationUserInfoKey.isProactiveKey`.
      */
     public static let routeControllerDidReroute = MBRouteControllerDidReroute
     
     /**
      Posted when `RouteController` receives a user location update representing movement along the expected route.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey`, `RouteControllerNotificationUserInfoKey.locationKey`, and `RouteControllerNotificationUserInfoKey.rawLocationKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey`, `RouteControllerNotificationUserInfoKey.locationKey`, `RouteControllerNotificationUserInfoKey.headingKey`, and `RouteControllerNotificationUserInfoKey.rawLocationKey`.
      */
     public static let routeControllerProgressDidChange = MBRouteControllerProgressDidChange
     

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -359,7 +359,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
 
         self.lastRerouteLocation = location
 
-        getDirections(from: location, along: progress) { [weak self] (route, error) in
+        getDirections(from: location, routeProgress: progress) { [weak self] (route, error) in
             guard let strongSelf = self else {
                 return
             }

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -301,11 +301,14 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             delegate?.router?(self, didUpdate: progress, with: location, rawLocation: rawLocation)
             
             //Fire the notification (for now)
-            NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: [
-                RouteControllerNotificationUserInfoKey.routeProgressKey: progress,
-                RouteControllerNotificationUserInfoKey.locationKey: location, //guaranteed value
-                RouteControllerNotificationUserInfoKey.rawLocationKey: rawLocation //raw
-                ])
+            var userInfo: [RouteControllerNotificationUserInfoKey: Any] = [
+                .routeProgressKey: progress,
+                .locationKey: location, //guaranteed value
+                .rawLocationKey: rawLocation, //raw
+            ]
+            userInfo[.headingKey] = heading
+            userInfo[.rawHeadingKey] = heading // heading snapping not yet implemented (an unnecessary?)
+            NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: userInfo)
         }
     }
         
@@ -354,9 +357,11 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         isRerouting = true
 
         delegate?.router?(self, willRerouteFrom: location)
-        NotificationCenter.default.post(name: .routeControllerWillReroute, object: self, userInfo: [
-            RouteControllerNotificationUserInfoKey.locationKey: location
-        ])
+        var userInfo: [RouteControllerNotificationUserInfoKey: Any] = [
+            .locationKey: location,
+        ]
+        userInfo[.headingKey] = heading
+        NotificationCenter.default.post(name: .routeControllerWillReroute, object: self, userInfo: userInfo)
 
         self.lastRerouteLocation = location
 

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -123,7 +123,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         return rawLocation?.snapped(to: routeProgress)
     }
 
-    var heading: CLHeading?
+    public var heading: CLHeading?
 
     /**
      The most recently received user location.
@@ -224,6 +224,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     
     @objc public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
         heading = newHeading
+        // TODO: Cause a map view to update its camera.
     }
 
     @objc public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/MapboxCoreNavigation/MBRouteController.h
+++ b/MapboxCoreNavigation/MBRouteController.h
@@ -80,6 +80,16 @@ extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteController
 extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocationKey;
 
 /**
+ A key in the user info dictionary of a `MBRouteControllerProgressDidChangeNotification` or `MBRouteControllerWillRerouteNotification` notification. The corresponding value is a `CLHeading` object representing the current idealized user heading. The value may be `nil`.
+ */
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerHeadingKey;
+
+/**
+ A key in the user info dictionary of a `MBRouteControllerProgressDidChangeNotification` or `MBRouteControllerWillRerouteNotification` notification. The corresponding value is a `CLHeading` object representing the current raw user heading. The value may be `nil`.
+ */
+extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerRawHeadingKey;
+
+/**
  A key in the user info dictionary of a `MBRouteControllerDidFailToRerouteNotification` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.
  */
 extern const _Nonnull MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey;

--- a/MapboxCoreNavigation/MBRouteController.m
+++ b/MapboxCoreNavigation/MBRouteController.m
@@ -11,6 +11,8 @@ const NSNotificationName MBRouteControllerDidFailToRerouteNotification          
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRouteProgressKey              = @"progress";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerLocationKey                   = @"location";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRawLocationKey                = @"rawLocation";
+const MBRouteControllerNotificationUserInfoKey MBRouteControllerHeadingKey                    = @"heading";
+const MBRouteControllerNotificationUserInfoKey MBRouteControllerRawHeadingKey                 = @"rawHeading";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerRoutingErrorKey               = @"error";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerVisualInstructionKey          = @"visualInstruction";
 const MBRouteControllerNotificationUserInfoKey MBRouteControllerSpokenInstructionKey          = @"spokenInstruction";

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -173,7 +173,9 @@ open class RouteController: NSObject {
         
         rawLocation = locations.last
         
-        locations.forEach { navigator.updateLocation(for: MBFixLocation($0)) }
+        for location in locations {
+            navigator.updateLocation(for: MBFixLocation(location))
+        }
         
         let status = navigator.getStatusForTimestamp(location.timestamp)
         
@@ -281,11 +283,14 @@ open class RouteController: NSObject {
             delegate?.router?(self, didUpdate: progress, with: location, rawLocation: rawLocation)
             
             //Fire the notification (for now)
-            NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: [
-                RouteControllerNotificationUserInfoKey.routeProgressKey: progress,
-                RouteControllerNotificationUserInfoKey.locationKey: location, //guaranteed value
-                RouteControllerNotificationUserInfoKey.rawLocationKey: rawLocation //raw
-                ])
+            var userInfo: [RouteControllerNotificationUserInfoKey: Any] = [
+                .routeProgressKey: progress,
+                .locationKey: location, //guaranteed value
+                .rawLocationKey: rawLocation, //raw
+            ]
+            userInfo[.headingKey] = heading
+            userInfo[.rawHeadingKey] = heading // heading snapping not yet implemented (an unnecessary?)
+            NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: userInfo)
         }
     }
     
@@ -363,9 +368,11 @@ extension RouteController: Router {
         }
         
         delegate?.router?(self, willRerouteFrom: location)
-        NotificationCenter.default.post(name: .routeControllerWillReroute, object: self, userInfo: [
-            RouteControllerNotificationUserInfoKey.locationKey: location
-            ])
+        var userInfo: [RouteControllerNotificationUserInfoKey: Any] = [
+            .locationKey: location,
+        ]
+        userInfo[.headingKey] = heading
+        NotificationCenter.default.post(name: .routeControllerWillReroute, object: self, userInfo: userInfo)
         
         self.lastRerouteLocation = location
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -96,7 +96,7 @@ open class RouteController: NSObject {
         return CLLocation(status.location)
     }
     
-    var heading: CLHeading?
+    public var heading: CLHeading?
     
     /**
      The most recently received user location.
@@ -156,6 +156,11 @@ open class RouteController: NSObject {
         
         // TODO: Add support for alternative route
         navigator.setRouteForRouteResponse(jsonString, route: 0, leg: 0)
+    }
+    
+    @objc public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
+        heading = newHeading
+        // TODO: Cause a map view to update its camera.
     }
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -368,7 +368,7 @@ extension RouteController: Router {
         if isRerouting { return }
         isRerouting = true
         
-        getDirections(from: location, along: progress) { [weak self] (route, error) in
+        getDirections(from: location, routeProgress: progress) { [weak self] (route, error) in
             self?.isRerouting = false
             
             guard let strongSelf: RouteController = self else {

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -253,12 +253,14 @@ open class RouteProgress: NSObject {
         }
     }
 
-    func reroutingOptions(with current: CLLocation) -> RouteOptions {
+    func reroutingOptions(from location: CLLocation) -> RouteOptions {
         let oldOptions = route.routeOptions
-        let user = Waypoint(coordinate: current.coordinate)
+        let user = Waypoint(coordinate: location.coordinate)
 
-        if (current.course >= 0) {
-            user.heading = current.course
+        // A pedestrian can turn on a dime; there’s no problem with a route that starts out by turning the pedestrian around.
+        let transportType = currentLegProgress.currentStep.transportType
+        if transportType != .walking && location.course >= 0 {
+            user.heading = location.course
             user.headingAccuracy = RouteProgress.reroutingAccuracy
         }
         let newWaypoints = [user] + remainingWaypointsForCalculatingRoute()

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -192,9 +192,8 @@ extension InternalRouter where Self: Router {
     
     func announce(reroute newRoute: Route, at location: CLLocation?, proactive: Bool) {
         var userInfo = [RouteControllerNotificationUserInfoKey: Any]()
-        if let location = location {
-            userInfo[.locationKey] = location
-        }
+        userInfo[.locationKey] = location
+        userInfo[.headingKey] = heading
         userInfo[.isProactiveKey] = proactive
         NotificationCenter.default.post(name: .routeControllerDidReroute, object: self, userInfo: userInfo)
         delegate?.router?(self, didRerouteAlong: routeProgress.route, at: location, proactive: proactive)

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -67,6 +67,10 @@ public protocol RouterDataSource {
      */
     @objc var rawLocation: CLLocation? { get }
     
+    /**
+     The most recently received user heading, if any.
+     */
+    @objc var heading: CLHeading? { get }
     
     /**
      If true, the `RouteController` attempts to calculate a more optimal route for the user on an interval defined by `RouteControllerProactiveReroutingInterval`.

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -135,7 +135,7 @@ extension InternalRouter where Self: Router {
         if isRerouting { return }
         isRerouting = true
         
-        getDirections(from: location, along: routeProgress) { [weak self] (route, error) in
+        getDirections(from: location, routeProgress: routeProgress) { [weak self] (route, error) in
             self?.isRerouting = false
             
             guard let route = route else { return }
@@ -156,9 +156,9 @@ extension InternalRouter where Self: Router {
         }
     }
     
-    func getDirections(from location: CLLocation, along progress: RouteProgress, completion: @escaping (_ route: Route?, _ error: Error?)->Void) {
+    func getDirections(from location: CLLocation, routeProgress: RouteProgress, completion: @escaping (_ route: Route?, _ error: Error?)->Void) {
         routeTask?.cancel()
-        let options = progress.reroutingOptions(with: location)
+        let options = routeProgress.reroutingOptions(from: location)
         
         lastRerouteLocation = location
         
@@ -168,7 +168,7 @@ extension InternalRouter where Self: Router {
                 return completion(nil, error)
             }
             
-            let mostSimilar = routes.mostSimilar(to: progress.route)
+            let mostSimilar = routes.mostSimilar(to: routeProgress.route)
             return completion(mostSimilar ?? routes.first, error)
         }
     }

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -272,7 +272,7 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
         // Update the user puck
         mapView?.updatePreferredFrameRate(for: routeProgress)
         let camera = MGLMapCamera(lookingAtCenter: location.coordinate, altitude: 120, pitch: 60, heading: location.course)
-        mapView?.updateCourseTracking(location: location, camera: camera, animated: true)
+        mapView?.updateCourseTracking(location: location, heading: nil, camera: camera, animated: true)
         
         let congestionLevel = routeProgress.averageCongestionLevelRemainingOnLeg ?? .unknown
         guard let maneuver = carSession.upcomingManeuvers.first else { return }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -493,7 +493,9 @@ extension NavigationViewController: NavigationServiceDelegate {
         
         if snapsUserLocationAnnotationToRoute,
             userHasArrivedAndShouldPreventRerouting {
-            mapViewController?.mapView.updateCourseTracking(location: location, animated: true)
+            let isWalking = progress.currentLegProgress.currentStep.transportType == .walking
+            let heading = isWalking ? navigationService.locationManager.heading : nil
+            mapViewController?.mapView.updateCourseTracking(location: location, heading: heading, animated: true)
         }
     }
     

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -229,15 +229,18 @@ class RouteMapViewController: UIViewController {
 
         mapView.tracksUserCourse = true
 
+        let isWalking = navService.routeProgress.currentLegProgress.currentStep.transportType == .walking
+        let heading = isWalking ? navService.locationManager.heading : nil
+        
         if let camera = pendingCamera {
             mapView.camera = camera
-        } else if let location = router.location, location.course > 0 {
-            mapView.updateCourseTracking(location: location, animated: false)
+        } else if let location = router.location, location.course >= 0 {
+            mapView.updateCourseTracking(location: location, heading: heading, animated: false)
         } else if let coordinates = router.routeProgress.currentLegProgress.currentStep.coordinates, let firstCoordinate = coordinates.first, coordinates.count > 1 {
             let secondCoordinate = coordinates[1]
             let course = firstCoordinate.direction(to: secondCoordinate)
             let newLocation = CLLocation(coordinate: router.location?.coordinate ?? firstCoordinate, altitude: 0, horizontalAccuracy: 0, verticalAccuracy: 0, course: course, speed: 0, timestamp: Date())
-            mapView.updateCourseTracking(location: newLocation, animated: false)
+            mapView.updateCourseTracking(location: newLocation, heading: heading, animated: false)
         } else {
             mapView.setCamera(tiltedCamera, animated: false)
         }
@@ -338,7 +341,9 @@ class RouteMapViewController: UIViewController {
     }
 
     @objc func applicationWillEnterForeground(notification: NSNotification) {
-        mapView.updateCourseTracking(location: router.location, animated: false)
+        let isWalking = navService.routeProgress.currentLegProgress.currentStep.transportType == .walking
+        let heading = isWalking ? navService.locationManager.heading : nil
+        mapView.updateCourseTracking(location: router.location, heading: heading, animated: false)
     }
 
     func updateMapOverlays(for routeProgress: RouteProgress) {


### PR DESCRIPTION
This PR contains these user-facing improvements to walking navigation:

* The user’s heading is used instead of the course when reorienting the camera while walking, since heading is more granular and more accurate at low speeds (i.e., walking speeds).
* When rerouting a pedestrian, avoid restricting the route’s initial heading. When driving or cycling, it makes sense to restrict the initial heading, to avoid routes that confusingly begin with a U-turn. However, a pedestrian can turn on a dime, and the direction in an initial “Head [direction] on [street]” instruction is more meaningful to a pedestrian than to a motorist or cyclist.

and these developer-facing improvements:

* Added `RouteControllerNotificationUserInfoKey.headingKey` to the user info dictionary of `Notification.Name.routeControllerWillReroute`, `Notification.Name.routeControllerDidReroute`, and `Notification.Name.routeControllerProgressDidChange` notifications. Core Location treats heading as first-class state instead of subordinating it under location, because heading updates from the magnetometer come in at a different rate than location updates from the GPS receiver.
* Both RouteController and LegacyRouteController can store a `heading`, so now the Router protocol requires it publicly. (Also fixed a latent issue where RouteController ignored heading updates. This issue didn’t matter previously because nothing was using `RouteController.heading`.)
* Deprecated the public but undocumented `NavigationMapView.updateCourseTracking(location:camera:animated:)` method in favor of a publicly documented `NavigationMapView.updateCourseTracking(location:heading:camera:animated:)` argument to the method for transitioning the map camera. (The existing method signature without the extra argument was undocumented but used in examples, so it has been retained in deprecated form.)

The user’s mode of transportation is determined by the current step’s `transportMode`, which is generally based on the routing profile but can be something else like `train` or `ferry` for walking and cycling routes. The improvements above affect only the walking transport mode.

To recap and to do:

* [x] Loosen rerouting heading while walking
* [x] Make heading a first-class piece of context alongside location
* [x] Rotate the map by heading instead of course while walking
* [ ] Initially rotate the map by heading instead of course when enabling course tracking mode while walking
* [ ] Update heading orientation: https://github.com/mapbox/mapbox-navigation-ios/issues/1942#issuecomment-479585406
* [ ] Test loosened rerouting – may be challenging given the lack of heading simulation

Fixes #1942.

/cc @mapbox/navigation-ios @d-prukop