### PR TITLE
Fix MapboxAccounts usage to match server-side expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Packaging
 * This SDK can no longer be used in applications written in pure Objective-C. If you need to use this SDK’s public API from Objective-C code, you will need to implement a wrapper in Swift that bridges the subset of the API you need from Swift to Objective-C. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
-* Added a new dependency on MapboxAccounts so that this SDK’s usage of Mapbox APIs is [billed](https://www.mapbox.com/pricing/) together based on [monthly active users](https://docs.mapbox.com/help/glossary/monthly-active-users/) rather than individually by HTTP request. If you use Carthage to install this SDK, remember to add MapboxAccounts.framework to the “Frameworks, Libraries, and Embedded Content” section and the input and output file lists of Carthage’s Run Script build phase. ([#2151](https://github.com/mapbox/mapbox-navigation-ios/pull/2151))
+* Added a new dependency on MapboxAccounts to prepare for upcoming improvements to how Mapbox [bills](https://www.mapbox.com/pricing/) this SDK’s usage of Mapbox APIs. If you use Carthage to install this SDK, remember to add MapboxAccounts.framework to the “Frameworks, Libraries, and Embedded Content” section and the input and output file lists of Carthage’s Run Script build phase. ([#2151](https://github.com/mapbox/mapbox-navigation-ios/pull/2151))
 * Upgraded to [Mapbox Maps SDK for iOS v5.6._x_](https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v5.6.0). ([#2302](https://github.com/mapbox/mapbox-navigation-ios/pull/2302))
 
 ### Top and bottom banners

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if isRunningTests() {
             window!.rootViewController = UIViewController()
         }
-        #if DEBUG
+        #if false
         if CommandLine.arguments.contains("enable-ui-testing") {
             if let viewController = (window?.rootViewController as? UINavigationController)?.visibleViewController as? ViewController {
                 viewController.testSKUTokens()

--- a/ExampleUITests/ExampleUITests.swift
+++ b/ExampleUITests/ExampleUITests.swift
@@ -11,6 +11,7 @@ class ExampleUITests: XCTestCase {
         app.launchArguments = ["enable-ui-testing"]
         app.launch()
 
+        #if false
         let mapViewLabel = app.staticTexts.element(matching:.any, identifier: "MapView SKU")
         let directionsLabel = app.staticTexts.element(matching:.any, identifier: "Directions SKU")
         let speechSynthesizerLabel = app.staticTexts.element(matching:.any, identifier: "SpeechSynthesizer SKU")
@@ -26,5 +27,6 @@ class ExampleUITests: XCTestCase {
         XCTAssertEqual(mapViewToken.skuId, SkuID.navigationUser.rawValue)
         XCTAssertEqual(mapViewToken, directionsToken)
         XCTAssertEqual(mapViewToken, speechSynthesizerToken)
+        #endif
     }
 }

--- a/MapboxCoreNavigation/MBXAccounts+CoreNavigationAdditions.m
+++ b/MapboxCoreNavigation/MBXAccounts+CoreNavigationAdditions.m
@@ -7,13 +7,11 @@ static NSString * const MBXNavigationBillingMethodRequest = @"request";
 
 + (void)load {
     NSString *billingMethodValue = [NSBundle.mainBundle objectForInfoDictionaryKey:@"MBXNavigationBillingMethod"];
-    if (!billingMethodValue.length || [billingMethodValue isEqualToString:MBXNavigationBillingMethodUser]) {
-        [MBXAccounts activateSKUID:MBXAccountsSKUIDNavigationUser];
-    } else if (![billingMethodValue isEqualToString:MBXNavigationBillingMethodRequest]) {
+    if (billingMethodValue.length && ![billingMethodValue isEqualToString:MBXNavigationBillingMethodRequest]) {
         // Billing method is not the default in the absence of a SKU ID.
         [NSException raise:@"MBXInvalidNavigationBillingMethod"
-                    format:@"Unrecognized billing method %@. Valid billing methods are: %@, %@.",
-         billingMethodValue, MBXNavigationBillingMethodUser, MBXNavigationBillingMethodRequest];
+                    format:@"Unrecognized billing method %@. Valid billing methods are: %@.",
+         billingMethodValue, MBXNavigationBillingMethodRequest];
     }
 }
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -400,8 +400,6 @@
 		DA8805002316EAED00B54D87 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
 		DA8F3A7623B5D84900B56786 /* SpeedLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7523B5D84900B56786 /* SpeedLimitView.swift */; };
 		DA8F3A7823B5DB7900B56786 /* SpeedLimitStyleKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7723B5DB7900B56786 /* SpeedLimitStyleKit.swift */; };
-		DAA3804E247D75AD007F4670 /* ViewController+UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EEA2424D0A700FA18A6 /* ViewController+UITests.swift */; };
-		DAA3804F247D75C8007F4670 /* SKUTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B469C22B9031E009CE634 /* SKUTestable.swift */; };
 		DAA96D18215A961D00BEF703 /* route-doubling-back.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA96D17215A961D00BEF703 /* route-doubling-back.json */; };
 		DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DAAE5F321EAE4C4700832871 /* Localizable.strings */; };
 		DAD17202214DB12B009C8161 /* CPMapTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD17201214DB12B009C8161 /* CPMapTemplateTests.swift */; };
@@ -2715,7 +2713,6 @@
 				C53F2EE420EBC95600D9798F /* ViewController.swift in Sources */,
 				DA303CAB21B7A93B00F921DC /* OfflineViewController.swift in Sources */,
 				C53F2EE520EBC95600D9798F /* CustomViewController.swift in Sources */,
