### PR TITLE
[Feedback][Part 4][WIP] Refactor FeedbackVC and extract TopLevelFeedbackVC + FeedbackDetailsVC

### DIFF
--- a/MapboxCoreNavigation/Feedback.swift
+++ b/MapboxCoreNavigation/Feedback.swift
@@ -40,10 +40,31 @@ public enum FeedbackType: CustomStringConvertible {
             return "road_closure"
         }
     }
+
+    public var subtypes: [FeedbackSubType] {
+        switch self {
+        case .general:
+            return []
+        case .incorrectVisual(_):
+            return IncorrectVisualSubtype.allCases
+        case .confusingAudio(_):
+            return ConfusingAudioSubtype.allCases
+        case .routeQuality(_):
+            return RouteQualitySubtype.allCases
+        case .illegalRoute(_):
+            return IllegalRouteSubtype.allCases
+        case .roadClosure(_):
+            return RoadClosureSubtype.allCases
+        }
+    }
+}
+
+public protocol FeedbackSubType {
+    func titleForCell() -> String
 }
 
 /// Enum denoting the subtypes of the  `Incorrect Visual` top-level category
-public enum IncorrectVisualSubtype: String {
+public enum IncorrectVisualSubtype: String, CaseIterable, FeedbackSubType  {
     case turnIconIncorrect
     case streetNameIncorrect
     case instructionUnnecessary
@@ -52,37 +73,65 @@ public enum IncorrectVisualSubtype: String {
     case exitInfoIncorrect
     case laneGuidanceIncorrect
     case roadKnownByDifferentName
+
+    // TODO: Return an actual (localized) title here. Using the `rawValue` as a temporary placeholder for now.
+    public func titleForCell() -> String {
+        return self.rawValue
+    }
 }
 
 /// Enum denoting the subtypes of the  `Confusing Audio` top-level category
-public enum ConfusingAudioSubtype: String {
+public enum ConfusingAudioSubtype: String, CaseIterable, FeedbackSubType {
     case guidanceTooEarly
     case guidanceTooLate
     case pronunciationIncorrect
     case roadNameRepeated
+
+    // TODO: Return an actual (localized) title here. Using the `rawValue` as a temporary placeholder for now.
+    public func titleForCell() -> String {
+        return self.rawValue
+    }
 }
 
 /// Enum denoting the subtypes of the  `Route Quality` top-level category
-public enum RouteQualitySubtype: String {
+public enum RouteQualitySubtype: String, CaseIterable, FeedbackSubType {
     case routeNonDrivable
     case routeNotPreferred
     case alternativeRouteNotExpected
     case routeIncludedMissingRoads
     case routeHadRoadsTooNarrowToPass
+
+    // TODO: Return an actual (localized) title here. Using the `rawValue` as a temporary placeholder for now.
+    public func titleForCell() -> String {
+        return self.rawValue
+    }
+
 }
 
 /// Enum denoting the subtypes of the  `Illegal Route` top-level category
-public enum IllegalRouteSubtype: String {
+public enum IllegalRouteSubtype: String, CaseIterable, FeedbackSubType {
     case routedDownAOneWay
     case turnWasNotAllowed
     case carsNotAllowedOnStreet
     case turnAtIntersectionUnprotected
+
+    // TODO: Return an actual (localized) title here. Using the `rawValue` as a temporary placeholder for now.
+    public func titleForCell() -> String {
+        return self.rawValue
+    }
+
 }
 
 /// Enum denoting the subtypes of the  `Road Closure` top-level category
-public enum RoadClosureSubtype: String {
+public enum RoadClosureSubtype: String, CaseIterable, FeedbackSubType {
     case streetPermanentlyBlockedOff
     case roadMissingFromMap
+
+    // TODO: Return an actual (localized) title here. Using the `rawValue` as a temporary placeholder for now.
+    public func titleForCell() -> String {
+        return self.rawValue
+    }
+
 }
 
 public enum FeedbackSource: Int, CustomStringConvertible {

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C36989524A4F55900E25A10 /* TopLevelFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C36989424A4F55900E25A10 /* TopLevelFeedbackViewController.swift */; };
+		0C36989724A4F72F00E25A10 /* FeedbackDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C36989624A4F72F00E25A10 /* FeedbackDetailsViewController.swift */; };
+		0C36989924A4F8F000E25A10 /* FeedbackSubTypeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C36989824A4F8F000E25A10 /* FeedbackSubTypeCell.swift */; };
 		1603C891214351EE00167D95 /* Cedar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1603C890214351EE00167D95 /* Cedar.framework */; };
 		160A4A712127A46C0028B070 /* CPBarButton+MBTestable.m in Sources */ = {isa = PBXBuildFile; fileRef = 160A4A69212791010028B070 /* CPBarButton+MBTestable.m */; };
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
@@ -623,6 +626,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0C36989424A4F55900E25A10 /* TopLevelFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopLevelFeedbackViewController.swift; sourceTree = "<group>"; };
+		0C36989624A4F72F00E25A10 /* FeedbackDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackDetailsViewController.swift; sourceTree = "<group>"; };
+		0C36989824A4F8F000E25A10 /* FeedbackSubTypeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSubTypeCell.swift; sourceTree = "<group>"; };
 		1603C890214351EE00167D95 /* Cedar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cedar.framework; path = Carthage/Build/iOS/Cedar.framework; sourceTree = "<group>"; };
 		160A4A68212791010028B070 /* CPBarButton+MBTestable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CPBarButton+MBTestable.h"; sourceTree = "<group>"; };
 		160A4A69212791010028B070 /* CPBarButton+MBTestable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CPBarButton+MBTestable.m"; sourceTree = "<group>"; };
@@ -1340,6 +1346,7 @@
 				C5A6B2DC1F4CE8E8004260EA /* StyleType.swift */,
 				2B72EC5F2412AA800003B370 /* SystemSpeechSynthesizer.swift */,
 				35B1E2941F1FF8EC00A13D32 /* UserCourseView.swift */,
+				0C36989424A4F55900E25A10 /* TopLevelFeedbackViewController.swift */,
 			);
 			path = MapboxNavigation;
 			sourceTree = "<group>";
@@ -1357,6 +1364,8 @@
 			isa = PBXGroup;
 			children = (
 				351BEC281E5BD530006FE110 /* Assets.xcassets */,
+				0C36989624A4F72F00E25A10 /* FeedbackDetailsViewController.swift */,
+				0C36989824A4F8F000E25A10 /* FeedbackSubTypeCell.swift */,
 				C520EE921EBB84F9008805BC /* Navigation.storyboard */,
 				DAAE5F321EAE4C4700832871 /* Localizable.strings */,
 				DA35256E2010A5200048DDFC /* Localizable.stringsdict */,
@@ -2404,6 +2413,7 @@
 				C58822001FB0F0D7008B0A2D /* Error.swift in Sources */,
 				C5F4D21920DC468B0059FABF /* CongestionLevel.swift in Sources */,
 				AE47A32B22B1F6AE0096458C /* InstructionsCardCell.swift in Sources */,
+				0C36989524A4F55900E25A10 /* TopLevelFeedbackViewController.swift in Sources */,
 				3597B9A42149B2C20021B0D9 /* UIViewController.swift in Sources */,
 				8D24A2FA20449B430098CBF8 /* Dictionary.swift in Sources */,
 				350E2C5F22707EB80014CEB3 /* UIScreen.swift in Sources */,
@@ -2439,6 +2449,7 @@
 				C57491DF1FACC42F006F97BC /* CGPoint.swift in Sources */,
 				16C2A421211526EE00FE6E68 /* CarPlayManager.swift in Sources */,
 				8D53136B20653FA20044891E /* ExitView.swift in Sources */,
+				0C36989924A4F8F000E25A10 /* FeedbackSubTypeCell.swift in Sources */,
 				8D3322272200E4CA001D44AA /* NavigationOptions.swift in Sources */,
 				C58159011EA6D02700FC6C3D /* MGLVectorTileSource.swift in Sources */,
 				AE47A32D22B1F6AE0096458C /* InstructionsCard+Font.swift in Sources */,
@@ -2478,6 +2489,7 @@
 				2B5407EB24470B0A006C820B /* AVAudioSession.swift in Sources */,
 				35F611C41F1E1C0500C43249 /* FeedbackViewController.swift in Sources */,
 				353AA5601FCEF583009F0384 /* StyleManager.swift in Sources */,
+				0C36989724A4F72F00E25A10 /* FeedbackDetailsViewController.swift in Sources */,
 				35F520C01FB482A200FC9C37 /* NextBannerView.swift in Sources */,
 				C5A6B2DD1F4CE8E8004260EA /* StyleType.swift in Sources */,
 				C5381F03204E052A00A5493E /* UIDevice.swift in Sources */,

--- a/MapboxNavigation/FeedbackCollectionViewCell.swift
+++ b/MapboxNavigation/FeedbackCollectionViewCell.swift
@@ -2,8 +2,6 @@ import Foundation
 import UIKit
 
 class FeedbackCollectionViewCell: UICollectionViewCell {
-    static let defaultIdentifier = "MapboxFeedbackCell"
-    
     struct Constants {
         static let circleSize: CGSize = 70.0
         static let imageSize: CGSize = 36.0

--- a/MapboxNavigation/FeedbackDetailsViewController.swift
+++ b/MapboxNavigation/FeedbackDetailsViewController.swift
@@ -1,0 +1,93 @@
+import UIKit
+import MapboxCoreNavigation
+
+class FeedbackDetailsViewController: UITableViewController {
+
+    var navigationItemTitle: String = ""
+    var feedbackSubTypes: [FeedbackSubType] = [] {
+        didSet {
+            self.tableView.reloadData()
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.tableView.register(FeedbackSubTypeCell.self, forCellReuseIdentifier: "feedbackSubTypeCell")
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationItem.title = navigationItemTitle
+        self.tableView.reloadData()
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return feedbackSubTypes.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "feedbackSubTypeCell", for: indexPath) as? FeedbackSubTypeCell else {
+            return UITableViewCell()
+        }
+
+        cell.configure(with: feedbackSubTypes[indexPath.row].titleForCell())
+        return cell
+    }
+
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MapboxNavigation/FeedbackSubTypeCell.swift
+++ b/MapboxNavigation/FeedbackSubTypeCell.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+class FeedbackSubTypeCell: UITableViewCell {
+
+    override var reuseIdentifier: String? {
+        return "feedbackSubTypeCell"
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+    func configure(with title: String) {
+        self.textLabel?.text = title
+    }
+}

--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -69,53 +69,14 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     static let cellReuseIdentifier = "collectionViewCellId"
     static let autoDismissInterval: TimeInterval = 10
     static let verticalCellPadding: CGFloat = 20.0
-    static let titleHeaderHeight: CGFloat = 30.0
     static let contentInset: UIEdgeInsets = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
     
     let interactor = Interactor()
-    /**
-     The feedback items that are visible and selectable by the user.
-     */
-    public var sections: [FeedbackItem] =  [FeedbackType.incorrectVisual(subtype: nil),
-                                            FeedbackType.confusingAudio(subtype: nil),
-                                            FeedbackType.illegalRoute(subtype: nil),
-                                            FeedbackType.roadClosure(subtype: nil),
-                                            FeedbackType.routeQuality(subtype: nil)].map { $0.generateFeedbackItem() }
-    
+
     public weak var delegate: FeedbackViewControllerDelegate?
-    
-    lazy var collectionView: UICollectionView = {
-        let view: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .clear
-        view.delegate = self
-        view.dataSource = self
-        view.contentInset = FeedbackViewController.contentInset
-        view.register(FeedbackCollectionViewCell.self, forCellWithReuseIdentifier: FeedbackCollectionViewCell.defaultIdentifier)
-        return view
-    }()
-    
-    lazy var reportIssueLabel: UILabel = {
-        let label: UILabel = .forAutoLayout()
-        label.textAlignment = .center
-        label.text = FeedbackViewController.sceneTitle
-        return label
-    }()
-    
-    lazy var flowLayout: UICollectionViewFlowLayout = {
-        let layout = UICollectionViewFlowLayout()
-        layout.minimumInteritemSpacing = 0.0
-        layout.minimumLineSpacing = 0.0
-        return layout
-    }()
-    
+
     var draggableHeight: CGFloat {
-        let numberOfRows = collectionView.numberOfRows(using: self)
-        let padding = (flowLayout.sectionInset.top + flowLayout.sectionInset.bottom) * CGFloat(numberOfRows)
-        let indexPath = IndexPath(row: 0, section: 0)
-        let collectionViewHeight = collectionView(collectionView, layout: collectionView.collectionViewLayout, sizeForItemAt: indexPath).height * CGFloat(numberOfRows) + padding + view.safeArea.bottom
-        let fullHeight = reportIssueLabel.bounds.height+collectionViewHeight + FeedbackViewController.titleHeaderHeight + FeedbackViewController.contentInset.top
-        return fullHeight
+        return topLevelFeedbackVC.draggableHeight
     }
     
     /**
@@ -150,11 +111,24 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
         self.modalPresentationStyle = .custom
         self.transitioningDelegate = self
     }
-    
+
+    var navController: UINavigationController!
+    var topLevelFeedbackVC: TopLevelFeedbackViewController!
+    var feedbackDetailsVC: FeedbackDetailsViewController!
+
     override public func viewDidLoad() {
         super.viewDidLoad()
-        setupViews()
-        setupConstraints()
+        topLevelFeedbackVC = TopLevelFeedbackViewController(nibName: nil, bundle: nil)
+        feedbackDetailsVC = FeedbackDetailsViewController(style: .plain)
+        navController = UINavigationController(rootViewController: topLevelFeedbackVC)
+        topLevelFeedbackVC.send = { (item: FeedbackItem) -> Void in
+            self.feedbackDetailsVC.navigationItemTitle = item.title
+            self.feedbackDetailsVC.feedbackSubTypes = item.feedbackType.subtypes
+            self.navController.pushViewController(self.feedbackDetailsVC, animated: true)
+        }
+
+        self.view.addSubview(navController.view)
+
         view.layoutIfNeeded()
         transitioningDelegate = self
         if #available(iOS 13.0, *) {
@@ -206,27 +180,6 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
         dismissFeedback()
     }
     
-    private func setupViews() {
-        let children = [reportIssueLabel, collectionView]
-        view.addSubviews(children)
-    }
-    
-    private func setupConstraints() {
-        let labelTop = reportIssueLabel.topAnchor.constraint(equalTo: view.topAnchor)
-        let labelHeight = reportIssueLabel.heightAnchor.constraint(equalToConstant: FeedbackViewController.titleHeaderHeight)
-        let labelLeading = reportIssueLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        let labelTrailing = reportIssueLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        let collectionLabelSpacing = collectionView.topAnchor.constraint(equalTo: reportIssueLabel.bottomAnchor)
-        let collectionLeading = collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        let collectionTrailing = collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        let collectionBarSpacing = collectionView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor)
-        
-        let constraints = [labelTop, labelHeight, labelLeading, labelTrailing,
-                           collectionLabelSpacing, collectionLeading, collectionTrailing, collectionBarSpacing]
-        
-        NSLayoutConstraint.activate(constraints)
-    }
-    
     func send(_ item: FeedbackItem) {
         if let uuid = self.uuid {
             delegate?.feedbackViewController(self, didSend: item, uuid: uuid)
@@ -249,52 +202,6 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
             eventsManager?.cancelFeedback(uuid: uuid)
         }
         dismiss(animated: true, completion: nil)
-    }
-}
-
-extension FeedbackViewController: UICollectionViewDataSource {
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FeedbackCollectionViewCell.defaultIdentifier, for: indexPath) as! FeedbackCollectionViewCell
-        let item = sections[indexPath.row]
-        
-        cell.titleLabel.text = item.title
-        cell.imageView.tintColor = .white
-        cell.imageView.image = item.image
-        
-        return cell
-    }
-    
-    public func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
-    }
-    
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return sections.count
-    }
-}
-
-extension FeedbackViewController: UICollectionViewDelegate {
-    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let item = sections[indexPath.row]
-        send(item)
-    }
-}
-
-extension FeedbackViewController: UICollectionViewDelegateFlowLayout {
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let availableWidth = collectionView.bounds.width
-        // 3 columns and 2 rows in portrait mode.
-        // 6 columns and 1 row in landscape mode.
-        let width = traitCollection.verticalSizeClass == .compact
-            ? floor(availableWidth / CGFloat(sections.count))
-            : floor(availableWidth / CGFloat(sections.count / 2))
-        let item = sections[indexPath.row]
-        let titleHeight = item.title.height(constrainedTo: width, font: FeedbackCollectionViewCell.Constants.titleFont)
-        let cellHeight: CGFloat = FeedbackCollectionViewCell.Constants.circleSize.height
-            + FeedbackCollectionViewCell.Constants.padding
-            + titleHeight
-            + FeedbackViewController.verticalCellPadding
-        return CGSize(width: width, height: cellHeight )
     }
 }
 

--- a/MapboxNavigation/TopLevelFeedbackViewController.swift
+++ b/MapboxNavigation/TopLevelFeedbackViewController.swift
@@ -1,0 +1,131 @@
+import UIKit
+import MapboxCoreNavigation
+
+class TopLevelFeedbackViewController: UIViewController {
+
+    static let defaultIdentifier = "MapboxFeedbackCell"
+    
+    static let cellReuseIdentifier = "collectionViewCellId"
+    static let verticalCellPadding: CGFloat = 20.0
+    static let titleHeaderHeight: CGFloat = 30.0
+
+    var send: ((FeedbackItem) -> Void)!
+
+    /**
+     The feedback items that are visible and selectable by the user.
+     */
+    public var sections: [FeedbackItem] =  [FeedbackType.incorrectVisual(subtype: nil),
+                                            FeedbackType.confusingAudio(subtype: nil),
+                                            FeedbackType.illegalRoute(subtype: nil),
+                                            FeedbackType.roadClosure(subtype: nil),
+                                            FeedbackType.routeQuality(subtype: nil)].map { $0.generateFeedbackItem() }
+    
+    lazy var collectionView: UICollectionView = {
+        let view: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        view.delegate = self
+        view.dataSource = self
+        view.register(FeedbackCollectionViewCell.self, forCellWithReuseIdentifier: TopLevelFeedbackViewController.defaultIdentifier)
+        return view
+    }()
+
+    lazy var reportIssueLabel: UILabel = {
+        let label: UILabel = .forAutoLayout()
+        label.textAlignment = .center
+        label.text = FeedbackViewController.sceneTitle
+        return label
+    }()
+
+    lazy var flowLayout: UICollectionViewFlowLayout = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumInteritemSpacing = 0.0
+        layout.minimumLineSpacing = 0.0
+        return layout
+    }()
+
+    var draggableHeight: CGFloat {
+        let numberOfRows = collectionView.numberOfRows(using: self)
+        let padding = (flowLayout.sectionInset.top + flowLayout.sectionInset.bottom) * CGFloat(numberOfRows)
+        let indexPath = IndexPath(row: 0, section: 0)
+        let collectionViewHeight = collectionView(collectionView, layout: collectionView.collectionViewLayout, sizeForItemAt: indexPath).height * CGFloat(numberOfRows) + padding + view.safeArea.bottom
+        let fullHeight = reportIssueLabel.bounds.height+collectionViewHeight + TopLevelFeedbackViewController.titleHeaderHeight + FeedbackViewController.contentInset.top
+        return fullHeight
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+        setupConstraints()
+        view.layoutIfNeeded()
+        self.navigationController?.navigationBar.topItem?.title = FeedbackViewController.sceneTitle
+
+    }
+
+    private func setupViews() {
+        let children = [reportIssueLabel, collectionView]
+        view.addSubviews(children)
+    }
+
+    private func setupConstraints() {
+        let labelTop = reportIssueLabel.topAnchor.constraint(equalTo: view.topAnchor)
+        let labelHeight = reportIssueLabel.heightAnchor.constraint(equalToConstant: TopLevelFeedbackViewController.titleHeaderHeight)
+        let labelLeading = reportIssueLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+        let labelTrailing = reportIssueLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        let collectionLabelSpacing = collectionView.topAnchor.constraint(equalTo: reportIssueLabel.bottomAnchor)
+        let collectionLeading = collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+        let collectionTrailing = collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        let collectionBarSpacing = collectionView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor)
+        
+        let constraints = [labelTop, labelHeight, labelLeading, labelTrailing,
+                           collectionLabelSpacing, collectionLeading, collectionTrailing, collectionBarSpacing]
+        
+        NSLayoutConstraint.activate(constraints)
+    }
+}
+
+extension TopLevelFeedbackViewController: UICollectionViewDataSource {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TopLevelFeedbackViewController.defaultIdentifier, for: indexPath) as! FeedbackCollectionViewCell
+        let item = sections[indexPath.row]
+
+        cell.titleLabel.text = item.title
+        cell.imageView.tintColor = .white
+        cell.imageView.image = item.image
+
+        return cell
+    }
+
+    public func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return sections.count
+    }
+}
+
+extension TopLevelFeedbackViewController: UICollectionViewDelegate {
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let item = sections[indexPath.row]
+        send(item)
+    }
+}
+
+extension TopLevelFeedbackViewController: UICollectionViewDelegateFlowLayout {
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let availableWidth = collectionView.bounds.width
+        // 3 columns and 2 rows in portrait mode.
+        // 6 columns and 1 row in landscape mode.
+        let width = traitCollection.verticalSizeClass == .compact
+            ? floor(availableWidth / CGFloat(sections.count))
+            : floor(availableWidth / CGFloat(sections.count / 2))
+        let item = sections[indexPath.row]
+        let titleHeight = item.title.height(constrainedTo: width, font: FeedbackCollectionViewCell.Constants.titleFont)
+        let cellHeight: CGFloat = FeedbackCollectionViewCell.Constants.circleSize.height
+            + FeedbackCollectionViewCell.Constants.padding
+            + titleHeight
+            + FeedbackViewController.verticalCellPadding
+        return CGSize(width: width, height: cellHeight )
+    }
+}


