### PR TITLE
Make End Navigation button localizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * When Dark Mode is enabled, user notifications now draw maneuver icons in white instead of black for better contrast. ([#2283](https://github.com/mapbox/mapbox-navigation-ios/pull/2283))
 * Added the `RouteLegProgress.currentSpeedLimit` property. ([#2114](https://github.com/mapbox/mapbox-navigation-ios/pull/2114))
 * Added convenience initializers for converting Turf geometry structures into `MGLShape` and `MGLFeature` objects such as `MGLPolyline` and `MGLPolygonFeature`. ([#2308](https://github.com/mapbox/mapbox-navigation-ios/pull/2308))
+* Fixed an issue where the “End Navigation” button in the end-of-route feedback panel appeared in English regardless of the current localization. ([#2315](https://github.com/mapbox/mapbox-navigation-ios/pull/2315))
 
 ## v0.38.2
 

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -128,14 +128,6 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5f2-dT-la4" customClass="MBEndOfRouteButton">
                                         <rect key="frame" x="136" y="10" width="103" height="30"/>
                                         <state key="normal" title="End Navigation"/>
-                                        <attributedString key="userComments">
-                                            <fragment content="DO NOT TRANSLATE">
-                                                <attributes>
-                                                    <font key="NSFont" metaFont="message" size="11"/>
-                                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                </attributes>
-                                            </fragment>
-                                        </attributedString>
                                         <connections>
                                             <action selector="endNavigationPressed:" destination="WD9-Na-hrx" eventType="touchUpInside" id="WD3-dO-JvE"/>
                                         </connections>

--- a/MapboxNavigation/Resources/Base.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Navigation.strings
@@ -1,3 +1,6 @@
 
+/* Class = "UIButton"; normalTitle = "End Navigation"; ObjectID = "5f2-dT-la4"; */
+"5f2-dT-la4.normalTitle" = "End Navigation";
+
 /* Class = "UILabel"; text = "Rate your trip"; ObjectID = "W5U-cV-cDO"; */
 "W5U-cV-cDO.text" = "Rate your trip";


### PR DESCRIPTION
Fixed an issue where the “End Navigation” button in the end-of-route feedback panel appeared in English regardless of the current localization. #848 set this button’s localization note to “DO NOT TRANSLATE” in the storyboard, which prevented scripts/extract_localizable.sh from detecting the string.

/cc @mapbox/navigation-ios