### PR TITLE
Fix CocoaPods combined module hack for jazzy docset generation

### DIFF
--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxNavigation/**/*.swift","MapboxCoreNavigation"]
+  s.source_files = ["MapboxNavigation/**/*.{h,m,swift}","MapboxCoreNavigation/**/*.swift"]
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
@@ -45,10 +45,12 @@ Pod::Spec.new do |s|
 
   s.frameworks = ['CarPlay']
 
+  s.dependency "MapboxAccounts", "~> 2.2.0"
   s.dependency "MapboxDirections", "~> 0.31.0"
   s.dependency "MapboxGeocoder.swift", "~> 0.10.0"
   s.dependency "Mapbox-iOS-SDK", "~> 5.6"
   s.dependency "MapboxMobileEvents", "~> 0.10.2"
+  s.dependency "MapboxNavigationNative", "~> 6.2.1"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 0.3.0"
   s.dependency "MapboxSpeech", "~> 0.3.0"

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -28,7 +28,7 @@ BASE_URL="https://docs.mapbox.com/ios/api"
 
 # Link to directions documentation
 DIRECTIONS_VERSION=$(grep 'mapbox-directions-swift' Cartfile.resolved | grep -oE '"v.+?"' | grep -oE '[^"v]+')
-DIRECTIONS_SYMBOLS="AttributeOptions|CoordinateBounds|Directions|DirectionsOptions|DirectionsPriority|DirectionsProfileIdentifier|DirectionsResult|Intersection|Lane|LaneIndication|Match|MatchOptions|RoadClasses|Route|RouteLeg|RouteOptions|RouteStep|SpokenInstruction|Tracepoint|VisualInstruction|VisualInstruction.Component|VisualInstruction.Component.ImageRepresentation|VisualInstruction.Component.TextRepresentation|VisualInstructionBanner|Waypoint"
+DIRECTIONS_SYMBOLS="AttributeOptions|CoordinateBounds|Directions|DirectionsCredentials|DirectionsOptions|DirectionsPriority|DirectionsProfileIdentifier|DirectionsResult|Intersection|Lane|LaneIndication|MapMatchingResponse|Match|MatchOptions|RoadClasses|Route|RouteLeg|RouteOptions|RouteResponse|RouteStep|SpokenInstruction|Tracepoint|VisualInstruction|VisualInstruction.Component|VisualInstruction.Component.ImageRepresentation|VisualInstruction.Component.TextRepresentation|VisualInstructionBanner|Waypoint"
 
 rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -44,10 +44,16 @@ perl -pi -e "s/\\$\\{MINOR_VERSION\\}/${MINOR_VERSION}/" "${README}"
 echo "## Changes in version ${RELEASE_VERSION}" >> "${README}"
 sed -n -e '/^## /{' -e ':a' -e 'n' -e '/^## /q' -e 'p' -e 'ba' -e '}' CHANGELOG.md >> "${README}"
 
+# Blow away any includes of MapboxCoreNavigation, because
+# MapboxNavigation-Documentation.podspec gloms the two targets into one.
+# https://github.com/mapbox/mapbox-navigation-ios/issues/2363
+find Mapbox{Core,}Navigation/ -name '*.swift' -exec \
+    perl -pi -e 's/\bMapboxCoreNavigation\b/MapboxNavigation/' {} \;
+
 # Blow away any platform-based availability attributes, since everything is
 # compatible enough to be documented.
 # https://github.com/mapbox/mapbox-navigation-ios/issues/1682
-find Mapbox{Core,}Navigation/ -name *.swift -exec \
+find Mapbox{Core,}Navigation/ -name '*.swift' -exec \
     perl -pi -e 's/\@available\s*\(\s*iOS \d+.\d,.*?\)//' {} \;
 
 jazzy \


### PR DESCRIPTION
Added Objective-C files back to the podspec that hackily gloms MapboxCoreNavigation and MapboxNavigation together for jazzy. The Objective-C files themselves are a hack, forward-declaring the private [`-[MGLMapView mapViewDidFinishRenderingFrameFullyRendered:]`](https://github.com/mapbox/mapbox-gl-native-ios/blob/aa3f3875628a7bbda67bf687b6b2dcbcde55e9ad/platform/ios/src/MGLMapView_Private.h#L40) method from the map SDK.

Locally remove explicit references to MapboxCoreNavigation before compiling documentation. Added explicit dependencies on MapboxAccounts and MapboxNavigationNative.

Did I mention our use of CocoaPods is a hack?

/ref #285 #402
/cc @mapbox/navigation-ios @frederoni