### PR TITLE
Mobile metrics hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,16 +76,15 @@ step-library:
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=13.4.1,name=iPhone 8 Plus' -project MapboxNavigation.xcodeproj -scheme Example clean build | xcpretty
 
-  - &trigger-metrics:
-    steps:
-      - run:
-          name: Trigger metrics
-          command: |
-            if [ -n "${MOBILE_METRICS_TOKEN}" ]; then
-              bash -c "curl -X POST --header \"Content-Type: application/json\" --data '{\"parameters\": {\"run_ios_navigation_benchmark\": true, \"ci_ref\": $CIRCLE_BUILD_NUM }, \"branch\": \"master\" }' https://circleci.com/api/v2/project/github/mapbox/mobile-metrics/pipeline?circle-token=${MOBILE_METRICS_TOKEN}"
-            else
-              echo "MOBILE_METRICS_TOKEN not provided"
-            fi
+  - &trigger-metrics
+      run:
+        name: Trigger metrics
+        command: |
+          if [ -n "${MOBILE_METRICS_TOKEN}" ]; then
+            bash -c "curl -X POST --header \"Content-Type: application/json\" --data '{\"parameters\": {\"run_ios_navigation_benchmark\": true, \"ci_ref\": $CIRCLE_BUILD_NUM }, \"branch\": \"master\" }' https://circleci.com/api/v2/project/github/mapbox/mobile-metrics/pipeline?circle-token=${MOBILE_METRICS_TOKEN}"
+          else
+            echo "MOBILE_METRICS_TOKEN not provided"
+          fi
 
 jobs:
   pod-job:
@@ -206,8 +205,10 @@ jobs:
   ios-trigger-metrics:
     macos:
       xcode: "11.4.1"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - trigger-metrics
+      - *trigger-metrics
 
 workflows:
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ workflows:
           iOS: "12.2"
           lint: true
       - xcode-11-examples
-      - ios-trigger-metrics
+      - ios-trigger-metrics:
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,17 @@ step-library:
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=13.4.1,name=iPhone 8 Plus' -project MapboxNavigation.xcodeproj -scheme Example clean build | xcpretty
 
+  - &trigger-metrics:
+    steps:
+      - run:
+          name: Trigger metrics
+          command: |
+            if [ -n "${MOBILE_METRICS_TOKEN}" ]; then
+              bash -c "curl -X POST --header \"Content-Type: application/json\" --data '{\"parameters\": {\"run_ios_navigation_benchmark\": true, \"ci_ref\": $CIRCLE_BUILD_NUM }, \"branch\": \"master\" }' https://circleci.com/api/v2/project/github/mapbox/mobile-metrics/pipeline?circle-token=${MOBILE_METRICS_TOKEN}"
+            else
+              echo "MOBILE_METRICS_TOKEN not provided"
+            fi
+
 jobs:
   pod-job:
     parameters:
@@ -192,6 +203,12 @@ jobs:
       - *build-Example
       - *save-cache
 
+  ios-trigger-metrics:
+    macos:
+      xcode: "11.4.1"
+    steps:
+      - trigger-metrics
+
 workflows:
   workflow:
     jobs:
@@ -223,3 +240,7 @@ workflows:
           iOS: "12.2"
           lint: true
       - xcode-11-examples
+      - ios-trigger-metrics
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Added a Circle CI config hook to trigger external Navigation metrics collection workflow.

This is meant to happen on each new commit to `master` branch (even though we are not working on `master` atm), to force metrics data collection. Such approach will create a data timeline for changes applied.