### PR TITLE
Document default initializers in place

### DIFF
--- a/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -24,7 +24,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
      - returns: True to allow the navigation service to calculate a new route; false to keep tracking the current route.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, shouldRerouteFrom location: CLLocation) -> Bool
     
@@ -35,7 +34,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation)
     
@@ -47,7 +45,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that discarded the location.
      - parameter location: The location that will be discarded.
      - returns: If `true`, the location is discarded and the `NavigationService` will not consider it. If `false`, the location will not be thrown out.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, shouldDiscard location: CLLocation) -> Bool
     
@@ -58,7 +55,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter route: The new route.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool)
     
@@ -69,7 +65,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didFailToRerouteWith error: Error)
     
@@ -80,7 +75,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter progress: the RouteProgress model that was updated.
      - parameter location: the guaranteed location, possibly snapped, associated with the progress update.
      - parameter rawLocation: the raw location, from the location manager, associated with the progress update.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation)
     
@@ -89,7 +83,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that passed the instruction point.
      - parameter instruction: The instruction to be presented.
      - parameter routeProgress: The route progress object that the navigation service is updating.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress)
     
@@ -98,7 +91,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that passed the instruction point.
      - parameter instruction: The instruction to be spoken.
      - parameter routeProgress: The route progress object that the navigation service is updating.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didPassSpokenInstructionPoint instruction: SpokenInstruction, routeProgress: RouteProgress)
     
@@ -111,7 +103,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter remainingTimeInterval: The estimated number of seconds until arrival.
      - parameter distance: The current distance from the waypoint, in meters.
      - important: This method will likely be called several times as you approach a destination. If only one consumption of this method is desired, then usage of an internal flag is recommended.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, willArriveAt waypoint: Waypoint, after remainingTimeInterval:TimeInterval, distance: CLLocationDistance)
     
@@ -124,7 +115,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that has arrived at a waypoint.
      - parameter waypoint: The waypoint that the controller has arrived at.
      - returns: True to advance to the next leg, if any, or false to remain on the completed leg.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didArriveAt waypoint: Waypoint) -> Bool
     
@@ -136,7 +126,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that has arrived at a waypoint.
      - parameter waypoint: The waypoint that the controller has arrived at.
      - returns: True to prevent the navigation service from checking if the user should be rerouted.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, shouldPreventReroutesWhenArrivingAt waypoint: Waypoint) -> Bool
     
@@ -147,7 +136,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      
      - parameter service: The navigation service that will change the state of battery monitoring.
      - returns: A bool indicating whether to disable battery monitoring when the RouteController is deinited.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationServiceShouldDisableBatteryMonitoring(_ service: NavigationService) -> Bool
     
@@ -159,7 +147,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that will simulate the routes' progress.
      - parameter progress: the current RouteProgress model.
      - parameter reason: The reason the simulation will be initiated. Either manual or poorGPS.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent)
     
@@ -171,7 +158,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that is simulating the routes' progress.
      - parameter progress: the current RouteProgress model.
      - parameter reason: The reason the simulation has been initiated. Either manual or poorGPS.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent)
     
@@ -183,7 +169,6 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that is simulating the routes' progress.
      - parameter progress: the current RouteProgress model.
      - parameter reason: The reason the simulation was initiated. Either manual or poorGPS.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent)
     
@@ -195,76 +180,124 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter service: The navigation service that was simulating the routes' progress.
      - parameter progress: the current RouteProgress model.
      - parameter reason: The reason the simulation was initiated. Either manual or poorGPS.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationService(_ service: NavigationService, didEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent)
 }
 
 public extension NavigationServiceDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, shouldRerouteFrom location: CLLocation) -> Bool {
         logUnimplemented( protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.shouldRerouteFromLocation
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, shouldDiscard location: CLLocation) -> Bool {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.shouldDiscardLocation
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .info)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didFailToRerouteWith error: Error) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .info)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didPassSpokenInstructionPoint instruction: SpokenInstruction, routeProgress: RouteProgress) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, willArriveAt waypoint: Waypoint, after remainingTimeInterval: TimeInterval, distance: CLLocationDistance) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didArriveAt waypoint: Waypoint) -> Bool {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.didArriveAtWaypoint
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, shouldPreventReroutesWhenArrivingAt waypoint: Waypoint) -> Bool {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.shouldPreventReroutesWhenArrivingAtWaypoint
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationServiceShouldDisableBatteryMonitoring(_ service: NavigationService) -> Bool {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.shouldDisableBatteryMonitoring
     }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, didEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }

