### PR TITLE
Require Xcode 11 to build SDK. #2281

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
         default: "12.2"
       xcode:
         type: string
-        default: "10.2.0"
+        default: "11.0.0"
       lint:
         type: boolean
         default: false
@@ -105,7 +105,7 @@ jobs:
     parameters:
       xcode:
         type: string
-        default: "10.1.0"
+        default: "11.0.0"
       device:
         type: string
         default: "iPhone 6 Plus"
@@ -157,9 +157,9 @@ jobs:
           steps:
             - run: bash <(curl -s https://codecov.io/bash)
 
-  xcode-10-examples:
+  xcode-11-examples:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.0.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -179,24 +179,24 @@ workflows:
           iOS: "13.1"
           device: "iPhone 8 Plus"
       - build-job:
-          name: "Xcode_10.3_iOS_12.1"
-          xcode: "10.3.0"
+          name: "Xcode_11_iOS_12.1"
+          xcode: "11.0.0"
           iOS: "12.1"
           codecoverage: true
       - build-job:
-          name: "Xcode_10.2_iOS_10.3.1"
-          xcode: "10.2.0"
+          name: "Xcode_11_iOS_10.3.1"
+          xcode: "11.0.0"
           iOS: "10.3.1"
           test: false
       - pod-job:
-          name: "Xcode_10.2_iOS_12.2_CP_install"
+          name: "Xcode_11_iOS_12.2_CP_install"
           update: false
-          xcode: "10.2.0"
+          xcode: "11.0.0"
           iOS: "12.2"
       - pod-job:
-          name: "Xcode_10.2_iOS_12.2_CP_update"
+          name: "Xcode_11_iOS_12.2_CP_update"
           update: true
-          xcode: "10.2.0"
+          xcode: "11.0.0"
           iOS: "12.2"
           lint: true
-      - xcode-10-examples
+      - xcode-11-examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
 ## master
+* Xcode 11 or above is now required for building this SDK. ([#2281](https://github.com/mapbox/mapbox-navigation-ios/issues/2281))
 
 ### Packaging
 * This library can no longer be used in applications written in pure Objective-C. If you need to use this library’s public API from Objective-C code, you will need to implement a wrapper in Swift that bridges the subset of the API you need from Swift to Objective-C. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Get up and running in a few minutes with our drop-in turn-by-turn navigation `Na
 
 ## Requirements
 
-The Mapbox Navigation SDK and Core Navigation are compatible with applications written in Swift 5 in Xcode 10.2 and above. The Mapbox Navigation and Mapbox Core Navigation frameworks run on iOS 10.0 and above.
+The Mapbox Navigation SDK and Core Navigation are compatible with applications written in Swift 5 in Xcode 11.0 and above. The Mapbox Navigation and Mapbox Core Navigation frameworks run on iOS 10.0 and above.
 
 The Mapbox Navigation SDK is also available [for Android](https://github.com/mapbox/mapbox-navigation-android/).
 


### PR DESCRIPTION
Fixes #2281.