### PR TITLE
Fix CarPlayNavigationViewController tests

### DIFF
--- a/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -457,6 +457,9 @@ func simulateCarPlayConnection(_ manager: CarPlayManager) {
     let fakeWindow = CPWindow()
     
     manager.application(UIApplication.shared, didConnectCarInterfaceController: fakeInterfaceController, to: fakeWindow)
+    if let mapViewController = manager.carWindow?.rootViewController?.view {
+        manager.carWindow?.addSubview(mapViewController)
+    }
 }
 
 @available(iOS 12.0, *)


### PR DESCRIPTION
Tests that exercise CarPlayNavigationViewController need it to be around after being presented. Presenting it requires the CarPlayMapViewController to be part of the view hierarchy. Merely making CarPlayMapViewController the root view controller of the CPWindow doesn’t automatically add the view to the view hierarchy, though it does happen in a realistic, non-testing scenario.

We previously worked around this issue in https://github.com/mapbox/mapbox-navigation-ios/pull/2360#issuecomment-615410538, but this change fixes the root cause and confirms that the issue was in our tests rather than the actual product in production, as far as I can tell.

Fixes #2441.

/cc @mapbox/navigation-ios