### PR TITLE
Fix conflicts when generating documentation from combined module

### DIFF
--- a/MapboxCoreNavigation/BundleAdditions.swift
+++ b/MapboxCoreNavigation/BundleAdditions.swift
@@ -39,7 +39,7 @@ extension Bundle {
     /**
      The Mapbox Navigation framework bundle, if installed.
      */
-    public class var mapboxNavigation: Bundle? {
+    class var mapboxNavigationIfInstalled: Bundle? {
         // Assumption: MapboxNavigation.framework includes NavigationViewController and exposes it to the Objective-C runtime as MapboxNavigation.NavigationViewController.
         guard let NavigationViewController = NSClassFromString("MapboxNavigation.NavigationViewController") else {
             return nil

--- a/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -31,7 +31,7 @@ open class NavigationEventsManager {
      Indicates whether the application depends on MapboxNavigation in addition to MapboxCoreNavigation.
      */
     var usesDefaultUserInterface = {
-        return Bundle.mapboxNavigation != nil
+        return Bundle.mapboxNavigationIfInstalled != nil
     }()
 
     /// :nodoc: the internal lower-level mobile events manager is an implementation detail which should not be manipulated directly

--- a/MapboxCoreNavigation/URLSession.swift
+++ b/MapboxCoreNavigation/URLSession.swift
@@ -11,7 +11,7 @@ extension URLSession {
         let bundles: [Bundle?] = [
             // Bundles in order from the application level on down
             .main,
-            .mapboxNavigation,
+            .mapboxNavigationIfInstalled,
             .mapboxCoreNavigation,
             .init(for: Directions.self),
         ]

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = ["MapboxNavigation/**/*.{h,m,swift}","MapboxCoreNavigation/**/*.swift"]
+  s.source_files = ["{MapboxNavigation,MapboxCoreNavigation}/**/*.{h,m,swift}"]
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/MapboxNavigation/Bundle.swift
+++ b/MapboxNavigation/Bundle.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 extension Bundle {
-    class var mapboxNavigation: Bundle {
+    /**
+     The Mapbox Navigation framework bundle.
+     */
+    public class var mapboxNavigation: Bundle {
         get { return Bundle(for: NavigationViewController.self) }
     }
     

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -49,6 +49,8 @@ sed -n -e '/^## /{' -e ':a' -e 'n' -e '/^## /q' -e 'p' -e 'ba' -e '}' CHANGELOG.
 # https://github.com/mapbox/mapbox-navigation-ios/issues/2363
 find Mapbox{Core,}Navigation/ -name '*.swift' -exec \
     perl -pi -e 's/\bMapboxCoreNavigation\b/MapboxNavigation/' {} \;
+find Mapbox{Core,}Navigation/ -name '*.[hm]' -exec \
+    perl -pi -e 's/([<"])MapboxCoreNavigation\b/$1MapboxNavigation/' {} \;
 
 # Blow away any platform-based availability attributes, since everything is
 # compatible enough to be documented.


### PR DESCRIPTION
The two `Bundle.mapboxNavigation` extension properties conflict when the documentation script gloms MapboxNavigation and MapboxCoreNavigation together into a single module. Make the one in MapboxNavigation public instead, since it has more certainty about the presence of MapboxNavigation.

/cc @mapbox/navigation-ios