### PR TITLE
Clean up RouteController user info keys

### DIFF
--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -88,8 +88,8 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
         // do not update if we are previewing instruction steps
         guard previewInstructionsView == nil else { return }
         
-        let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
-        let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
+        let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as! RouteProgress
+        let location = notification.userInfo![RouteController.NotificationUserInfoKey.locationKey] as! CLLocation
         
         // Add maneuver arrow
         if routeProgress.currentLegProgress.followOnStep != nil {
@@ -107,7 +107,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
     }
     
     @objc func updateInstructionsBanner(notification: NSNotification) {
-        guard let routeProgress = notification.userInfo?[RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress else { return }
+        guard let routeProgress = notification.userInfo?[RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress else { return }
         instructionsBannerView.update(for: routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction)
     }
 

--- a/MapboxCoreNavigation/CoreConstants.swift
+++ b/MapboxCoreNavigation/CoreConstants.swift
@@ -119,42 +119,42 @@ public extension Notification.Name {
     /**
      Posted when `RouteController` receives a user location update representing movement along the expected route.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey`, `RouteControllerNotificationUserInfoKey.locationKey`, and `RouteControllerNotificationUserInfoKey.rawLocationKey`.
+     The user info dictionary contains the keys `RouteController.NotificationUserInfoKey.routeProgressKey`, `RouteController.NotificationUserInfoKey.locationKey`, and `RouteController.NotificationUserInfoKey.rawLocationKey`.
      */
     static let routeControllerProgressDidChange: Notification.Name = .init(rawValue: "RouteControllerProgressDidChange")
     
     /**
      Posted after the user diverges from the expected route, just before `RouteController` attempts to calculate a new route.
      
-     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.locationKey`.
+     The user info dictionary contains the key `RouteController.NotificationUserInfoKey.locationKey`.
      */
     static let routeControllerWillReroute: Notification.Name = .init(rawValue: "RouteControllerWillReroute")
     
     /**
      Posted when `RouteController` obtains a new route in response to the user diverging from a previous route.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.locationKey` and `RouteControllerNotificationUserInfoKey.isProactiveKey`.
+     The user info dictionary contains the keys `RouteController.NotificationUserInfoKey.locationKey` and `RouteController.NotificationUserInfoKey.isProactiveKey`.
      */
     static let routeControllerDidReroute: Notification.Name = .init(rawValue: "RouteControllerDidReroute")
     
     /**
      Posted when `RouteController` fails to reroute the user after the user diverges from the expected route.
      
-     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.routingErrorKey`.
+     The user info dictionary contains the key `RouteController.NotificationUserInfoKey.routingErrorKey`.
      */
     static let routeControllerDidFailToReroute: Notification.Name = .init(rawValue: "RouteControllerDidFailToReroute")
     
     /**
      Posted when `RouteController` detects that the user has passed an ideal point for saying an instruction aloud.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.spokenInstructionKey`.
+     The user info dictionary contains the keys `RouteController.NotificationUserInfoKey.routeProgressKey` and `RouteController.NotificationUserInfoKey.spokenInstructionKey`.
      */
     static let routeControllerDidPassSpokenInstructionPoint: Notification.Name =  .init(rawValue: "RouteControllerDidPassSpokenInstructionPoint")
     
     /**
      Posted when `RouteController` detects that the user has passed an ideal point for display an instruction visually.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.visualInstructionKey`.
+     The user info dictionary contains the keys `RouteController.NotificationUserInfoKey.routeProgressKey` and `RouteController.NotificationUserInfoKey.visualInstructionKey`.
      */
     static let routeControllerDidPassVisualInstructionPoint: Notification.Name = .init(rawValue: "RouteControllerDidPassVisualInstructionPoint")
     
@@ -166,52 +166,54 @@ public extension Notification.Name {
     static let navigationSettingsDidChange: Notification.Name = .init(rawValue: "NavigationSettingsDidChange")
 }
 
-/**
- Keys in the user info dictionaries of various notifications posted by instances
- of `RouteController`.
- */
-public struct RouteControllerNotificationUserInfoKey: Hashable, Equatable, RawRepresentable {
-    public typealias RawValue = String
+extension RouteController {
+    /**
+     Keys in the user info dictionaries of various notifications posted by instances
+     of `RouteController`.
+     */
+    public struct NotificationUserInfoKey: Hashable, Equatable, RawRepresentable {
+        public typealias RawValue = String
 
-    public var rawValue: String
+        public var rawValue: String
 
-    public init(rawValue: String) {
-        self.rawValue = rawValue
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange`, `Notification.Name.routeControllerDidPassVisualInstructionPoint`, or `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is a `RouteProgress` object representing the current route progress.
+         */
+        public static let routeProgressKey: NotificationUserInfoKey = .init(rawValue: "progress")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange`, `Notification.Name.routeControllerWillReroute`, or `Notification.Name.routeControllerDidReroute` notification. The corresponding value is a `CLLocation` object representing the current idealized user location.
+         */
+        public static let locationKey: NotificationUserInfoKey = .init(rawValue: "location")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange` notification. The corresponding value is a `CLLocation` object representing the current raw user location.
+         */
+        public static let rawLocationKey: NotificationUserInfoKey = .init(rawValue: "rawLocation")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.routeControllerDidFailToReroute` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.
+         */
+        public static let routingErrorKey: NotificationUserInfoKey = .init(rawValue: "error")
+        
+        /**
+         A key in the user info dictionary of an `Notification.Name.routeControllerDidPassVisualInstructionPoint`. The corresponding value is an `VisualInstruction` object representing the current visual instruction.
+         */
+        public static let visualInstructionKey: NotificationUserInfoKey = .init(rawValue: "visualInstruction")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is an `SpokenInstruction` object representing the current visual instruction.
+         */
+        public static let spokenInstructionKey: NotificationUserInfoKey = .init(rawValue: "spokenInstruction")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.routeControllerDidReroute` notification. The corresponding value is an `NSNumber` instance containing a Boolean value indicating whether `RouteController` proactively rerouted the user onto a faster route.
+         */
+        public static let isProactiveKey: NotificationUserInfoKey = .init(rawValue: "RouteControllerDidFindFasterRoute")
     }
-    
-    /**
-     A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange`, `Notification.Name.routeControllerDidPassVisualInstructionPoint`, or `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is a `RouteProgress` object representing the current route progress.
-     */
-    public static let routeProgressKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "progress")
-    
-    /**
-     A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange`, `Notification.Name.routeControllerWillReroute`, or `Notification.Name.routeControllerDidReroute` notification. The corresponding value is a `CLLocation` object representing the current idealized user location.
-     */
-    public static let locationKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "location")
-    
-    /**
-     A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange` notification. The corresponding value is a `CLLocation` object representing the current raw user location.
-     */
-    public static let rawLocationKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "rawLocation")
-    
-    /**
-     A key in the user info dictionary of a `Notification.Name.routeControllerDidFailToReroute` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.
-     */
-    public static let routingErrorKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "error")
-    
-    /**
-     A key in the user info dictionary of an `Notification.Name.routeControllerDidPassVisualInstructionPoint`. The corresponding value is an `VisualInstruction` object representing the current visual instruction.
-     */
-    public static let visualInstructionKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "visualInstruction")
-    
-    /**
-     A key in the user info dictionary of a `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is an `SpokenInstruction` object representing the current visual instruction.
-     */
-    public static let spokenInstructionKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "spokenInstruction")
-    
-    /**
-     A key in the user info dictionary of a `Notification.Name.routeControllerDidReroute` notification. The corresponding value is an `NSNumber` instance containing a Boolean value indicating whether `RouteController` proactively rerouted the user onto a faster route.
-     */
-    public static let isProactiveKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "RouteControllerDidFindFasterRoute")
 }
 

