### PR TITLE
Add tiles manager

### DIFF
--- a/MapboxCoreNavigation/NavigatorTilesManager.swift
+++ b/MapboxCoreNavigation/NavigatorTilesManager.swift
@@ -1,0 +1,151 @@
+import Foundation
+import MapboxDirections
+import MapboxNavigationNative
+
+private let tilesManager = NavigatorTilesManager()
+
+extension Navigator {
+    static func createWith(profile: SettingsProfile, config: NavigatorConfig, customConfig: String) -> Navigator {
+        let navigator = Navigator(profile: profile, config: config, customConfig: customConfig)
+        tilesManager.getVersion { version in
+            guard let version = version else { return }
+            navigator.updateTiles(version: version)
+        }
+        return navigator
+    }
+
+    /**
+    Creates a cache for tiles of the given version and configures the navigator to use this cache.
+    */
+    func updateTiles(version: String) {
+        let directions = Directions.shared
+        let endpointConfig = TileEndpointConfiguration(directions: directions, tilesVersion: version)
+        tilesManager.createFolder(forVersion: version)
+        if let tilesURL = tilesManager.folder(forVersion: version) {
+            let params = RouterParams(tilesPath: tilesURL.path, inMemoryTileCache: nil, mapMatchingSpatialCache: nil, threadsCount: nil, endpointConfig: endpointConfig)
+
+            configureRouter(for: params)
+        }
+    }
+}
+
+class NavigatorTilesManager {
+    enum Constants {
+        static let tilesFolder = ".mapbox"
+        static let tileNameFormat = "yyyy_MM_dd-HH_mm_ss"
+        static let lastUpdated = "com.mapbox.NavigatorTilesManager.lastUpdated"
+        static let dayInSeconds: TimeInterval = 24 * 60 * 60
+    }
+
+    private var versions: [String] = []
+    private var lastUpdated: TimeInterval {
+        get {
+            UserDefaults.standard.double(forKey: Constants.lastUpdated)
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.lastUpdated)
+            DispatchQueue.main.async {
+                self.removeOutdatedTiles()
+            }
+        }
+    }
+
+    func getVersion(completion: @escaping (String?) -> Void) {
+        if Date().timeIntervalSince1970 - lastUpdated > Constants.dayInSeconds {
+            completion(latestVersion())
+        } else {
+            updateVersionsList { [weak self] in
+                completion(self?.latestVersion())
+            }
+        }
+    }
+
+    func latestVersion() -> String? {
+        let versions = downloadedVersions()
+        return versions.last
+    }
+
+    func folder(forVersion version: String) -> URL? {
+        let fileManager = FileManager.default
+        // ~/Library/Caches/tld.app.bundle.id/.mapbox/2020_08_08-03_00_00/
+        var documentsURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+        documentsURL?.appendPathComponent(Constants.tilesFolder, isDirectory: true)
+        documentsURL?.appendPathComponent(version, isDirectory: true)
+        return documentsURL
+    }
+
+    func createFolder(forVersion version: String) {
+        guard let folder = folder(forVersion: version) else { return }
+        do {
+            // Tiles with different versions shouldn't be mixed, it may cause inappropriate Navigator's behaviour
+            try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+        }
+    }
+
+    func isDownloaded(version: String) -> Bool {
+        let versions = downloadedVersions()
+        return versions.contains(version)
+    }
+
+    func removeOutdatedTiles() {
+        let tilesToRemove = downloadedVersions()
+        let latestVersion = self.latestVersion()
+
+        for tileVersion in tilesToRemove {
+            if tileVersion != latestVersion {
+                remove(version: tileVersion)
+            }
+        }
+    }
+
+    func remove(version: String) {
+        let fileManager = FileManager.default
+        var versionFolder = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        versionFolder.appendPathComponent(Constants.tilesFolder, isDirectory: true)
+        versionFolder.appendPathComponent(version, isDirectory: false)
+        do {
+            try fileManager.removeItem(at: versionFolder)
+        } catch {
+        }
+    }
+
+    func downloadedVersions() -> [String] {
+        let fileManager = FileManager.default
+        var documentsURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        documentsURL.appendPathComponent(Constants.tilesFolder, isDirectory: true)
+        do {
+            let fileURLs = try fileManager.contentsOfDirectory(at: documentsURL, includingPropertiesForKeys: nil)
+            let folders = fileURLs.map { fileURL in
+                fileURL.lastPathComponent
+            }
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = Constants.tileNameFormat
+            let versions = folders
+                .compactMap { version in
+                    dateFormatter.date(from: version)
+                }.sorted {
+                    $0 < $1
+                }.map {
+                    dateFormatter.string(from: $0)
+                }
+            return versions
+        } catch {
+            print("Error while enumerating files \(documentsURL.path): \(error.localizedDescription)")
+        }
+        return []
+    }
+
+    func updateVersionsList(completion: @escaping () -> Void) {
+        Directions.shared.fetchAvailableOfflineVersions { [weak self] (versions, error) in
+            guard error == nil, let versions = versions?.filter({ !$0.isEmpty }) else { return }
+            guard let last = versions.first else { return }
+            self?.versions = versions
+            if last != self?.latestVersion() {
+                self?.createFolder(forVersion: last)
+            }
+            self?.lastUpdated = Date().timeIntervalSince1970
+            completion()
+        }
+   }
+}

