### PR TITLE
Offline Directions errors-clarification

### DIFF
--- a/MapboxCoreNavigation/OfflineDirections.swift
+++ b/MapboxCoreNavigation/OfflineDirections.swift
@@ -166,7 +166,8 @@ public class NavigationDirections: Directions {
      
      - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
      - parameter offline: Determines whether to calculate the route offline or online.
-     - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread. If called `NavigationDirections` instance is deallocated before route calculation is finished - completion won't be called.
+     - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
+     If called `NavigationDirections` instance is deallocated before route calculation is finished - completion won't be called.
      */
     public func calculate(_ options: RouteOptions, offline: Bool = true, completionHandler: @escaping OfflineRouteCompletionHandler) {
         

--- a/MapboxCoreNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/Base.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Found an invalid route while offline.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Unable to calculate the requested route while offline.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "Mapbox Navigation SDK for iOS version %@ is now available.";
 

--- a/MapboxCoreNavigation/Resources/de.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/de.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Es wurde eine ungültige Route berechnet, da keine Verbindung besteht.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Es ist nicht möglich, die gewünschte Route zu berechnen, da keine Verbindung besteht.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "Mapbox Navigation SDK für iOS Version %@ ist jetzt verfügbar.";
 

--- a/MapboxCoreNavigation/Resources/es.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/es.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Ha encontrado una ruta no válida en modo offline.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "No se puede calcular la ruta peticionada en modo offline.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "La versión %@ de Mapbox Navigation SDK para iOS está disponible.";
 

--- a/MapboxCoreNavigation/Resources/fr.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/fr.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Impossible de charger cet itinéraire hors ligne";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Impossible de calculer cet itinéraire hors ligne";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "La version %@ du SDK iOS Mapbox est maintenant disponible";
 

--- a/MapboxCoreNavigation/Resources/ja.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/ja.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "オフラインの為ルートを作成できません";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "オフラインの為、ルートを作成できません";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "iOS %@用 Mapbox Navigation SDKが使用できます";
 

--- a/MapboxCoreNavigation/Resources/pt-PT.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/pt-PT.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Foi encontrada uma rota inválida desligado da internet.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Não é possível calcular a rota pedida desligado da internet.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "O SDK de Navegação Mapbox para iOS versão %@ já está disponível.";
 

--- a/MapboxCoreNavigation/Resources/ru.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/ru.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Получен неверный маршрут без интернета.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Требуемый маршрут невозможно рассчитать без интернета.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "Доступна версия Mapbox Navigation SDK %@ для iOS.";
 

--- a/MapboxCoreNavigation/Resources/sv.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/sv.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Ogiltligt offline-rutt.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Kunde inte beräkna rutten i offline-läge.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "Mapbox Navigation SDK for iOS version %@ är nu tillgängligt.";
 

--- a/MapboxCoreNavigation/Resources/vi.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/vi.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Đã tìm thấy tuyến đường không hợp lệ trong khi ngoại tuyến.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Không tìm thấy tuyến đường trong khi ngoại tuyến.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "Mapbox Navigation SDK cho iOS mới ra phiên bản %@.";
 

--- a/MapboxCoreNavigation/Resources/yo.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/yo.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* Error message when an offline route request returns a response that can’t be deserialized */
 "OFFLINE_CORRUPT_DATA" = "Found an invalid route while offline.";
 
-/* Error description when an offline route request returns no result */
-"OFFLINE_NO_RESULT" = "Unable to calculate the requested route while offline.";
-
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "Mapbox Navigation SDK for iOS version %@ is now available.";
 


### PR DESCRIPTION
Resolves #2273  
Added new error case for indicating incorrect offline router object handling.

I hope I got original idea, described in the linked issue correctly...

What is the correct way of adding new localizations here? How can I add `OFFLINE_CANCELLED` translation and verify that it's correct?