### PR TITLE
RouteController Delegate fix for no voice navigation

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -272,8 +272,7 @@ open class RouteController: NSObject {
         guard let currentDestination = legProgress.leg.destination else {
             preconditionFailure("Route legs used for navigation must have destinations")
         }
-        guard let remainingVoiceInstructions = legProgress.currentStepProgress.remainingSpokenInstructions else { return
-        }
+        let remainingVoiceInstructions = legProgress.currentStepProgress.remainingSpokenInstructions ?? []
         
         // We are at least at the "You will arrive" instruction
         if legProgress.remainingSteps.count <= 2 && remainingVoiceInstructions.count <= 2 {


### PR DESCRIPTION
Fixes #2099 
Fixed case when RouteController Delegate did not receive arriving messages for routes without voice instructions enabled.