--- a/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -22,7 +22,7 @@ open class PassiveLocationDataSource: NSObject {
         self.directions = directions
         
         let settingsProfile = SettingsProfile(application: ProfileApplication.kMobile, platform: ProfilePlatform.KIOS)
-        self.navigator = Navigator(profile: settingsProfile, config: NavigatorConfig() , customConfig: "")
+        self.navigator = Navigator.createWith(profile: settingsProfile, config: NavigatorConfig() , customConfig: "")
         
         self.systemLocationManager = systemLocationManager ?? NavigationLocationManager()
         
@@ -56,42 +56,7 @@ open class PassiveLocationDataSource: NSObject {
      */
     public func startUpdatingLocation(completionHandler: ((Error?) -> Void)? = nil) {
         systemLocationManager.startUpdatingLocation()
-        
-        directions.fetchAvailableOfflineVersions { [weak self] (versions, error) in
-            guard let self = self, let latestVersion = versions?.first(where: { !$0.isEmpty }), error == nil else {
-                completionHandler?(error)
-                return
-            }
-            
-            do {
-                try self.configureNavigator(withTilesVersion: latestVersion)
-                completionHandler?(nil)
-            } catch {
-                completionHandler?(error)
-            }
-        }
-    }
-    
-    /**
-     Creates a cache for tiles of the given version and configures the navigator to use this cache.
-     */
-    func configureNavigator(withTilesVersion tilesVersion: String) throws {
-        let endpointConfig = TileEndpointConfiguration(directions: directions, tilesVersion: tilesVersion)
-
-        // ~/Library/Caches/tld.app.bundle.id/.mapbox/2020_08_08-03_00_00/
-        guard var tilesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            preconditionFailure("No Caches directory to create the tile directory inside")
-        }
-        if let bundleIdentifier = Bundle.main.bundleIdentifier ?? Bundle.mapboxCoreNavigation.bundleIdentifier {
-            tilesURL.appendPathComponent(bundleIdentifier, isDirectory: true)
-        }
-        tilesURL.appendPathComponent(".mapbox", isDirectory: true)
-        tilesURL.appendPathComponent(tilesVersion, isDirectory: true)
-        // Tiles with different versions shouldn't be mixed, it may cause inappropriate Navigator's behaviour
-        try FileManager.default.createDirectory(at: tilesURL, withIntermediateDirectories: true, attributes: nil)
-        let params = RouterParams(tilesPath: tilesURL.path, inMemoryTileCache: nil, mapMatchingSpatialCache: nil, threadsCount: nil, endpointConfig: endpointConfig)
-        
-        navigator.configureRouter(for: params)
+        completionHandler?(nil)
     }
     
     /**

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -24,7 +24,7 @@ open class RouteController: NSObject {
     lazy var navigator: Navigator = {
         let settingsProfile = SettingsProfile(application: ProfileApplication.kMobile,
                                               platform: ProfilePlatform.KIOS)
-        return Navigator(profile: settingsProfile, config: NavigatorConfig(), customConfig: "")
+        return Navigator.createWith(profile: settingsProfile, config: NavigatorConfig(), customConfig: "")
     }()
     
     public var route: Route {

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		5A39B9282498F9890026DFD1 /* PassiveLocationDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A39B9272498F9890026DFD1 /* PassiveLocationDataSource.swift */; };
 		5A3D212E24DADFA000EA652A /* SkuTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3D212D24DADF9F00EA652A /* SkuTokenProvider.swift */; };
 		5A43FC8B24B488DC00BF7943 /* PassiveLocationDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A43FC8A24B488DC00BF7943 /* PassiveLocationDataSourceTests.swift */; };