--- a/MapboxCoreNavigation/UnimplementedLogging.swift
+++ b/MapboxCoreNavigation/UnimplementedLogging.swift
@@ -10,11 +10,13 @@ import Dispatch
  The default method implementations should be provided as part of the protocol or an extension thereof. If the default implementations reside in an extension, the extension should have the same visibility level as the protocol itself.
  */
 public protocol UnimplementedLogging {
+    /**
+     Prints a warning to standard output.
+     */
     func logUnimplemented(protocolType: Any, level: OSLogType, function: String)
 }
 
 public extension UnimplementedLogging {
-        
     func logUnimplemented(protocolType: Any, level: OSLogType, function: String = #function) {
         
         let protocolDescription = String(describing: protocolType)
@@ -31,7 +33,7 @@ public extension UnimplementedLogging {
         }
         
         let log = OSLog(subsystem: "com.mapbox.navigation", category: "delegation.\(selfDescription)")
-        let formatted: StaticString = "Unimplemented Delegate Method in %@: %@.%@. This message will only be logged once."
+        let formatted: StaticString = "Unimplemented delegate method in %@: %@.%@. This message will only be logged once."
         os_log(formatted, log: log, type: level, selfDescription, protocolDescription, function)
         unimplementedTestLogs?.append((selfDescription, function))
         warned.append(description)

--- a/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -36,7 +36,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter carPlayTemplate: The template into which the returned bar buttons will be inserted.
      - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
      - returns: An array of bar buttons to display on the trailing side of the navigation bar while `template` is visible.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in carPlayTemplate: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]?
    
@@ -51,7 +50,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter carPlayTemplate: The template into which the returned map buttons will be inserted.
      - parameter activity: What the user is currently doing on the CarPlay screen. Use this parameter to distinguish between multiple templates of the same kind, such as multiple `CPMapTemplate`s.
      - returns: An array of map buttons to display on the map while `template` is visible.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in carPlayTemplate: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]?
     
@@ -62,7 +60,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter route: The route for which the returned route controller will manage location updates.
      - parameter desiredSimulationMode: The desired simulation mode to use.
      - returns: A navigation service that manages location updates along `route`.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, navigationServiceAlong route: Route, desiredSimulationMode: SimulationMode) -> NavigationService
     
@@ -73,7 +70,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter searchTemplate: The search template currently accepting user input.
      - parameter searchText: The updated search text in `searchTemplate`.
      - parameter completionHandler: Called when the search is complete. Accepts a list of search results.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      
      - postcondition: You must call `completionHandler` within this method.
      */
@@ -86,7 +82,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter searchTemplate: The search template currently accepting user input.
      - parameter item: The search result the user has selected.
      - parameter completionHandler: Called when the delegate is done responding to the selection.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      
      - postcondition: You must call `completionHandler` within this method.
      */
@@ -99,7 +94,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter options: The route options that were attached to the route request.
      - parameter error: The error returned from the directions API.
      - returns: Optionally, a `CPNavigationAlert` to present to the user. If this method returns an alert, the CarPlay manager will transition back to the map template and display the alert. If it returns `nil`, the CarPlay manager will do nothing.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, didFailToFetchRouteBetween waypoints: [Waypoint]?, options: RouteOptions, error: DirectionsError) -> CPNavigationAlert?
     
@@ -111,7 +105,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter carPlayManager: The CarPlay manager instance.
      - parameter trip: The trip that will be previewed.
      - returns: The actual trip to be previewed. This can be the same trip or a new/alternate trip if desired.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, willPreview trip: CPTrip) -> (CPTrip)
 
