### PR TITLE
Update analytics script in docs template

### DIFF
--- a/docs/theme/templates/doc.mustache
+++ b/docs/theme/templates/doc.mustache
@@ -18,22 +18,10 @@
       }
     </style>
     <script type="text/javascript">
-      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
-          analytics.load("fl0c8p240n");
-          var xhttp = new XMLHttpRequest();
-          xhttp.onreadystatechange = function() {
-            if(this.readyState == 4 && this.status == 200) {
-              var resp = JSON.parse(xhttp.responseText);
-              analytics.identify(resp.id, {email: resp.email}, {}, function() {
-                analytics.page();
-              });
-            } else {
-              analytics.page();
-            }
-          }
-          xhttp.open("GET", "https://www.mapbox.com/api/session", true);
-          xhttp.send();
-        }}();
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error('Segment snippet included twice.');else{analytics.invoked=!0;analytics.methods=['trackSubmit','trackClick','trackLink','trackForm','pageview','identify','reset','group','track','ready','alias','debug','page','once','off','on'];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement('script');n.type='text/javascript';n.async=!0;n.src=('https:'===document.location.protocol?'https://':'http://')+'cdn.segment.com/analytics.js/v1/'+t+'/analytics.min.js';var o=document.getElementsByTagName('script')[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e;};analytics.SNIPPET_VERSION='4.1.0';
+      analytics.load('fl0c8p240n',{integrations: {All: false,'Google Analytics': true,'Segment.io': true, 'Facebook Pixel': true}});
+      analytics.page();
+      }}();
     </script>
   </head>
   <body>


### PR DESCRIPTION
Some folks (👋 @captainbarbosa) noticed some stray trackers showing up on these pages. After some 🕵️‍♀️, @katydecorah noticed we had a pretty loosely configured analytics initialization happening in a template file. This PR brings that file more in line with the way we initialize analytics elsewhere on the website with configurable integrations. 

The biggest change here is in `analytics.load()`: 

```js
analytics.load=function(t){
  var e=document.createElement('script');
  e.type='text/javascript';
  e.async=!0;
  e.src('https:'===document.location.protocol?'https://':'http://') + 'cdn.segment.com/analytics.js/v1/' + t + '/analytics.min.js';
  var n=document.getElementsByTagName('script')[0];
  n.parentNode.insertBefore(e,n)
};
```
👇 
```js
analytics.load = function(t, e) { 
  var n = document.createElement('script'); 
  n.type = 'text/javascript'; 
  n.async = !0; 
  n.src = ('https:' === document.location.protocol ? 'https://' : 'http://') + 'cdn.segment.com/analytics.js/v1/' + t + '/analytics.min.js'; 
  var o = document.getElementsByTagName('script')[0]; 
  o.parentNode.insertBefore(n, o); 
  analytics._loadOptions = e;
};
```

@1ec5 for review, please :pray: related: https://github.com/mapbox/mapbox-directions-swift/pull/408