### PR TITLE
Rerouting waypoints fix

### DIFF
--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -73,7 +73,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
 
     func suspendNotifications() {
         NotificationCenter.default.removeObserver(self, name: .routeControllerProgressDidChange, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .routeControllerWillReroute, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .routeControllerDidReroute, object: nil)
         NotificationCenter.default.removeObserver(self, name: .routeControllerDidPassVisualInstructionPoint, object: nil)
     }
 
@@ -112,6 +112,7 @@ class CustomViewController: UIViewController, MGLMapViewDelegate {
     // Fired when the user is no longer on the route.
     // Update the route on the map.
     @objc func rerouted(_ notification: NSNotification) {
+        self.mapView.removeWaypoints()
         self.mapView.show([navigationService.route])
     }
 

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -509,6 +509,8 @@ extension RouteMapViewController: NavigationComponent {
         let stepIndex = router.routeProgress.currentLegProgress.stepIndex
         let legIndex = router.routeProgress.legIndex
         
+        mapView.removeWaypoints()
+        
         mapView.addArrow(route: route, legIndex: legIndex, stepIndex: stepIndex + 1)
         mapView.show([route], legIndex: legIndex)
         mapView.showWaypoints(on: route)


### PR DESCRIPTION
Fixes #2037 

Usual mechanism for displaying routes works correctly with replacing existing elements, but since after multi-leg rerouting response will contain only the last leg, data on the previous legs was not cleared correctly. Explicitly wiping existing Waypoints before presenting new route solves the issue.

Also this PR fixed `Custom UI` navigation as it had obsolete view classes used.