### PR TITLE
Adding method for progress updates on the NVC delegate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 * Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
-* Added `NavigationViewControllerDelegate.navigationViewController(_:didUpdate:location:rawLocation)` method that allows the client developer to capture progress updates without having to inject themselves between the `NavigationViewController` and the `NavigationService`.  ([#2224](https://github.com/mapbox/mapbox-navigation-ios/pull/2224))
+* Added `NavigationViewControllerDelegate.navigationViewController(_:didUpdate:location:rawLocation)` method that allows you to capture progress updates without having to inject a class between the `NavigationViewController` and the `NavigationService`.  ([#2224](https://github.com/mapbox/mapbox-navigation-ios/pull/2224))
 
 ## v0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 * Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
-* Added `NavigationViewControllerDelegate.navigationViewController(_:didUpdate:location:rawLocation)` method that allows the client developer to capture progress updates without having to inject themselves between the `NavigationViewController` and the `NavigationService`. 
+* Added `NavigationViewControllerDelegate.navigationViewController(_:didUpdate:location:rawLocation)` method that allows the client developer to capture progress updates without having to inject themselves between the `NavigationViewController` and the `NavigationService`.  ([#2224](https://github.com/mapbox/mapbox-navigation-ios/pull/2224))
 
 ## v0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 * Fixed an issue where swiping the banner down after the StepsTableViewController has already displayed could put the UI in an unstable state. ([#2197](https://github.com/mapbox/mapbox-navigation-ios/pull/2197))
+* Added `NavigationViewControllerDelegate.navigationViewController(_:didUpdate:location:rawLocation)` method that allows the client developer to capture progress updates without having to inject themselves between the `NavigationViewController` and the `NavigationService`. 
 
 ## v0.36.0
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -494,6 +494,9 @@ extension NavigationViewController: NavigationServiceDelegate {
             userHasArrivedAndShouldPreventRerouting {
             mapViewController?.mapView.updateCourseTracking(location: location, animated: true)
         }
+        
+        // Finally, pass the message onto the NVC delegate.
+        delegate?.navigationViewController?(self, didUpdate: progress, with: location, rawLocation: rawLocation)
     }
     
     @objc public func navigationService(_ service: NavigationService, didPassSpokenInstructionPoint instruction: SpokenInstruction, routeProgress: RouteProgress) {

--- a/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MapboxDirections
+import MapboxCoreNavigation
 
 /**
  The `NavigationViewControllerDelegate` protocol provides methods for configuring the map view shown by a `NavigationViewController` and responding to the cancellation of a navigation session.
@@ -15,6 +16,17 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      - parameter canceled: True if the user dismissed the navigation view controller by tapping the Cancel button; false if the navigation view controller dismissed by some other means.
      */
     @objc optional func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool)
+    
+    /**
+     Called when movement of the user updates the route progress model.
+     
+     - parameter navigationViewController: The ViewController that received the new locations.
+     - parameter progress: the RouteProgress model that was updated.
+     - parameter location: the guaranteed location, possibly snapped, associated with the progress update.
+     - parameter rawLocation: the raw location, from the location manager, associated with the progress update.
+     */
+    @objc(navigationViewController:didUpdateProgress:withLocation:rawLocation:)
+    optional func navigationViewController(_ navigationViewController: NavigationViewController, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation)
     
     /**
      Called as the user approaches a waypoint.


### PR DESCRIPTION
Fixes #2212 by adding a progress update method to `NavigationViewControllerDelegate`. 

/cc @mapbox/navigation-ios 