--- a/MapboxCoreNavigation/CoreConstants.swift
+++ b/MapboxCoreNavigation/CoreConstants.swift
@@ -119,7 +119,7 @@ public extension Notification.Name {
     /**
      Posted when `RouteController` receives a user location update representing movement along the expected route.
      
-     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.locationKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey`, `RouteControllerNotificationUserInfoKey.locationKey`, and `RouteControllerNotificationUserInfoKey.rawLocationKey`.
      */
     static let routeControllerProgressDidChange: Notification.Name = .init(rawValue: "RouteControllerProgressDidChange")
     
@@ -147,14 +147,14 @@ public extension Notification.Name {
     /**
      Posted when `RouteController` detects that the user has passed an ideal point for saying an instruction aloud.
      
-     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.routeProgressKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.spokenInstructionKey`.
      */
     static let routeControllerDidPassSpokenInstructionPoint: Notification.Name =  .init(rawValue: "RouteControllerDidPassSpokenInstructionPoint")
     
     /**
      Posted when `RouteController` detects that the user has passed an ideal point for display an instruction visually.
      
-     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.routeProgressKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.visualInstructionKey`.
      */
     static let routeControllerDidPassVisualInstructionPoint: Notification.Name = .init(rawValue: "MBRouteControllerDidPassVisualInstructionPoint")
     
@@ -162,7 +162,6 @@ public extension Notification.Name {
      Posted when something changes in the shared `NavigationSettings` object.
      
      The user info dictionary indicates which keys and values changed.
-     
      */
     static let navigationSettingsDidChange: Notification.Name = .init(rawValue: "MBNavigationSettingsDidChange")
 }
@@ -181,37 +180,37 @@ public struct RouteControllerNotificationUserInfoKey: Hashable, Equatable, RawRe
     }
     
     /**
-     A key in the user info dictionary of a `routeControllerProgressDidChange`, `routeControllerDidPassVisualInstructionPoint`, or `routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is a `RouteProgress` object representing the current route progress.
+     A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange`, `Notification.Name.routeControllerDidPassVisualInstructionPoint`, or `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is a `RouteProgress` object representing the current route progress.
      */
     public static let routeProgressKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "progress")
     
     /**
-     A key in the user info dictionary of a `routeControllerProgressDidChange` or `routeControllerWillReroute` notification. The corresponding value is a `CLLocation` object representing the current idealized user location.
+     A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange`, `Notification.Name.routeControllerWillReroute`, or `Notification.Name.routeControllerDidReroute` notification. The corresponding value is a `CLLocation` object representing the current idealized user location.
      */
     public static let locationKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "location")
     
     /**
-     A key in the user info dictionary of a `routeControllerProgressDidChange` or `routeControllerWillReroute` notification. The corresponding value is a `CLLocation` object representing the current raw user location.
+     A key in the user info dictionary of a `Notification.Name.routeControllerProgressDidChange` notification. The corresponding value is a `CLLocation` object representing the current raw user location.
      */
     public static let rawLocationKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "rawLocation")
     
     /**
-     A key in the user info dictionary of a `routeControllerDidFailToReroute` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.
+     A key in the user info dictionary of a `Notification.Name.routeControllerDidFailToReroute` notification. The corresponding value is an `NSError` object indicating why `RouteController` was unable to calculate a new route.
      */
     public static let routingErrorKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "error")
     
     /**
-     A key in the user info dictionary of an `routeControllerDidPassVisualInstructionPoint`. The corresponding value is an `VisualInstruction` object representing the current visual instruction.
+     A key in the user info dictionary of an `Notification.Name.routeControllerDidPassVisualInstructionPoint`. The corresponding value is an `VisualInstruction` object representing the current visual instruction.
      */
     public static let visualInstructionKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "visualInstruction")
     
     /**
-     A key in the user info dictionary of a `routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is an `SpokenInstruction` object representing the current visual instruction.
+     A key in the user info dictionary of a `Notification.Name.routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is an `SpokenInstruction` object representing the current visual instruction.
      */
     public static let spokenInstructionKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "spokenInstruction")
     
     /**
-     A key in the user info dictionary of a `routeControllerDidReroute` notification. The corresponding value is an `NSNumber` instance containing a Boolean value indicating whether `RouteController` proactively rerouted the user onto a faster route.
+     A key in the user info dictionary of a `Notification.Name.routeControllerDidReroute` notification. The corresponding value is an `NSNumber` instance containing a Boolean value indicating whether `RouteController` proactively rerouted the user onto a faster route.
      */
     public static let isProactiveKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "RouteControllerDidFindFasterRoute")
 }