@@ -122,7 +115,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter trip: The trip that will be previewed.
      - parameter previewTextConfiguration: The trip preview text configuration that will be presented alongside the trip.
      - returns: The actual preview text configuration to be presented alongside the trip.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, willPreview trip: CPTrip, with previewTextConfiguration: CPTripPreviewTextConfiguration) -> (CPTripPreviewTextConfiguration)
 
@@ -132,7 +124,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - parameter carPlayManager: The CarPlay manager instance.
      - parameter trip: The trip to begin navigating along.
      - parameter routeChoice: The possible route for the chosen trip.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, selectedPreviewFor trip: CPTrip, using routeChoice: CPRouteChoice) -> ()
     
@@ -141,7 +132,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      
      - parameter carPlayManager: The CarPlay manager instance.
      - parameter service: The navigation service that has begun managing location updates for a navigation session.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith service: NavigationService) -> ()
     
@@ -149,7 +139,6 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      Called when navigation ends so that the containing app can update accordingly.
      
      - parameter carPlayManager: The CarPlay manager instance.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) -> ()
     
@@ -160,63 +149,98 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      
      - parameter carPlayManager: The CarPlay manager instance.
      - returns: A Boolean value indicating whether to disable idle timer when carplay is connected and enable when disconnected.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool
 }
 
 @available(iOS 12.0, *)
 public extension CarPlayManagerDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in carPlayTemplate: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]? {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, in carPlayTemplate: CPTemplate, for activity: CarPlayActivity) -> [CPBarButton]? {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, mapButtonsCompatibleWith traitCollection: UITraitCollection, in carPlayTemplate: CPTemplate, for activity: CarPlayActivity) -> [CPMapButton]? {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([CPListItem]) -> Void) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, searchTemplate: CPSearchTemplate, selectedResult item: CPListItem, completionHandler: @escaping () -> Void) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, didFailToFetchRouteBetween waypoints: [Waypoint]?, options: RouteOptions, error: DirectionsError) -> CPNavigationAlert? {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, willPreview trip: CPTrip) -> (CPTrip) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return trip
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, willPreview trip: CPTrip, with previewTextConfiguration: CPTripPreviewTextConfiguration) -> (CPTripPreviewTextConfiguration) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return previewTextConfiguration
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, selectedPreviewFor trip: CPTrip, using routeChoice: CPRouteChoice) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith service: NavigationService) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return false

--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -542,7 +542,6 @@ public protocol CarPlayNavigationDelegate: class, UnimplementedLogging {
      
      - parameter carPlayNavigationViewController: The CarPlay navigation view controller that was dismissed.
      - parameter canceled: True if the user dismissed the CarPlay navigation view controller by tapping the Cancel button; false if the navigation view controller dismissed by some other means.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     
      */
     func carPlayNavigationViewControllerDidDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController, byCanceling canceled: Bool)
     
