### PR TITLE
Specify ManeuverView and LaneView as non-opaque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fixed an issue where manually incrementing `RouteProgress.legIndex` could lead to undefined behavior. ([#2229](https://github.com/mapbox/mapbox-navigation-ios/pull/2229))
 * `DistanceFormatter` now inherits directly from `Formatter` rather than `LengthFormatter`. ([#2206](https://github.com/mapbox/mapbox-navigation-ios/pull/2206))
 * Fixed an issue where `DistanceFormatter.attributedString(for:withDefaultAttributes:)` set `NSAttributedString.Key.quantity` to the original distance value rather than the potentially rounded value represented by the attributed string. ([#2206](https://github.com/mapbox/mapbox-navigation-ios/pull/2206))
+* Fixed an issue where a black background could be rendered in a ManeuverView under the arrow regardless of the backgroundColor set on the view. ([#2279](https://github.com/mapbox/mapbox-navigation-ios/pull/2279))
 
 ## v0.37.0
 

--- a/MapboxNavigation/LaneView.swift
+++ b/MapboxNavigation/LaneView.swift
@@ -58,7 +58,23 @@ open class LaneView: UIView {
         maneuverDirection = ManeuverDirection(description: component.indications.description)
         isValid = component.isUsable
     }
-    
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    @objc public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    func commonInit() {
+        // Explicitly mark the view as non-opaque.
+        // This is needed to obtain correct compositing since we implement our own draw function that includes transparency.
+        isOpaque = false
+    }
+
     override open func draw(_ rect: CGRect) {
         super.draw(rect)
         

--- a/MapboxNavigation/ManeuverView.swift
+++ b/MapboxNavigation/ManeuverView.swift
@@ -6,6 +6,23 @@ import Turf
 /// :nodoc:
 @IBDesignable
 open class ManeuverView: UIView {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    @objc public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    func commonInit() {
+        // Explicitly mark the view as non-opaque.
+        // This is needed to obtain correct compositing since we implement our own draw function that includes transparency.
+        isOpaque = false
+    }
+
     @objc public dynamic var primaryColor: UIColor = .defaultTurnArrowPrimary {
         didSet {
             setNeedsDisplay()


### PR DESCRIPTION
This is needed since they implement their own draw(rect:) functions and any transparent pixels will appear as black since they are not automatically blended and composited with the rest of the view hierarchy.