--- a/MapboxCoreNavigation/CoreConstants.swift
+++ b/MapboxCoreNavigation/CoreConstants.swift
@@ -119,47 +119,47 @@ public extension Notification.Name {
     /**
      Posted when `RouteController` receives a user location update representing movement along the expected route.
      
-     The user info dictionary contains the keys `MBRouteControllerRouteProgressKey` and `MBRouteControllerLocationKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.locationKey`.
      */
     static let routeControllerProgressDidChange: Notification.Name = .init(rawValue: "RouteControllerProgressDidChange")
     
     /**
      Posted after the user diverges from the expected route, just before `RouteController` attempts to calculate a new route.
      
-     The user info dictionary contains the key `MBRouteControllerLocationKey`.
+     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.locationKey`.
      */
     static let routeControllerWillReroute: Notification.Name = .init(rawValue: "RouteControllerWillReroute")
     
     /**
      Posted when `RouteController` obtains a new route in response to the user diverging from a previous route.
      
-     The user info dictionary contains the keys `MBRouteControllerLocationKey` and `MBRouteControllerIsProactiveKey`.
+     The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.locationKey` and `RouteControllerNotificationUserInfoKey.isProactiveKey`.
      */
     static let routeControllerDidReroute: Notification.Name = .init(rawValue: "RouteControllerDidReroute")
     
     /**
      Posted when `RouteController` fails to reroute the user after the user diverges from the expected route.
      
-     The user info dictionary contains the key `MBRouteControllerRoutingErrorKey`.
+     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.routingErrorKey`.
      */
     static let routeControllerDidFailToReroute: Notification.Name = .init(rawValue: "RouteControllerDidFailToReroute")
     
     /**
      Posted when `RouteController` detects that the user has passed an ideal point for saying an instruction aloud.
      
-     The user info dictionary contains the key `MBRouteControllerRouteProgressKey`.
+     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.routeProgressKey`.
      */
     static let routeControllerDidPassSpokenInstructionPoint: Notification.Name =  .init(rawValue: "RouteControllerDidPassSpokenInstructionPoint")
     
     /**
      Posted when `RouteController` detects that the user has passed an ideal point for display an instruction visually.
      
-     The user info dictionary contains the key `MBRouteControllerRouteProgressKey`.
+     The user info dictionary contains the key `RouteControllerNotificationUserInfoKey.routeProgressKey`.
      */
     static let routeControllerDidPassVisualInstructionPoint: Notification.Name = .init(rawValue: "MBRouteControllerDidPassVisualInstructionPoint")
     
     /**
-     Posted when something changes in the shared `MBNavigationSettings` object.
+     Posted when something changes in the shared `NavigationSettings` object.
      
      The user info dictionary indicates which keys and values changed.
      
@@ -201,12 +201,12 @@ public struct RouteControllerNotificationUserInfoKey: Hashable, Equatable, RawRe
     public static let routingErrorKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "error")
     
     /**
-     A key in the user info dictionary of an `routeControllerDidPassVisualInstructionPoint`. The corresponding value is an `MBVisualInstruction` object representing the current visual instruction.
+     A key in the user info dictionary of an `routeControllerDidPassVisualInstructionPoint`. The corresponding value is an `VisualInstruction` object representing the current visual instruction.
      */
     public static let visualInstructionKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "visualInstruction")
     
     /**
-     A key in the user info dictionary of a `routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is an `MBSpokenInstruction` object representing the current visual instruction.
+     A key in the user info dictionary of a `routeControllerDidPassSpokenInstructionPoint` notification. The corresponding value is an `SpokenInstruction` object representing the current visual instruction.
      */
     public static let spokenInstructionKey: RouteControllerNotificationUserInfoKey = .init(rawValue: "spokenInstruction")
     

