### PR TITLE
Expose secondary highlight colors used in guidance cards

### DIFF
--- a/MapboxNavigation/DayInstructionsCardStyle.swift
+++ b/MapboxNavigation/DayInstructionsCardStyle.swift
@@ -65,6 +65,10 @@ public class DayInstructionsCardStyle: InstructionsCardStyle {
     public var maneuverViewHighlightedColor: UIColor {
         return .cardLight
     }
+
+    public var maneuverViewSecondaryHighlightedColor: UIColor {
+        return UIColor.cardLight.withAlphaComponent(0.4)
+    }
     
     public var nextBannerViewPrimaryColor: UIColor {
         return .cardBlue
@@ -84,6 +88,10 @@ public class DayInstructionsCardStyle: InstructionsCardStyle {
     
     public var nextBannerInstructionHighlightedColor: UIColor {
         return .cardLight
+    }
+
+    public var nextBannerInstructionSecondaryHighlightedColor: UIColor {
+        return UIColor.cardLight.withAlphaComponent(0.4)
     }
     
     public var lanesViewDefaultColor: UIColor {

--- a/MapboxNavigation/InstructionsCardContainerView.swift
+++ b/MapboxNavigation/InstructionsCardContainerView.swift
@@ -277,7 +277,7 @@ public class InstructionsCardContainerView: UIView {
     fileprivate func hightlightNextBannerView(_ gradientLayer: CAGradientLayer, colors: [CGColor]) {
         gradientLayer.colors = colors
         nextBannerView.maneuverView.primaryColor = style.nextBannerInstructionHighlightedColor
-        nextBannerView.maneuverView.secondaryColor = style.nextBannerInstructionHighlightedColor
+        nextBannerView.maneuverView.secondaryColor = style.nextBannerInstructionSecondaryHighlightedColor
         nextBannerView.instructionLabel.normalTextColor = style.nextBannerInstructionHighlightedColor
     }
     
@@ -290,7 +290,7 @@ public class InstructionsCardContainerView: UIView {
         instructionsCardView.distanceLabel.valueTextColor = style.distanceLabelHighlightedTextColor
         // maneuver view
         instructionsCardView.maneuverView.primaryColor = style.maneuverViewHighlightedColor
-        instructionsCardView.maneuverView.secondaryColor = style.maneuverViewHighlightedColor
+        instructionsCardView.maneuverView.secondaryColor = style.maneuverViewSecondaryHighlightedColor
     }
 }
 

--- a/MapboxNavigation/InstructionsCardStyle.swift
+++ b/MapboxNavigation/InstructionsCardStyle.swift
@@ -26,6 +26,7 @@ public protocol InstructionsCardStyle: class {
     var maneuverViewPrimaryColor: UIColor { get }
     var maneuverViewSecondaryColor: UIColor { get }
     var maneuverViewHighlightedColor: UIColor { get }
+    var maneuverViewSecondaryHighlightedColor: UIColor { get }
     
     // MARK: Next Banner Instruction custom formats
     var nextBannerViewPrimaryColor: UIColor { get }
@@ -33,6 +34,7 @@ public protocol InstructionsCardStyle: class {
     var nextBannerInstructionLabelTextColor: UIColor { get }
     var nextBannerInstructionLabelNormalFont: UIFont { get }
     var nextBannerInstructionHighlightedColor: UIColor { get }
+    var nextBannerInstructionSecondaryHighlightedColor: UIColor { get }
     
     // MARK: Lanes View custom formats
     var lanesViewDefaultColor: UIColor { get }

--- a/MapboxNavigationTests/InstructionsCardCollectionTests.swift
+++ b/MapboxNavigationTests/InstructionsCardCollectionTests.swift
@@ -191,11 +191,13 @@ class TestInstructionsCardStyle: InstructionsCardStyle {
     var maneuverViewPrimaryColor: UIColor = .blue
     var maneuverViewSecondaryColor: UIColor = .clear
     var maneuverViewHighlightedColor: UIColor = .brown
+    var maneuverViewSecondaryHighlightedColor: UIColor = .orange
     
     var nextBannerViewPrimaryColor: UIColor = .cardBlue
     var nextBannerViewSecondaryColor: UIColor = .cardLight
     var nextBannerInstructionLabelTextColor: UIColor = .cardDark
     var nextBannerInstructionHighlightedColor: UIColor = .cardLight
+    var nextBannerInstructionSecondaryHighlightedColor: UIColor = .orange
     var lanesViewDefaultColor: UIColor = .cardBlue
     var lanesViewHighlightedColor: UIColor = .cardLight
     lazy var nextBannerInstructionLabelNormalFont: UIFont = {


### PR DESCRIPTION
Nav SDK users are unable to override the secondary highlight colors for the ManeuverView or NextBanner maneuver view. Expose these values and use a transparent version of the primary color as the default value.