### PR TITLE
Building highlights before reaching the destination (#2582)

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -508,6 +508,7 @@ extension ViewController: WaypointConfirmationViewControllerDelegate {
             guard router.route.legs.count > router.routeProgress.legIndex + 1 else { return }
             
             router.routeProgress.legIndex += 1
+            navigationViewController.mapView?.unhighlightBuildings()
             navService.start()
         })
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -228,6 +228,10 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     
     private var traversingTunnel = false
     
+    private var approachingDestinationThreshold: CLLocationDistance = 250.0
+    private var passedApproachingDestinationThreshold: Bool = false
+    private var currentLeg: RouteLeg?
+    
     /**
      Initializes a navigation view controller that presents the user interface for following a predefined route based on the given options.
 
@@ -562,6 +566,22 @@ extension NavigationViewController: NavigationServiceDelegate {
             mapViewController?.mapView.updateCourseTracking(location: location, animated: true)
         }
         
+        if currentLeg != progress.currentLeg {
+            currentLeg = progress.currentLeg
+            passedApproachingDestinationThreshold = false
+            mapViewController?.supressAutomaticAltitudeChanges = false
+            if let mapView = mapView {
+                mapView.altitude = mapView.defaultAltitude
+            }
+        }
+        
+        if let mapView = mapView, passedApproachingDestinationThreshold == false, waypointStyle != .annotation, let currentLegWaypoint = progress.currentLeg.destination?.targetCoordinate, progress.currentLegProgress.distanceRemaining < approachingDestinationThreshold {
+            passedApproachingDestinationThreshold = true
+            mapViewController?.supressAutomaticAltitudeChanges = true
+            mapView.highlightBuildings(at: [currentLegWaypoint], in3D: self.waypointStyle == .extrudedBuilding ? true : false)
+            mapView.altitude = MGLAltitudeForZoomLevel(16.1, mapView.camera.pitch, location.coordinate.latitude, mapView.frame.size)
+        }
+        
         // Finally, pass the message onto the NVC delegate.
         delegate?.navigationViewController(self, didUpdate: progress, with: location, rawLocation: rawLocation)
     }
@@ -604,13 +624,13 @@ extension NavigationViewController: NavigationServiceDelegate {
         if service.routeProgress.isFinalLeg && advancesToNextLeg && showsEndOfRouteFeedback {
             // In case of final destination present end of route view first and then zoom in to extruded building.
             showEndOfRouteFeedback { [weak self] _ in
-                self?.zoomInAndHighlightBuilding(for: service.router.location)
+                self?.frameDestinationArrival(for: service.router.location)
             }
         }
         return advancesToNextLeg
     }
     
-    private func zoomInAndHighlightBuilding(for location: CLLocation?) {
+    private func frameDestinationArrival(for location: CLLocation?) {
         if waypointStyle == .annotation { return }
         guard let mapViewController = self.mapViewController else { return }
         guard let location = location else { return }
@@ -630,14 +650,11 @@ extension NavigationViewController: NavigationServiceDelegate {
                           direction: location.course,
                           animated: true,
                           completionHandler: {
-                            // Highlight buildings which were marked as target destination coordinate in waypoint.
-                            mapView.highlightBuildings(at: self.routeOptions.waypoints.compactMap({ $0.targetCoordinate }), in3D: self.waypointStyle == .extrudedBuilding ? true : false)
-                            
                             // Update insets to be able to correctly center map view after presenting end of route view.
-                            mapViewController.updateMapViewContentInsets()
-                            
-                            // Update user course view to correctly place it in map view.
-                            mapView.updateCourseTracking(location: location, animated: false)
+                            mapViewController.updateMapViewContentInsets(animated: true, completion: {
+                                // Update user course view to correctly place it in map view.
+                                self.mapView?.updateCourseTracking(location: location, animated: false)
+                            })
         })
     }
     

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -102,6 +102,11 @@ class RouteMapViewController: UIViewController {
     typealias LabelRoadNameCompletionHandler = (_ defaultRaodNameAssigned: Bool) -> Void
 
     var labelRoadNameCompletionHandler: (LabelRoadNameCompletionHandler)?
+    
+    /**
+     A Boolean value that determines whether the map altitude should change based on internal conditions.
+    */
+    var supressAutomaticAltitudeChanges: Bool = false
 
     convenience init(navigationService: NavigationService, delegate: RouteMapViewControllerDelegate? = nil, topBanner: ContainerViewController, bottomBanner: ContainerViewController) {
         self.init()
@@ -492,7 +497,9 @@ extension RouteMapViewController: NavigationComponent {
     }
     
     public func navigationService(_ service: NavigationService, didPassSpokenInstructionPoint instruction: SpokenInstruction, routeProgress: RouteProgress) {
-        updateCameraAltitude(for: routeProgress)
+        if !supressAutomaticAltitudeChanges {
+            updateCameraAltitude(for: routeProgress)
+        }
     }
     
     func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {


### PR DESCRIPTION
* Building highlights when the distanceRemaining on the current leg is less than 500 meters

* Guarding for redundant queries. Adjusted query so that only the current leg's building is highlighted. Responded to comments.

* Adjustments to arrival experience

* Added zoom when approaching waypoints and destination.

* Using new mapbox directions

* Use Mapbox directions v1.0.0-rc.1.

Co-authored-by: Maxim Makhun <maxim.makhun@mapbox.com>
(cherry picked from commit d295b47d6a1909d5629a1b3d354305c2739a90ac)