### PR TITLE
Consume Navigation Native through SDK Registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ step-library:
       run:
         name: Prepare .netrc file
         command: |
-          echo >> ~/.netrc
           echo "machine api.mapbox.com" >> ~/.netrc
           echo "login mapbox" >> ~/.netrc
           echo "password $SDK_REGISTRY_TOKEN" >> ~/.netrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,6 @@ step-library:
       run:
         name: Prepare .netrc file
         command: |
-          echo "machine dl.bintray.com" > ~/.netrc
-          echo "login $BINTRAY_LOGIN" >> ~/.netrc
-          echo "password $BINTRAY_API_KEY" >> ~/.netrc
           echo >> ~/.netrc
           echo "machine api.mapbox.com" >> ~/.netrc
           echo "login mapbox" >> ~/.netrc

--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,6 @@
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" ~> 2.3.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" ~> 6.0
-binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" ~> 14.1.5
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" ~> 14.1.5
 github "mapbox/mapbox-directions-swift" ~> 0.33
 github "mapbox/turf-swift" ~> 0.5
 github "mapbox/mapbox-events-ios" ~> 0.10

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" "14.1.6"
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.3.0"
-binary "https://www.mapbox.com/ios-sdk/MapboxNavigationNative.json" "14.1.6"
 github "CedarBDD/Cedar" "v1.0"
 github "Quick/Nimble" "v8.1.1"
 github "Quick/Quick" "v2.2.1"

--- a/README.md
+++ b/README.md
@@ -66,18 +66,6 @@ To install Mapbox Navigation using [CocoaPods](https://cocoapods.org/):
    ```
    where _PRIVATE_MAPBOX_API_TOKEN_ is your Mapbox API token with the `DOWNLOADS:READ` scope. 
 
-1. Create a [Bintray](https://bintray.com/mapbox) account, then [request to be added to the Mapbox Navigation SDK beta testing program](https://docs.google.com/forms/d/1mzknLZf5W9o8-KnQJ1GiYyG2grXVRqNxqHruWYTRVPc/viewform).
-
-1. [Get a Bintray API key](https://bintray.com/profile/edit).
-
-1. Add or append to a .netrc file in your home directory:
-   ```
-   machine dl.bintray.com
-     login username@mapbox
-     password BINTRAY_API_KEY
-   ```
-   where _username_ is your user name and _BINTRAY_API_KEY_ is your Bintray API key.
-
 1. Create a [Podfile](https://guides.cocoapods.org/syntax/podfile.html) with the following specification:
    ```ruby
    pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v1.0.0-beta.1'
@@ -97,18 +85,6 @@ Alternatively, to install Mapbox Navigation using [Carthage](https://github.com/
      password PRIVATE_MAPBOX_API_TOKEN
    ```
    where _PRIVATE_MAPBOX_API_TOKEN_ is your Mapbox API token with the `DOWNLOADS:READ` scope. 
-
-1. Create a [Bintray](https://bintray.com/mapbox) account, then [request to be added to the Mapbox Navigation SDK beta testing program](https://docs.google.com/forms/d/1mzknLZf5W9o8-KnQJ1GiYyG2grXVRqNxqHruWYTRVPc/viewform).
-
-1. [Get a Bintray API key](https://bintray.com/profile/edit).
-
-1. Add or append to a .netrc file in your home directory:
-   ```
-   machine dl.bintray.com
-     login username@mapbox
-     password BINTRAY_API_KEY
-   ```
-   where _username_ is your user name and _BINTRAY_API_KEY_ is your Bintray API key.
 
 1. _(Optional)_ Clear your Carthage caches:
    ```bash


### PR DESCRIPTION
This PR changes the source of Navigation Native dependency from Bintray to SDK Registry.
Although the changes to the release process are still in review at https://github.com/mapbox/mapbox-navigation-native/pull/1480, navigation-ios can already upgrade to manually added version.

cc: @mapbox/navigation-ios 
ref: https://github.com/mapbox/mapbox-navigation-native/issues/1479