--- a/MapboxCoreNavigation/CoreConstants.swift
+++ b/MapboxCoreNavigation/CoreConstants.swift
@@ -156,14 +156,14 @@ public extension Notification.Name {
      
      The user info dictionary contains the keys `RouteControllerNotificationUserInfoKey.routeProgressKey` and `RouteControllerNotificationUserInfoKey.visualInstructionKey`.
      */
-    static let routeControllerDidPassVisualInstructionPoint: Notification.Name = .init(rawValue: "MBRouteControllerDidPassVisualInstructionPoint")
+    static let routeControllerDidPassVisualInstructionPoint: Notification.Name = .init(rawValue: "RouteControllerDidPassVisualInstructionPoint")
     
     /**
      Posted when something changes in the shared `NavigationSettings` object.
      
      The user info dictionary indicates which keys and values changed.
      */
-    static let navigationSettingsDidChange: Notification.Name = .init(rawValue: "MBNavigationSettingsDidChange")
+    static let navigationSettingsDidChange: Notification.Name = .init(rawValue: "NavigationSettingsDidChange")
 }
 
 /**

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -291,10 +291,10 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             
             //Fire the notification (for now)
             NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: [
-                RouteControllerNotificationUserInfoKey.routeProgressKey: progress,
-                RouteControllerNotificationUserInfoKey.locationKey: location, //guaranteed value
-                RouteControllerNotificationUserInfoKey.rawLocationKey: rawLocation //raw
-                ])
+                RouteController.NotificationUserInfoKey.routeProgressKey: progress,
+                RouteController.NotificationUserInfoKey.locationKey: location, //guaranteed value
+                RouteController.NotificationUserInfoKey.rawLocationKey: rawLocation, //raw
+            ])
         }
     }
         
@@ -342,7 +342,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
 
         delegate?.router(self, willRerouteFrom: location)
         NotificationCenter.default.post(name: .routeControllerWillReroute, object: self, userInfo: [
-            RouteControllerNotificationUserInfoKey.locationKey: location
+            RouteController.NotificationUserInfoKey.locationKey: location,
         ])
 
         self.lastRerouteLocation = location
@@ -356,7 +356,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             if let error = error {
                 strongSelf.delegate?.router(strongSelf, didFailToRerouteWith: error)
                 NotificationCenter.default.post(name: .routeControllerDidFailToReroute, object: self, userInfo: [
-                    RouteControllerNotificationUserInfoKey.routingErrorKey: error
+                    RouteController.NotificationUserInfoKey.routingErrorKey: error,
                 ])
                 return
             }
@@ -467,8 +467,8 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             if userSnapToStepDistanceFromManeuver <= spokenInstruction.distanceAlongStep || firstInstructionOnFirstStep {
                 delegate?.router(self, didPassSpokenInstructionPoint: spokenInstruction, routeProgress: routeProgress)
                 NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: [
-                    RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress,
-                    RouteControllerNotificationUserInfoKey.spokenInstructionKey: spokenInstruction
+                    RouteController.NotificationUserInfoKey.routeProgressKey: routeProgress,
+                    RouteController.NotificationUserInfoKey.spokenInstructionKey: spokenInstruction,
                 ])
 
                 routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex += 1
@@ -486,8 +486,8 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             if userSnapToStepDistanceFromManeuver <= visualInstruction.distanceAlongStep || isFirstLocation {
                 delegate?.router(self, didPassVisualInstructionPoint: visualInstruction, routeProgress: routeProgress)
                 NotificationCenter.default.post(name: .routeControllerDidPassVisualInstructionPoint, object: self, userInfo: [
-                    RouteControllerNotificationUserInfoKey.routeProgressKey: routeProgress,
-                    RouteControllerNotificationUserInfoKey.visualInstructionKey: visualInstruction,
+                    RouteController.NotificationUserInfoKey.routeProgressKey: routeProgress,
+                    RouteController.NotificationUserInfoKey.visualInstructionKey: visualInstruction,
                 ])
                 currentStepProgress.visualInstructionIndex += 1
                 return

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -298,9 +298,9 @@ open class RouteController: NSObject {
             
             //Fire the notification (for now)
             NotificationCenter.default.post(name: .routeControllerProgressDidChange, object: self, userInfo: [
-                RouteControllerNotificationUserInfoKey.routeProgressKey: progress,
-                RouteControllerNotificationUserInfoKey.locationKey: location, //guaranteed value
-                RouteControllerNotificationUserInfoKey.rawLocationKey: rawLocation //raw
+                NotificationUserInfoKey.routeProgressKey: progress,
+                NotificationUserInfoKey.locationKey: location, //guaranteed value
+                NotificationUserInfoKey.rawLocationKey: rawLocation, //raw
                 ])
         }
     }
@@ -308,9 +308,9 @@ open class RouteController: NSObject {
     private func announcePassage(of spokenInstructionPoint: SpokenInstruction, routeProgress: RouteProgress) {
         delegate?.router(self, didPassSpokenInstructionPoint: spokenInstructionPoint, routeProgress: routeProgress)
         
-        let info: [RouteControllerNotificationUserInfoKey: Any] = [
+        let info: [NotificationUserInfoKey: Any] = [
             .routeProgressKey: routeProgress,
-            .spokenInstructionKey: spokenInstructionPoint
+            .spokenInstructionKey: spokenInstructionPoint,
         ]
         
         NotificationCenter.default.post(name: .routeControllerDidPassSpokenInstructionPoint, object: self, userInfo: info)
@@ -319,9 +319,9 @@ open class RouteController: NSObject {
     private func announcePassage(of visualInstructionPoint: VisualInstructionBanner, routeProgress: RouteProgress) {
         delegate?.router(self, didPassVisualInstructionPoint: visualInstructionPoint, routeProgress: routeProgress)
         
-        let info: [RouteControllerNotificationUserInfoKey: Any] = [
+        let info: [NotificationUserInfoKey: Any] = [
             .routeProgressKey: routeProgress,
-            .visualInstructionKey: visualInstructionPoint
+            .visualInstructionKey: visualInstructionPoint,
         ]
         
         NotificationCenter.default.post(name: .routeControllerDidPassVisualInstructionPoint, object: self, userInfo: info)
@@ -376,8 +376,8 @@ extension RouteController: Router {
         
         delegate?.router(self, willRerouteFrom: location)
         NotificationCenter.default.post(name: .routeControllerWillReroute, object: self, userInfo: [
-            RouteControllerNotificationUserInfoKey.locationKey: location
-            ])
+            NotificationUserInfoKey.locationKey: location,
+        ])
         
         self.lastRerouteLocation = location
         
@@ -395,8 +395,8 @@ extension RouteController: Router {
             if let error = error {
                 strongSelf.delegate?.router(strongSelf, didFailToRerouteWith: error)
                 NotificationCenter.default.post(name: .routeControllerDidFailToReroute, object: self, userInfo: [
-                    RouteControllerNotificationUserInfoKey.routingErrorKey: error
-                    ])
+                    NotificationUserInfoKey.routingErrorKey: error,
+                ])
                 return
             }
             

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -178,7 +178,7 @@ extension InternalRouter where Self: Router {
     }
     
     func announce(reroute newRoute: Route, at location: CLLocation?, proactive: Bool) {
-        var userInfo = [RouteControllerNotificationUserInfoKey: Any]()
+        var userInfo = [RouteController.NotificationUserInfoKey: Any]()
         if let location = location {
             userInfo[.locationKey] = location
         }

--- a/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -118,7 +118,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
     }
     
     @objc private func progressDidChange(_ notification: Notification) {
-        routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
+        routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
     }
     
     @objc private func didReroute(_ notification: Notification) {

--- a/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -59,7 +59,7 @@ class MapboxCoreNavigationTests: XCTestCase {
                                                                   timestamp: now + $0.offset) }
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation.router) { (notification) -> Bool in
-            let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
+            let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
             
             return routeProgress != nil && routeProgress?.currentLegProgress.userHasArrivedAtWaypoint == false
         }
@@ -88,7 +88,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         
         navigation = MapboxNavigationService(route: route, directions: directions, simulating: .never)
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation.router) { (notification) -> Bool in
-            let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
+            let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
             
             return routeProgress?.currentLegProgress.stepIndex == 2
         }
@@ -114,7 +114,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         navigation = MapboxNavigationService(route: route, directions: directions, locationSource: locationManager, simulating: .never)
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: navigation.router) { (notification) -> Bool in
-            let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
+            let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
             return routeProgress?.currentLegProgress.stepIndex == 4
         }
         
@@ -149,7 +149,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         expectation(forNotification: .routeControllerWillReroute, object: navigation.router) { (notification) -> Bool in
             XCTAssertEqual(notification.userInfo?.count, 1)
             
-            let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as? CLLocation
+            let location = notification.userInfo![RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
             return location?.coordinate == offRouteLocations[1].coordinate
         }
         
@@ -176,7 +176,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         navigation = MapboxNavigationService(route: route, directions: directions, locationSource: locationManager, simulating: .never)
 
         expectation(forNotification: .routeControllerProgressDidChange, object: navigation.router) { (notification) -> Bool in
-            let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
+            let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
             return routeProgress != nil
         }
 
@@ -239,7 +239,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         var points = [InstructionPoint]()
         
         expectation(forNotification: .routeControllerDidPassSpokenInstructionPoint, object: nil) { (notification) -> Bool in
-            let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
+            let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as! RouteProgress
             let legIndex = routeProgress.legIndex
             let stepIndex = routeProgress.currentLegProgress.stepIndex
             let spokenInstructionIndex = routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex
@@ -252,7 +252,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         }
         
         expectation(forNotification: .routeControllerDidPassVisualInstructionPoint, object: nil) { (notification) -> Bool in
-            let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
+            let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as! RouteProgress
             let legIndex = routeProgress.legIndex
             let stepIndex = routeProgress.currentLegProgress.stepIndex
             let spokenInstructionIndex = routeProgress.currentLegProgress.currentStepProgress.spokenInstructionIndex

--- a/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -252,16 +252,16 @@ class NavigationServiceTests: XCTestCase {
         navigationService.eventsManager.delaysEventFlushing = false
         
         let willRerouteNotificationExpectation = expectation(forNotification: .routeControllerWillReroute, object: router) { (notification) -> Bool in
-            let fromLocation = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as? CLLocation
+            let fromLocation = notification.userInfo![RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
             return fromLocation == testLocation
         }
         
         let didRerouteNotificationExpectation = expectation(forNotification: .routeControllerDidReroute, object: router, handler: nil)
         
         let routeProgressDidChangeNotificationExpectation = expectation(forNotification: .routeControllerProgressDidChange, object: router) { (notification) -> Bool in
-            let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as? CLLocation
-            let rawLocation = notification.userInfo![RouteControllerNotificationUserInfoKey.rawLocationKey] as? CLLocation
-            let _ = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
+            let location = notification.userInfo![RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
+            let rawLocation = notification.userInfo![RouteController.NotificationUserInfoKey.rawLocationKey] as? CLLocation
+            let _ = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as! RouteProgress
             
             return location!.distance(from: rawLocation!) <= 0.0005
         }
@@ -442,7 +442,7 @@ class NavigationServiceTests: XCTestCase {
         let locationManager = NavigationLocationManager()
         
         let _ = expectation(forNotification: .routeControllerDidReroute, object: router) { (notification) -> Bool in
-            let isProactive = notification.userInfo![RouteControllerNotificationUserInfoKey.isProactiveKey] as? Bool
+            let isProactive = notification.userInfo![RouteController.NotificationUserInfoKey.isProactiveKey] as? Bool
             return isProactive == true
         }
         let rerouteExpectation = expectation(description: "Proactive reroute should trigger")

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -286,15 +286,15 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
     }
     
     @objc func visualInstructionDidChange(_ notification: NSNotification) {
-        let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
+        let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as! RouteProgress
         updateManeuvers(for: routeProgress)
         mapView?.showWaypoints(on: routeProgress.route)
         mapView?.addArrow(route: routeProgress.route, legIndex: routeProgress.legIndex, stepIndex: routeProgress.currentLegProgress.stepIndex + 1)
     }
     
     @objc func progressDidChange(_ notification: NSNotification) {
-        let routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
-        let location = notification.userInfo![RouteControllerNotificationUserInfoKey.locationKey] as! CLLocation
+        let routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as! RouteProgress
+        let location = notification.userInfo![RouteController.NotificationUserInfoKey.locationKey] as! CLLocation
         
         // Update the user puck
         mapView?.updatePreferredFrameRate(for: routeProgress)

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -82,7 +82,7 @@ open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {
     }
     
     open override func didPassSpokenInstructionPoint(notification: NSNotification) {
-        let routeProgresss = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as! RouteProgress
+        let routeProgresss = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as! RouteProgress
         locale = routeProgresss.route.routeOptions.locale
         let currentLegProgress: RouteLegProgress = routeProgresss.currentLegProgress
         

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -134,7 +134,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     
     @objc func didReroute(notification: NSNotification) {
         // Play reroute sound when a faster route is found
-        if notification.userInfo?[RouteControllerNotificationUserInfoKey.isProactiveKey] as! Bool {
+        if notification.userInfo?[RouteController.NotificationUserInfoKey.isProactiveKey] as! Bool {
             pauseSpeechAndPlayReroutingDing(notification: notification)
         }
     }
@@ -213,7 +213,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     @objc open func didPassSpokenInstructionPoint(notification: NSNotification) {
         guard !NavigationSettings.shared.voiceMuted else { return }
         
-        routeProgress = notification.userInfo![RouteControllerNotificationUserInfoKey.routeProgressKey] as? RouteProgress
+        routeProgress = notification.userInfo![RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
         assert(routeProgress != nil, "routeProgress should not be nil.")
 
         guard let instruction = routeProgress!.currentLegProgress.currentStepProgress.currentSpokenInstruction else { return }

--- a/MapboxNavigation/Style.swift
+++ b/MapboxNavigation/Style.swift
@@ -50,7 +50,7 @@ open class Style: NSObject {
 
 /**
  :nodoc:
- `MBButton` sets the tintColor according to the style.
+ `Button` sets the tintColor according to the style.
  */
 @objc(MBButton)
 open class Button: StylableButton { }

