### PR TITLE
Set the foregroundColor of the ExitView and GenericShieldView to the datasource textColor before snapshotting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Renamed `NavigationMapView.showWaypoints(_:legIndex:)` to `NavigationMapView.showWaypoints(on:legIndex:)`. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
 * Renamed `MapboxVoiceController.play(_:)` to `MapboxVoiceController.play(instruction:data:)`. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
 * Fixed an issue where a black background could be rendered in a `ManeuverView` under the arrow regardless of the `backgroundColor` set on the view. ([#2279](https://github.com/mapbox/mapbox-navigation-ios/pull/2279))
-* Fixed an issue where the foregroundColor property of the `ExitView` and `GenericShieldView` were not being properly set to match the text color of the `InstructionPresenter` datasource. ([#2161](https://github.com/mapbox/mapbox-navigation-ios/issues/2161))
+* Fixed an issue where the wrong style was applied to exit numbers in the top banner and for subsequent maneuver banners in CarPlay, resulting in poor contrast. ([#2161](https://github.com/mapbox/mapbox-navigation-ios/issues/2161))
 
 ### Error handling
 * The `MapboxVoiceController` and `RouteVoiceController` now emit `SpeechError`s instead of an `NSError` object. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Renamed `NavigationMapView.showWaypoints(_:legIndex:)` to `NavigationMapView.showWaypoints(on:legIndex:)`. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
 * Renamed `MapboxVoiceController.play(_:)` to `MapboxVoiceController.play(instruction:data:)`. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
 * Fixed an issue where a black background could be rendered in a `ManeuverView` under the arrow regardless of the `backgroundColor` set on the view. ([#2279](https://github.com/mapbox/mapbox-navigation-ios/pull/2279))
+* Fixed an issue where the foregroundColor property of the `ExitView` and `GenericShieldView` were not being properly set to match the text color of the `InstructionPresenter` datasource. ([#2161](https://github.com/mapbox/mapbox-navigation-ios/issues/2161))
 
 ### Error handling
 * The `MapboxVoiceController` and `RouteVoiceController` now emit `SpeechError`s instead of an `NSError` object. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -153,8 +153,10 @@ public class ExitView: StylableView {
             let bgColor = backgroundColor, bgColor.responds(to: resolvedColorSelector),
             let fgColor = foregroundColor, fgColor.responds(to: resolvedColorSelector),
             let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
-            backgroundColor = bgColor.resolvedColor(with: currentTraitCollection)
-            foregroundColor = fgColor.resolvedColor(with: currentTraitCollection)
+            if let backgroundColorInstance = bgColor.perform(resolvedColorSelector, with: currentTraitCollection), let foregroundColorInstance = fgColor.perform(resolvedColorSelector, with: currentTraitCollection) {
+                backgroundColor = backgroundColorInstance.takeRetainedValue() as? UIColor
+                foregroundColor = foregroundColorInstance.takeRetainedValue() as? UIColor
+            }
         }
         let criticalProperties: [AnyHashable?] = [side, dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -146,7 +146,13 @@ public class ExitView: StylableView {
      */
     static func criticalHash(side: ExitSide, dataSource: DataSource) -> String {
         let proxy = ExitView.appearance()
-        let criticalProperties: [AnyHashable?] = [side, dataSource.font.pointSize, proxy.backgroundColor, proxy.foregroundColor, proxy.borderWidth, proxy.cornerRadius]
+        var backgroundColor = proxy.backgroundColor
+        var foregroundColor = proxy.foregroundColor
+        if #available(iOS 13.0, *), let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
+            backgroundColor = proxy.backgroundColor?.resolvedColor(with: currentTraitCollection)
+            foregroundColor = proxy.foregroundColor?.resolvedColor(with: currentTraitCollection)
+        }
+        let criticalProperties: [AnyHashable?] = [side, dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))
     }
 }

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -148,9 +148,10 @@ public class ExitView: StylableView {
         let proxy = ExitView.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
+        let resolvedColorSelector = Selector(("resolvedColorWithTraitCollection:" as NSString) as String)
         if #available(iOS 13.0, *),
-            let bgColor = backgroundColor, bgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
-            let fgColor = foregroundColor, fgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
+            let bgColor = backgroundColor, bgColor.responds(to: resolvedColorSelector),
+            let fgColor = foregroundColor, fgColor.responds(to: resolvedColorSelector),
             let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
             backgroundColor = bgColor.resolvedColor(with: currentTraitCollection)
             foregroundColor = fgColor.resolvedColor(with: currentTraitCollection)

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -148,9 +148,12 @@ public class ExitView: StylableView {
         let proxy = ExitView.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
-        if #available(iOS 13.0, *), let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
-            backgroundColor = proxy.backgroundColor?.resolvedColor(with: currentTraitCollection)
-            foregroundColor = proxy.foregroundColor?.resolvedColor(with: currentTraitCollection)
+        if #available(iOS 13.0, *),
+            let bgColor = backgroundColor, bgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
+            let fgColor = foregroundColor, fgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
+            let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
+            backgroundColor = bgColor.resolvedColor(with: currentTraitCollection)
+            foregroundColor = fgColor.resolvedColor(with: currentTraitCollection)
         }
         let criticalProperties: [AnyHashable?] = [side, dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))

--- a/MapboxNavigation/GenericRouteShield.swift
+++ b/MapboxNavigation/GenericRouteShield.swift
@@ -98,9 +98,12 @@ public class GenericRouteShield: StylableView {
         let proxy = GenericRouteShield.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
-        if #available(iOS 13.0, *), let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
-            backgroundColor = proxy.backgroundColor?.resolvedColor(with: currentTraitCollection)
-            foregroundColor = proxy.foregroundColor?.resolvedColor(with: currentTraitCollection)
+        if #available(iOS 13.0, *),
+            let bgColor = backgroundColor, bgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
+            let fgColor = foregroundColor, fgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
+            let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
+            backgroundColor = bgColor.resolvedColor(with: currentTraitCollection)
+            foregroundColor = fgColor.resolvedColor(with: currentTraitCollection)
         }
         let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))

--- a/MapboxNavigation/GenericRouteShield.swift
+++ b/MapboxNavigation/GenericRouteShield.swift
@@ -96,7 +96,13 @@ public class GenericRouteShield: StylableView {
      */
     static func criticalHash(dataSource: DataSource) -> String {
         let proxy = GenericRouteShield.appearance()
-        let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, proxy.backgroundColor, proxy.foregroundColor, proxy.borderWidth, proxy.cornerRadius]
+        var backgroundColor = proxy.backgroundColor
+        var foregroundColor = proxy.foregroundColor
+        if #available(iOS 13.0, *), let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
+            backgroundColor = proxy.backgroundColor?.resolvedColor(with: currentTraitCollection)
+            foregroundColor = proxy.foregroundColor?.resolvedColor(with: currentTraitCollection)
+        }
+        let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))
     }
 }

--- a/MapboxNavigation/GenericRouteShield.swift
+++ b/MapboxNavigation/GenericRouteShield.swift
@@ -98,9 +98,10 @@ public class GenericRouteShield: StylableView {
         let proxy = GenericRouteShield.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
+        let resolvedColorSelector = Selector(("resolvedColorWithTraitCollection:" as NSString) as String)
         if #available(iOS 13.0, *),
-            let bgColor = backgroundColor, bgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
-            let fgColor = foregroundColor, fgColor.responds(to: #selector(UIColor.resolvedColor(with:))),
+            let bgColor = backgroundColor, bgColor.responds(to: resolvedColorSelector),
+            let fgColor = foregroundColor, fgColor.responds(to: resolvedColorSelector),
             let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
             backgroundColor = bgColor.resolvedColor(with: currentTraitCollection)
             foregroundColor = fgColor.resolvedColor(with: currentTraitCollection)

--- a/MapboxNavigation/GenericRouteShield.swift
+++ b/MapboxNavigation/GenericRouteShield.swift
@@ -103,9 +103,11 @@ public class GenericRouteShield: StylableView {
             let bgColor = backgroundColor, bgColor.responds(to: resolvedColorSelector),
             let fgColor = foregroundColor, fgColor.responds(to: resolvedColorSelector),
             let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
-            backgroundColor = bgColor.resolvedColor(with: currentTraitCollection)
-            foregroundColor = fgColor.resolvedColor(with: currentTraitCollection)
-        }
+                if let backgroundColorInstance = bgColor.perform(resolvedColorSelector, with: currentTraitCollection), let foregroundColorInstance = fgColor.perform(resolvedColorSelector, with: currentTraitCollection) {
+                    backgroundColor = backgroundColorInstance.takeRetainedValue() as? UIColor
+                    foregroundColor = foregroundColorInstance.takeRetainedValue() as? UIColor
+                }
+            }
         let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))
     }

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -186,6 +186,7 @@ class InstructionPresenter {
             attachment.image = image
         } else {
             let view = GenericRouteShield(pointSize: dataSource.font.pointSize, text: text)
+            view.foregroundColor = dataSource.textColor
             guard let image = takeSnapshot(on: view) else { return nil }
             imageRepository.storeImage(image, forKey: key, toDisk: false)
             attachment.image = image
@@ -207,6 +208,7 @@ class InstructionPresenter {
             attachment.image = image
         } else {
             let view = ExitView(pointSize: dataSource.font.pointSize, side: side, text: text)
+            view.foregroundColor = dataSource.textColor
             guard let image = takeSnapshot(on: view) else { return nil }
             imageRepository.storeImage(image, forKey: key, toDisk: false)
             attachment.image = image


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-navigation-ios/issues/2161 and fixes https://github.com/mapbox/mapbox-navigation-ios/issues/2191