### PR TITLE
Make timestamps consumed by Navigator.getStatus consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@
 * If the user’s raw course as reported by Core Location differs significantly from the direction of the road ahead, the camera and user puck are oriented according to the raw course. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
 * `RouteController` now tracks the user’s location more accurately within roundabouts. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
 * Fixed an issue where departure instructions were briefly missing when beginning turn-by-turn navigation. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
-* Removed the `RouteController.projectedLocation(for:)` method in favor of `RouteController.location`. It is no longer possible to predict the user’s location at an arbitrary time. ([#2583](https://github.com/mapbox/mapbox-navigation-ios/issues/2583))
-* Renamed the `Router.advanceLegIndex(location:)` method to `Router.advanceLegIndex()`. It is no longer possible to advance to an arbitrary leg using this method. ([#2583](https://github.com/mapbox/mapbox-navigation-ios/issues/2583))
+* Removed the `RouteController.projectedLocation(for:)` method in favor of `RouteController.location`. It is no longer possible to predict the user’s location at an arbitrary time. ([#2610](https://github.com/mapbox/mapbox-navigation-ios/pull/2610))
+* Renamed the `Router.advanceLegIndex(location:)` method to `Router.advanceLegIndex()`. It is no longer possible to advance to an arbitrary leg using this method. ([#2610](https://github.com/mapbox/mapbox-navigation-ios/pull/2610))
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * If the user’s raw course as reported by Core Location differs significantly from the direction of the road ahead, the camera and user puck are oriented according to the raw course. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
 * `RouteController` now tracks the user’s location more accurately within roundabouts. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
 * Fixed an issue where departure instructions were briefly missing when beginning turn-by-turn navigation. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
+* Removed `RouteController.projectedLocation(for:)` method and `location` parameter from `advanceLegIndex` method to avoid inconsistencies with utilized timestamps ([#2583](https://github.com/mapbox/mapbox-navigation-ios/issues/2583))
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,8 @@
 * If the user’s raw course as reported by Core Location differs significantly from the direction of the road ahead, the camera and user puck are oriented according to the raw course. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
 * `RouteController` now tracks the user’s location more accurately within roundabouts. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
 * Fixed an issue where departure instructions were briefly missing when beginning turn-by-turn navigation. ([#2417](https://github.com/mapbox/mapbox-navigation-ios/pull/2417))
-* Removed `RouteController.projectedLocation(for:)` method and `location` parameter from `advanceLegIndex` method to avoid inconsistencies with utilized timestamps ([#2583](https://github.com/mapbox/mapbox-navigation-ios/issues/2583))
+* Removed the `RouteController.projectedLocation(for:)` method in favor of `RouteController.location`. It is no longer possible to predict the user’s location at an arbitrary time. ([#2583](https://github.com/mapbox/mapbox-navigation-ios/issues/2583))
+* Renamed the `Router.advanceLegIndex(location:)` method to `Router.advanceLegIndex()`. It is no longer possible to advance to an arbitrary leg using this method. ([#2583](https://github.com/mapbox/mapbox-navigation-ios/issues/2583))
 
 ### Other changes
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -3,7 +3,7 @@ binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" "18.0.3"
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.3.0"
 github "CedarBDD/Cedar" "v1.0"
-github "Quick/Nimble" "v8.1.1"
+github "Quick/Nimble" "v8.1.2"
 github "Quick/Quick" "v2.2.1"
 github "Udumft/SnappyShrimp" "66f3e3ba70370ad5e889ac8ed72a8730ca79958e"
 github "ceeK/Solar" "2.1.0"

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -508,12 +508,10 @@ extension ViewController: WaypointConfirmationViewControllerDelegate {
             guard let navigationViewController = self.presentedViewController as? NavigationViewController,
                 let navService = navigationViewController.navigationService else { return }
 
-            let router = navService.router!
-            guard router.route.legs.count > router.routeProgress.legIndex + 1 else { return }
-            
-            router.routeProgress.legIndex += 1
-            navigationViewController.mapView?.unhighlightBuildings()
+            navService.router?.advanceLegIndex()
             navService.start()
+
+            navigationViewController.mapView?.unhighlightBuildings()
         })
     }
 }

--- a/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/MapboxCoreNavigation/LegacyRouteController.swift
@@ -222,7 +222,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         return isCloseToCurrentStep
     }
     
-    public func advanceLegIndex(location: CLLocation) {
+    public func advanceLegIndex() {
         precondition(!routeProgress.isFinalLeg, "Can not increment leg index beyond final leg.")
         routeProgress.legIndex += 1
     }
@@ -341,7 +341,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                 let advancesToNextLeg = delegate?.router(self, didArriveAt: currentDestination) ?? RouteController.DefaultBehavior.didArriveAtWaypoint
                 
                 guard !routeProgress.isFinalLeg && advancesToNextLeg else { return }
-                advanceLegIndex(location: location)
+                advanceLegIndex()
                 updateDistanceToManeuver()
             } else { //we are approaching the destination
                 delegate?.router(self, willArriveAt: currentDestination, after: legProgress.durationRemaining, distance: legProgress.distanceRemaining)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -348,14 +348,6 @@ open class RouteController: NSObject {
         NotificationCenter.default.post(name: .routeControllerDidPassVisualInstructionPoint, object: self, userInfo: info)
     }
     
-    /**
-     Returns an estimated location at a given timestamp. The timestamp must be
-     a future timestamp compared to the last location received by the location manager.
-     */
-    public func projectedLocation(for timestamp: Date) -> CLLocation {
-        return CLLocation(navigator.status(at:timestamp).location)
-    }
-    
     public func advanceLegIndex(location: CLLocation) {
         let status = navigator.status(at: location.timestamp)
         routeProgress.legIndex = Int(status.legIndex)

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -194,7 +194,6 @@ open class RouteController: NSObject {
     /// updateRouteLeg is used to notify nav-native of the developer changing the active route-leg.
     private func updateRouteLeg(to value: Int) {
         let legIndex = UInt32(value)
-        navigator.changeRouteLeg(forRoute: 0, leg: legIndex)
         let newStatus = navigator.changeRouteLeg(forRoute: 0, leg: legIndex)
         updateIndexes(status: newStatus, progress: routeProgress)
     }
@@ -355,9 +354,8 @@ open class RouteController: NSObject {
         NotificationCenter.default.post(name: .routeControllerDidPassVisualInstructionPoint, object: self, userInfo: info)
     }
     
-    public func advanceLegIndex(location: CLLocation) {
-        let status = navigator.status(at: location.timestamp)
-        routeProgress.legIndex = Int(status.legIndex)
+    public func advanceLegIndex() {
+        updateRouteLeg(to: routeProgress.legIndex + 1)
     }
     
     public func enableLocationRecording() {

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -102,7 +102,9 @@ open class RouteController: NSObject {
         return CLLocation(status.location)
     }
 
-    private var lastLocationUpdateDate: Date?
+    private var lastLocationUpdateDate: Date? {
+        return rawLocation?.timestamp
+    }
 
     var heading: CLHeading?
 
@@ -209,7 +211,6 @@ open class RouteController: NSObject {
         
         locations.forEach { navigator.updateLocation(for: FixLocation($0)) }
 
-        lastLocationUpdateDate = location.timestamp
         let status = navigator.status(at: location.timestamp)
         
         // Notify observers if the step’s remaining distance has changed.

--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -91,15 +91,21 @@ open class RouteController: NSObject {
      - important: If the rawLocation is outside of the route snapping tolerances, this value is nil.
      */
     var snappedLocation: CLLocation? {
-        let status = navigator.status(at: Date())
+        guard let locationUpdateDate = lastLocationUpdateDate else {
+            return nil
+        }
+
+        let status = navigator.status(at: locationUpdateDate)
         guard status.routeState == .tracking || status.routeState == .complete else {
             return nil
         }
         return CLLocation(status.location)
     }
-    
+
+    private var lastLocationUpdateDate: Date?
+
     var heading: CLHeading?
-    
+
     /**
      The most recently received user location.
      - note: This is a raw location received from `locationManager`. To obtain an idealized location, use the `location` property.
@@ -200,10 +206,11 @@ open class RouteController: NSObject {
             return
         }
         
-        rawLocation = locations.last
+        rawLocation = location
         
         locations.forEach { navigator.updateLocation(for: FixLocation($0)) }
-        
+
+        lastLocationUpdateDate = location.timestamp
         let status = navigator.status(at: location.timestamp)
         
         // Notify observers if the step’s remaining distance has changed.

--- a/MapboxCoreNavigation/Router.swift
+++ b/MapboxCoreNavigation/Router.swift
@@ -88,7 +88,7 @@ public protocol Router: class, CLLocationManagerDelegate {
      
      This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
      */
-    func advanceLegIndex(location: CLLocation)
+    func advanceLegIndex()
     
     func enableLocationRecording()
     func disableLocationRecording()


### PR DESCRIPTION
The PR addresses 3 points described in https://github.com/mapbox/mapbox-navigation-ios/issues/2583 to enhance the consistency across timestamps provided to `Navigator.getStatus`.

Fixes #2583.