### PR TITLE
Constrain current route shield; simplify current road name label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Renamed `NavigationMapView.showWaypoints(_:legIndex:)` to `NavigationMapView.showWaypoints(on:legIndex:)`. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
 * Removed the `NavigationMapView.navigationMapDelegate` property in favor of `NavigationMapView.navigationMapViewDelegate`. ([#2297](https://github.com/mapbox/mapbox-navigation-ios/pull/2297))
 * Added a speed limit indicator to the upper-left corner of the map view during turn-by-turn navigation (upper-right corner in CarPlay). To hide the speed limit indicator, set the `NavigationViewController.showsSpeedLimits` property to `false`. To customize the indicator’s colors, configure `SpeedLimitView`’s appearance proxy inside a `Style` subclass. ([#2291](https://github.com/mapbox/mapbox-navigation-ios/pull/2291))
+* Fixed an issue where the current road name label contained an oversized route shield when the current map style was a custom style created in Mapbox Studio. ([#2357](https://github.com/mapbox/mapbox-navigation-ios/pull/2357))
 
 ### Spoken instructions
 * Removed `MapboxVoiceController.play(_:)` in favor of `MapboxVoiceController.play(instruction:data:)`. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230), [#2297](https://github.com/mapbox/mapbox-navigation-ios/pull/2297))

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -268,12 +268,7 @@ class RoadNameLabelAttachment: TextInstruction {
             return nil
         }
         
-        var currentImage: UIImage?
-        let textHeight = font.lineHeight
-        let pointY = (image.size.height - textHeight) / 2
-        currentImage = image.insert(text: text as NSString, color: color, font: font, atPoint: CGPoint(x: 0, y: pointY), scale: scale)
-        
-        return currentImage
+        return image.insert(text: text as NSString, color: color, font: font, scale: scale)
     }
     
     convenience init(image: UIImage, text: String, color: UIColor, font: UIFont, scale: CGFloat) {

--- a/MapboxNavigation/InstructionPresenter.swift
+++ b/MapboxNavigation/InstructionPresenter.swift
@@ -259,28 +259,6 @@ class TextInstruction: ImageInstruction {}
 class ShieldAttachment: ImageInstruction {}
 class GenericShieldAttachment: ShieldAttachment {}
 class ExitAttachment: ImageInstruction {}
-class RoadNameLabelAttachment: TextInstruction {
-    var scale: CGFloat?
-    var color: UIColor?
-
-    var compositeImage: UIImage? {
-        guard let image = image, let text = text, let color = color, let scale = scale else {
-            return nil
-        }
-        
-        return image.insert(text: text as NSString, color: color, font: font, scale: scale)
-    }
-    
-    convenience init(image: UIImage, text: String, color: UIColor, font: UIFont, scale: CGFloat) {
-        self.init()
-        self.image = image
-        self.font = font
-        self.text = text
-        self.color = color
-        self.scale = scale
-        self.image = compositeImage ?? image
-    }
-}
 
 extension CGSize {
     fileprivate static func +(lhs: CGSize, rhs: CGSize) -> CGSize {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -704,17 +704,15 @@ extension RouteMapViewController: NavigationViewDelegate {
     }
 
     private func roadFeature(for line: MGLFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
-        let ref = line.attribute(forKey: "ref")
-        let shield = line.attribute(forKey: "shield")
-        let reflen = line.attribute(forKey: "reflen")
-        let name = line.attribute(forKey: "name")
         var currentShieldName: NSAttributedString?, currentRoadName: String?
 
-        if let text = ref as? String, let shieldID = shield as? String, let reflenDigit = reflen as? Int {
-            currentShieldName = roadShieldName(for: text, shield: shieldID, reflen: reflenDigit)
+        if let text = line.attribute(forKey: "ref") as? String,
+            let shield = line.attribute(forKey: "shield") as? String,
+            let reflen = line.attribute(forKey: "reflen") as? Int {
+            currentShieldName = roadShieldName(for: text, shield: shield, reflen: reflen)
         }
 
-        if let roadName = name as? String {
+        if let roadName = line.attribute(forKey: "name") as? String {
             currentRoadName = roadName
         }
 
@@ -727,9 +725,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         return (roadName: currentRoadName, shieldName: currentShieldName)
     }
 
-    private func roadShieldName(for text: String?, shield: String?, reflen: Int?) -> NSAttributedString? {
-        guard let text = text, let shield = shield, let reflen = reflen else { return nil }
-
+    private func roadShieldName(for text: String, shield: String, reflen: Int) -> NSAttributedString? {
         let currentShield = HighwayShield.RoadType(rawValue: shield)
         let textColor = currentShield?.textColor ?? .black
         let imageName = "\(shield)-\(reflen)"

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -752,7 +752,8 @@ extension RouteMapViewController: NavigationViewDelegate {
             return nil
         }
 
-        let attachment = RoadNameLabelAttachment(image: image, text: text, color: textColor, font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize), scale: UIScreen.main.scale)
+        let attachment = ShieldAttachment()
+        attachment.image = image.withCenteredText(text, color: textColor, font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize), scale: UIScreen.main.scale)
         return NSAttributedString(attachment: attachment)
     }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -703,25 +703,11 @@ extension RouteMapViewController: NavigationViewDelegate {
         }
     }
 
-    private func roadFeature(for line: MGLPolylineFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
-        let roadNameRecord = roadFeatureHelper(ref: line.attribute(forKey: "ref"),
-                                               shield: line.attribute(forKey: "shield"),
-                                               reflen: line.attribute(forKey: "reflen"),
-                                               name: line.attribute(forKey: "name"))
-
-        return (roadName: roadNameRecord.roadName, shieldName: roadNameRecord.shieldName)
-    }
-
-    private func roadFeature(for line: MGLMultiPolylineFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
-        let roadNameRecord = roadFeatureHelper(ref: line.attribute(forKey: "ref"),
-                                               shield: line.attribute(forKey: "shield"),
-                                               reflen: line.attribute(forKey: "reflen"),
-                                               name: line.attribute(forKey: "name"))
-
-        return (roadName: roadNameRecord.roadName, shieldName: roadNameRecord.shieldName)
-    }
-
-    private func roadFeatureHelper(ref: Any?, shield: Any?, reflen: Any?, name: Any?) -> (roadName: String?, shieldName: NSAttributedString?) {
+    private func roadFeature(for line: MGLFeature) -> (roadName: String?, shieldName: NSAttributedString?) {
+        let ref = line.attribute(forKey: "ref")
+        let shield = line.attribute(forKey: "shield")
+        let reflen = line.attribute(forKey: "reflen")
+        let name = line.attribute(forKey: "name")
         var currentShieldName: NSAttributedString?, currentRoadName: String?
 
         if let text = ref as? String, let shieldID = shield as? String, let reflenDigit = reflen as? Int {

--- a/MapboxNavigation/UIImage.swift
+++ b/MapboxNavigation/UIImage.swift
@@ -18,21 +18,17 @@ extension UIImage {
         return UIGraphicsGetImageFromCurrentImageContext()
     }
     
-    func insert(text: NSString, color: UIColor, font: UIFont, atPoint: CGPoint, scale: CGFloat) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        
-        let textStyle = NSMutableParagraphStyle()
-        textStyle.alignment = .center
-        
-        let textFontAttributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: color, .paragraphStyle: textStyle]
-        draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
-        
-        let rect = CGRect(x: atPoint.x, y: atPoint.y, width: size.width, height: size.height)
-        text.draw(in: rect.integral, withAttributes: textFontAttributes)
-        
-        let compositedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        return compositedImage
+    func insert(text: NSString, color: UIColor, font: UIFont, scale: CGFloat) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { (context) in
+            let textStyle = NSMutableParagraphStyle()
+            textStyle.alignment = .center
+            
+            let textFontAttributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: color, .paragraphStyle: textStyle]
+            let rect = CGRect(origin: .zero, size: size)
+            draw(in: rect)
+            
+            text.draw(in: rect.offsetBy(dx: 0, dy: (size.height - font.lineHeight) / 2).integral, withAttributes: textFontAttributes)
+        }
     }
 }

--- a/MapboxNavigation/UIImage.swift
+++ b/MapboxNavigation/UIImage.swift
@@ -18,7 +18,7 @@ extension UIImage {
         return UIGraphicsGetImageFromCurrentImageContext()
     }
     
-    func insert(text: NSString, color: UIColor, font: UIFont, scale: CGFloat) -> UIImage {
+    func withCenteredText(_ text: String, color: UIColor, font: UIFont, scale: CGFloat) -> UIImage {
         let renderer = UIGraphicsImageRenderer(size: size)
         return renderer.image { (context) in
             let textStyle = NSMutableParagraphStyle()
@@ -28,7 +28,7 @@ extension UIImage {
             let rect = CGRect(origin: .zero, size: size)
             draw(in: rect)
             
-            text.draw(in: rect.offsetBy(dx: 0, dy: (size.height - font.lineHeight) / 2).integral, withAttributes: textFontAttributes)
+            (text as NSString).draw(in: rect.offsetBy(dx: 0, dy: (size.height - font.lineHeight) / 2).integral, withAttributes: textFontAttributes)
         }
     }
 }

--- a/MapboxNavigation/UIImage.swift
+++ b/MapboxNavigation/UIImage.swift
@@ -19,16 +19,21 @@ extension UIImage {
     }
     
     func withCenteredText(_ text: String, color: UIColor, font: UIFont, scale: CGFloat) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: size)
+        let maxHeight = font.lineHeight * 2
+        var constrainedSize = size
+        constrainedSize.width = min(constrainedSize.width, constrainedSize.width * maxHeight / constrainedSize.height)
+        constrainedSize.height = min(constrainedSize.height, maxHeight)
+        
+        let renderer = UIGraphicsImageRenderer(size: constrainedSize)
         return renderer.image { (context) in
             let textStyle = NSMutableParagraphStyle()
             textStyle.alignment = .center
             
             let textFontAttributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: color, .paragraphStyle: textStyle]
-            let rect = CGRect(origin: .zero, size: size)
+            let rect = CGRect(origin: .zero, size: constrainedSize)
             draw(in: rect)
             
-            (text as NSString).draw(in: rect.offsetBy(dx: 0, dy: (size.height - font.lineHeight) / 2).integral, withAttributes: textFontAttributes)
+            (text as NSString).draw(in: rect.offsetBy(dx: 0, dy: (constrainedSize.height - font.lineHeight) / 2).integral, withAttributes: textFontAttributes)
         }
     }
 }


### PR DESCRIPTION
Simplified the code that creates the attributed string to show in the current road name label (WayNameLabel) when the current road is part of a numbered route.

Constrain the route shield in this label to twice the height of the text within the shield, maintaining the image’s aspect ratio. This fixes an issue where the shield was oversized when the current map style was a custom style created in Mapbox Studio.

When the current style uses Mapbox Streets source v8, get the foreground text color [from the road feature](https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#--road---shield_text_color-text) instead of using the hard-coded logic that’s based on v7. This corrects the text color for certain shield types that were added in v8.

Fixes #2355. Once this fix lands, we should cherry-pick it into a new branch based on release-v0.39 for a v0.40 release.

/cc @mapbox/navigation-ios