### PR TITLE
Use built-in ISO date formatter

### DIFF
--- a/MapboxCoreNavigation/Date.swift
+++ b/MapboxCoreNavigation/Date.swift
@@ -5,10 +5,9 @@ extension Date {
         return Date.ISO8601Formatter.string(from: self)
     }
 
-    static let ISO8601Formatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    static let ISO8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = .withInternetDateTime
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
     }()


### PR DESCRIPTION
Now that we’ve dropped support for iOS 9._x_, use ISO8601DateFormatter instead of rolling our own ISO&nbsp;8601 date formatter.

/cc @mapbox/navigation-ios