### PR TITLE
changing default simulation mode to .never

### DIFF
--- a/MapboxCoreNavigation/NavigationService.swift
+++ b/MapboxCoreNavigation/NavigationService.swift
@@ -235,7 +235,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
                          directions: Directions? = nil,
                          locationSource: NavigationLocationManager? = nil,
                          eventsManagerType: NavigationEventsManager.Type? = nil,
-                         simulating simulationMode: SimulationMode = .onPoorGPS,
+                         simulating simulationMode: SimulationMode = .never,
                          routerType: Router.Type? = nil) {
         nativeLocationSource = locationSource ?? NavigationLocationManager()
         self.directions = directions ?? Directions.shared


### PR DESCRIPTION
Hi I would like to change the default simulation mode from `.onPoorGPS` to `.never`.

This is great that Mapbox provides navigation simulation as it is very useful for debugging.
However, the setting is very implicit as it is configured deeply in the `MapboxNavigationService` initializer, which is called by default in `NavigationViewController` initializer.
The last one accepts `NavigationOptions` which one might think these are all the options to possibly customize a navigation service by, which is totally misleading as the navigation service initializer has more (including mentioned simulationMode).
These options also have a possibility to specify a custom instance of NavigationService which one might think is unnecessary by assuming the default one should be safe and configured for the main purpose (real use in the field) of any navigation app.

Thus it is just too easy to miss and ship a simulation mode to production.
I came across this while sitting in an underground garage where GPS could not reach me and the simulation just kicked off! 😄 

I think if one is interested in simulating navigation then they will find a way to turn it on.
It should not be the other way around. The default values should be as simple as possible and work in the most expected way of a general purpose of the framework.
