### PR TITLE
Fix crash when using dynamic UIColors in guidance card styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Added the `RouteLegProgress.currentSpeedLimit` property. ([#2114](https://github.com/mapbox/mapbox-navigation-ios/pull/2114))
 * Added convenience initializers for converting Turf geometry structures into `MGLShape` and `MGLFeature` objects such as `MGLPolyline` and `MGLPolygonFeature`. ([#2308](https://github.com/mapbox/mapbox-navigation-ios/pull/2308))
 * Fixed an issue where the “End Navigation” button in the end-of-route feedback panel appeared in English regardless of the current localization. ([#2315](https://github.com/mapbox/mapbox-navigation-ios/pull/2315))
+* Fixed a crash when setting certain properties of a Style subclass to a dynamic color. ([#2338](https://github.com/mapbox/mapbox-navigation-ios/pull/2338))
 
 ## v0.38.3
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.6.1"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.7.0"
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "6.2.1"
 github "AndriiDoroshko/SnappyShrimp" "1.6.4"
 github "CedarBDD/Cedar" "v1.0"

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -148,14 +148,12 @@ public class ExitView: StylableView {
         let proxy = ExitView.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
-        let resolvedColorSelector = Selector(("resolvedColorWithTraitCollection:" as NSString) as String)
-        if #available(iOS 13.0, *),
-            let bgColor = backgroundColor, bgColor.responds(to: resolvedColorSelector),
-            let fgColor = foregroundColor, fgColor.responds(to: resolvedColorSelector),
-            let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
-            if let backgroundColorInstance = bgColor.perform(resolvedColorSelector, with: currentTraitCollection), let foregroundColorInstance = fgColor.perform(resolvedColorSelector, with: currentTraitCollection) {
-                backgroundColor = backgroundColorInstance.takeRetainedValue() as? UIColor
-                foregroundColor = foregroundColorInstance.takeRetainedValue() as? UIColor
+        if #available(iOS 13.0, *) {
+            if let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection, let backgroundCGColor = backgroundColor?.cgColor, let foregroundCGColor = foregroundColor?.cgColor {
+                currentTraitCollection.performAsCurrent {
+                    backgroundColor = UIColor(cgColor: backgroundCGColor)
+                    foregroundColor = UIColor(cgColor: foregroundCGColor)
+                }
             }
         }
         let criticalProperties: [AnyHashable?] = [side, dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]

--- a/MapboxNavigation/ExitView.swift
+++ b/MapboxNavigation/ExitView.swift
@@ -148,12 +148,16 @@ public class ExitView: StylableView {
         let proxy = ExitView.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
+        let performAsCurrentSelector = Selector(("performAsCurrentTraitCollection:" as NSString) as String)
         if #available(iOS 13.0, *) {
-            if let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection, let backgroundCGColor = backgroundColor?.cgColor, let foregroundCGColor = foregroundColor?.cgColor {
-                currentTraitCollection.performAsCurrent {
+            if let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection, currentTraitCollection.responds(to: performAsCurrentSelector), let backgroundCGColor = backgroundColor?.cgColor, let foregroundCGColor = foregroundColor?.cgColor {
+
+                let colorCopyingClosure = {
                     backgroundColor = UIColor(cgColor: backgroundCGColor)
                     foregroundColor = UIColor(cgColor: foregroundCGColor)
                 }
+                let colorCopyingBlock: @convention(block) () -> Void = colorCopyingClosure
+                currentTraitCollection.perform(performAsCurrentSelector, with: colorCopyingBlock)
             }
         }
         let criticalProperties: [AnyHashable?] = [side, dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]

--- a/MapboxNavigation/GenericRouteShield.swift
+++ b/MapboxNavigation/GenericRouteShield.swift
@@ -98,16 +98,14 @@ public class GenericRouteShield: StylableView {
         let proxy = GenericRouteShield.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
-        let resolvedColorSelector = Selector(("resolvedColorWithTraitCollection:" as NSString) as String)
-        if #available(iOS 13.0, *),
-            let bgColor = backgroundColor, bgColor.responds(to: resolvedColorSelector),
-            let fgColor = foregroundColor, fgColor.responds(to: resolvedColorSelector),
-            let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection {
-                if let backgroundColorInstance = bgColor.perform(resolvedColorSelector, with: currentTraitCollection), let foregroundColorInstance = fgColor.perform(resolvedColorSelector, with: currentTraitCollection) {
-                    backgroundColor = backgroundColorInstance.takeRetainedValue() as? UIColor
-                    foregroundColor = foregroundColorInstance.takeRetainedValue() as? UIColor
+        if #available(iOS 13.0, *) {
+            if let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection, let backgroundCGColor = backgroundColor?.cgColor, let foregroundCGColor = foregroundColor?.cgColor {
+                currentTraitCollection.performAsCurrent {
+                    backgroundColor = UIColor(cgColor: backgroundCGColor)
+                    foregroundColor = UIColor(cgColor: foregroundCGColor)
                 }
             }
+        }
         let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))
     }

--- a/MapboxNavigation/GenericRouteShield.swift
+++ b/MapboxNavigation/GenericRouteShield.swift
@@ -98,12 +98,18 @@ public class GenericRouteShield: StylableView {
         let proxy = GenericRouteShield.appearance()
         var backgroundColor = proxy.backgroundColor
         var foregroundColor = proxy.foregroundColor
+
+        let performAsCurrentSelector = Selector(("performAsCurrentTraitCollection:" as NSString) as String)
+
         if #available(iOS 13.0, *) {
-            if let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection, let backgroundCGColor = backgroundColor?.cgColor, let foregroundCGColor = foregroundColor?.cgColor {
-                currentTraitCollection.performAsCurrent {
+            if let currentTraitCollection = UIApplication.shared.keyWindow?.traitCollection, currentTraitCollection.responds(to: performAsCurrentSelector), let backgroundCGColor = backgroundColor?.cgColor, let foregroundCGColor = foregroundColor?.cgColor {
+
+                let colorCopyingClosure = {
                     backgroundColor = UIColor(cgColor: backgroundCGColor)
                     foregroundColor = UIColor(cgColor: foregroundCGColor)
                 }
+                let colorCopyingBlock: @convention(block) () -> Void = colorCopyingClosure
+                currentTraitCollection.perform(performAsCurrentSelector, with: colorCopyingBlock)
             }
         }
         let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]

--- a/MapboxNavigation/InstructionsCardContainerView.swift
+++ b/MapboxNavigation/InstructionsCardContainerView.swift
@@ -219,7 +219,7 @@ public class InstructionsCardContainerView: UIView {
         
         let colors = [style.highlightedBackgroundColor.cgColor,
                       style.highlightedBackgroundColor.withAlphaComponent(alphaComponent).cgColor]
-        
+
         let containerGradientLayer = gradientLayer(for: self)
         var instructionsCardViewGradientLayer = gradientLayer(for: instructionsCardView)
         var lanesViewGradientLayer = gradientLayer(for: lanesView)


### PR DESCRIPTION
Problem:
If you provide dynamic UIColor as a color for ExitView or GenericShieldView styling, you will get a crash due to the way the hash value is calculated for storing the rendered image in the image crash.

Fix is to create our own UIColor instances based on the CGColor values of the resolved underlying UIColor.