### PR TITLE
Fixes memory leaks and rootTemplate usage in CarPlayManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Added the ability for the route line to disappear as the puck travels along a route during turn-by-turn navigation. ([#2377](https://github.com/mapbox/mapbox-navigation-ios/pull/2377))
 * Fixed an issue where the casing for the main route would not overlap alternative routes. ([#2377](https://github.com/mapbox/mapbox-navigation-ios/pull/2377))
 * Removed the `NavigationViewControllerDelegate.navigationViewController(_:imageFor:)` and `NavigationViewControllerDelegate.navigationViewController(_:viewFor:)` methods in favor of `MGLMapViewDelegate.mapView(_:imageFor:)` and `MGLMapViewDelegate.mapView(_:viewFor:)`, respectively. ([#2396](https://github.com/mapbox/mapbox-navigation-ios/pull/2396))
+* Fixed memory leaks after disconnecting the application from CarPlay. ([#2470](https://github.com/mapbox/mapbox-navigation-ios/pull/2470))
 
 ## v0.40.0
 

--- a/MapboxNavigation/CarPlayManager.swift
+++ b/MapboxNavigation/CarPlayManager.swift
@@ -142,8 +142,8 @@ public class CarPlayManager: NSObject {
      The bar button that prompts the presented navigation view controller to display the feedback screen.
      */
     public lazy var showFeedbackButton: CPMapButton = {
-        let showFeedbackButton = CPMapButton { button in
-            self.currentNavigator?.showFeedback()
+        let showFeedbackButton = CPMapButton { [weak self] button in
+            self?.currentNavigator?.showFeedback()
         }
         showFeedbackButton.image = UIImage(named: "carplay_feedback", in: .mapboxNavigation, compatibleWith: nil)
         
@@ -154,8 +154,8 @@ public class CarPlayManager: NSObject {
      The bar button that shows the selected route overview on the map.
      */
     public lazy var userTrackingButton: CPMapButton = {
-        let userTrackingButton = CPMapButton { button in
-            guard let navigationViewController = self.currentNavigator else {
+        let userTrackingButton = CPMapButton { [weak self] button in
+            guard let navigationViewController = self?.currentNavigator else {
                 return
             }
             navigationViewController.tracksUserCourse = !navigationViewController.tracksUserCourse

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -70,11 +70,9 @@ public class CarPlayMapViewController: UIViewController {
      The map button for zooming out the current map view.
      */
     public lazy var zoomOutButton: CPMapButton = {
-        let zoomOutButton = CPMapButton { [weak self] (button) in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.mapView.setZoomLevel(strongSelf.mapView.zoomLevel - 1, animated: true)
+        let zoomOutButton = CPMapButton { [weak self] button in
+            guard let self = self else { return }
+            self.mapView.setZoomLevel(self.mapView.zoomLevel - 1, animated: true)
         }
         let bundle = Bundle.mapboxNavigation
         zoomOutButton.image = UIImage(named: "carplay_minus", in: bundle, compatibleWith: traitCollection)
@@ -155,7 +153,8 @@ public class CarPlayMapViewController: UIViewController {
      - parameter mapTemplate: The map template available to the pan map button for display.
      */
     @discardableResult public func panningInterfaceDisplayButton(for mapTemplate: CPMapTemplate) -> CPMapButton {
-        let panButton = CPMapButton { _ in
+        let panButton = CPMapButton { [weak mapTemplate] _ in
+            guard let mapTemplate = mapTemplate else { return }
             if !mapTemplate.isPanningInterfaceVisible {
                 mapTemplate.showPanningInterface(animated: true)
             }


### PR DESCRIPTION
This PR takes care of several CarPlay(Manager) related memory leaks:

- Fixes memory leaks in any `CPBarButton` creation without a `weak self` reference
- Ensures `CarPlayMapViewController` and the main `CPMapTemplate` are released upon disconnecting the phone from CarPlay

And: Before any navigation attempt on CarPlay a new `rootTemplate` is set, while keeping the original main `CPMapTemplate` (for browsing) still referenced in the `CarPlayManager`. Upon completing or cancelling the navigation session, this template is then to be restored (while the navigation template is popped from the stack). This seems to work fine, but we noticed that it is impossible from that moment on to update / reload the `CPBarButtons`. That's why we discard the template and completely re-create if every time a navigation session is finished.

**Important**: There's still some memory leak open as the original CarPlay UIWindow `CPWindow` is kept in memory after each connect-disconnect attempt. We're still figuring out what's causing this.