### PR TITLE
Determine user agent based on presence of MapboxNavigation

### DIFF
--- a/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -29,8 +29,13 @@ open class NavigationEventsManager: NSObject {
     
     weak var dataSource: EventsManagerDataSource?
     
-    /// :nodoc: This is used internally when the navigation UI is being used
-    var usesDefaultUserInterface = false
+    /**
+     Indicates whether the application depends on MapboxNavigation in addition to MapboxCoreNavigation.
+     */
+    var usesDefaultUserInterface = {
+        // Assumption: MapboxNavigation.framework includes NavigationViewController and exposes it to the Objective-C runtime as MBNavigationViewController.
+        return NSClassFromString("MBNavigationViewController") != nil
+    }()
 
     /// :nodoc: the internal lower-level mobile events manager is an implementation detail which should not be manipulated directly
     private var mobileEventsManager: MMEEventsManager!

--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -30,13 +30,6 @@ public enum SimulationMode: Int {
     case never
 }
 
-/// :nodoc: Internal "using default interaface" flag. Used for telemetry.
-@objc(MBDefaultInterfaceFlag)
-public protocol DefaultInterfaceFlag {
-    /// :nodoc: Internal "using default interaface" flag. Used for telemetry.
-    var usesDefaultUserInterface: Bool { get set }
-}
-
 /**
  A navigation service coordinates various nonvisual components that track the user as they navigate along a predetermined route. You use `MapboxNavigationService`, which conforms to this protocol, either as part of `NavigationViewController` or by itself as part of a custom user interface. A navigation service calls methods on its `delegate`, which conforms to the `NavigationServiceDelegate` protocol, whenever significant events or decision points occur along the route.
  
@@ -47,7 +40,7 @@ public protocol DefaultInterfaceFlag {
  If you use a navigation service by itself, outside of `NavigationViewController`, call `start()` when the user is ready to begin navigating along the route.
  */
 @objc(MBNavigationService)
-public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, EventsManagerDataSource, DefaultInterfaceFlag {
+public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, EventsManagerDataSource {
     /**
      The location manager for the service. This will be the object responsible for notifying the service of GPS updates.
      */
@@ -125,7 +118,7 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
  If you use a navigation service by itself, outside of `NavigationViewController`, call `start()` when the user is ready to begin navigating along the route.
  */
 @objc(MBNavigationService)
-public class MapboxNavigationService: NSObject, NavigationService, DefaultInterfaceFlag {
+public class MapboxNavigationService: NSObject, NavigationService {
     
     typealias DefaultRouter = RouteController
     
@@ -215,16 +208,6 @@ public class MapboxNavigationService: NSObject, NavigationService, DefaultInterf
     var poorGPSTimer: DispatchTimer!
     private var isSimulating: Bool { return simulatedLocationSource != nil }
     private var _simulationSpeedMultiplier: Double = 1.0
-    
-    /// :nodoc: Internal Telemetry flag.
-    public var usesDefaultUserInterface: Bool {
-        get {
-            return eventsManager.usesDefaultUserInterface
-        }
-        set {
-            eventsManager.usesDefaultUserInterface = newValue
-        }
-    }
     
     /**
      Intializes a new `NavigationService`. Useful convienence initalizer for OBJ-C users, for when you just want to set up a service without customizing anything.

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -48,8 +48,7 @@ class NavigationServiceTests: XCTestCase {
     }
     
     func testDefaultUserInterfaceUsage() {
-        let service = dependencies.navigationService as? NavigationEventsManager
-        XCTAssertFalse(service?.usesDefaultUserInterface ?? true)
+        XCTAssertTrue(dependencies.navigationService.eventsManager.usesDefaultUserInterface, "MapboxCoreNavigationTests should have an implicit dependency on MapboxNavigation due to running inside the Example application target.")
     }
     
     func testUserIsOnRoute() {

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -47,6 +47,11 @@ class NavigationServiceTests: XCTestCase {
         delegate.reset()
     }
     
+    func testDefaultUserInterfaceUsage() {
+        let service = dependencies.navigationService as? NavigationEventsManager
+        XCTAssertFalse(service?.usesDefaultUserInterface ?? true)
+    }
+    
     func testUserIsOnRoute() {
         let navigation = dependencies.navigationService
         let firstLocation = dependencies.routeLocations.firstLocation

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -198,7 +198,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         super.init(nibName: nil, bundle: nil)
         
         self.navigationService = options?.navigationService ?? MapboxNavigationService(route: route)
-        self.navigationService.usesDefaultUserInterface = true
         self.navigationService.delegate = self
         self.voiceController = options?.voiceController ?? MapboxVoiceController(navigationService: navigationService, speechClient: SpeechSynthesizer(accessToken: navigationService?.directions.accessToken))
 


### PR DESCRIPTION
The user agent string for navigation events now varies based on whether the process has loaded the MapboxNavigation module. The previous implementation stopped working when mapbox/mapbox-navigation-ios#1602 decomposed the NavigationViewController initializer. The undocumented DefaultInterfaceFlag protocol is no longer relevant and has been removed.

/cc @mapbox/navigation-ios @mapbox/mobile-metrics