### PR TITLE
Make sure to access application state from UI thread.

### DIFF
--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -118,6 +118,8 @@ struct NavigationEventDetails: EventDetails {
     var newDistanceRemaining: CLLocationDistance?
     var newDurationRemaining: TimeInterval?
     var newGeometry: String?
+    var totalTimeInForeground: TimeInterval
+    var totalTimeInBackground: TimeInterval
     
     init(dataSource: EventsManagerDataSource, session: SessionState, defaultInterface: Bool) {
         coordinate = dataSource.router.rawLocation?.coordinate
@@ -178,8 +180,8 @@ struct NavigationEventDetails: EventDetails {
         }
         percentTimeInPortrait = totalTimeInPortrait + totalTimeInLandscape == 0 ? 100 : Int((totalTimeInPortrait / (totalTimeInPortrait + totalTimeInLandscape)) * 100)
         
-        var totalTimeInForeground = session.timeSpentInForeground
-        var totalTimeInBackground = session.timeSpentInBackground
+        totalTimeInForeground = session.timeSpentInForeground
+        totalTimeInBackground = session.timeSpentInBackground
         if applicationState == .active {
             totalTimeInForeground += abs(session.lastTimeInForeground.timeIntervalSinceNow)
         } else {
@@ -249,6 +251,8 @@ struct NavigationEventDetails: EventDetails {
         case newDurationRemaining
         case newGeometry
         case routeLegProgress = "step"
+        case totalTimeInForeground
+        case totalTimeInBackground
     }
     
     func encode(to encoder: Encoder) throws {
@@ -303,6 +307,8 @@ struct NavigationEventDetails: EventDetails {
         try container.encodeIfPresent(secondsSinceLastReroute, forKey: .secondsSinceLastReroute)
         try container.encodeIfPresent(newDistanceRemaining, forKey: .newDistanceRemaining)
         try container.encodeIfPresent(newDurationRemaining, forKey: .newDurationRemaining)
+        try container.encodeIfPresent(totalTimeInForeground, forKey: .totalTimeInForeground)
+        try container.encodeIfPresent(totalTimeInBackground, forKey: .totalTimeInBackground)
     }
 }
 

--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -307,8 +307,9 @@ struct NavigationEventDetails: EventDetails {
         try container.encodeIfPresent(secondsSinceLastReroute, forKey: .secondsSinceLastReroute)
         try container.encodeIfPresent(newDistanceRemaining, forKey: .newDistanceRemaining)
         try container.encodeIfPresent(newDurationRemaining, forKey: .newDurationRemaining)
-        try container.encodeIfPresent(totalTimeInForeground, forKey: .totalTimeInForeground)
-        try container.encodeIfPresent(totalTimeInBackground, forKey: .totalTimeInBackground)
+        try container.encode(totalTimeInForeground, forKey: .totalTimeInForeground)
+        try container.encode(totalTimeInBackground, forKey: .totalTimeInBackground)
+        try container.encodeIfPresent(rating, forKey: .rating)
     }
 }
 

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -79,6 +79,8 @@ class NavigationEventsManagerTests: XCTestCase {
         let dataSource = MapboxNavigationService(route: route, routeOptions: routeOptions)
         let sessionState = SessionState(currentRoute: route, originalRoute: route)
         
+        // Attempt to create NavigationEventDetails object from global queue, no errors from Main Thread Checker
+        // are expected.
         let expectation = XCTestExpectation()
         DispatchQueue.global().async {
             let _ = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: false)
@@ -86,5 +88,8 @@ class NavigationEventsManagerTests: XCTestCase {
         }
         
         wait(for: [expectation], timeout: 0.1)
+        
+        // Sanity check to verify that no issues occur when creating NavigationEventDetails from main queue.
+        let _ = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: false)
     }
 }

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -67,4 +67,24 @@ class NavigationEventsManagerTests: XCTestCase {
         XCTAssertEqual(durationBetweenRerouteAndArrive, 816, accuracy: 1)
         XCTAssertEqual(arriveEvent.rerouteCount, 1)
     }
+    
+    // Test allows to verify whether no Main Thread Checker errors occur during
+    // NavigationEventDetails object creation.
+    func testNavigationEventDetailsGlobalQueue() {
+        let routeOptions = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 38.853108, longitude: -77.043331),
+            CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
+        ])
+        let route = Fixture.route(from: "DCA-Arboretum", options: routeOptions)
+        let dataSource = MapboxNavigationService(route: route, routeOptions: routeOptions)
+        let sessionState = SessionState(currentRoute: route, originalRoute: route)
+        
+        let expectation = XCTestExpectation()
+        DispatchQueue.global().async {
+            let _ = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: false)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
 }


### PR DESCRIPTION
Closes #2468.

I've added `testNavigationEventDetailsGlobalQueue` to `NavigationEventsManagerTests.swift`. If needed I can create separate file for `NavigationEventDetails` tests. Also if makes sense test to ensure all keys are encoded to dictionary correctly can be added.