### PR TITLE
Puck desaturation while Location updates are missing

### DIFF
--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -159,6 +159,7 @@ open class DayStyle: Style {
         TimeRemainingLabel.appearance().trafficUnknownColor = .defaultPrimaryText
         TopBannerView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         UserPuckCourseView.appearance().puckColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 1)
+        UserPuckCourseView.appearance().stalePuckColor = #colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1)
         WayNameLabel.appearance().normalFont = UIFont.systemFont(ofSize:20, weight: .medium).adjustedFont
         WayNameLabel.appearance().normalTextColor = #colorLiteral(red: 0.968627451, green: 0.968627451, blue: 0.968627451, alpha: 1)
         WayNameView.appearance().backgroundColor = UIColor.defaultRouteLayer.withAlphaComponent(0.85)


### PR DESCRIPTION
Resolves #2358 

I tried to find implementation that was done in Maps SDK, but had no luck.
I used Router notifications to receive location updates, and linear interpolation for transitioning between colors.
Not sure if 1 second tick is good enough but since total 'stale' timeout is 1 minute, that shouldn't become visible to a user. Anyway, I thought that these configs might be public so it is possible to adjust it as required.