@@ -554,6 +553,9 @@ public protocol CarPlayNavigationDelegate: class, UnimplementedLogging {
 
 @available(iOS 12.0, *)
 public extension CarPlayNavigationDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayNavigationViewControllerDidDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController, byCanceling canceled: Bool) {
         logUnimplemented(protocolType: CarPlayNavigationDelegate.self, level: .debug)
     }

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -23,32 +23,38 @@ extension FeedbackViewController: UIViewControllerTransitioningDelegate {
 public protocol FeedbackViewControllerDelegate: class, UnimplementedLogging {
     /**
      Called when the user opens the feedback form.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func feedbackViewControllerDidOpen(_ feedbackViewController: FeedbackViewController)
     
     /**
      Called when the user submits a feedback event.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func feedbackViewController(_ feedbackViewController: FeedbackViewController, didSend feedbackItem: FeedbackItem, uuid: UUID)
     
     /**
      Called when a `FeedbackViewController` is dismissed for any reason without giving explicit feedback.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     
      */
     func feedbackViewControllerDidCancel(_ feedbackViewController: FeedbackViewController)
 }
 
 public extension FeedbackViewControllerDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func feedbackViewControllerDidOpen(_ feedbackViewController: FeedbackViewController) {
         logUnimplemented(protocolType: FeedbackViewControllerDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func feedbackViewController(_ feedbackViewController: FeedbackViewController, didSend feedbackItem: FeedbackItem, uuid: UUID) {
         logUnimplemented(protocolType: FeedbackViewControllerDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func feedbackViewControllerDidCancel(_ feedbackViewController: FeedbackViewController) {
         logUnimplemented(protocolType: FeedbackViewControllerDelegate.self, level: .debug)
     } 

--- a/MapboxNavigation/InstructionLabel.swift
+++ b/MapboxNavigation/InstructionLabel.swift
@@ -47,12 +47,14 @@ public protocol VisualInstructionDelegate: class, UnimplementedLogging {
      - parameter instruction: the `VisualInstruction` that will be presented.
      - parameter presented: the formatted string that is provided by the instruction presenter
      - returns: optionally, a customized NSAttributedString that will be presented instead of the default, or if nil, the default behavior will be used.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     
      */
     func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString?
 }
 
 public extension VisualInstructionDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
         logUnimplemented(protocolType: InstructionLabel.self, level: .debug)
         return nil

--- a/MapboxNavigation/InstructionsBannerView.swift
+++ b/MapboxNavigation/InstructionsBannerView.swift
@@ -8,19 +8,20 @@ import MapboxDirections
 public protocol InstructionsBannerViewDelegate: class, UnimplementedLogging {
     /**
      Called when the user taps the `InstructionsBannerView`.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func didTapInstructionsBanner(_ sender: BaseInstructionsBannerView)
     
     
     /**
      Called when the user swipes either left, right, or down on the `InstructionsBannerView`
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     
      */
     func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizer.Direction)
 }
 
 public extension InstructionsBannerViewDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func didTapInstructionsBanner(_ sender: BaseInstructionsBannerView) {
         logUnimplemented(protocolType: InstructionsBannerViewDelegate.self, level: .debug)
     }
@@ -29,6 +30,9 @@ public extension InstructionsBannerViewDelegate {
         //no-op, deprecated.
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizer.Direction) {
         logUnimplemented(protocolType: InstructionsBannerViewDelegate.self, level: .debug)
     }

--- a/MapboxNavigation/InstructionsCardContainerView.swift
+++ b/MapboxNavigation/InstructionsCardContainerView.swift
@@ -14,7 +14,6 @@ public protocol InstructionsCardContainerViewDelegate: VisualInstructionDelegate
      - parameter instruction: the `VisualInstruction` that will be presented.
      - parameter presented: the formatted string that is provided by the instruction presenter
      - returns: optionally, a customized NSAttributedString that will be presented instead of the default, or if nil, the default behavior will be used.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func primaryLabel(_ primaryLabel: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString?
     
@@ -25,17 +24,22 @@ public protocol InstructionsCardContainerViewDelegate: VisualInstructionDelegate
      - parameter instruction: the `VisualInstruction` that will be presented.
      - parameter presented: the formatted string that is provided by the instruction presenter
      - returns: optionally, a customized NSAttributedString that will be presented instead of the default, or if nil, the default behavior will be used.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     
      */
     func secondaryLabel(_ secondaryLabel: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString?
 }
 
 public extension InstructionsCardContainerViewDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func primaryLabel(_ primaryLabel: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
         logUnimplemented(protocolType: InstructionsCardContainerViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func secondaryLabel(_ secondaryLabel: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
         logUnimplemented(protocolType: InstructionsCardContainerViewDelegate.self,level: .debug)
         return nil

--- a/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -13,7 +13,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter identifier: The style identifier.
      - parameter source: The Layer source containing the route data that this method would style.
      - returns: An MGLStyleLayer that the map applies to all routes.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -24,7 +23,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter identifier: The style identifier.
      - parameter source: The Layer source containing the waypoint data that this method would style.
      - returns: An MGLStyleLayer that the map applies to all waypoints.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -35,7 +33,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter identifier: The style identifier.
      - parameter source: The Layer source containing the waypoint data that this method would style.
      - returns: An MGLStyleLayer that the map applies to all waypoint symbols.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -47,7 +44,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter identifier: The style identifier.
      - parameter source: The Layer source containing the route data that this method would style.
      - returns: An MGLStyleLayer that the map applies to the route.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -55,7 +51,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      Tells the receiver that the user has selected a route by interacting with the map view.
      - parameter mapView: The NavigationMapView.
      - parameter route: The route that was selected.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route)
     
@@ -63,7 +58,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      Tells the receiver that a waypoint was selected.
      - parameter mapView: The NavigationMapView.
      - parameter waypoint: The waypoint that was selected.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, didSelect waypoint: Waypoint)
     
@@ -73,7 +67,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter mapView: The NavigationMapView.
      - parameter routes: The routes that the sender is asking about. The first route will always be rendered as the main route, while all subsequent routes will be rendered as alternate routes.
      - returns: Optionally, a `MGLShape` that defines the shape of the route, or `nil` to use default behavior.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, shapeFor routes: [Route]) -> MGLShape?
     
@@ -83,7 +76,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter mapView: The NavigationMapView.
      - parameter route: The route that the sender is asking about.
      - returns: Optionally, a `MGLShape` that defines the shape of the route at lower zoomlevels, or `nil` to use default behavior.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape?
     
@@ -92,7 +84,6 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter mapView: The NavigationMapView.
      - parameter waypoints: The waypoints to be displayed on the map.
      - returns: Optionally, a `MGLShape` that defines the shape of the waypoint, or `nil` to use default behavior.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape?
     
@@ -101,56 +92,85 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - important: The return value should be returned in the normal UIKit coordinate-space, NOT CoreAnimation's unit coordinate-space.
      - parameter mapView: The NavigationMapView.
      - returns: A CGPoint (in regular coordinate-space) that represents the point on-screen where the user location icon should be drawn.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     
      */
     func navigationMapViewUserAnchorPoint(_ mapView: NavigationMapView) -> CGPoint
     
 }
 
 public extension NavigationMapViewDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, didSelect waypoint: Waypoint) {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, shapeFor routes: [Route]) -> MGLShape? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, simplifiedShapeFor route: Route) -> MGLShape? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ mapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapViewUserAnchorPoint(_ mapView: NavigationMapView) -> CGPoint {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return .zero

--- a/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -13,7 +13,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      
      - parameter navigationViewController: The navigation view controller that was dismissed.
      - parameter canceled: True if the user dismissed the navigation view controller by tapping the Cancel button; false if the navigation view controller dismissed by some other means.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool)
     
@@ -24,7 +23,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      - parameter progress: the RouteProgress model that was updated.
      - parameter location: the guaranteed location, possibly snapped, associated with the progress update.
      - parameter rawLocation: the raw location, from the location manager, associated with the progress update.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation)
     
@@ -37,7 +35,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      - parameter remainingTimeInterval: The estimated number of seconds until arrival.
      - parameter distance: The current distance from the waypoint, in meters.
      - note: This method will likely be called several times as you approach a destination. To respond to the user’s arrival only once, your delegate can define a property that keeps track of whether this method has already been called for the given waypoint.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, willArriveAt waypoint: Waypoint, after remainingTimeInterval: TimeInterval, distance: CLLocationDistance)
     
