### PR TITLE
Swap to centralized analytics script

### DIFF
--- a/docs/theme/templates/doc.mustache
+++ b/docs/theme/templates/doc.mustache
@@ -17,12 +17,7 @@
         padding-left: 5px
       }
     </style>
-    <script type="text/javascript">
-      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error('Segment snippet included twice.');else{analytics.invoked=!0;analytics.methods=['trackSubmit','trackClick','trackLink','trackForm','pageview','identify','reset','group','track','ready','alias','debug','page','once','off','on'];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement('script');n.type='text/javascript';n.async=!0;n.src=('https:'===document.location.protocol?'https://':'http://')+'cdn.segment.com/analytics.js/v1/'+t+'/analytics.min.js';var o=document.getElementsByTagName('script')[0];o.parentNode.insertBefore(n,o);analytics._loadOptions=e;};analytics.SNIPPET_VERSION='4.1.0';
-      analytics.load('fl0c8p240n',{integrations: {All: false,'Google Analytics': true,'Segment.io': true, 'Facebook Pixel': true}});
-      analytics.page();
-      }}();
-    </script>
+    <script src="https://docs.mapbox.com/analytics.js"></script>
   </head>
   <body>
 


### PR DESCRIPTION
I hope I'm not giving you too much whiplash, but we had some discussion internally and decided it would be best to link to a centralized analytics script instead of inlining analytics initialization in each and every repo. 