### PR TITLE
Add taginfo project file

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -174,17 +174,17 @@
     {
       "key": "turn:lanes",
       "object_types": ["way"],
-      "description": "📱🔨 🚗 Shown in top banner. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
+      "description": "📱🔨 🚗 Shown in top banner. None values may cause entire tag to be ignored. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
     },
     {
       "key": "turn:lanes:forward",
       "object_types": ["way"],
-      "description": "📱🔨 🚗 Shown in top banner. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
+      "description": "📱🔨 🚗 Shown in top banner. None values may cause entire tag to be ignored. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
     },
     {
       "key": "turn:lanes:backward",
       "object_types": ["way"],
-      "description": "📱🔨 🚗 Shown in top banner. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
+      "description": "📱🔨 🚗 Shown in top banner. None values may cause entire tag to be ignored. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
     },
     {
       "key": "type",

--- a/taginfo.json
+++ b/taginfo.json
@@ -1,0 +1,196 @@
+{
+  "data_format": 1,
+  "project": {
+    "name": "Mapbox Navigation SDK for iOS",
+    "description": "User interface and components for turn-by-turn navigation in iOS applications for iPhone, iPad, and CarPlay. Powered by the Mapbox Directions API. Some tags are 📱 shown in UI, 🗣 spoken out loud, or 🔨 available in code. Some tags are limited to 🚗 driving, 🚲 cycling, or 👟 walking profiles.",
+    "project_url": "https://docs.mapbox.com/ios/navigation/",
+    "doc_url": "http://docs.mapbox.com/ios/api/navigation/",
+    "icon_url": "https://static-assets.mapbox.com/branding/favicon/v1/favicon-16x16.png",
+    "contact_name": "Minh Nguyen",
+    "contact_email": "minh@mapbox.com"
+  },
+  "tags": [
+    {
+      "key": "access",
+      "value": "private",
+      "object_types": ["way"],
+      "description": "🔨 In code, the Intersection.outletRoadClasses property is set to RoadClasses.restricted."
+    },
+    {
+      "key": "bridge",
+      "value": "movable",
+      "object_types": ["way"],
+      "description": "🔨 🚗🚲 In code, RouteStep.transportType is set to TransportType.movableBridge."
+    },
+    {
+      "key": "destination",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. Common words abbreviated. Interpreted as semicolon-delimited list. In code, use the RouteStep.destinations property."
+    },
+    {
+      "key": "destination:forward",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. Common words abbreviated. Interpreted as semicolon-delimited list. In code, use the RouteStep.destinations property."
+    },
+    {
+      "key": "destination:backward",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. Common words abbreviated. Interpreted as semicolon-delimited list. In code, use the RouteStep.destinations property."
+    },
+    {
+      "key": "destination:street",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance if destination=* is unspecified. Common words abbreviated. Interpreted as semicolon-delimited list. In code, use the RouteStep.destinations property."
+    },
+    {
+      "key": "destination:ref",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. Common words abbreviated. Interpreted as semicolon-delimited list. In 🇺🇸, represented by route shield image chosen based on prefix and/or containing state. In code, use the RouteStep.destinationCodes property."
+    },
+    {
+      "key": "destination:ref:forward",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. Common words abbreviated. Interpreted as semicolon-delimited list. In 🇺🇸, represented by route shield image chosen based on prefix and/or containing state. In code, use the RouteStep.destinationCodes property."
+    },
+    {
+      "key": "destination:ref:backward",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. Common words abbreviated. Interpreted as semicolon-delimited list. In 🇺🇸, represented by route shield image chosen based on prefix and/or containing state. In code, use the RouteStep.destinationCodes property."
+    },
+    {
+      "key": "driving_side",
+      "object_types": ["way"],
+      "description": "📱🔨 🚗 Affects roundabout icons in top banner and step table and U-turn lane icons in top banner. In code, use the RouteStep.drivingSide property."
+    },
+    {
+      "key": "highway",
+      "value": "footway",
+      "object_types": ["way"],
+      "description": "🔨 👟 In code, adjust the RouteOptions.walkwayPriority property to try to prefer or avoid the way. Valhalla-powered profiles only."
+    },
+    {
+      "key": "highway",
+      "value": "motorway",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Generally suppresses name=* in top banner, step table, and voice guidance if ref=* is specified. In code, the Intersection.outletRoadClasses property is set to RoadClasses.motorway. Set the RouteOptions.roadClassesToAvoid property to RoadClasses.motorway to avoid the way."
+    },
+    {
+      "key": "highway",
+      "value": "motorway_link",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. In code, the RouteStep.maneuverType property is set to ManeuverType.takeOnRamp or ManeuverType.takeOffRamp. In code, the Intersection.outletRoadClasses property is set to RoadClasses.motorway. Set the RouteOptions.roadClassesToAvoid property to RoadClasses.motorway to avoid the way."
+    },
+    {
+      "key": "highway",
+      "value": "trunk",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Generally suppresses name=* in top banner, step table, and voice guidance if ref=* is specified. In code, the Intersection.outletRoadClasses property is set to RoadClasses.motorway. Set the RouteOptions.roadClassesToAvoid property to RoadClasses.motorway to avoid the way."
+    },
+    {
+      "key": "highway",
+      "value": "trunk_link",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in top banner and step table and mentioned in voice guidance. In code, the RouteStep.maneuverType property is set to ManeuverType.takeOnRamp or ManeuverType.takeOffRamp. Set the RouteOptions.roadClassesToAvoid property to RoadClasses.motorway to avoid the way."
+    },
+    {
+      "key": "hov",
+      "object_types": ["way"],
+      "description": "🔨 In code, the Intersection.outletRoadClasses property is set to RoadClasses.restricted."
+    },
+    {
+      "key": "junction:ref",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 🚗 Shown in top banner and step table and mentioned in voice guidance. Interpreted as semicolon-delimited list. In code, use the RouteStep.exitCodes property."
+    },
+    {
+      "key": "junction",
+      "value": "circular",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 🚗 Shown in top banner and step table and mentioned in voice guidance. In code, the RouteStep.maneuverType property is set to ManeuverType.takeRotary and ManeuverType.exitRotary."
+    },
+    {
+      "key": "junction",
+      "value": "roundabout",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 🚗 Shown in top banner and step table and mentioned in voice guidance. In code, the RouteStep.maneuverType property is set to ManeuverType.takeRoundabout and ManeuverType.exitRoundabout (ManeuverType.turnAtRoundabout for roundabouts with very small diameter)."
+    },
+    {
+      "key": "maxspeed",
+      "object_types": ["way"],
+      "description": "📱🔨 🚗 Shown in corner of map. Converted into the local speed unit and rounded to the nearest 5. In code, use the RouteLeg.segmentMaximumSpeedLimits or RouteLegProgress.currentSpeedLimit property. OSRM-powered profiles only."
+    },
+    {
+      "key": "maxspeed:forward",
+      "object_types": ["way"],
+      "description": "📱🔨 🚗 Shown in corner of map. Converted into the local speed unit and rounded to the nearest 5. In code, use the RouteLeg.segmentMaximumSpeedLimits or RouteLegProgress.currentSpeedLimit property. OSRM-powered profiles only."
+    },
+    {
+      "key": "maxspeed:backward",
+      "object_types": ["way"],
+      "description": "📱🔨 🚗 Shown in corner of map. Converted into the local speed unit and rounded to the nearest 5. In code, use the RouteLeg.segmentMaximumSpeedLimits or RouteLegProgress.currentSpeedLimit property. OSRM-powered profiles only."
+    },
+    {
+      "key": "name",
+      "object_types": ["way"],
+      "description": "📱🗣🔨 Shown in current road name label at bottom of map, shown in top banner and step table, and mentioned in voice guidance. Common words abbreviated except in voice guidance. Pronounced according to current application language and name:pronunciation=*. In code, use the RouteStep.names property (RouteStep.exitNames if junction=circular/roundabout). The RouteLeg.description and Waypoint.name properties may contain the way’s name."
+    },
+    {
+      "key": "name:pronunciation",
+      "object_types": ["way"],
+      "description": "🗣🔨 Affects voice guidance, subject to TTS engine support. Interpreted as IPA in semicolon-delimited list. In code, use the RouteStep.phoneticNames property (RouteStep.phoneticExitNames if junction=circular). OSRM-powered profiles only."
+    },
+    {
+      "key": "ref",
+      "object_types": ["node", "way"],
+      "description": "📱🗣🔨 For highway=* ways and highway=motorway_junction nodes, values are shown in top banner and step table and mentioned in voice guidance. Interpreted as semicolon-delimited list. For highway=* ways in 🇺🇸, represented by route shield image chosen based on prefix and/or containing state. In code, use the RouteStep.codes property."
+    },
+    {
+      "key": "railway",
+      "object_types": ["way"],
+      "description": "🔨 🚲 In code, RouteStep.transportType is set to TransportType.train."
+    },
+    {
+      "key": "route",
+      "value": "ferry",
+      "object_types": ["way"],
+      "description": "🔨 In code, RouteStep.transportType is set to TransportType.ferry. Set the RouteOptions.roadClassesToAvoid property to RoadClasses.ferry to avoid the way."
+    },
+    {
+      "key": "service",
+      "value": "alley",
+      "object_types": ["way"],
+      "description": "🔨 👟 In code, adjust the RouteOptions.alleyPriority property to try to prefer or avoid the way. Valhalla-powered profiles only."
+    },
+    {
+      "key": "toll",
+      "object_types": ["way"],
+      "description": "🔨 In code, the Intersection.outletRoadClasses property is set to RoadClasses.toll. Set the RouteOptions.roadClassesToAvoid property to RoadClasses.toll to avoid the way."
+    },
+    {
+      "key": "tunnel",
+      "object_types": ["way"],
+      "description": "📱🔨 All UI elements, including the map, switch to night/dark style, even during the day. In code, the Intersection.outletRoadClasses property is set to RoadClasses.tunnel. Set the RouteOptions.roadClassesToAvoid property to RoadClasses.tunnel to avoid the way."
+    },
+    {
+      "key": "turn:lanes",
+      "object_types": ["way"],
+      "description": "📱🔨 🚗 Shown in top banner. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
+    },
+    {
+      "key": "turn:lanes:forward",
+      "object_types": ["way"],
+      "description": "📱🔨 🚗 Shown in top banner. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
+    },
+    {
+      "key": "turn:lanes:backward",
+      "object_types": ["way"],
+      "description": "📱🔨 🚗 Shown in top banner. In OSRM-powered profiles, values that conflict with OSRM turn angle heuristics are ignored unless overridden by manoeuvre relations. In code, use the Lane.indications property and the indications argument of VisualInstruction.Component.lane(indications:isUsable:)."
+    },
+    {
+      "key": "type",
+      "value": "route",
+      "object_types": ["relation"],
+      "description": "📱🗣 🚗 A north/south/east/west role causes cardinal direction to appear in top banner and step table and be mentioned in voice guidance after each ref=* or destination:ref=* value."
+    }
+  ]
+}


### PR DESCRIPTION
Between MapboxDirections.swift and the navigation SDK, at least 34 OpenStreetMap keys or tags are used in notable ways beyond how [OSRM](https://github.com/Project-OSRM/osrm-backend/blob/master/taginfo.json) and [Valhalla](https://github.com/valhalla/valhalla/blob/master/taginfo.json) use them. This JSON file documents the SDK’s usage for the [taginfo](http://taginfo.openstreetmap.org/) website, which OSM contributors rely on to discover tags and learn how to use them. Documenting these tags in the context of the SDK promotes better coverage in OSM (and thus the navigation SDK) and raises awareness about the practical needs of navigation applications among members of the OSM community.

/cc @mapbox/mobile-navigation-team @mapbox/navigation-api @mapbox/docs