### PR TITLE
Fix maneuver icon orientation in user notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## master
+
+* Fixed an issue where user notifications displayed right turn arrows for left turn maneuvers. ([#2270](https://github.com/mapbox/mapbox-navigation-ios/pull/2270))
+
 ## v0.38.0
 
 * This library now requires a minimum deployment target of iOS 10.0 or above. iOS 9._x_ is no longer supported. ([#2206](https://github.com/mapbox/mapbox-navigation-ios/pull/2206))

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -338,8 +338,11 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
             content.subtitle = secondaryText
         }
         
-        if let image = instruction.primaryInstruction.maneuverImage(side: instruction.drivingSide, color: .black, size: CGSize(width: 72, height: 72)),
-            let imageData = image.pngData() {
+        if let image = instruction.primaryInstruction.maneuverImage(side: instruction.drivingSide, color: .black, size: CGSize(width: 72, height: 72)) {
+            // Bake in any transform required for left turn arrows etc.
+            let imageData = UIGraphicsImageRenderer(size: image.size).pngData { (context) in
+                image.draw(at: .zero)
+            }
             let temporaryURL = FileManager.default.temporaryDirectory.appendingPathComponent("com.mapbox.navigation.notification-icon.png")
             do {
                 try imageData.write(to: temporaryURL)


### PR DESCRIPTION
Fixed an issue where user notifications displayed right turn arrows for left turn maneuvers. The problem is that we were relying on metadata to flip the image to the left, but that metadata doesn’t get persisted to the image file that gets attached to the notification. The fix is to rerender the image into a new context.

<img src="https://user-images.githubusercontent.com/1231218/68730197-d83c3a80-0580-11ea-869e-d9e0043539d3.png" width="300" alt="left">

Fixes #2267.

/cc @mapbox/navigation-ios