@@ -50,7 +47,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      - parameter navigationViewController: The navigation view controller that has arrived at a waypoint.
      - parameter waypoint: The waypoint that the user has arrived at.
      - returns: True to automatically advance to the next leg, or false to remain on the now completed leg.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool
     
@@ -62,7 +58,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      - parameter navigationViewController: The navigation view controller that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
      - returns: True to allow the navigation view controller to calculate a new route; false to keep tracking the current route.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldRerouteFrom location: CLLocation) -> Bool
     
@@ -73,7 +68,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
      - parameter location: The user’s current location.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?)
     
@@ -84,7 +78,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter route: The new route.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didRerouteAlong route: Route)
     
@@ -95,7 +88,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didFailToRerouteWith error: Error)
     
@@ -103,7 +95,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Returns an `MGLStyleLayer` that determines the appearance of the route line.
      
      If this method is unimplemented, the navigation view controller’s map view draws the route line using an `MGLLineStyleLayer`.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -111,7 +102,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Returns an `MGLStyleLayer` that determines the appearance of the route line’s casing.
      
      If this method is unimplemented, the navigation view controller’s map view draws the route line’s casing using an `MGLLineStyleLayer` whose width is greater than that of the style layer returned by `navigationViewController(_:routeStyleLayerWithIdentifier:source:)`.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -119,7 +109,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Returns an `MGLShape` that represents the path of the route line.
      
      If this method is unimplemented, the navigation view controller’s map view represents the route line using an `MGLPolylineFeature` based on `route`’s `coordinates` property.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor routes: [Route]) -> MGLShape?
     
