### PR TITLE
Re-enable MAU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+### MAU Billing
+
+* Enabled MAU billing by default, so that SDKs usage of Mapbox APIs is [billed](https://www.mapbox.com/pricing/) together based on [monthly active users](https://docs.mapbox.com/help/glossary/monthly-active-users/) rather than individually by HTTP request. If you prefer to still use request-based billing, set the `MBXNavigationBillingMethod` key in Info.plist to `request` ([#2405](https://github.com/mapbox/mapbox-navigation-ios/pull/2405).
+
 ### Offline navigation
 
 * Fixed a crash that occurred after setting `RouteOptions.shapeFormat` to `RouteShapeFormat.geoJSON`. ([valhalla/valhalla#1867](https://github.com/valhalla/valhalla/pull/1867))
@@ -21,7 +25,7 @@
 
 ### Packaging
 * This SDK can no longer be used in applications written in pure Objective-C. If you need to use this SDK’s public API from Objective-C code, you will need to implement a wrapper in Swift that bridges the subset of the API you need from Swift to Objective-C. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
-* Added a new dependency on MapboxAccounts so that this SDK’s usage of Mapbox APIs is [billed](https://www.mapbox.com/pricing/) together based on [monthly active users](https://docs.mapbox.com/help/glossary/monthly-active-users/) rather than individually by HTTP request. If you use Carthage to install this SDK, remember to add MapboxAccounts.framework to the “Frameworks, Libraries, and Embedded Content” section and the input and output file lists of Carthage’s Run Script build phase. ([#2151](https://github.com/mapbox/mapbox-navigation-ios/pull/2151))
+* Added a new dependency on MapboxAccounts to prepare for upcoming improvements to how Mapbox [bills](https://www.mapbox.com/pricing/) this SDK’s usage of Mapbox APIs. If you use Carthage to install this SDK, remember to add MapboxAccounts.framework to the “Frameworks, Libraries, and Embedded Content” section and the input and output file lists of Carthage’s Run Script build phase. ([#2151](https://github.com/mapbox/mapbox-navigation-ios/pull/2151))
 * Upgraded to [Mapbox Maps SDK for iOS v5.6._x_](https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v5.6.0). ([#2302](https://github.com/mapbox/mapbox-navigation-ios/pull/2302))
 * Fixed sporadic build failures after installing this SDK using CocoaPods. ([#2368](https://github.com/mapbox/mapbox-navigation-ios/pull/2368))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Packaging
 * This SDK can no longer be used in applications written in pure Objective-C. If you need to use this SDK’s public API from Objective-C code, you will need to implement a wrapper in Swift that bridges the subset of the API you need from Swift to Objective-C. ([#2230](https://github.com/mapbox/mapbox-navigation-ios/pull/2230))
-* Added a new dependency on MapboxAccounts to prepare for upcoming improvements to how Mapbox [bills](https://www.mapbox.com/pricing/) this SDK’s usage of Mapbox APIs. If you use Carthage to install this SDK, remember to add MapboxAccounts.framework to the “Frameworks, Libraries, and Embedded Content” section and the input and output file lists of Carthage’s Run Script build phase. ([#2151](https://github.com/mapbox/mapbox-navigation-ios/pull/2151))
+* Added a new dependency on MapboxAccounts so that this SDK’s usage of Mapbox APIs is [billed](https://www.mapbox.com/pricing/) together based on [monthly active users](https://docs.mapbox.com/help/glossary/monthly-active-users/) rather than individually by HTTP request. If you use Carthage to install this SDK, remember to add MapboxAccounts.framework to the “Frameworks, Libraries, and Embedded Content” section and the input and output file lists of Carthage’s Run Script build phase. ([#2151](https://github.com/mapbox/mapbox-navigation-ios/pull/2151))
 * Upgraded to [Mapbox Maps SDK for iOS v5.6._x_](https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v5.6.0). ([#2302](https://github.com/mapbox/mapbox-navigation-ios/pull/2302))
 * Fixed sporadic build failures after installing this SDK using CocoaPods. ([#2368](https://github.com/mapbox/mapbox-navigation-ios/pull/2368))
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" ~> 2.2
+binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" ~> 2.3
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.6
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" == 9.0.4
 github "mapbox/mapbox-directions-swift" ~> 0.32

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.9.0"
-binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.2.0"
+binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.3.0"
 binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "9.0.4"
 github "CedarBDD/Cedar" "v1.0"
 github "Quick/Nimble" "v8.1.1"

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if isRunningTests() {
             window!.rootViewController = UIViewController()
         }
-        #if false
+        #if DEBUG
         if CommandLine.arguments.contains("enable-ui-testing") {
             if let viewController = (window?.rootViewController as? UINavigationController)?.visibleViewController as? ViewController {
                 viewController.testSKUTokens()

--- a/ExampleUITests/ExampleUITests.swift
+++ b/ExampleUITests/ExampleUITests.swift
@@ -11,7 +11,6 @@ class ExampleUITests: XCTestCase {
         app.launchArguments = ["enable-ui-testing"]
         app.launch()
 
-        #if false
         let mapViewLabel = app.staticTexts.element(matching:.any, identifier: "MapView SKU")
         let directionsLabel = app.staticTexts.element(matching:.any, identifier: "Directions SKU")
         let speechSynthesizerLabel = app.staticTexts.element(matching:.any, identifier: "SpeechSynthesizer SKU")
@@ -27,6 +26,5 @@ class ExampleUITests: XCTestCase {
         XCTAssertEqual(mapViewToken.skuId, SkuID.navigationUser.rawValue)
         XCTAssertEqual(mapViewToken, directionsToken)
         XCTAssertEqual(mapViewToken, speechSynthesizerToken)
-        #endif
     }
 }

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxCoreNavigation"
 
   s.dependency "MapboxNavigationNative", "= 9.0.4"
-  s.dependency "MapboxAccounts", "~> 2.2.0"
+  s.dependency "MapboxAccounts", "~> 2.3.0"
   s.dependency "MapboxDirections", "~> 0.32.0"
   s.dependency "MapboxMobileEvents", "~> 0.10.2"        # Always pin to a patch release if pre-1.0
   s.dependency "Turf", "~> 0.5.0"                       # Always pin to a patch release if pre-1.0

--- a/MapboxCoreNavigation/MBXAccounts+CoreNavigationAdditions.m
+++ b/MapboxCoreNavigation/MBXAccounts+CoreNavigationAdditions.m
@@ -7,11 +7,13 @@ static NSString * const MBXNavigationBillingMethodRequest = @"request";
 
 + (void)load {
     NSString *billingMethodValue = [NSBundle.mainBundle objectForInfoDictionaryKey:@"MBXNavigationBillingMethod"];
-    if (billingMethodValue.length && ![billingMethodValue isEqualToString:MBXNavigationBillingMethodRequest]) {
+    if (!billingMethodValue.length || [billingMethodValue isEqualToString:MBXNavigationBillingMethodUser]) {
+        [MBXAccounts activateSKUID:MBXAccountsSKUIDNavigationUser];
+    } else if (![billingMethodValue isEqualToString:MBXNavigationBillingMethodRequest]) {
         // Billing method is not the default in the absence of a SKU ID.
         [NSException raise:@"MBXInvalidNavigationBillingMethod"
-                    format:@"Unrecognized billing method %@. Valid billing methods are: %@.",
-         billingMethodValue, MBXNavigationBillingMethodRequest];
+                    format:@"Unrecognized billing method %@. Valid billing methods are: %@, %@.",
+         billingMethodValue, MBXNavigationBillingMethodUser, MBXNavigationBillingMethodRequest];
     }
 }
 

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Mapbox-iOS-SDK (5.9.0):
     - MapboxMobileEvents (= 0.10.2)
-  - MapboxAccounts (2.2.0)
+  - MapboxAccounts (2.3.0)
   - MapboxCoreNavigation (0.40.0):
-    - MapboxAccounts (~> 2.2.0)
+    - MapboxAccounts (~> 2.3.0)
     - MapboxDirections (~> 0.32.0)
     - MapboxMobileEvents (~> 0.10.2)
     - MapboxNavigationNative (= 9.0.4)
@@ -48,7 +48,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956
-  MapboxAccounts: 3c04a1df56c1ac4ff714619296fb47310cf70ad0
+  MapboxAccounts: 84abfdde95d9dc483f604c1b0fe1861edf691ce7
   MapboxCoreNavigation: e172e4407f69e4dbef19c20bce2045347ea6dc34
   MapboxDirections: 7f36b3e9ef6a53fc997c114a341ab4da721756bd
   MapboxMobileEvents: 2bc0ca2eedb627b73cf403258dce2b2fa98074a6

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -49,7 +49,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956
   MapboxAccounts: 84abfdde95d9dc483f604c1b0fe1861edf691ce7
-  MapboxCoreNavigation: e172e4407f69e4dbef19c20bce2045347ea6dc34
+  MapboxCoreNavigation: ddd42a0c92935d7d6090fdccd63fc8c84e5dbf8b
   MapboxDirections: 7f36b3e9ef6a53fc997c114a341ab4da721756bd
   MapboxMobileEvents: 2bc0ca2eedb627b73cf403258dce2b2fa98074a6
   MapboxNavigation: 42bae50b0381dce317c85884ba0de38fc68a4814

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
 
   s.frameworks = ['CarPlay']
 
-  s.dependency "MapboxAccounts", "~> 2.2.0"
+  s.dependency "MapboxAccounts", "~> 2.3.0"
   s.dependency "MapboxDirections", "~> 0.32.0"
   s.dependency "MapboxGeocoder.swift", "~> 0.10.0"
   s.dependency "Mapbox-iOS-SDK", "~> 5.6"

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		16EF6C1E21193A9600AA580B /* CarPlayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EF6C1D21193A9600AA580B /* CarPlayManagerTests.swift */; };
 		16EF6C22211BA4B300AA580B /* CarPlayMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EF6C21211BA4B300AA580B /* CarPlayMapViewController.swift */; };
 		2B2B1EE02424B95600FA18A6 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EDF2424B95600FA18A6 /* ExampleUITests.swift */; };
+		2B2B1EE72424CE8100FA18A6 /* SKUTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B469C22B9031E009CE634 /* SKUTestable.swift */; };
+		2B2B1EE82424CEBA00FA18A6 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 355B469E22B904D2009CE634 /* OHHTTPStubs.framework */; };
+		2B2B1EE92424CEC600FA18A6 /* OHHTTPStubs.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 355B469E22B904D2009CE634 /* OHHTTPStubs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		2B2B1EEB2424D0A700FA18A6 /* ViewController+UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EEA2424D0A700FA18A6 /* ViewController+UITests.swift */; };
 		2B2B1EEE2424E55800FA18A6 /* SKUIDTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EED2424E55800FA18A6 /* SKUIDTestable.swift */; };
 		2B2B1EEF2424E55800FA18A6 /* SKUIDTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EED2424E55800FA18A6 /* SKUIDTestable.swift */; };
 		35002D611E5F6ADB0090E733 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35002D5F1E5F6ADB0090E733 /* Assets.xcassets */; };
@@ -396,6 +400,8 @@
 		DA8805002316EAED00B54D87 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
 		DA8F3A7623B5D84900B56786 /* SpeedLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7523B5D84900B56786 /* SpeedLimitView.swift */; };
 		DA8F3A7823B5DB7900B56786 /* SpeedLimitStyleKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7723B5DB7900B56786 /* SpeedLimitStyleKit.swift */; };
+		DAA3804E247D75AD007F4670 /* ViewController+UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2B1EEA2424D0A700FA18A6 /* ViewController+UITests.swift */; };
+		DAA3804F247D75C8007F4670 /* SKUTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B469C22B9031E009CE634 /* SKUTestable.swift */; };
 		DAA96D18215A961D00BEF703 /* route-doubling-back.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA96D17215A961D00BEF703 /* route-doubling-back.json */; };
 		DAAE5F301EAE4C4700832871 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DAAE5F321EAE4C4700832871 /* Localizable.strings */; };
 		DAD17202214DB12B009C8161 /* CPMapTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD17201214DB12B009C8161 /* CPMapTemplateTests.swift */; };
@@ -562,6 +568,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				2B2B1EE92424CEC600FA18A6 /* OHHTTPStubs.framework in Embed Frameworks */,
 				C549F8331F17F2C5001A0A2D /* MapboxMobileEvents.framework in Embed Frameworks */,
 				35CC14181F79A434009E872A /* Turf.framework in Embed Frameworks */,
 				492B6F85213703EE0076D2C6 /* MapboxGeocoder.framework in Embed Frameworks */,
@@ -1096,6 +1103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B2B1EE82424CEBA00FA18A6 /* OHHTTPStubs.framework in Frameworks */,
 				35E9B0AD1F9E0F8F00BF84AB /* MapboxNavigation.framework in Frameworks */,
 				35C98736212E045200808B82 /* MapboxNavigationNative.framework in Frameworks */,
 				3504DF7522B79B1D00D2FD3C /* MapboxAccounts.framework in Frameworks */,
@@ -2601,7 +2609,9 @@
 				3529FCF821A5C62400AEA9AA /* SettingsViewController.swift in Sources */,
 				3529FCF421A5C5C600AEA9AA /* SettingsItems.swift in Sources */,
 				3529FCF221A5C5B400AEA9AA /* ResizableView.swift in Sources */,
+				2B2B1EEB2424D0A700FA18A6 /* ViewController+UITests.swift in Sources */,
 				C5D9800D1EFA8BA9006DBF2E /* CustomViewController.swift in Sources */,
+				2B2B1EE72424CE8100FA18A6 /* SKUTestable.swift in Sources */,
 				AED6285622CBE4CE00058A51 /* ViewController+GuidanceCards.swift in Sources */,
 				C51FC31720F689F800400CE7 /* CustomStyles.swift in Sources */,
 				6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */,
@@ -2711,6 +2721,7 @@
 				C53F2EE420EBC95600D9798F /* ViewController.swift in Sources */,
 				DA303CAB21B7A93B00F921DC /* OfflineViewController.swift in Sources */,
 				C53F2EE520EBC95600D9798F /* CustomViewController.swift in Sources */,
+				DAA3804F247D75C8007F4670 /* SKUTestable.swift in Sources */,
 				DA303CAA21B7A93400F921DC /* ResizableView.swift in Sources */,
 				C53F2EE720EBC95600D9798F /* WaypointConfirmationViewController.swift in Sources */,
 				C5DE4B6220F6B6B3007AFBE6 /* CustomStyles.swift in Sources */,
@@ -2720,6 +2731,7 @@
 				C53F2EE820EBC95600D9798F /* AppDelegate.swift in Sources */,
 				DA303CA621B7A90100F921DC /* UIViewController.swift in Sources */,
 				3577B878214FF35800094294 /* FavoritesList.swift in Sources */,
+				DAA3804E247D75AD007F4670 /* ViewController+UITests.swift in Sources */,
 				DA303CA921B7A93100F921DC /* SettingsItems.swift in Sources */,
 				DA303CA721B7A91C00F921DC /* SettingsViewController.swift in Sources */,
 			);

--- a/MapboxNavigationTests/SKUIDTestable.swift
+++ b/MapboxNavigationTests/SKUIDTestable.swift
@@ -8,7 +8,7 @@ extension String {
 enum SkuID: String {
     typealias RawValue = String
     case mapsUser = "00"
-    case navigationUser = "02"
     case navigationSession = "03"
+    case navigationUser = "08"
 }
 #endif

--- a/MapboxNavigationTests/SKUTests.swift
+++ b/MapboxNavigationTests/SKUTests.swift
@@ -14,7 +14,7 @@ class SKUTests: XCTestCase {
         
         XCTAssertNotNil(directionsSkuToken)
         
-        XCTAssertEqual(directionsSkuToken?.skuId, SkuID.mapsUser.rawValue)
+        XCTAssertEqual(directionsSkuToken?.skuId, SkuID.navigationUser.rawValue)
     }
     
     func testSpeechSynthesizerSKU() {
@@ -22,6 +22,6 @@ class SKUTests: XCTestCase {
         
         XCTAssertNotNil(speechSkuToken)
         
-        XCTAssertEqual(speechSkuToken?.skuId, SkuID.mapsUser.rawValue)
+        XCTAssertEqual(speechSkuToken?.skuId, SkuID.navigationUser.rawValue)
     }
 }


### PR DESCRIPTION
Resolved [mapbox/navigation-sdks/issues/129](https://github.com/mapbox/navigation-sdks/issues/129).
This PR reverts [changes](https://github.com/mapbox/mapbox-navigation-ios/pull/2375), that reverted [MAU biliing implementation](https://github.com/mapbox/mapbox-navigation-ios/pull/2151). Also updates `MapboxAccounts` dependency to version `2.3.0`.