### PR TITLE
Add Turkish localization; update translations from Transifex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * MapboxNavigation depends on Mapbox Maps SDK for iOS v6.0.0. Before CocoaPods or Carthage can download Mapbox.framework, you need to create a special-purpose access token. See [the updated installation instructions in the readme](./README.md#installing-the-latest-prerelease) for more details. ([#2437](https://github.com/mapbox/mapbox-navigation-ios/pull/2437)) 
 * Xcode 11.4.1 or above is now required for building this SDK from source. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
 * Enabled MAU billing by default, so that SDKs usage of Mapbox APIs is [billed](https://www.mapbox.com/pricing/) together based on [monthly active users](https://docs.mapbox.com/help/glossary/monthly-active-users/) rather than individually by HTTP request. If you prefer to still use request-based billing, set the `MBXNavigationBillingMethod` key in Info.plist to `request` ([#2405](https://github.com/mapbox/mapbox-navigation-ios/pull/2405).
-* Added a Greek localization. ([#2385](https://github.com/mapbox/mapbox-navigation-ios/pull/2385))
+* Added Greek and Turkish localizations. ([#2385](https://github.com/mapbox/mapbox-navigation-ios/pull/2385), [#2475](https://github.com/mapbox/mapbox-navigation-ios/pull/2475))
 
 ### User location
 

--- a/Example/tr.lproj/Main.strings
+++ b/Example/tr.lproj/Main.strings
@@ -1,0 +1,15 @@
+
+/* Class = "UIButton"; normalTitle = "Continue to next destination"; ObjectID = "1vl-kS-fBt"; */
+"1vl-kS-fBt.normalTitle" = "Bir sonraki hedefe devam edin.";
+
+/* Class = "UILabel"; text = "Long press to select a destination"; ObjectID = "dEY-t6-Ect"; */
+"dEY-t6-Ect.text" = "Hedef seçmek için uzun basın.";
+
+/* Class = "UIButton"; normalTitle = "Simulate Locations"; ObjectID = "iiq-Gf-SKY"; */
+"iiq-Gf-SKY.normalTitle" = "Simulate Locations";
+
+/* Class = "UIButton"; normalTitle = "Start Navigation"; ObjectID = "nMe-Tl-a1N"; */
+"nMe-Tl-a1N.normalTitle" = "Navigasyonu başlat.";
+
+/* Class = "UINavigationItem"; title = "Mapbox Navigation"; ObjectID = "zxr-0T-HBr"; */
+"zxr-0T-HBr.title" = "Mapbox Navigasyon";

--- a/MapboxCoreNavigation/Resources/el.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/el.lproj/Localizable.strings
@@ -1,0 +1,6 @@
+/* Error message when an offline route request returns a response that can’t be deserialized */
+"OFFLINE_CORRUPT_DATA" = "Βρέθηκε μη έγκυρη διαδρομή ενώ είστε εκτός σύνδεσης.";
+
+/* Inform developer an update is available */
+"UPDATE_AVAILABLE" = "Το Mapbox Navigation SDK για την iOS έκδοση %@ είναι πλέον διαθέσιμο.";
+

--- a/MapboxCoreNavigation/Resources/tr.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/tr.lproj/Localizable.strings
@@ -1,0 +1,6 @@
+/* Error message when an offline route request returns a response that can’t be deserialized */
+"OFFLINE_CORRUPT_DATA" = "Geçersiz bir çevrimdışı rota bulundu.";
+
+/* Inform developer an update is available */
+"UPDATE_AVAILABLE" = "iOS için Mapbox Navigation SDK %@ sürümü artık erişilebilir.";
+

--- a/MapboxCoreNavigation/Resources/uk.lproj/Localizable.strings
+++ b/MapboxCoreNavigation/Resources/uk.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Error message when an offline route request returns a response that can’t be deserialized */
+"OFFLINE_CORRUPT_DATA" = "Знайдено хибний маршрут в режимі офлайн.";
+
 /* Inform developer an update is available */
 "UPDATE_AVAILABLE" = "Mapbox Navigation SDK для iOS версії %@ в наявності.";
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -1005,6 +1005,7 @@
 		DA678B7C1F6CF47200F05913 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA678B7D1F6CF47A00F05913 /* vi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA67EA5523CAF345001686EA /* MGLShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLShape.swift; sourceTree = "<group>"; };
+		DA6C925424C604B7003A0AD6 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA73F87820BF851B0067649B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = Resources/de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA754E1623AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MBXAccounts+CoreNavigationAdditions.h"; sourceTree = "<group>"; };
 		DA754E1723AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MBXAccounts+CoreNavigationAdditions.m"; sourceTree = "<group>"; };
@@ -2852,6 +2853,7 @@
 				DA9059B2223B1758006E8B46 /* ja */,
 				354691B022C0D97000626C4F /* yo */,
 				8B808F892487CFEC00EEE453 /* el */,
+				DA6C925424C604B7003A0AD6 /* uk */,
 			);
 			name = Localizable.strings;
 			path = Resources;

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -1006,6 +1006,11 @@
 		DA678B7D1F6CF47A00F05913 /* vi */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA67EA5523CAF345001686EA /* MGLShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLShape.swift; sourceTree = "<group>"; };
 		DA6C925424C604B7003A0AD6 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DA6C925624C6074B003A0AD6 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Main.strings; sourceTree = "<group>"; };
+		DA6C925724C6078B003A0AD6 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DA6C925824C60A3D003A0AD6 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DA6C925924C60A43003A0AD6 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tr; path = Resources/tr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DA6C925A24C60C92003A0AD6 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Navigation.strings; sourceTree = "<group>"; };
 		DA73F87820BF851B0067649B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = Resources/de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA754E1623AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MBXAccounts+CoreNavigationAdditions.h"; sourceTree = "<group>"; };
 		DA754E1723AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MBXAccounts+CoreNavigationAdditions.m"; sourceTree = "<group>"; };
@@ -2070,6 +2075,7 @@
 				ja,
 				yo,
 				el,
+				tr,
 			);
 			mainGroup = C5ADFBBF1DDCC7840011824B;
 			productRefGroup = C5ADFBCA1DDCC7840011824B /* Products */;
@@ -2785,6 +2791,7 @@
 				DAE26B20206441D8001D6E1F /* pt-PT */,
 				DA9059B1223B158D006E8B46 /* ja */,
 				8B808F852487CFEC00EEE453 /* el */,
+				DA6C925624C6074B003A0AD6 /* tr */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -2824,6 +2831,7 @@
 				DAFEB36A2093A0D800A86A83 /* ko */,
 				DA9059B3223B1769006E8B46 /* ja */,
 				8B808F862487CFEC00EEE453 /* el */,
+				DA6C925A24C60C92003A0AD6 /* tr */,
 			);
 			name = Navigation.storyboard;
 			path = Resources;
@@ -2854,6 +2862,7 @@
 				354691B022C0D97000626C4F /* yo */,
 				8B808F892487CFEC00EEE453 /* el */,
 				DA6C925424C604B7003A0AD6 /* uk */,
+				DA6C925724C6078B003A0AD6 /* tr */,
 			);
 			name = Localizable.strings;
 			path = Resources;
@@ -2902,6 +2911,7 @@
 				DA9059B5223B1778006E8B46 /* ja */,
 				354691B222C0D97000626C4F /* yo */,
 				8B808F982487D2BE00EEE453 /* el */,
+				DA6C925924C60A43003A0AD6 /* tr */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";
@@ -2931,6 +2941,7 @@
 				DA9059B4223B1770006E8B46 /* ja */,
 				354691B122C0D97000626C4F /* yo */,
 				8B808F972487D2B900EEE453 /* el */,
+				DA6C925824C60A3D003A0AD6 /* tr */,
 			);
 			name = Localizable.strings;
 			path = Resources;

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Faster Route Found";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Bad \nRoute";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Confusing\nInstruction";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Other\nMap Issue";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Not\nAllowed";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Report\nTraffic";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Road\nClosed";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Thank you for your report!";
 

--- a/MapboxNavigation/Resources/bg.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/bg.lproj/Localizable.strings
@@ -7,30 +7,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Открит по-бърз маршрут";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Лош \nМаршрут";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Объркваща\nИнструкция";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Друг\nКартов проблем";
-
-/* Feedback type for Missing Exit */
-"FEEDBACK_MISSING_EXIT" = "Липсващ\nИзход";
-
-/* Feedback type for Missing Road */
-"FEEDBACK_MISSING_ROAD" = "Липсващ\nПът";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Не е\nРазрешено";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Съобщи\nТрафика";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Пътят е\nЗатворен";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Благодарим за сигнала!";
 

--- a/MapboxNavigation/Resources/ca.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ca.lproj/Localizable.strings
@@ -1,33 +1,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "S’ha trobat una ruta més ràpida";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Ruta\ndolenta";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Instruccions\nimprecises";
-
-/* Feedback type for inaccurate GPS */
-"FEEDBACK_GPS_INACCURATE" = "GPS\nerroni";
-
-/* Feedback type for Heavy Traffic */
-"FEEDBACK_HEAVY_TRAFFIC" = "Tràfic\nespès";
-
-/* Feedback type for Instruction Issue */
-"FEEDBACK_INSTRUCTION_ISSUE" = "Problema amb \nles instruccions";
-
-/* Feedback type for Instruction Timing */
-"FEEDBACK_INSTRUCTION_TIMING" = "Cronometratge\ninstruccions";
-
-/* Feedback type for turn not allowed */
-"FEEDBACK_NOT_ALLOWED" = "No\npermès";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Informe \ntràfic";
-
-/* Feedback type for Closure */
-"FEEDBACK_ROAD_CLOSURE" = "Carretera\ntancada";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Gràcies pel vostre informe!";
 

--- a/MapboxNavigation/Resources/da.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/da.lproj/Localizable.strings
@@ -16,30 +16,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Hurtigere rute fundet";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Dårlig \nRute";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Uklar\nInstruktion";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Andre\nKort problemer";
-
-/* Feedback type for Missing Exit */
-"FEEDBACK_MISSING_EXIT" = "Manglende\nAfkørsel";
-
-/* Feedback type for Missing Road */
-"FEEDBACK_MISSING_ROAD" = "Manglende\nVej";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Ikke\nTilladt";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Anmeld\nKø";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Lukket\nVej";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Tak for din anmeldelse";
 

--- a/MapboxNavigation/Resources/de.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/de.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Schnellere Route gefunden";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Schlechte\nRoute";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Verwirrende\nAnweisung";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Anderes\nKartenproblem";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Nicht\nerlaubt";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Verkehr\nmelden";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Straße\ngesperrt";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Danke für deine Nachricht!";
 

--- a/MapboxNavigation/Resources/es.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/es.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Ruta más rápida encontrada";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Ruta\npobre";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Instrucción\nengañosa";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Otra problema\nen la mapa";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Prohibido";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Reportar\ncongestión";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Camino\ncerrado";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "¡Gracias por su informe!";
 

--- a/MapboxNavigation/Resources/fr.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/fr.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Itinéraire plus rapide trouvé";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Mauvais \nitinéraire";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Instruction \nconfusive";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Autre \nproblème de carte";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Non \nautorisé";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Signaler \nle trafic";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Route \nfermée";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Merci pour votre signalement !";
 

--- a/MapboxNavigation/Resources/he.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/he.lproj/Localizable.strings
@@ -16,30 +16,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "דרך מהירה יותר נמצאה";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "דרך\nמשובשת";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "הוראות\nמבולבלות";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "בעיה אחרת\nבמפה";
-
-/* Feedback type for Missing Exit */
-"FEEDBACK_MISSING_EXIT" = "יציאה\nלא קיימת";
-
-/* Feedback type for Missing Road */
-"FEEDBACK_MISSING_ROAD" = "דרך\nלא קיימת";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "לא\nמורשה";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "דיווח\nתנועה";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "דרך\nסגורה";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "תודה על הדיווח שלך!";
 

--- a/MapboxNavigation/Resources/hu.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/hu.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Gyorsabb útvonal elérhető";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Rossz \nútvonal";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Megtévesztő\nutasítás";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Egyéb\ntérkép probléma";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Nem\nengedélyezett";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Forgalom\njelentése";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Út\nlezárva";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Köszönjük bejelentésed!";
 

--- a/MapboxNavigation/Resources/ja.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ja.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "より早い経路が見つかりました";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "経路が悪い";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "案内がわかりにくい";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "その他、地図の問題";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "ルートが法規に反する";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "渋滞状況を報告する";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "通行止めの道があった";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "フィードバックにご協力頂きありがとうございました";
 

--- a/MapboxNavigation/Resources/ko.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ko.lproj/Localizable.strings
@@ -16,30 +16,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "더 빠른 경로를 찾았습니다";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "잘못된 \n경로";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "혼동스러운\n지시";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "다른\n지도 문제";
-
-/* Feedback type for Missing Exit */
-"FEEDBACK_MISSING_EXIT" = "없어진\n출구";
-
-/* Feedback type for Missing Road */
-"FEEDBACK_MISSING_ROAD" = "없어진\n도로";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "허용\n불가";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "교통\n보고";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "통행\n금지";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "당신의 보고에 감사드립니다!";
 

--- a/MapboxNavigation/Resources/nl.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/nl.lproj/Localizable.strings
@@ -7,30 +7,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Snellere route gevonden";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Verkeerde\nRoute";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Inaccuraat";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Ander";
-
-/* Feedback type for Missing Exit */
-"FEEDBACK_MISSING_EXIT" = "Ontbrekende\nafslag";
-
-/* Feedback type for Missing Road */
-"FEEDBACK_MISSING_ROAD" = "Ontbrekende\nstraat";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Niet\ntoegestaan";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Rapporteer\nverkeer";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Straat\nafgesloten";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Dankjewel voor je rapport!";
 

--- a/MapboxNavigation/Resources/pt-BR.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/pt-BR.lproj/Localizable.strings
@@ -1,33 +1,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Rota mais rápida encontrada";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Rota\nRuim";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Instrução\nConfusa";
-
-/* Feedback type for inaccurate GPS */
-"FEEDBACK_GPS_INACCURATE" = "GPS\nImpreciso";
-
-/* Feedback type for Heavy Traffic */
-"FEEDBACK_HEAVY_TRAFFIC" = "Tráfego\nPesado";
-
-/* Feedback type for Instruction Issue */
-"FEEDBACK_INSTRUCTION_ISSUE" = "Problema\nInstrução";
-
-/* Feedback type for Instruction Timing */
-"FEEDBACK_INSTRUCTION_TIMING" = "Instrução\nCronometragem";
-
-/* Feedback type for turn not allowed */
-"FEEDBACK_NOT_ALLOWED" = "Não\nPermitido";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Reportar\nTráfego";
-
-/* Feedback type for Closure */
-"FEEDBACK_ROAD_CLOSURE" = "Rota\nBloqueada";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Obrigado por seu relato !";
 

--- a/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/pt-PT.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Encontrado Percurso Mais Rápido";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Percurso \nRuim";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Instrução\nConfusa";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Outro\nProblema no Mapa";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Não\nPermitido";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Relatar\nTrânsito";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Estrada\nFechada";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Obrigado pelo seu relatório!";
 

--- a/MapboxNavigation/Resources/ru.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/ru.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Найден маршрут быстрее";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Плохой\nмаршрут";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Непонятная\nинструкция";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Ошибка\nна карте";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Манёвр\nнедопустим";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Сообщить\nо заторе";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Дорога\nзакрыта";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Благодарим за отзыв!";
 

--- a/MapboxNavigation/Resources/sv.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/sv.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Hittade snabbare rutt";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Dålig\nRutt";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Förvirrande\nInstruktion";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Övrigt\nKartproblem";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Ej\nTillåtet";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Rapportera\nTrafik";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Väg\nAvstängd";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Tack för din feedback!";
 

--- a/MapboxNavigation/Resources/tr.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/tr.lproj/Localizable.strings
@@ -1,0 +1,129 @@
+/* Delimiter between lines in an address when displayed inline */
+"ADDRESS_LINE_SEPARATOR" = ". ";
+
+/* Title on arrival action sheet */
+"CARPLAY_ARRIVED" = "Hedefe vardınız";
+
+/* Message on arrival action sheet */
+"CARPLAY_ARRIVED_MESSAGE" = "Ne yapmak istersiniz?";
+
+/* Name of the waypoint associated with the current location */
+"CARPLAY_CURRENT_LOCATION" = "Mevcut Konum";
+
+/* Title for dismiss button */
+"CARPLAY_DISMISS" = "İptal Et";
+
+/* Title for end navigation button */
+"CARPLAY_END" = "Bitir";
+
+/* Title on the exit button in the arrival form */
+"CARPLAY_EXIT_NAVIGATION" = "Navigasyondan çık";
+
+/* Title for feedback template in CarPlay */
+"CARPLAY_FEEDBACK" = "Geri bildirim";
+
+/* Title for start button in CPTripPreviewTextConfiguration */
+"CARPLAY_GO" = "Başla";
+
+/* Title for alternative routes in CPTripPreviewTextConfiguration */
+"CARPLAY_MORE_ROUTES" = "Daha fazla rota";
+
+/* Title for mute button */
+"CARPLAY_MUTE" = "Sessiz";
+
+/* Title for overview button in CPTripPreviewTextConfiguration */
+"CARPLAY_OVERVIEW" = "Genel Bakış";
+
+/* Title for rating template in CarPlay */
+"CARPLAY_RATE_RIDE" = "Sürüşünüzü derecelendirin";
+
+/* Title on rate button in CarPlay */
+"CARPLAY_RATE_TRIP" = "Seyehatinizi derecelendirin";
+
+/* Message when search returned zero results in CarPlay */
+"CARPLAY_SEARCH_NO_RESULTS" = "Sonuç bulunamadı";
+
+/* Alert title that shows when feedback has been submitted */
+"CARPLAY_SUBMITTED_FEEDBACK" = "Gönderildi";
+
+/* Title for unmute button */
+"CARPLAY_UNMUTE" = "Sesi aç";
+
+/* Dismiss button title on the steps view */
+"DISMISS_STEPS_TITLE" = "Kapat";
+
+/* Title used for arrival */
+"END_OF_ROUTE_ARRIVED" = "Hedefe vardınız";
+
+/* Comment Placeholder Text */
+"END_OF_ROUTE_TITLE" = "How can we improve?";
+
+/* Error message when the SDK is unable to read a spoken instruction. */
+"FAILED_INSTRUCTION" = "Unable to read instruction aloud.";
+
+/* Indicates a faster route was found */
+"FASTER_ROUTE_FOUND" = "Daha hızlı bir rota bulundu";
+
+/* Feedback type for Bad Route */
+"FEEDBACK_BAD_ROUTE" = "Kötü\nRota";
+
+/* Feedback type for Confusing Instruction */
+"FEEDBACK_CONFUSING_INSTRUCTION" = "Kafa karıştıran talimat";
+
+/* Feedback type for Other Map Issue Issue */
+"FEEDBACK_GENERAL_ISSUE" = "Diğer harita sorunu";
+
+/* Feedback type for a maneuver that is Not Allowed */
+"FEEDBACK_NOT_ALLOWED" = "Erişime kapalı";
+
+/* Feedback type for Report Traffic */
+"FEEDBACK_REPORT_TRAFFIC" = "Trafik yoğunluğu";
+
+/* Feedback type for Road Closed */
+"FEEDBACK_ROAD_CLOSURE" = "Yol kapalı";
+
+/* Message confirming that the user has successfully sent feedback */
+"FEEDBACK_THANK_YOU" = "Geri bildiriminiz için teşekkür ederiz.";
+
+/* Title of view controller for sending feedback */
+"FEEDBACK_TITLE" = "Sorun bildir.";
+
+/* Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased */
+"INAUDIBLE_INSTRUCTIONS_CTA" = "Sesli talimatları duyabilmek için sesi yükseltin.";
+
+/* Format for displaying the first two major ways */
+"LEG_MAJOR_WAYS_FORMAT" = "%1$@ ve %2$@";
+
+/* Format string for a short distance or time less than a minimum threshold; 1 = duration remaining */
+"LESS_THAN" = "<%@";
+
+/* Accessibility value of label indicating the absence of a rating */
+"NO_RATING" = "Derecelendirme yok";
+
+/* Rating Reset To Zero Accessability Hint */
+"RATING_ACCESSIBILITY_RESET" = "Derecelendirmeyi sıfırlamak için dokunun.";
+
+/* Format for accessibility label of button for setting a rating; 1 = number of stars */
+"RATING_ACCESSIBILITY_SET" = "%ld-yıldız ile derecelendir.";
+
+/* Format for accessibility value of label indicating the existing rating; 1 = number of stars */
+"RATING_STARS_FORMAT" = "%ld yıldız.";
+
+/* Indicates that rerouting is in progress */
+"REROUTING" = "Yeniden yönlendiriliyor…";
+
+/* Button title for resume tracking */
+"RESUME" = "Devam et";
+
+/* Label above the speed limit in an MUTCD-style speed limit sign. Keep as short as possible. */
+"SPEED_LIMIT_LEGEND" = "Max";
+
+/* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
+"USER_IN_SIMULATION_MODE" = "Simulating Navigation at %@×";
+
+/* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
+"WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@, via %2$@";
+
+/* Format for displaying start and endpoint for leg; 1 = source ; 2 = destination */
+"WAYPOINT_SOURCE_DESTINATION_FORMAT" = "%1$@ and %2$@";
+

--- a/MapboxNavigation/Resources/tr.lproj/Localizable.stringsdict
+++ b/MapboxNavigation/Resources/tr.lproj/Localizable.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>RATING_ACCESSIBILITY_SET</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%ld-yıldız ile derecelendir.</string>
+			<key>other</key>
+			<string>%ld-yıldız ile derecelendir.</string>
+		</dict>
+	</dict>
+	<key>RATING_STARS_FORMAT</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%ld yıldız.</string>
+			<key>other</key>
+			<string>%ld yıldız.</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/MapboxNavigation/Resources/tr.lproj/Navigation.strings
+++ b/MapboxNavigation/Resources/tr.lproj/Navigation.strings
@@ -1,0 +1,6 @@
+
+/* Class = "UIButton"; normalTitle = "End Navigation"; ObjectID = "5f2-dT-la4"; */
+"5f2-dT-la4.normalTitle" = "Navigasyonu bitir";
+
+/* Class = "UILabel"; text = "Rate your trip"; ObjectID = "W5U-cV-cDO"; */
+"W5U-cV-cDO.text" = "Seyahatinizi derecelendirin";

--- a/MapboxNavigation/Resources/uk.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/uk.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Знайдено швидший маршрут";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Поганий\nмаршрут";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Заплутані\nінструкції";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Інші\nпомилки мапи";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Заборонено";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Повідомити\nпро затор";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Дорогу\nзакрито";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Дякуємо за повідомлення!";
 

--- a/MapboxNavigation/Resources/vi.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/vi.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Đã Tìm thấy Đường Nhanh Hơn";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Đường\nSai";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Hướng dẫn\nKhó hiểu";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Vấn đề\nBản đồ Khác";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Cấm";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Báo cáo\nTắc đường";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Đường\nĐóng cửa";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Cảm ơn bạn đã báo cáo!";
 

--- a/MapboxNavigation/Resources/yo.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/yo.lproj/Localizable.strings
@@ -64,24 +64,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "Ilana ti o yara ju";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "Buburu\nIpa ọna";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "Iroro\nIlana";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "Miiran\nOro Akoko";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "Ko\nGba laaye";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "Iroyin\nIjabọ";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "Opopona\nTi pa";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "Mo ṣeun fun iroyin rẹ!";
 

--- a/MapboxNavigation/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/zh-Hans.lproj/Localizable.strings
@@ -16,30 +16,6 @@
 /* Indicates a faster route was found */
 "FASTER_ROUTE_FOUND" = "发现一条更快的路线";
 
-/* Feedback type for Bad Route */
-"FEEDBACK_BAD_ROUTE" = "路线问题";
-
-/* Feedback type for Confusing Instruction */
-"FEEDBACK_CONFUSING_INSTRUCTION" = "导航指令不清";
-
-/* Feedback type for Other Map Issue Issue */
-"FEEDBACK_GENERAL_ISSUE" = "其它问题";
-
-/* Feedback type for Missing Exit */
-"FEEDBACK_MISSING_EXIT" = "出口缺失";
-
-/* Feedback type for Missing Road */
-"FEEDBACK_MISSING_ROAD" = "道路缺失";
-
-/* Feedback type for a maneuver that is Not Allowed */
-"FEEDBACK_NOT_ALLOWED" = "道路禁行";
-
-/* Feedback type for Report Traffic */
-"FEEDBACK_REPORT_TRAFFIC" = "道路拥挤";
-
-/* Feedback type for Road Closed */
-"FEEDBACK_ROAD_CLOSURE" = "道路关闭";
-
 /* Message confirming that the user has successfully sent feedback */
 "FEEDBACK_THANK_YOU" = "谢谢您的反馈！";
 


### PR DESCRIPTION
Added a Turkish localization. Thanks to @CosmosExmo for contributing this localization!

Added a missing Ukrainian resource to the project. It had been committed but not included in the SDK.

Removed feedback category strings that are no longer needed as of #2419. #2474 tracks making the new feedback categories and subcategories localizable.

/cc @mapbox/navigation-ios