### PR TITLE
Unanimating MapView content insets

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -276,7 +276,7 @@ class RouteMapViewController: UIViewController {
             // Don't move mapView content on rotation or when e.g. top banner expands.
             return
         }
-        mapView.setContentInset(contentInset(forOverviewing: isInOverviewMode), animated: true, completionHandler: nil)
+        mapView.setContentInset(contentInset(forOverviewing: isInOverviewMode), animated: false, completionHandler: nil)
         mapView.setNeedsUpdateConstraints()
     }
 


### PR DESCRIPTION
A fix for an issue, reported by our users, which causes the `NavigationMapView`'s `UserPuck` view to malfunction after view's bounds are updated (updating bottom banner view's height cause User Puck view to deviate from it's correct position unless new Location Update event occurs).

I feel that removing animation for updating content insets is legit because this method is called after the actual layout is done, and also because otherwise it becomes tricky to convert user location position to view's viewport coordinates while the animation is ongoing.

The problem is that User Puck view frame is set to converted real geo coordinates to view space immediately after the resizing occurs, but since `contentInsets` are updated with animation, the viewport is not yet updated to final position. Thus, user coordinates on screen become invalid. 
I saw several solutions:
1. Disable the animation for `contentInsets` (which I did)
2. Somehow calculate "final" viewport position and do a parallel User Puck animation to slide it into place (could not find appropriate API for implementing this, and didn't want to implement too complex solution for that in Nav SDK)
3. Update User Puck view location in `contentInset` update completion block (but it results in user puck view sliding into place 'late' after the animation completes)