### PR TITLE
Location projection looking forward during free driving

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -600,6 +600,13 @@ extension ViewController {
             
             var coordinates: [CLLocationCoordinate2D] = [location.coordinate]
             trackPolyline?.appendCoordinates(&coordinates, count: UInt(coordinates.count))
+            
+            if mapView?.userTrackingMode != .followWithCourse, location.horizontalAccuracy < 65.0, location.speed > 8.0, let camera = mapView?.camera {
+                mapView?.userTrackingMode = .followWithCourse
+                camera.altitude = 750.0
+                camera.pitch = 45.0
+                mapView?.setCamera(camera, animated: true)
+            }
         }
         
         if let rawLocation = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.rawLocationKey] as? CLLocation {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -600,13 +600,6 @@ extension ViewController {
             
             var coordinates: [CLLocationCoordinate2D] = [location.coordinate]
             trackPolyline?.appendCoordinates(&coordinates, count: UInt(coordinates.count))
-            
-            if mapView?.userTrackingMode != .followWithCourse, location.horizontalAccuracy < 65.0, location.speed > 8.0, let camera = mapView?.camera {
-                mapView?.userTrackingMode = .followWithCourse
-                camera.altitude = 750.0
-                camera.pitch = 45.0
-                mapView?.setCamera(camera, animated: true)
-            }
         }
         
         if let rawLocation = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.rawLocationKey] as? CLLocation {

--- a/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -117,7 +117,8 @@ extension PassiveLocationDataSource: CLLocationManagerDelegate {
             return
         }
         
-        let status = navigator.status(at: lastRawLocation.timestamp)
+        let timestampForStatus = Date().addingTimeInterval(TimeInterval(1.1))
+        let status = navigator.status(at: timestampForStatus)
         let lastLocation = CLLocation(status.location)
         
         delegate?.passiveLocationDataSource(self, didUpdateLocation: lastLocation, rawLocation: lastRawLocation)

--- a/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -117,7 +117,7 @@ extension PassiveLocationDataSource: CLLocationManagerDelegate {
             return
         }
         
-        let timestampForStatus = Date().addingTimeInterval(TimeInterval(1.1))
+        let timestampForStatus = Date().addingTimeInterval(RouteControllerDeadReckoningTimeInterval)
         let status = navigator.status(at: timestampForStatus)
         let lastLocation = CLLocation(status.location)
         

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -193,7 +193,8 @@ open class RouteController: NSObject {
         
         locations.forEach { navigator.updateLocation(for: FixLocation($0)) }
         
-        let status = navigator.status(at: location.timestamp)
+        let timestampForStatus = Date().addingTimeInterval(RouteControllerDeadReckoningTimeInterval)
+        let status = navigator.status(at: timestampForStatus)
         
         // Notify observers if the step’s remaining distance has changed.
         update(progress: routeProgress, with: CLLocation(status.location), rawLocation: location)


### PR DESCRIPTION
This PR adds an adjustment so that the timestamp used in `Navigator.status(at:)` is now a time in the future.