### PR TITLE
Fix code snippet in Configuration section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ let destination = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.8977,
 // Set options
 let routeOptions = NavigationRouteOptions(waypoints: [origin, destination])
 
-// Request a route using MapboxDirections.swift
+// Request a route using MapboxDirections
 Directions.shared.calculate(routeOptions) { [weak self] (session, result) in
     switch result {
     case .failure(let error):

--- a/README.md
+++ b/README.md
@@ -72,20 +72,27 @@ import MapboxNavigation
 ```
 
 ```swift
+// Define two waypoints to travel between
 let origin = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.9131752, longitude: -77.0324047), name: "Mapbox")
 let destination = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365), name: "White House")
 
+// Set options
 let routeOptions = NavigationRouteOptions(waypoints: [origin, destination])
 
-Directions.shared.calculate(routeOptions) { (session, result) in
-    guard case let .success(response) = result,
-        let route = response.routes?.first else {
-        return
+// Request a route using MapboxDirections.swift
+Directions.shared.calculate(routeOptions) { [weak self] (session, result) in
+    switch result {
+    case .failure(let error):
+        print(error.localizedDescription)
+    case .success(let response):
+        guard let route = response.routes?.first, let strongSelf = self else {
+            return
+        }
+        // Pass the generated route to the the NavigationViewController
+        let viewController = NavigationViewController(for: route, routeOptions: routeOptions)
+        viewController.modalPresentationStyle = .fullScreen
+        strongSelf.present(viewController, animated: true, completion: nil)
     }
-    
-    let viewController = NavigationViewController(for: route, routeOptions: routeOptions)
-    viewController.modalPresentationStyle = .fullScreen
-    present(viewController, animated: true, completion: nil)
 }
 ```
 

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -57,7 +57,7 @@ let destination = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.8977,
 // Set options
 let routeOptions = NavigationRouteOptions(waypoints: [origin, destination])
 
-// Request a route using MapboxDirections.swift
+// Request a route using MapboxDirections
 Directions.shared.calculate(routeOptions) { [weak self] (session, result) in
     switch result {
     case .failure(let error):

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -50,16 +50,27 @@ import MapboxNavigation
 ```
 
 ```swift
+// Define two waypoints to travel between
 let origin = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.9131752, longitude: -77.0324047), name: "Mapbox")
 let destination = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365), name: "White House")
 
-let options = NavigationRouteOptions(waypoints: [origin, destination])
+// Set options
+let routeOptions = NavigationRouteOptions(waypoints: [origin, destination])
 
-Directions.shared.calculate(options) { (waypoints, routes, error) in
-    guard let route = routes?.first else { return }
-
-    let viewController = NavigationViewController(for: route)
-    present(viewController, animated: true, completion: nil)
+// Request a route using MapboxDirections.swift
+Directions.shared.calculate(routeOptions) { [weak self] (session, result) in
+    switch result {
+    case .failure(let error):
+        print(error.localizedDescription)
+    case .success(let response):
+        guard let route = response.routes?.first, let strongSelf = self else {
+            return
+        }
+        // Pass the generated route to the the NavigationViewController
+        let viewController = NavigationViewController(for: route, routeOptions: routeOptions)
+        viewController.modalPresentationStyle = .fullScreen
+        strongSelf.present(viewController, animated: true, completion: nil)
+    }
 }
 ```
 


### PR DESCRIPTION
Code snippet in docs/cover.md wasn't changed to use updated Directions API.
Code snippet in README.md wasn't correctly compiling with error:
``Implicit use of 'self' in closure; use 'self.' to make capture semantics explicit``.

Closes #2389.