### PR TITLE
Replace obsolete contentInset workaround

### DIFF
--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -29,8 +29,7 @@ public class CarPlayMapViewController: UIViewController {
     
     var isOverviewingRoutes: Bool = false {
         didSet {
-            // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/15574
-            // In overview mode, content insets are set to .zero, avoid getting them changed.
+            // Fix content insets in overview mode.
             automaticallyAdjustsScrollViewInsets = !isOverviewingRoutes
         }
     }

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -462,10 +462,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         setUserTrackingMode(.none, animated: false, completionHandler: nil)
         let line = MGLPolyline(shape)
         
-        // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/15574
-        // Set content insets .zero, before cameraThatFitsShape + setCamera.
-        contentInset = .zero
-        let camera = cameraThatFitsShape(line, direction: direction, edgePadding: safeArea + NavigationMapView.defaultPadding)
+        // Current contentInset gets incorporated to cameraThatFitsShape.
+        // edgePadding is set to .zero as there's no need for additional padding.
+        contentInset = safeArea + NavigationMapView.defaultPadding
+        let camera = cameraThatFitsShape(line, direction: direction, edgePadding: .zero)
         setCamera(camera, animated: animated)
     }
     
@@ -1291,10 +1291,10 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         currentCamera.pitch = 0
         currentCamera.heading = 0
 
-        // Workaround for https://github.com/mapbox/mapbox-gl-native/issues/15574
-        // Set content insets .zero, before cameraThatFitsShape + setCamera.
-        contentInset = .zero
-        let newCamera = camera(currentCamera, fitting: line, edgePadding: padding)
+        contentInset = padding
+        // Current contentInset gets incorporated to calculated camera.
+        // edgePadding is set to .zero as there's no need for additional padding.
+        let newCamera = camera(currentCamera, fitting: line, edgePadding: .zero)
         
         setCamera(newCamera, withDuration: 1, animationTimingFunction: nil) { [weak self] in
             self?.isAnimatingToOverheadMode = false

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -242,7 +242,6 @@ class RouteMapViewController: UIViewController {
         mapView.enableFrameByFrameCourseViewTracking(for: 3)
         if let shape = router.route.shape,
             let userLocation = router.location {
-            mapView.contentInset = contentInset(forOverviewing: true)
             mapView.setOverheadCameraView(from: userLocation, along: shape, for: contentInset(forOverviewing: true))
         }
         isInOverviewMode = true
@@ -503,7 +502,6 @@ extension RouteMapViewController: NavigationComponent {
         
         if isInOverviewMode {
             if let shape = route.shape, let userLocation = router.location {
-                mapView.contentInset = contentInset(forOverviewing: true)
                 mapView.setOverheadCameraView(from: userLocation, along: shape, for: contentInset(forOverviewing: true))
             }
         } else {


### PR DESCRIPTION
As a result of fix https://github.com/mapbox/mapbox-gl-native/pull/16067, contentInsets are taken into account when calculating camera.
in iOS code, current view's contentInset is passed to calculate camera.
Simplify the approach here by passing .zero, as edgePadding in MGLMapView in cameraThatFitsShape and camera has additive character: gets appended to view's contentInset.

Patch is manually verified on top of master branch (didn't manage to resolve Carthage issues with release-v1.0-pre-registry).