### PR DESCRIPTION
This work-in-progress PR refactors the FeedbackVC and extracts a (newly defined) `TopLevelFeedbackVC` and a `FeedbackDetailsVC`. 

#### What has been done in this PR:

- Refactored `FeedbackVC` and made it hold a `NavigationController`
- Pulled out the `collectionView` from `FeedbackVC` and created a new `TopLevelFeedbackViewController` which is responsible for its management / rendering.
- Created a new `FeedbackDetailsVC`  which is responsible for the `tableView` that shows with the different subtypes.
- Associated UI stuff like `FeedbackDetailsTableViewCell`

#### Things to do:
There is a bit of tail-work from previous PRs that I've tracked below: 
- [ ] Nest subtype enums under `FeedbackType` to avoid cluttering the namespace (as per [this comment](https://github.com/mapbox/mapbox-navigation-ios/pull/2419#discussion_r445693124) by @1ec5)
- [ ] Fix the images displayed in the top level feedback view so that they respond to application tint color (as per this [comment](https://github.com/mapbox/mapbox-navigation-ios/pull/2419#discussion_r445196887)).
- [ ] Localize any user facing strings as per [review comment](https://github.com/mapbox/mapbox-navigation-ios/pull/2419#discussion_r445196054) from #2419 .
- [ ] Update documentation to allow jazzy to link to data structures ( as per https://github.com/mapbox/mapbox-navigation-ios/pull/2419#discussion_r445691580 )