### PR TITLE
Timer memory leak

### DIFF
--- a/MapboxCoreNavigation/DispatchTimer.swift
+++ b/MapboxCoreNavigation/DispatchTimer.swift
@@ -61,10 +61,6 @@ public class DispatchTimer {
         timer.schedule(deadline: deadline, repeating: repetitionInterval, leeway: accuracy)
     }
     
-    private func fire() {
-        executionQueue.async(execute: payload)
-    }
-    
     /**
      Arm the timer. Countdown will begin after this function returns.
     */
@@ -72,7 +68,12 @@ public class DispatchTimer {
         guard state == .disarmed, !timer.isCancelled else { return }
         state = .armed
         scheduleTimer()
-        timer.setEventHandler(handler: fire)
+        timer.setEventHandler { [weak self] in
+            if let strongSelf = self {
+                strongSelf.executionQueue.async(execute: strongSelf.payload)
+            }
+            
+        }
         timer.resume()
     }
     

--- a/MapboxCoreNavigation/DispatchTimer.swift
+++ b/MapboxCoreNavigation/DispatchTimer.swift
@@ -69,8 +69,8 @@ public class DispatchTimer {
         state = .armed
         scheduleTimer()
         timer.setEventHandler { [weak self] in
-            if let strongSelf = self {
-                strongSelf.executionQueue.async(execute: strongSelf.payload)
+            if let unwrappedSelf = self {
+                unwrappedSelf.executionQueue.async(execute: unwrappedSelf.payload)
             }
             
         }


### PR DESCRIPTION
The way the dispatch timer code is currently written, it creates an invisible strong reference to self (via fire and payload). This leads to the block keeping the timers around in memory after usage, see screenshot.

<img width="1650" alt="Screenshot 2019-09-19 at 00 12 11" src="https://user-images.githubusercontent.com/645674/65192872-103f6980-da79-11e9-95d4-9b340d668fe0.png">


This PR fixes the issue by making the references to self explicit, and making them weak.