### PR TITLE
Minimize NSObject inheritance

### DIFF
--- a/MapboxCoreNavigation/EndOfRouteFeedback.swift
+++ b/MapboxCoreNavigation/EndOfRouteFeedback.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  Feedback Model Object for End Of Route Experience.
  */
-open class EndOfRouteFeedback: NSObject {
+open class EndOfRouteFeedback {
     /**
      Rating: The user's rating for the route. Normalized between 0 and 100.
      */
@@ -17,7 +17,6 @@ open class EndOfRouteFeedback: NSObject {
     @nonobjc public init(rating: Int? = nil, comment: String? = nil) {
         self.rating = rating
         self.comment = comment
-        super.init()
     }
     public convenience init(rating ratingNumber: NSNumber?, comment: String?) {
         let rating = ratingNumber?.intValue

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -272,7 +272,7 @@ open class RouteProgress: NSObject {
 /**
  `RouteLegProgress` stores the user’s progress along a route leg.
  */
-open class RouteLegProgress: NSObject {
+open class RouteLegProgress {
     /**
      Returns the current `RouteLeg`.
      */
@@ -281,7 +281,7 @@ open class RouteLegProgress: NSObject {
     /**
      Index representing the current step.
      */
-    @objc public var stepIndex: Int {
+    public var stepIndex: Int {
         didSet {
             assert(stepIndex >= 0 && stepIndex < leg.steps.endIndex)
             currentStepProgress = RouteStepProgress(step: currentStep)
@@ -515,7 +515,7 @@ open class RouteLegProgress: NSObject {
 /**
  `RouteStepProgress` stores the user’s progress along a route step.
  */
-open class RouteStepProgress: NSObject {
+open class RouteStepProgress {
     /**
      Returns the current `RouteStep`.
      */

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -5,7 +5,7 @@ import Turf
 /**
  `RouteProgress` stores the user’s progress along a route.
  */
-open class RouteProgress: NSObject {
+open class RouteProgress {
     private static let reroutingAccuracy: CLLocationAccuracy = 90
 
     /**
@@ -16,14 +16,17 @@ open class RouteProgress: NSObject {
     /**
      Index representing current `RouteLeg`.
      */
-    @objc dynamic public var legIndex: Int {
+    public var legIndex: Int {
         didSet {
             assert(legIndex >= 0 && legIndex < route.legs.endIndex)
             // TODO: Set stepIndex to 0 or last index based on whether leg index was incremented or decremented.
             currentLegProgress = RouteLegProgress(leg: currentLeg)
+            
+            legIndexHandler?(oldValue, legIndex)
         }
     }
-
+    typealias LegIndexHandlerAction = (_ oldValue: Int, _ newValue: Int) -> ()
+    var legIndexHandler: LegIndexHandlerAction?
     /**
      If waypoints are provided in the `Route`, this will contain which leg the user is on.
      */
@@ -175,7 +178,6 @@ open class RouteProgress: NSObject {
         self.route = route
         self.legIndex = legIndex
         self.currentLegProgress = RouteLegProgress(leg: route.legs[legIndex], stepIndex: 0, spokenInstructionIndex: spokenInstructionIndex)
-        super.init()
 
         for (legIndex, leg) in route.legs.enumerated() {
             var maneuverCoordinateIndex = 0

--- a/MapboxNavigation/DataCache.swift
+++ b/MapboxNavigation/DataCache.swift
@@ -1,14 +1,12 @@
 import Foundation
 
-public class DataCache: NSObject, BimodalDataCache {
+public class DataCache: BimodalDataCache {
     let memoryCache: NSCache<NSString, NSData>
     let fileCache = FileCache()
 
-    public override init() {
+    public init() {
         memoryCache = NSCache<NSString, NSData>()
         memoryCache.name = "In-Memory Data Cache"
-
-        super.init()
         
         NotificationCenter.default.addObserver(self, selector: #selector(DataCache.clearMemory), name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
     }

--- a/MapboxNavigation/FeedbackItem.swift
+++ b/MapboxNavigation/FeedbackItem.swift
@@ -10,7 +10,7 @@ extension UIImage {
 /**
  A single feedback item displayed on an instance of `FeedbackViewController`.
  */
-public class FeedbackItem: NSObject {
+public class FeedbackItem {
     /**
      The title of feedback item. This will be rendered directly below the image.
      */

--- a/MapboxNavigation/MapboxVoiceController.swift
+++ b/MapboxNavigation/MapboxVoiceController.swift
@@ -48,21 +48,6 @@ open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {
         super.init(navigationService: navigationService)
         
         audioPlayer?.delegate = self
-        
-        volumeToken = NavigationSettings.shared.observe(\.voiceVolume) { [weak self] (settings, change) in
-            self?.audioPlayer?.volume = settings.voiceVolume
-        }
-        
-        muteToken = NavigationSettings.shared.observe(\.voiceMuted) { [weak self] (settings, change) in
-            if settings.voiceMuted {
-                self?.audioPlayer?.stop()
-                
-                guard let strongSelf = self else { return }
-                strongSelf.safeUnduckAudio(instruction: nil, engine: self?.speech) {
-                    strongSelf.voiceControllerDelegate?.voiceController(strongSelf, spokenInstructionsDidFailWith: $0)
-                }
-            }
-        }
     }
     
     deinit {
@@ -73,6 +58,19 @@ open class MapboxVoiceController: RouteVoiceController, AVAudioPlayerDelegate {
         }
         
         audioPlayer?.delegate = nil
+    }
+    
+    @objc override func didUpdateSettings(notification: NSNotification) {
+        if let isMuted = notification.userInfo?[NavigationSettings.StoredProperty.voiceMuted.key] as? Bool, isMuted {
+            audioPlayer?.stop()
+            
+            safeUnduckAudio(instruction: nil, engine: speech) {
+                voiceControllerDelegate?.voiceController(self, spokenInstructionsDidFailWith: $0)
+            }
+        }
+        if let voiceVolume = notification.userInfo?[NavigationSettings.StoredProperty.voiceVolume.key] as? Float {
+            audioPlayer?.volume = voiceVolume
+        }
     }
     
     public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {

--- a/MapboxNavigation/NavigationOptions.swift
+++ b/MapboxNavigation/NavigationOptions.swift
@@ -8,7 +8,7 @@ import MapboxCoreNavigation
  
  - note: `NavigationOptions` is designed to be used with the `NavigationViewController` class to customize the user experience. To specify criteria when calculating routes, use the `NavigationRouteOptions` class. To modify user preferences that persist across navigation sessions, use the `NavigationSettings` class.
  */
-open class NavigationOptions: NSObject, NavigationCustomizable {
+open class NavigationOptions: NavigationCustomizable {
     /**
      The styles that the view controller’s internal `StyleManager` object can select from for display.
      
@@ -41,8 +41,8 @@ open class NavigationOptions: NSObject, NavigationCustomizable {
     open var bottomBanner: ContainerViewController?
     
     // This makes the compiler happy.
-    required public override init() {
-        super.init()
+    required public init() {
+        // do nothing
     }
     
     /**


### PR DESCRIPTION
Resolves #2294 
Removes some objects NSObject Inheritance. Existing KVO observers are removed in favor of using NSNotifications observations.

There are also some other Public available classes, inheriting NSObject:
- LanesStyleKit
- ManeuversStyleKit
- StyleKitMarker
- SpeedLimitStyleKit
- Style

Didn't check in detail, if such inheritance is legitimate, but quick removing NSObject from declaration showed successful compile. Should I check these too?