### PR TITLE
#2245: next instructions display fix

### DIFF
--- a/MapboxNavigation/NextBannerView.swift
+++ b/MapboxNavigation/NextBannerView.swift
@@ -90,9 +90,31 @@ open class NextBannerView: UIView, NavigationComponent {
     }
     
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
+        guard shouldShowNextBanner(for: routeProgress) else {
+            hide()
+            return
+        }
+
         update(for: instruction)
     }
     
+    func shouldShowNextBanner(for routeProgress: RouteProgress) -> Bool {
+        guard let upcomingStep = routeProgress.currentLegProgress.upcomingStep else {
+            return false
+        }
+        
+        let durationForNext = RouteControllerHighAlertInterval * RouteControllerLinkedInstructionBufferMultiplier
+        
+        guard routeProgress.currentLegProgress.currentStepProgress.durationRemaining <= durationForNext, upcomingStep.expectedTravelTime <= durationForNext else {
+            return false
+        }
+        guard let _ = upcomingStep.instructionsDisplayedAlongStep?.last else {
+            return false
+        }
+        
+        return true
+    }
+            
     /**
      Updates the instructions banner info with a given `VisualInstructionBanner`.
      */

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -363,7 +363,7 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
         instructionsBannerView.update(for: instruction)
         lanesView.update(for: instruction)
-        nextBannerView.update(for: instruction)
+        nextBannerView.navigationService(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress)
     }
     
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {


### PR DESCRIPTION
Fixed displaying next instructions banner at the end of current step. Code based on previous implementation. 
NavigationBannerView may be called to respect showing next  banner based on route progress (by calling as `NavigationServiceDelegate`, or called to display such info unconditionally (if called by `update(for:)` directly)