-				DAA3804F247D75C8007F4670 /* SKUTestable.swift in Sources */,
 				DA303CAA21B7A93400F921DC /* ResizableView.swift in Sources */,
 				C53F2EE720EBC95600D9798F /* WaypointConfirmationViewController.swift in Sources */,
 				C5DE4B6220F6B6B3007AFBE6 /* CustomStyles.swift in Sources */,
@@ -2725,7 +2722,6 @@
 				C53F2EE820EBC95600D9798F /* AppDelegate.swift in Sources */,
 				DA303CA621B7A90100F921DC /* UIViewController.swift in Sources */,
 				3577B878214FF35800094294 /* FavoritesList.swift in Sources */,
-				DAA3804E247D75AD007F4670 /* ViewController+UITests.swift in Sources */,
 				DA303CA921B7A93100F921DC /* SettingsItems.swift in Sources */,
 				DA303CA721B7A91C00F921DC /* SettingsViewController.swift in Sources */,
 			);

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -27,10 +27,6 @@
 		16EF6C1E21193A9600AA580B /* CarPlayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EF6C1D21193A9600AA580B /* CarPlayManagerTests.swift */; };
 		16EF6C22211BA4B300AA580B /* CarPlayMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EF6C21211BA4B300AA580B /* CarPlayMapViewController.swift */; };
 		2B2B1EE02424B95600FA18A6 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EDF2424B95600FA18A6 /* ExampleUITests.swift */; };
-		2B2B1EE72424CE8100FA18A6 /* SKUTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B469C22B9031E009CE634 /* SKUTestable.swift */; };
-		2B2B1EE82424CEBA00FA18A6 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 355B469E22B904D2009CE634 /* OHHTTPStubs.framework */; };
-		2B2B1EE92424CEC600FA18A6 /* OHHTTPStubs.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 355B469E22B904D2009CE634 /* OHHTTPStubs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		2B2B1EEB2424D0A700FA18A6 /* ViewController+UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EEA2424D0A700FA18A6 /* ViewController+UITests.swift */; };
 		2B2B1EEE2424E55800FA18A6 /* SKUIDTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EED2424E55800FA18A6 /* SKUIDTestable.swift */; };
 		2B2B1EEF2424E55800FA18A6 /* SKUIDTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EED2424E55800FA18A6 /* SKUIDTestable.swift */; };
 		35002D611E5F6ADB0090E733 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35002D5F1E5F6ADB0090E733 /* Assets.xcassets */; };
@@ -566,7 +562,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				2B2B1EE92424CEC600FA18A6 /* OHHTTPStubs.framework in Embed Frameworks */,
 				C549F8331F17F2C5001A0A2D /* MapboxMobileEvents.framework in Embed Frameworks */,
 				35CC14181F79A434009E872A /* Turf.framework in Embed Frameworks */,
 				492B6F85213703EE0076D2C6 /* MapboxGeocoder.framework in Embed Frameworks */,
@@ -1096,7 +1091,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B2B1EE82424CEBA00FA18A6 /* OHHTTPStubs.framework in Frameworks */,
 				35E9B0AD1F9E0F8F00BF84AB /* MapboxNavigation.framework in Frameworks */,
 				35C98736212E045200808B82 /* MapboxNavigationNative.framework in Frameworks */,
 				3504DF7522B79B1D00D2FD3C /* MapboxAccounts.framework in Frameworks */,
@@ -2601,9 +2595,7 @@
 				3529FCF821A5C62400AEA9AA /* SettingsViewController.swift in Sources */,
 				3529FCF421A5C5C600AEA9AA /* SettingsItems.swift in Sources */,
 				3529FCF221A5C5B400AEA9AA /* ResizableView.swift in Sources */,
-				2B2B1EEB2424D0A700FA18A6 /* ViewController+UITests.swift in Sources */,
 				C5D9800D1EFA8BA9006DBF2E /* CustomViewController.swift in Sources */,
-				2B2B1EE72424CE8100FA18A6 /* SKUTestable.swift in Sources */,
 				AED6285622CBE4CE00058A51 /* ViewController+GuidanceCards.swift in Sources */,
 				C51FC31720F689F800400CE7 /* CustomStyles.swift in Sources */,
 				6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */,

--- a/MapboxNavigationTests/SKUTests.swift
+++ b/MapboxNavigationTests/SKUTests.swift
@@ -14,7 +14,7 @@ class SKUTests: XCTestCase {
         
         XCTAssertNotNil(directionsSkuToken)
         
-        XCTAssertEqual(directionsSkuToken?.skuId, SkuID.navigationUser.rawValue)
+        XCTAssertEqual(directionsSkuToken?.skuId, SkuID.mapsUser.rawValue)
     }
     
     func testSpeechSynthesizerSKU() {
@@ -22,6 +22,6 @@ class SKUTests: XCTestCase {
         
         XCTAssertNotNil(speechSkuToken)
         
-        XCTAssertEqual(speechSkuToken?.skuId, SkuID.navigationUser.rawValue)
+        XCTAssertEqual(speechSkuToken?.skuId, SkuID.mapsUser.rawValue)
     }
 }


### PR DESCRIPTION
Removed code that used a billing method that was unsupported on the server side. This billing method was turned on by default in #2151 but never included in a release or prerelease. A future release of the MapboxAccounts framework will add support for a new billing method. At that point, once all the pieces are in place, it might be possible to revert bfd8be364c38e754d5958cb72e4470a72d230120 cleanly.

This PR also reverts 7a3245e8f4e5bcb05bcaccfb09cd1e19895020ae and excludes MapboxAccounts debugging code from the example applications, since it requires OHHTTPStubs.

/cc @mapbox/navigation-ios @zugaldia @asinghal22 @mapbox/billing