### PR TITLE
Remove rounding corners method which is causing presentation issues in end of route view.

### DIFF
--- a/MapboxNavigation/EndOfRouteViewController.swift
+++ b/MapboxNavigation/EndOfRouteViewController.swift
@@ -69,8 +69,8 @@ class EndOfRouteViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        view.roundCorners([.topLeft, .topRight])
+        super.viewWillAppear(animated)
+        
         preferredContentSize.height = height(for: .normal)
         updateInterface()
     }

--- a/MapboxNavigation/UIView.swift
+++ b/MapboxNavigation/UIView.swift
@@ -13,13 +13,6 @@ extension UIView {
         subviews.forEach(addSubview(_:))
     }
     
-    func roundCorners(_ corners: UIRectCorner = [.allCorners], radius: CGFloat = 5.0) {
-        let path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
-        let maskLayer = CAShapeLayer()
-        maskLayer.path = path.cgPath
-        layer.mask = maskLayer
-    }
-    
     func applyDefaultCornerRadiusShadow(cornerRadius: CGFloat? = 4, shadowOpacity: CGFloat? = 0.1) {
         layer.cornerRadius = cornerRadius!
         layer.shadowOffset = CGSize(width: 0, height: 0)


### PR DESCRIPTION
Closing #2516.

I've decided to remove `roundCorners(_:radius:)` as it was causing presentation issues during rotation and in case of early arrival. Since rounded corners are almost invisible in case if end of route view fills whole width I think it's acceptable.