### PR TITLE
Show heading indicator instead of rotating map in example application

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -393,7 +393,8 @@ class ViewController: UIViewController {
         
         trackLocations(mapView: mapView)
         mapView.showsUserLocation = true
-        mapView.userTrackingMode = .followWithHeading
+        mapView.userTrackingMode = .follow
+        mapView.showsUserHeadingIndicator = true
     }
     
     func uninstall(_ mapView: NavigationMapView) {


### PR DESCRIPTION
Avoid conflicts between map rotation animations and panning animations that could cause the map in the example application to lag behind the user location. The map is more useful as a preview map when it always faces due north.

/ref https://github.com/mapbox/mapbox-gl-native/issues/3625#issuecomment-173128298
/cc @mapbox/navigation-ios @avi-c @d-prukop