### PR TITLE
Resume camera update

### DIFF
--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -274,7 +274,7 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
                 mapView?.setContentInset(contentInset(forOverviewing: false), animated: true, completionHandler: nil)
             } else if tracksUserCourse && !newValue {
                 isOverviewingRoutes = !isPanningAway
-                guard let userLocation = self.navigationService.router.location?.coordinate,
+                guard let userLocation = self.navigationService.router.location,
                     let shape = navigationService.route.shape else {
                     return
                 }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -241,7 +241,7 @@ class RouteMapViewController: UIViewController {
     @objc func toggleOverview(_ sender: Any) {
         mapView.enableFrameByFrameCourseViewTracking(for: 3)
         if let shape = router.route.shape,
-            let userLocation = router.location?.coordinate {
+            let userLocation = router.location {
             mapView.contentInset = contentInset(forOverviewing: true)
             mapView.setOverheadCameraView(from: userLocation, along: shape, for: contentInset(forOverviewing: true))
         }
@@ -493,7 +493,7 @@ extension RouteMapViewController: NavigationComponent {
         }
         
         if isInOverviewMode {
-            if let shape = route.shape, let userLocation = router.location?.coordinate {
+            if let shape = route.shape, let userLocation = router.location {
                 mapView.contentInset = contentInset(forOverviewing: true)
                 mapView.setOverheadCameraView(from: userLocation, along: shape, for: contentInset(forOverviewing: true))
             }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -218,6 +218,8 @@ class RouteMapViewController: UIViewController {
         mapView.enableFrameByFrameCourseViewTracking(for: 3)
         isInOverviewMode = false
 
+        
+        mapView.updateCourseTracking(location: mapView.userLocationForCourseTracking)
         updateCameraAltitude(for: router.routeProgress)
         
         mapView.addArrow(route: router.route,


### PR DESCRIPTION
Fixes #2217 

Aside of the specified issue, this PR also takes care about updating user puck heading update when entering overview mode (previously it didn't rotate correctly until new location update arrives).