### PR TITLE
MapboxSpeechSynthesizer API update

### DIFF
--- a/MapboxNavigation/MultiplexedSpeechSynthesizer.swift
+++ b/MapboxNavigation/MultiplexedSpeechSynthesizer.swift
@@ -65,7 +65,7 @@ open class MultiplexedSpeechSynthesizer: SpeechSynthesizing {
     
     public init(_ speechSynthesizers: [SpeechSynthesizing]? = nil, accessToken: String? = nil, host: String? = nil) {
         let synthesizers = speechSynthesizers ?? [
-            MapboxSpeechSynthesizer(accessToken, host: host),
+            MapboxSpeechSynthesizer(accessToken: accessToken, host: host),
             SystemSpeechSynthesizer()]
         self.speechSynthesizers = synthesizers
         


### PR DESCRIPTION
Updated `MapboxSpeechSynthesizer` public API to allow access Mapbox Speech and calling `speak` method.
This change is induced by [examples project](https://github.com/mapbox/navigation-ios-examples/pull/67) to simplify  `MapboxSpeechSynthesizer` subclassing.