### PR TITLE
Update suggested usage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Alternatively, to install Mapbox Navigation using [Carthage](https://github.com/
 1. Mapbox APIs and vector tiles require a Mapbox account and API access token. In the project editor, select the application target, then go to the Info tab. Under the “Custom iOS Target Properties” section, set `MGLMapboxAccessToken` to your access token. You can obtain an access token from the [Mapbox account page](https://account.mapbox.com/access-tokens/).
 
 1. In order for the SDK to track the user’s location as they move along the route, set `NSLocationWhenInUseUsageDescription` to:
-   > Shows your location on the map and helps improve OpenStreetMap.
+   > Shows your location on the map and helps improve the map.
 
 1. Users expect the SDK to continue to track the user’s location and deliver audible instructions even while a different application is visible or the device is locked. Go to the Capabilities tab. Under the Background Modes section, enable “Audio, AirPlay, and Picture in Picture” and “Location updates”. (Alternatively, add the `audio` and `location` values to the `UIBackgroundModes` array in the Info tab.)
 

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -37,7 +37,7 @@ Alternatively, to install Mapbox Navigation using [Carthage](https://github.com/
 1. Mapbox APIs and vector tiles require a Mapbox account and API access token. In the project editor, select the application target, then go to the Info tab. Under the “Custom iOS Target Properties” section, set `MGLMapboxAccessToken` to your access token. You can obtain an access token from the [Mapbox account page](https://account.mapbox.com/access-tokens/).
 
 1. In order for the SDK to track the user’s location as they move along the route, set `NSLocationWhenInUseUsageDescription` to:
-   > Shows your location on the map and helps improve OpenStreetMap.
+   > Shows your location on the map and helps improve the map.
 
 1. Users expect the SDK to continue to track the user’s location and deliver audible instructions even while a different application is visible or the device is locked. Go to the Capabilities tab. Under the Background Modes section, enable “Audio, AirPlay, and Picture in Picture” and “Location updates”. (Alternatively, add the `audio` and `location` values to the `UIBackgroundModes` array in the Info tab.)
 


### PR DESCRIPTION
This PR changes the recommended `NSLocationWhenInUseUsageDescription` string that iOS displays when the application requests Location Services permissions and, as of iOS 13, periodically if the application receives Always permissions.

The new wording omits mention of OpenStreetMap, because a Location Services permission prompt isn’t the right place to name-check a project that most users are unfamiliar with. To a user who has never heard of OSM before, mentioning it here would make OSM seem like some mysterious third party – even though OSM doesn’t directly use or require the requested permissions – and leave them no better informed about how the location data would be used.

/cc @mapbox/navigation-ios @mapbox/maps-ios @mapbox/mobile-telemetry @mapbox/docs @mikelmaron