### PR TITLE
Add passive location manager to CarPlay pre-navigation map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Upgraded to [Mapbox Maps SDK for iOS v6.1.0-beta.2](https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v6.1.0-beta.2). ([#2565](https://github.com/mapbox/mapbox-navigation-ios/pull/2565))
 
+### Other changes
+
+* In CarPlay, the map view’s camera and user location indicator also snap to the road network during the browsing and previewing activities, just as in the navigating activity. ([#2588](https://github.com/mapbox/mapbox-navigation-ios/pull/2588))
+
 ## v1.0.0
 
 ### Packaging

--- a/MapboxNavigation/CarPlayMapViewController.swift
+++ b/MapboxNavigation/CarPlayMapViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MapboxCoreNavigation
 #if canImport(CarPlay)
 import CarPlay
 
@@ -121,6 +122,10 @@ public class CarPlayMapViewController: UIViewController {
         let mapView = NavigationMapView()
         mapView.logoView.isHidden = true
         mapView.attributionButton.isHidden = true
+        
+        let dataSource = PassiveLocationDataSource()
+        let locationManager = PassiveLocationManager(dataSource: dataSource)
+        mapView.locationManager = locationManager
         
         styleObservation = mapView.observe(\.style, options: .new) { (mapView, change) in
             guard change.newValue != nil else {


### PR DESCRIPTION
In CarPlay, the map view’s camera and user location indicator also snap to the road network during the browsing (free-driving) and previewing activities, just as in the navigating activity, thanks to a PassiveLocationManager.

/cc @mapbox/navigation-ios