### PR TITLE
Tests fix

### DIFF
--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -75,6 +75,7 @@ class NavigationEventsManagerTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 38.853108, longitude: -77.043331),
             CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
         ])
+        let eventTimeout = 0.3
         let route = Fixture.route(from: "DCA-Arboretum", options: routeOptions)
         let dataSource = MapboxNavigationService(route: route, routeOptions: routeOptions)
         let sessionState = SessionState(currentRoute: route, originalRoute: route)
@@ -87,7 +88,7 @@ class NavigationEventsManagerTests: XCTestCase {
             expectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: 0.3)
+        wait(for: [expectation], timeout: eventTimeout)
         
         // Sanity check to verify that no issues occur when creating NavigationEventDetails from main queue.
         let _ = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: false)

--- a/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -87,7 +87,7 @@ class NavigationEventsManagerTests: XCTestCase {
             expectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: 0.1)
+        wait(for: [expectation], timeout: 0.3)
         
         // Sanity check to verify that no issues occur when creating NavigationEventDetails from main queue.
         let _ = NavigationEventDetails(dataSource: dataSource, session: sessionState, defaultInterface: false)

--- a/MapboxNavigationTests/Support/TokenTestViewController.swift
+++ b/MapboxNavigationTests/Support/TokenTestViewController.swift
@@ -46,6 +46,7 @@ class TokenTestViewController: UIViewController {
         
         DispatchQueue.global().async {
             
+            // waiting for MapView token to be extracted from a style request
             _ = self.semaphore.wait(timeout: .now() + 4)
 
             self.directionsToken = Directions.skuToken

--- a/MapboxNavigationTests/Support/TokenTestViewController.swift
+++ b/MapboxNavigationTests/Support/TokenTestViewController.swift
@@ -45,10 +45,11 @@ class TokenTestViewController: UIViewController {
         super.viewDidLoad()
         
         DispatchQueue.global().async {
-            self.directionsToken = Directions.skuToken
-            self.speechSynthesizerToken = SpeechSynthesizer.skuToken
             
             _ = self.semaphore.wait(timeout: .now() + 4)
+
+            self.directionsToken = Directions.skuToken
+            self.speechSynthesizerToken = SpeechSynthesizer.skuToken
             
             DispatchQueue.main.async {
                 OHHTTPStubs.removeAllStubs()


### PR DESCRIPTION
Resolves #2525 
Attempt to fix `SKUTokensMatch` and `testNavigationEventDetailsGlobalQueue` tests.

I could not reproduce the SKU test failure locally, so had to test it on the CI.
I also increased the timeout period for `testNavigationEventDetailsGlobalQueue` because it failed sometimes , but this test is not about performance measurement. It uses background queue and sometimes it fails to fall into strict `0.1` timeout.

