### PR TITLE
Gracefully snapshot route shield when window is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Top and bottom banners
 * Removed `BottomBannerViewController(delegate:)` in favor of `BottomBannerViewController()` and the `BottomBannerViewController.delegate` property’s setter. ([#2297](https://github.com/mapbox/mapbox-navigation-ios/pull/2297))
 * Removed the `StatusView.canChangeValue` property in favor of `StatusView.isEnabled`. ([#2297](https://github.com/mapbox/mapbox-navigation-ios/pull/2297))
+* Fixed a crash when the first visual instruction contained a route shield or exit number and the application’s user interface was written in SwiftUI. ([#2323](https://github.com/mapbox/mapbox-navigation-ios/pull/2323))
 * Fixed an issue where the wrong style was applied to exit numbers in the top banner and for subsequent maneuver banners in CarPlay, resulting in poor contrast. ([#2280](https://github.com/mapbox/mapbox-navigation-ios/pull/2280))
 * Fixed an issue where a black background could appear under the arrow in a `ManeuverView` regardless of the view’s `backgroundColor` property. ([#2279](https://github.com/mapbox/mapbox-navigation-ios/pull/2279))
 

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -218,15 +218,15 @@ class InstructionPresenter {
     }
     
     private func takeSnapshot(on view: UIView) -> UIImage? {
-        let window: UIWindow
+        let window: UIWindow?
         if let hostView = dataSource as? UIView, let hostWindow = hostView.window {
             window = hostWindow
         } else {
-            window = UIApplication.shared.delegate!.window!!
+            window = UIApplication.shared.delegate?.window ?? nil
         }
         
         // Temporarily add the view to the view hierarchy for UIAppearance to work its magic.
-        window.addSubview(view)
+        window?.addSubview(view)
         let image = view.imageRepresentation
         view.removeFromSuperview()
         return image


### PR DESCRIPTION
Avoid force-unwrapping the window just to temporarily add the view to it during snapshotting. In SwiftUI, NavigationViewController hasn’t been added to a window by the time `NavigationViewController.viewDidLoad()` explicitly causes a view to be snapshotted. Adding the view to the window enables the style to be applied, but that’s less important than avoiding a crash.

Fixes #2300.

/cc @mapbox/navigation-ios @zacharyblank