### PR TITLE
Fix maneuver location.

### DIFF
--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -731,7 +731,12 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
         let legProgress = RouteLegProgress(leg: progress.route.legs[legIndex], stepIndex: stepIndex)
         let step = legProgress.currentStep
         self.preview(step: step, in: banner, remaining: progress.remainingSteps, route: progress.route, animated: false)
-        banner.dismissStepsTable()
+        
+        // After selecting maneuver and dismissing steps table make sure to update contentInsets of NavigationMapView
+        // to correctly place selected maneuver in the center of the screen (taking into account top and bottom banner heights).
+        banner.dismissStepsTable { [weak self] in
+            self?.mapViewController?.updateMapViewContentInsets()
+        }
     }
     
     public func topBanner(_ banner: TopBannerViewController, didDisplayStepsController: StepsViewController) {

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -276,7 +276,12 @@ class RouteMapViewController: UIViewController {
             // Don't move mapView content on rotation or when e.g. top banner expands.
             return
         }
-        mapView.setContentInset(contentInset(forOverviewing: isInOverviewMode), animated: false, completionHandler: nil)
+        
+        updateMapViewContentInsets()
+    }
+    
+    func updateMapViewContentInsets(animated: Bool = false, completion: CompletionHandler? = nil) {
+        mapView.setContentInset(contentInset(forOverviewing: isInOverviewMode), animated: animated, completionHandler: completion)
         mapView.setNeedsUpdateConstraints()
     }
 


### PR DESCRIPTION
Closes #2451.

Looks like this is regression which was introduced between `0.37.0` and `0.38.1` after modifying `contentInset(forOverviewing:)`. Since `topBannerContainerView.bounds.height` is used as top inset this leads to setting large content inset for map view, this in turn leads to placing maneuver below bottom banner. Fix aims to update content insets only after closing list with maneuvers and finishing animation. 

Original issue is not reproducible when using guidance cards.