@@ -127,7 +116,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Returns an `MGLShape` that represents the path of the route line’s casing.
      
      If this method is unimplemented, the navigation view controller’s map view represents the route line’s casing using an `MGLPolylineFeature` identical to the one returned by `navigationViewController(_:shapeFor:)`.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, simplifiedShapeFor route: Route) -> MGLShape?
     
@@ -135,7 +123,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Returns an `MGLStyleLayer` that marks the location of each destination along the route when there are multiple destinations. The returned layer is added to the map below the layer returned by `navigationViewController(_:waypointSymbolStyleLayerWithIdentifier:source:)`.
      
      If this method is unimplemented, the navigation view controller’s map view marks each destination waypoint with a circle.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -143,7 +130,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Returns an `MGLStyleLayer` that places an identifying symbol on each destination along the route when there are multiple destinations. The returned layer is added to the map above the layer returned by `navigationViewController(_:waypointStyleLayerWithIdentifier:source:)`.
      
      If this method is unimplemented, the navigation view controller’s map view labels each destination waypoint with a number, starting with 1 at the first destination, 2 at the second destination, and so on.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
@@ -151,7 +137,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Returns an `MGLShape` that represents the destination waypoints along the route (that is, excluding the origin).
      
      If this method is unimplemented, the navigation map view represents the route waypoints using `navigationViewController(_:shapeFor:legIndex:)`.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape?
     
@@ -159,7 +144,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      Called when the user taps to select a route on the navigation view controller’s map view.
      - parameter navigationViewController: The navigation view controller presenting the route that the user selected.
      - parameter route: The route on the map that the user selected.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didSelect route: Route)
     
@@ -176,7 +160,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      - parameter navigationViewController: The navigation view controller that discarded the location.
      - parameter location: The location that will be discarded.
      - returns: If `true`, the location is discarded and the `NavigationViewController` will not consider it. If `false`, the location will not be thrown out.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool
     
@@ -188,7 +171,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      - parameter navigationViewController: The navigation view controller that will display the road name.
      - parameter location: The user’s current location.
      - returns: The road name to display in the label, or nil to hide the label.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, roadNameAt location: CLLocation) -> String?
     
@@ -204,99 +186,162 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
 }
 
 public extension NavigationViewControllerDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .info)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, willArriveAt waypoint: Waypoint, after remainingTimeInterval: TimeInterval, distance: CLLocationDistance) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return RouteController.DefaultBehavior.didArriveAtWaypoint
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldRerouteFrom location: CLLocation) -> Bool {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return RouteController.DefaultBehavior.shouldRerouteFromLocation
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, didRerouteAlong route: Route) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, didFailToRerouteWith error: Error) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor routes: [Route]) -> MGLShape? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, simplifiedShapeFor route: Route) -> MGLShape? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointSymbolStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor waypoints: [Waypoint], legIndex: Int) -> MGLShape? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, didSelect route: Route) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .info)
         return .zero
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return RouteController.DefaultBehavior.shouldDiscardLocation
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, roadNameAt location: CLLocation) -> String? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, imageFor annotation: MGLAnnotation) -> MGLAnnotationImage? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil

