### PR TITLE
Fix traffic congestion rendering issues.

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -610,9 +610,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     
     @discardableResult func addAlternativeRoutesLayer(_ style: MGLStyle, source: MGLSource, below layer: MGLStyleLayer) -> MGLStyleLayer {
         let customAlternativeRoutesLayer = navigationMapViewDelegate?.navigationMapView(self,
-                                                                                      alternativeRouteStyleLayerWithIdentifier: StyleLayerIdentifier.alternativeRoutes,
-                                                                                      source: source)
-        
+                                                                                        alternativeRouteStyleLayerWithIdentifier: StyleLayerIdentifier.alternativeRoutes,
+                                                                                        source: source)
         let currentAlternativeRoutesLayer = style.layer(withIdentifier: StyleLayerIdentifier.alternativeRoutes)
         
         if let alternativeRoutesLayer = customAlternativeRoutesLayer, let _ = currentAlternativeRoutesLayer {
@@ -641,9 +640,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     
     @discardableResult func addAlternativeRoutesCasingLayer(_ style: MGLStyle, source: MGLSource, below layer: MGLStyleLayer) -> MGLStyleLayer {
         let customAlternativeRoutesCasingLayer = navigationMapViewDelegate?.navigationMapView(self,
-                                                                                            alternativeRouteCasingStyleLayerWithIdentifier: StyleLayerIdentifier.alternativeRoutesCasing,
-                                                                                            source: source)
-        
+                                                                                              alternativeRouteCasingStyleLayerWithIdentifier: StyleLayerIdentifier.alternativeRoutesCasing,
+                                                                                              source: source)
         let currentAlternativeRoutesCasingLayer = style.layer(withIdentifier: StyleLayerIdentifier.alternativeRoutesCasing)
         
         if let alternativeRoutesCasingLayer = customAlternativeRoutesCasingLayer, let _ = currentAlternativeRoutesCasingLayer {
@@ -691,6 +689,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
         // In case if mainRouteLayer was already added - extract congestion segments out of it.
         if let mainRouteLayer = style?.layer(withIdentifier: StyleLayerIdentifier.mainRoute) as? MGLLineStyleLayer,
+            // lineGradient contains 4 arguments, last one (stops) allows to store line gradient stops, if they're present - reuse them.
             let lineGradients = mainRouteLayer.lineGradient?.arguments?[3],
             let stops = lineGradients.expressionValue(with: nil, context: nil) as? NSDictionary {
             

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -97,8 +97,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
 
         static let mainRoute = "\(identifierNamespace).mainRoute"
         static let mainRouteCasing = "\(identifierNamespace).mainRouteCasing"
-        static let alternateRoutes = "\(identifierNamespace).alternateRoutes"
-        static let alternateRoutesCasing = "\(identifierNamespace).alternateRoutesCasing"
+        static let alternativeRoutes = "\(identifierNamespace).alternativeRoutes"
+        static let alternativeRoutesCasing = "\(identifierNamespace).alternativeRoutesCasing"
 
         static let route = "\(identifierNamespace).route"
         static let routeCasing = "\(identifierNamespace).routeCasing"
@@ -490,8 +490,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
         let mainRouteLayer = addMainRouteLayer(style, source: allRoutesSource, lineGradient: routeLineGradient(mainRoute, fractionTraveled: 0.0))
         let mainRouteCasingLayer = addMainRouteCasingLayer(style, source: mainRouteCasingSource, lineGradient: routeCasingGradient(0.0), below: mainRouteLayer)
-        let alternateRoutesLayer = addAlternateRoutesLayer(style, source: allRoutesSource, below: mainRouteCasingLayer)
-        addAlternateRoutesCasingLayer(style, source: allRoutesSource, below: alternateRoutesLayer)
+        let alternativeRoutesLayer = addAlternativeRoutesLayer(style, source: allRoutesSource, below: mainRouteCasingLayer)
+        addAlternativeRoutesCasingLayer(style, source: allRoutesSource, below: alternativeRoutesLayer)
     }
     
     // MARK: - Route line insertion methods
@@ -608,66 +608,66 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         return mainRouteCasingLayer
     }
     
-    @discardableResult func addAlternateRoutesLayer(_ style: MGLStyle, source: MGLSource, below layer: MGLStyleLayer) -> MGLStyleLayer {
-        let customAlternateRoutesLayer = navigationMapViewDelegate?.navigationMapView(self,
-                                                                                      alternativeRouteStyleLayerWithIdentifier: StyleLayerIdentifier.alternateRoutes,
+    @discardableResult func addAlternativeRoutesLayer(_ style: MGLStyle, source: MGLSource, below layer: MGLStyleLayer) -> MGLStyleLayer {
+        let customAlternativeRoutesLayer = navigationMapViewDelegate?.navigationMapView(self,
+                                                                                      alternativeRouteStyleLayerWithIdentifier: StyleLayerIdentifier.alternativeRoutes,
                                                                                       source: source)
         
-        let currentAlternateRoutesLayer = style.layer(withIdentifier: StyleLayerIdentifier.alternateRoutes)
+        let currentAlternativeRoutesLayer = style.layer(withIdentifier: StyleLayerIdentifier.alternativeRoutes)
         
-        if let alternateRoutesLayer = customAlternateRoutesLayer, let _ = currentAlternateRoutesLayer {
-            return alternateRoutesLayer
+        if let alternativeRoutesLayer = customAlternativeRoutesLayer, let _ = currentAlternativeRoutesLayer {
+            return alternativeRoutesLayer
         }
         
-        if let alternateRoutesLayer = customAlternateRoutesLayer, currentAlternateRoutesLayer == nil {
-            style.insertLayer(alternateRoutesLayer, below: layer)
-            return alternateRoutesLayer
+        if let alternativeRoutesLayer = customAlternativeRoutesLayer, currentAlternativeRoutesLayer == nil {
+            style.insertLayer(alternativeRoutesLayer, below: layer)
+            return alternativeRoutesLayer
         }
         
-        if let alternateRoutesLayer = currentAlternateRoutesLayer {
-            return alternateRoutesLayer
+        if let alternativeRoutesLayer = currentAlternativeRoutesLayer {
+            return alternativeRoutesLayer
         }
         
-        let alternateRoutesLayer = MGLLineStyleLayer(identifier: StyleLayerIdentifier.alternateRoutes, source: source)
-        alternateRoutesLayer.predicate = NSPredicate(format: "isAlternateRoute == true")
-        alternateRoutesLayer.lineColor = NSExpression(forConstantValue: routeAlternateColor)
-        alternateRoutesLayer.lineWidth = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)", MBRouteLineWidthByZoomLevel)
-        alternateRoutesLayer.lineJoin = NSExpression(forConstantValue: "round")
-        alternateRoutesLayer.lineCap = NSExpression(forConstantValue: "round")
-        style.insertLayer(alternateRoutesLayer, below: layer)
+        let alternativeRoutesLayer = MGLLineStyleLayer(identifier: StyleLayerIdentifier.alternativeRoutes, source: source)
+        alternativeRoutesLayer.predicate = NSPredicate(format: "isAlternateRoute == true")
+        alternativeRoutesLayer.lineColor = NSExpression(forConstantValue: routeAlternateColor)
+        alternativeRoutesLayer.lineWidth = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)", MBRouteLineWidthByZoomLevel)
+        alternativeRoutesLayer.lineJoin = NSExpression(forConstantValue: "round")
+        alternativeRoutesLayer.lineCap = NSExpression(forConstantValue: "round")
+        style.insertLayer(alternativeRoutesLayer, below: layer)
         
-        return alternateRoutesLayer
+        return alternativeRoutesLayer
     }
     
-    @discardableResult func addAlternateRoutesCasingLayer(_ style: MGLStyle, source: MGLSource, below layer: MGLStyleLayer) -> MGLStyleLayer {
-        let customAlternateRoutesCasingLayer = navigationMapViewDelegate?.navigationMapView(self,
-                                                                                            alternateRouteCasingStyleLayerWithIdentifier: StyleLayerIdentifier.alternateRoutesCasing,
+    @discardableResult func addAlternativeRoutesCasingLayer(_ style: MGLStyle, source: MGLSource, below layer: MGLStyleLayer) -> MGLStyleLayer {
+        let customAlternativeRoutesCasingLayer = navigationMapViewDelegate?.navigationMapView(self,
+                                                                                            alternativeRouteCasingStyleLayerWithIdentifier: StyleLayerIdentifier.alternativeRoutesCasing,
                                                                                             source: source)
         
-        let currentAlternateRoutesCasingLayer = style.layer(withIdentifier: StyleLayerIdentifier.alternateRoutesCasing)
+        let currentAlternativeRoutesCasingLayer = style.layer(withIdentifier: StyleLayerIdentifier.alternativeRoutesCasing)
         
-        if let alternateRoutesCasingLayer = customAlternateRoutesCasingLayer, let _ = currentAlternateRoutesCasingLayer {
-            return alternateRoutesCasingLayer
+        if let alternativeRoutesCasingLayer = customAlternativeRoutesCasingLayer, let _ = currentAlternativeRoutesCasingLayer {
+            return alternativeRoutesCasingLayer
         }
         
-        if let alternateRoutesCasingLayer = customAlternateRoutesCasingLayer, currentAlternateRoutesCasingLayer == nil {
-            style.insertLayer(alternateRoutesCasingLayer, below: layer)
-            return alternateRoutesCasingLayer
+        if let alternativeRoutesCasingLayer = customAlternativeRoutesCasingLayer, currentAlternativeRoutesCasingLayer == nil {
+            style.insertLayer(alternativeRoutesCasingLayer, below: layer)
+            return alternativeRoutesCasingLayer
         }
         
-        if let alternateRoutesCasingLayer = currentAlternateRoutesCasingLayer {
-            return alternateRoutesCasingLayer
+        if let alternativeRoutesCasingLayer = currentAlternativeRoutesCasingLayer {
+            return alternativeRoutesCasingLayer
         }
         
-        let alternateRoutesCasingLayer = MGLLineStyleLayer(identifier: StyleLayerIdentifier.alternateRoutesCasing, source: source)
-        alternateRoutesCasingLayer.predicate = NSPredicate(format: "isAlternateRoute == true")
-        alternateRoutesCasingLayer.lineColor = NSExpression(forConstantValue: routeAlternateCasingColor)
-        alternateRoutesCasingLayer.lineWidth = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)", MBRouteLineWidthByZoomLevel.multiplied(by: 1.5))
-        alternateRoutesCasingLayer.lineJoin = NSExpression(forConstantValue: "round")
-        alternateRoutesCasingLayer.lineCap = NSExpression(forConstantValue: "round")
-        style.insertLayer(alternateRoutesCasingLayer, below: layer)
+        let alternativeRoutesCasingLayer = MGLLineStyleLayer(identifier: StyleLayerIdentifier.alternativeRoutesCasing, source: source)
+        alternativeRoutesCasingLayer.predicate = NSPredicate(format: "isAlternateRoute == true")
+        alternativeRoutesCasingLayer.lineColor = NSExpression(forConstantValue: routeAlternateCasingColor)
+        alternativeRoutesCasingLayer.lineWidth = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)", MBRouteLineWidthByZoomLevel.multiplied(by: 1.5))
+        alternativeRoutesCasingLayer.lineJoin = NSExpression(forConstantValue: "round")
+        alternativeRoutesCasingLayer.lineCap = NSExpression(forConstantValue: "round")
+        style.insertLayer(alternativeRoutesCasingLayer, below: layer)
         
-        return alternateRoutesCasingLayer
+        return alternativeRoutesCasingLayer
     }
 
     // MARK: - Vanishing route line methods
@@ -828,8 +828,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         style.remove([
             StyleLayerIdentifier.mainRoute,
             StyleLayerIdentifier.mainRouteCasing,
-            StyleLayerIdentifier.alternateRoutes,
-            StyleLayerIdentifier.alternateRoutesCasing
+            StyleLayerIdentifier.alternativeRoutes,
+            StyleLayerIdentifier.alternativeRoutesCasing
         ].compactMap { style.layer(withIdentifier: $0) })
         style.remove(Set([
             SourceIdentifier.allRoutes,

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -612,7 +612,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         }
         
         if let mainRouteCasingLayer = currentMainRouteCasingLayer as? MGLLineStyleLayer {
-            if !routeGradientStops.line.isEmpty {
+            if !routeGradientStops.casing.isEmpty {
                 mainRouteCasingLayer.lineGradient = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($lineProgress, 'linear', nil, %@)", NSDictionary(dictionary: routeGradientStops.casing))
             }
             
@@ -1179,12 +1179,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         var routeGradientStops = RouteGradientStops(line: [:], casing: [:])
 
         /**
-         The resulting set of key/value stops that will be used
-         for the route's line gradient.
-         */
-        var stops = [[CGFloat:UIColor]]()
-
-        /**
          We will keep track of this value as we iterate through
          the various congestion segments.
          */
@@ -1229,9 +1223,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
              percentage point will be zero.
              */
             if index == congestionSegments.startIndex {
-                let segmentStartPercentTraveled = CGFloat.zero
-                stops.append([segmentStartPercentTraveled: associatedCongestionColor])
-
                 distanceTraveled = distanceTraveled + distance
 
                 let segmentEndPercentTraveled = CGFloat((distanceTraveled / route.distance))
@@ -1244,9 +1235,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
              percentage point will be 1.0, to represent 100%.
              */
             if index == congestionSegments.endIndex - 1 {
-                let segmentStartPercentTraveled = CGFloat((distanceTraveled / route.distance))
-                stops.append([segmentStartPercentTraveled.nextUp: associatedCongestionColor])
-
                 let segmentEndPercentTraveled = CGFloat(1.0)
                 routeGradientStops.line[segmentEndPercentTraveled.nextDown] = associatedCongestionColor
                 continue

--- a/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -45,7 +45,7 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter source: The source containing the route data that this method would style.
      - returns: An MGLStyleLayer that is applied as a casing around alternative route lines.
     */
-    func navigationMapView(_ mapView: NavigationMapView, alternateRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationMapView(_ mapView: NavigationMapView, alternativeRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
     /**
      Asks the receiver to return an MGLStyleLayer for waypoints, given an identifier and source.
@@ -85,7 +85,7 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      Asks the receiver to return an MGLShape that describes the geometry of the route.
      - note: The returned value represents the route in full detail. For example, individual `MGLPolyline` objects in an `MGLShapeCollectionFeature` object can represent traffic congestion segments. For improved performance, you should also implement `navigationMapView(_:simplifiedShapeFor:)`, which defines the overall route as a single feature.
      - parameter mapView: The NavigationMapView.
-     - parameter routes: The routes that the sender is asking about. The first route will always be rendered as the main route, while all subsequent routes will be rendered as alternate routes.
+     - parameter routes: The routes that the sender is asking about. The first route will always be rendered as the main route, while all subsequent routes will be rendered as alternative routes.
      - returns: Optionally, a `MGLShape` that defines the shape of the route, or `nil` to use default behavior.
      */
     func navigationMapView(_ mapView: NavigationMapView, shapeFor routes: [Route]) -> MGLShape?
@@ -146,7 +146,7 @@ public extension NavigationMapViewDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
-    func navigationMapView(_ mapView: NavigationMapView, alternateRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    func navigationMapView(_ mapView: NavigationMapView, alternativeRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
         return nil
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -414,8 +414,8 @@ extension NavigationViewController: RouteMapViewControllerDelegate {
         return delegate?.navigationViewController(self, alternativeRouteStyleLayerWithIdentifier: identifier, source: source)
     }
 
-    public func navigationMapView(_ mapView: NavigationMapView, alternateRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationViewController(self, alternateRouteCasingStyleLayerWithIdentifier: identifier, source: source)
+    public func navigationMapView(_ mapView: NavigationMapView, alternativeRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return delegate?.navigationViewController(self, alternativeRouteCasingStyleLayerWithIdentifier: identifier, source: source)
     }
     
     public func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {

--- a/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -118,7 +118,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
 
      If this method is unimplemented, the navigation view controller’s map view draws the casing for the alternative route lines using an `MGLLineStyleLayer`.
     */
-    func navigationViewController(_ navigationViewController: NavigationViewController, alternateRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
+    func navigationViewController(_ navigationViewController: NavigationViewController, alternativeRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer?
     
     /**
      Returns an `MGLShape` that represents the path of the route line.
@@ -267,7 +267,7 @@ public extension NavigationViewControllerDelegate {
         return nil
     }
 
-    func navigationViewController(_ navigationViewController: NavigationViewController, alternateRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+    func navigationViewController(_ navigationViewController: NavigationViewController, alternativeRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
     }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -465,7 +465,7 @@ extension RouteMapViewController: NavigationComponent {
         let stepIndex = progress.currentLegProgress.stepIndex
 
         if mapView.routeLineTracksTraversal {
-            mapView.fadeRoute(progress.fractionTraveled)
+            mapView.fade(route, fractionTraveled: progress.fractionTraveled)
         }
 
         mapView.updatePreferredFrameRate(for: progress)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -464,10 +464,6 @@ extension RouteMapViewController: NavigationComponent {
         let legIndex = progress.legIndex
         let stepIndex = progress.currentLegProgress.stepIndex
 
-        if mapView.routeLineTracksTraversal {
-            mapView.fade(route, fractionTraveled: progress.fractionTraveled)
-        }
-
         mapView.updatePreferredFrameRate(for: progress)
         if currentLegIndexMapped != legIndex {
             mapView.showWaypoints(on: route, legIndex: legIndex)
@@ -483,6 +479,10 @@ extension RouteMapViewController: NavigationComponent {
         
         if annotatesSpokenInstructions {
             mapView.showVoiceInstructionsOnMap(route: route)
+        }
+        
+        if mapView.routeLineTracksTraversal {
+            mapView.fade(route, fractionTraveled: progress.fractionTraveled)
         }
         
         navigationView.speedLimitView.signStandard = progress.currentLegProgress.currentStep.speedLimitSignStandard

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -568,8 +568,8 @@ extension RouteMapViewController: NavigationViewDelegate {
         return delegate?.navigationMapView(mapView, alternativeRouteStyleLayerWithIdentifier: identifier, source: source)
     }
 
-    func navigationMapView(_ mapView: NavigationMapView, alternateRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
-        return delegate?.navigationMapView(mapView, alternateRouteCasingStyleLayerWithIdentifier: identifier, source: source)
+    func navigationMapView(_ mapView: NavigationMapView, alternativeRouteCasingStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {
+        return delegate?.navigationMapView(mapView, alternativeRouteCasingStyleLayerWithIdentifier: identifier, source: source)
     }
 
     func navigationMapView(_ mapView: NavigationMapView, waypointStyleLayerWithIdentifier identifier: String, source: MGLSource) -> MGLStyleLayer? {


### PR DESCRIPTION
Closing #2574.

I've slightly re-worked original implementation. Now there are such methods which allow to add route layers:
```swift
addMainRouteLayer(_:source:lineGradient:)
addMainRouteCasingLayer(_:source:lineGradient:below:)
addAlternateRoutesLayer(_:source:below:)
addAlternateRoutesCasingLayer(_:source:below:)
```

Such methods are used to create line gradient:
```swift
routeLineGradient(_:fractionTraveled:)
routeCasingGradient(_:)
```

In case if route layer was already added route line gradient with congestion segments will be retrieved out of it.
For route casing color is always the same (without congestions), but fading is also added depending on route progress.

Current PR also fixes #2423 and #2512.