--- a/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
+++ b/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
@@ -64,8 +64,10 @@ fileprivate class CarPlayNavigationViewControllerTests: XCTestCase {
         //create the subject and notification
         let subject = CarPlayNavigationViewController(navigationService: navService, mapTemplate: mapSpy, interfaceController: interface, manager: manager)
         subject.startNavigationSession(for: trip)
-        let payload: [RouteControllerNotificationUserInfoKey:Any] = [.routeProgressKey : navService.routeProgress,
-                                                                     .locationKey: location]
+        let payload: [RouteController.NotificationUserInfoKey: Any] = [
+            .routeProgressKey: navService.routeProgress,
+            .locationKey: location,
+        ]
         let fakeNotication = NSNotification(name: .routeControllerProgressDidChange, object: navService.router, userInfo: payload)
         
         //fire the fake notification

--- a/MapboxNavigationTests/MapboxVoiceControllerTests.swift
+++ b/MapboxNavigationTests/MapboxVoiceControllerTests.swift
@@ -34,7 +34,9 @@ class MapboxVoiceControllerTests: XCTestCase {
     func testControllerDownloadsAndCachesInstructionDataWhenNotified() {
         let service = MapboxNavigationService(route: route)
         let subject = MapboxVoiceController(navigationService: service, speechClient: speechAPISpy, audioPlayerType: AudioPlayerDummy.self)
-        let userInfo = [RouteControllerNotificationUserInfoKey.routeProgressKey : service.routeProgress]
+        let userInfo = [
+            RouteController.NotificationUserInfoKey.routeProgressKey: service.routeProgress,
+        ]
         let notification = Notification.init(name: .routeControllerDidPassSpokenInstructionPoint, object: service.router, userInfo: userInfo)
 
         NotificationCenter.default.post(notification)


### PR DESCRIPTION
#2230 left some references to Objective-C symbols in documentation comments. This PR updates the references to the corresponding Swift symbols. It also renames RouteControllerNotificationUserInfoKey to RouteController.NotificationUserInfoKey.

/cc @mapbox/navigation-ios