--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -271,9 +271,7 @@ public protocol VoiceControllerDelegate: class, UnimplementedLogging {
      - parameter voiceController: The voice controller that experienced the failure.
      - parameter synthesizer: the Speech engine that was used as the fallback.
      - parameter error: An error explaining the failure and its cause.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
-    
     func voiceController(_ voiceController: RouteVoiceController, didFallBackTo synthesizer: AVSpeechSynthesizer, error: SpeechError)
    
     /**
@@ -281,7 +279,6 @@ public protocol VoiceControllerDelegate: class, UnimplementedLogging {
      
      - parameter voiceController: The voice controller that experienced the failure.
      - parameter error: An error explaining the failure and its cause.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func voiceController(_ voiceController: RouteVoiceController, spokenInstructionsDidFailWith error: SpeechError)
     
@@ -291,7 +288,6 @@ public protocol VoiceControllerDelegate: class, UnimplementedLogging {
      - parameter voiceController: The voice controller that experienced the interruption.
      - parameter interruptedInstruction: The spoken instruction currently in progress that has been interrupted.
      - parameter interruptingInstruction: The spoken instruction that is interrupting the current instruction.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func voiceController(_ voiceController: RouteVoiceController, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction)
     
@@ -301,25 +297,35 @@ public protocol VoiceControllerDelegate: class, UnimplementedLogging {
      - parameter voiceController: The voice controller that will speak an instruction.
      - parameter instruction: The spoken instruction that will be said.
      - parameter routeProgress: The `RouteProgress` just before when the instruction is scheduled to be spoken.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction, routeProgress: RouteProgress) -> SpokenInstruction?
 }
 
 public extension VoiceControllerDelegate {
-    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func voiceController(_ voiceController: RouteVoiceController, didFallBackTo synthesizer: AVSpeechSynthesizer, error: SpeechError) {
         logUnimplemented(protocolType: VoiceControllerDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func voiceController(_ voiceController: RouteVoiceController, spokenInstructionsDidFailWith error: Error) {
         logUnimplemented(protocolType: VoiceControllerDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func voiceController(_ voiceController: RouteVoiceController, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction) {
         logUnimplemented(protocolType: VoiceControllerDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func voiceController(_ voiceController: RouteVoiceController, willSpeak instruction: SpokenInstruction, routeProgress: RouteProgress) -> SpokenInstruction? {
         logUnimplemented(protocolType: VoiceControllerDelegate.self, level: .debug)
         return nil

--- a/MapboxNavigation/StyleManager.swift
+++ b/MapboxNavigation/StyleManager.swift
@@ -8,36 +8,41 @@ import MapboxCoreNavigation
 public protocol StyleManagerDelegate: class, UnimplementedLogging {
     /**
      Asks the delegate for a location to use when calculating sunset and sunrise
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.     .
      */
     func location(for styleManager: StyleManager) -> CLLocation?
     
     /**
      Informs the delegate that a style was applied.
-     This delegate method is the equivalent of `Notification.Name.styleManagerDidApplyStyle`.
-
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      
+     This delegate method is the equivalent of `Notification.Name.styleManagerDidApplyStyle`.
      */
     func styleManager(_ styleManager: StyleManager, didApply style: Style)
     
     /**
      Informs the delegate that the manager forcefully refreshed UIAppearance.
-     - note: This delegate method includes a default implementation that prints a warning to the console when this method is called. See `UnimplementedLogging` for details.
      */
     func styleManagerDidRefreshAppearance(_ styleManager: StyleManager)
 }
 
 public extension StyleManagerDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func location(for styleManager: StyleManager) -> CLLocation? {
         logUnimplemented(protocolType: StyleManagerDelegate.self, level: .debug)
         return nil
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         logUnimplemented(protocolType: StyleManagerDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
         logUnimplemented(protocolType: StyleManagerDelegate.self, level: .debug)
     }


### PR DESCRIPTION
jazzy has built-in support for documenting default implementations: https://github.com/realm/jazzy/issues/531#issuecomment-213273044. So the approach we took in https://github.com/mapbox/mapbox-navigation-ios/pull/2230#discussion_r337097896 of calling out the default implementation in `note` blocks is unnecessary. Indeed, the [v1.0.0-alpha.1 documentation](https://docs.mapbox.com/ios/api/navigation/1.0.0-alpha.1/Protocols/NavigationMapViewDelegate.html) shows a generated “Default implementation” header right below the note callout.

This PR moves the default implementation documentation to the default implementations themselves so jazzy can pick them up and apply a standard style to them:

![default](https://user-images.githubusercontent.com/1231218/72475730-5d6de680-37a0-11ea-932e-4598e308d45d.png)

/cc @mapbox/navigation-ios