### PR TITLE
Add conversions between Turf and MGLShape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Removed the `NavigationViewController.carPlayManager(_:didBeginNavigationWith:window:delegate:)` and `NavigationViewController.carPlayManagerDidEndNavigation(_:window:)` methods. To mirror CarPlay navigation on the main device, present and dismiss a `NavigationViewController` in the `CarPlayManagerDelegate.carPlayManager(_:didBeginNavigationWith:)` and `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:)` methods, respectively. ([#2297](https://github.com/mapbox/mapbox-navigation-ios/pull/2297))
 * When Dark Mode is enabled, user notifications now draw maneuver icons in white instead of black for better contrast. ([#2283](https://github.com/mapbox/mapbox-navigation-ios/pull/2283))
 * Added the `RouteLegProgress.currentSpeedLimit` property. ([#2114](https://github.com/mapbox/mapbox-navigation-ios/pull/2114))
+* Added convenience initializers for converting Turf geometry structures into `MGLShape` and `MGLFeature` objects such as `MGLPolyline` and `MGLPolygonFeature`. ([#2308](https://github.com/mapbox/mapbox-navigation-ios/pull/2308))
 
 ## v0.38.2
 

--- a/MapboxCoreNavigation/RouteLeg.swift
+++ b/MapboxCoreNavigation/RouteLeg.swift
@@ -2,7 +2,7 @@ import MapboxDirections
 import Turf
 
 extension RouteLeg {
-    var shape: LineString {
+    public var shape: LineString {
         return steps.dropFirst().reduce(into: steps.first?.shape ?? LineString([])) { (result, step) in
             result.coordinates += (step.shape?.coordinates ?? []).dropFirst()
         }

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		DA3525702010A5210048DDFC /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DA35256E2010A5200048DDFC /* Localizable.stringsdict */; };
 		DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA443DDD2278C90E00ED1307 /* CPTrip.swift */; };
 		DA66063023B32F99007832E5 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA66062F23B32F99007832E5 /* Array.swift */; };
+		DA67EA5623CAF345001686EA /* MGLShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA67EA5523CAF345001686EA /* MGLShape.swift */; };
 		DA8805002316EAED00B54D87 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
 		DA8F3A7623B5D84900B56786 /* SpeedLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7523B5D84900B56786 /* SpeedLimitView.swift */; };
 		DA8F3A7823B5DB7900B56786 /* SpeedLimitStyleKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7723B5DB7900B56786 /* SpeedLimitStyleKit.swift */; };
@@ -982,6 +983,7 @@
 		DA678B7B1F6CF46600F05913 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA678B7C1F6CF47200F05913 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA678B7D1F6CF47A00F05913 /* vi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DA67EA5523CAF345001686EA /* MGLShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLShape.swift; sourceTree = "<group>"; };
 		DA73F87820BF851B0067649B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = Resources/de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA8264851F2AAD8400454B24 /* zh-Hant */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Main.strings"; sourceTree = "<group>"; };
 		DA8264871F2AADC200454B24 /* zh-Hant */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Navigation.strings"; sourceTree = "<group>"; };
@@ -1557,6 +1559,7 @@
 				351BEBDF1E5BCC63006FE110 /* MGLMapView.swift */,
 				35D825F91E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.h */,
 				35D825FA1E6A2DBE0088F83B /* MGLMapView+MGLNavigationAdditions.m */,
+				DA67EA5523CAF345001686EA /* MGLShape.swift */,
 				353E3C8E20A3501C00FD1789 /* MGLStyle.swift */,
 				C58159001EA6D02700FC6C3D /* MGLVectorTileSource.swift */,
 				8D5DFFF0207C04840093765A /* NSAttributedString.swift */,
@@ -2399,6 +2402,7 @@
 				AE47A32C22B1F6AE0096458C /* InstructionsCardViewController.swift in Sources */,
 				358E31D622562698009B3EC2 /* CarPayCompassView.swift in Sources */,
 				AE47A33322B1F6AE0096458C /* Constants+InstructionsCard.swift in Sources */,
+				DA67EA5623CAF345001686EA /* MGLShape.swift in Sources */,
 				8D9ADEA720A0C61A0067E845 /* GenericRouteShield.swift in Sources */,
 				35DC9D911F4323AA001ECD64 /* LanesView.swift in Sources */,
 				AE7DE6C421A47A03002653D1 /* CarPlaySearchController.swift in Sources */,

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -275,13 +275,13 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
             } else if tracksUserCourse && !newValue {
                 isOverviewingRoutes = !isPanningAway
                 guard let userLocation = self.navigationService.router.location?.coordinate,
-                    let coordinates = navigationService.route.shape?.coordinates else {
+                    let shape = navigationService.route.shape else {
                     return
                 }
                 mapView?.enableFrameByFrameCourseViewTracking(for: 1)
                 mapView?.contentInset = contentInset(forOverviewing: isOverviewingRoutes)
                 if (isOverviewingRoutes) {
-                    mapView?.setOverheadCameraView(from: userLocation, along: coordinates, for: contentInset(forOverviewing: true))
+                    mapView?.setOverheadCameraView(from: userLocation, along: shape, for: contentInset(forOverviewing: true))
                 }
             }
         }

--- a/MapboxNavigation/MGLShape.swift
+++ b/MapboxNavigation/MGLShape.swift
@@ -1,0 +1,131 @@
+import Mapbox
+import Turf
+
+extension MGLPointAnnotation {
+    /**
+     Initializes a map point representation of the given Turf point.
+     
+     - parameter point: The Turf point to convert to a map point.
+     */
+    public convenience init(_ point: Point) {
+        self.init()
+        coordinate = point.coordinates
+    }
+}
+
+extension MGLPointFeature {
+    /**
+     Initializes a map point feature representation of the given Turf point feature.
+     
+     - parameter pointFeature: The Turf point feature to convert to a map point feature.
+     */
+    public convenience init(_ pointFeature: PointFeature) {
+        self.init(pointFeature.geometry)
+        identifier = pointFeature.identifier
+        attributes = pointFeature.properties ?? [:]
+    }
+}
+
+extension MGLPolyline {
+    /**
+     Initializes a map polyline representation of the given Turf linestring.
+     
+     - parameter lineString: The Turf linestring to convert to a map polyline.
+     */
+    public convenience init(_ lineString: LineString) {
+        self.init(coordinates: lineString.coordinates, count: UInt(lineString.coordinates.count))
+    }
+}
+
+extension MGLPolylineFeature {
+    /**
+     Initializes a map polyline feature representation of the given Turf linestring feature.
+     
+     - parameter lineStringFeature: The Turf linestring feature to convert to a map polyline feature.
+     */
+    public convenience init(_ lineStringFeature: LineStringFeature) {
+        self.init(lineStringFeature.geometry)
+        identifier = lineStringFeature.identifier
+        attributes = lineStringFeature.properties ?? [:]
+    }
+}
+
+extension MGLMultiPolyline {
+    /**
+     Initializes a map multipolyline representation of the given Turf multi linestring.
+     
+     - parameter lineString: The Turf multilinestring to convert to a map multipolyline.
+     */
+    public convenience init(_ multiLineString: MultiLineString) {
+        let polylines = multiLineString.coordinates.map { MGLPolyline(LineString($0)) }
+        self.init(polylines: polylines)
+    }
+}
+
+extension MGLMultiPolylineFeature {
+    /**
+     Initializes a map multipolyline feature representation of the given Turf multilinestring feature.
+     
+     - parameter multiLineStringFeature: The Turf multilinestring feature to convert to a map multipolyline feature.
+     */
+    public convenience init(_ multiLineStringFeature: MultiLineStringFeature) {
+        self.init(multiLineStringFeature.geometry)
+        identifier = multiLineStringFeature.identifier
+        attributes = multiLineStringFeature.properties ?? [:]
+    }
+}
+
+extension MGLPolygon {
+    /**
+     Initializes a map polygon representation of the given Turf ring.
+     
+     - parameter ring: The Turf ring to convert to a map polygon.
+     */
+    public convenience init(_ ring: Ring) {
+        self.init(coordinates: ring.coordinates, count: UInt(ring.coordinates.count))
+    }
+    
+    /**
+     Initializes a map polygon representation of the given Turf polygon.
+     
+     - parameter ring: The Turf ring to convert to a map polygon.
+     */
+    public convenience init(_ polygon: Polygon) {
+        let outerCoordinates = polygon.outerRing.coordinates
+        let interiorPolygons = polygon.innerRings?.map { MGLPolygon($0) }
+        self.init(coordinates: outerCoordinates, count: UInt(outerCoordinates.count), interiorPolygons: interiorPolygons)
+    }
+}
+
+extension MGLPolygonFeature {
+    /**
+     Initializes a map polygon feature representation of the given Turf polygon feature.
+     
+     - parameter polygonFeature: The Turf polygon feature to convert to a map polygon feature.
+     */
+    public convenience init(_ polygonFeature: PolygonFeature) {
+        self.init(polygonFeature.geometry)
+        identifier = polygonFeature.identifier
+        attributes = polygonFeature.properties ?? [:]
+    }
+}
+
+extension MGLMultiPolygon {
+    public convenience init(_ multiPolygon: MultiPolygon) {
+        let polygons = multiPolygon.coordinates.map { MGLPolygon(Polygon($0)) }
+        self.init(polygons: polygons)
+    }
+}
+
+extension MGLMultiPolygonFeature {
+    /**
+     Initializes a map multipolygon feature representation of the given Turf multipolygon feature.
+     
+     - parameter multipolygonFeature: The Turf multipolygon feature to convert to a map multipolygon feature.
+     */
+    public convenience init(_ multiPolygonFeature: MultiPolygonFeature) {
+        self.init(multiPolygonFeature.geometry)
+        identifier = multiPolygonFeature.identifier
+        attributes = multiPolygonFeature.properties ?? [:]
+    }
+}

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -414,10 +414,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     }
     
     func fit(to route: Route, facing direction:CLLocationDirection = 0, animated: Bool = false) {
-        guard let coords = route.shape?.coordinates, !coords.isEmpty else { return }
+        guard let shape = route.shape, !shape.coordinates.isEmpty else { return }
       
         setUserTrackingMode(.none, animated: false, completionHandler: nil)
-        let line = MGLPolyline(coordinates: coords, count: UInt(coords.count))
+        let line = MGLPolyline(shape)
         
         // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/15574
         // Set content insets .zero, before cameraThatFitsShape + setCamera.
@@ -775,7 +775,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         var altRoutes: [MGLPolylineFeature] = []
         
         for route in routes.suffix(from: 1) {
-            let polyline = MGLPolylineFeature(coordinates: route.shape!.coordinates, count: UInt(route.shape!.coordinates.count))
+            let polyline = MGLPolylineFeature(route.shape!)
             polyline.attributes["isAlternateRoute"] = true
             altRoutes.append(polyline)
         }
@@ -809,7 +809,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
                     return polyline
                 }
             } else {
-                lines = [MGLPolylineFeature(coordinates: route.shape!.coordinates, count: UInt(route.shape!.coordinates.count))]
+                lines = [MGLPolylineFeature(route.shape!)]
             }
             
             for line in lines {
@@ -848,11 +848,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         var linesPerLeg: [MGLPolylineFeature] = []
         
         for (index, leg) in route.legs.enumerated() {
-            let legCoordinates: [CLLocationCoordinate2D] = Array(leg.steps.compactMap {
-                $0.shape?.coordinates
-            }.joined())
-            
-            let polyline = MGLPolylineFeature(coordinates: legCoordinates, count: UInt(legCoordinates.count))
+            let polyline = MGLPolylineFeature(leg.shape)
             if let legIndex = legIndex {
                 polyline.attributes[MBCurrentLegAttribute] = index == legIndex
             } else {
@@ -1046,10 +1042,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     /**
      Sets the camera directly over a series of coordinates.
      */
-    public func setOverheadCameraView(from userLocation: CLLocationCoordinate2D, along coordinates: [CLLocationCoordinate2D], for padding: UIEdgeInsets) {
+    public func setOverheadCameraView(from userLocation: CLLocationCoordinate2D, along lineString: LineString, for padding: UIEdgeInsets) {
         isAnimatingToOverheadMode = true
         
-        let line = MGLPolyline(coordinates: coordinates, count: UInt(coordinates.count))
+        let line = MGLPolyline(lineString)
         
         tracksUserCourse = false
         

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -238,10 +238,10 @@ class RouteMapViewController: UIViewController {
 
     @objc func toggleOverview(_ sender: Any) {
         mapView.enableFrameByFrameCourseViewTracking(for: 3)
-        if let coordinates = router.route.shape?.coordinates,
+        if let shape = router.route.shape,
             let userLocation = router.location?.coordinate {
             mapView.contentInset = contentInset(forOverviewing: true)
-            mapView.setOverheadCameraView(from: userLocation, along: coordinates, for: contentInset(forOverviewing: true))
+            mapView.setOverheadCameraView(from: userLocation, along: shape, for: contentInset(forOverviewing: true))
         }
         isInOverviewMode = true
     }
@@ -412,9 +412,9 @@ class RouteMapViewController: UIViewController {
         guard let height = navigationView.endOfRouteHeightConstraint?.constant else { return }
         let insets = UIEdgeInsets(top: topBannerContainerView.bounds.height, left: 20, bottom: height + 20, right: 20)
         
-        if let coordinates = route.shape?.coordinates, let userLocation = navService.router.location?.coordinate {
-            let slicedLine = Polyline(coordinates).sliced(from: userLocation).coordinates
-            let line = MGLPolyline(coordinates: slicedLine, count: UInt(slicedLine.count))
+        if let shape = route.shape, let userLocation = navService.router.location?.coordinate {
+            let slicedLineString = shape.sliced(from: userLocation)
+            let line = MGLPolyline(slicedLineString)
 
             let camera = navigationView.mapView.cameraThatFitsShape(line, direction: navigationView.mapView.camera.heading, edgePadding: insets)
             camera.pitch = 0
@@ -491,9 +491,9 @@ extension RouteMapViewController: NavigationComponent {
         }
         
         if isInOverviewMode {
-            if let coordinates = route.shape?.coordinates, let userLocation = router.location?.coordinate {
+            if let shape = route.shape, let userLocation = router.location?.coordinate {
                 mapView.contentInset = contentInset(forOverviewing: true)
-                mapView.setOverheadCameraView(from: userLocation, along: coordinates, for: contentInset(forOverviewing: true))
+                mapView.setOverheadCameraView(from: userLocation, along: shape, for: contentInset(forOverviewing: true))
             }
         } else {
             mapView.tracksUserCourse = true


### PR DESCRIPTION
Factored out convenience initializers for converting Turf geometry structures into `MGLShape` and `MGLFeature` objects such as `MGLPolyline` and `MGLPolygonFeature`. These conversions happen quite frequently in the codebase but the process was too verbose.

/cc @mapbox/navigation-ios @mapbox/maps-ios