+        5A6DEF4C24EBD7A400ED78AF /* NavigatorTilesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6DEF4B24EBD7A400ED78AF /* NavigatorTilesManager.swift */; };
 		5A8DB89424DE0ED70041F863 /* MBXPeerWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A8DB89224DE0E4E0041F863 /* MBXPeerWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5A8DB89624DE16A10041F863 /* SkuTokenProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB89524DE16A10041F863 /* SkuTokenProviderTests.swift */; };
 		6441B16A1EFC64E50076499F /* WaypointConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */; };
@@ -855,6 +856,7 @@
 		5A39B9272498F9890026DFD1 /* PassiveLocationDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassiveLocationDataSource.swift; sourceTree = "<group>"; };
 		5A3D212D24DADF9F00EA652A /* SkuTokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkuTokenProvider.swift; sourceTree = "<group>"; };
 		5A43FC8A24B488DC00BF7943 /* PassiveLocationDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassiveLocationDataSourceTests.swift; sourceTree = "<group>"; };
+		5A6DEF4B24EBD7A400ED78AF /* NavigatorTilesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorTilesManager.swift; sourceTree = "<group>"; };
 		5A8DB89224DE0E4E0041F863 /* MBXPeerWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBXPeerWrapper.h; sourceTree = "<group>"; };
 		5A8DB89524DE16A10041F863 /* SkuTokenProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkuTokenProviderTests.swift; sourceTree = "<group>"; };
 		6441B1691EFC64E50076499F /* WaypointConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WaypointConfirmationViewController.swift; path = Example/WaypointConfirmationViewController.swift; sourceTree = "<group>"; };
@@ -1771,6 +1773,7 @@
 				5A39B9272498F9890026DFD1 /* PassiveLocationDataSource.swift */,
 				5A8DB89224DE0E4E0041F863 /* MBXPeerWrapper.h */,
 				5A3D212D24DADF9F00EA652A /* SkuTokenProvider.swift */,
+                5A6DEF4B24EBD7A400ED78AF /* NavigatorTilesManager.swift */,
 			);
 			path = MapboxCoreNavigation;
 			sourceTree = "<group>";
@@ -2689,6 +2692,7 @@
 				8D4CF9C621349FFB009C3FEE /* NavigationServiceDelegate.swift in Sources */,
 				C5CFE4881EF2FD4C006F48E8 /* MMEEventsManager.swift in Sources */,
 				C578DA081EFD0FFF0052079F /* ProcessInfo.swift in Sources */,
+				5A6DEF4C24EBD7A400ED78AF /* NavigatorTilesManager.swift in Sources */,
 				64847A041F04629D003F3A69 /* Feedback.swift in Sources */,
 				C58D6BAD1DDCF2AE00387F53 /* CoreConstants.swift in Sources */,
 				35C77F621FE8219900338416 /* NavigationSettings.swift in Sources */,


### PR DESCRIPTION
The pr adds a convenient way to create navigators configured with the tiles and tile endpoint config.

For now the sdk contains three places where the navigator objects can be created.
![Untitled Diagram](https://user-images.githubusercontent.com/50099011/92128167-cc20b280-ee0a-11ea-850f-1eb14d193423.png)


Regular arrows shows who creates the objects, for example User app creates an instance of `NavigationViewController`, etc. Hollow arrow shows inheritance. The chart does not display all dependencies.

The problem is that we don't have a place which can control all of these three places and manage the navigators according with the recommendations from the navnative team. The recommendations are:
1. Navigator with a route set will map raw coords most likely to the route instead of to the road graph which is not suitable for free drive mode.
1. Navigator which is used for route tracking will be work more accurate and will have higher performance if it will be configured with navigation tiles as well.
1. It's not recommended to have more than one navigators at the same time because of performance.

The idea for this pr is to use `FileManager` as a point of synchronization for the navigators created from different places.
![Untitled Diagram (1)](https://user-images.githubusercontent.com/50099011/92130531-84e7f100-ee0d-11ea-93a8-ee7178549736.png)


TilesManager is able to:
1. Get the list of the downloaded tiles by checking content of the `.mapbox/` folder in the cache directory.
1. Fetch the list of available versions using MapboxDirections.
1. Delete outdated tiles.

Resolves mapbox/navigation-sdks#430