### PR TITLE
Codable Progress classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Upgraded to [Mapbox Maps SDK for iOS v6.1.0-beta.2](https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v6.1.0-beta.2). ([#2565](https://github.com/mapbox/mapbox-navigation-ios/pull/2565))
 
+### Other changes
+
+* `RouteProgress`, `RouteLegProgress`, and `RouteStepProgress` now conform to the `Codable` protocol. ([#2615](https://github.com/mapbox/mapbox-navigation-ios/pull/2615))
+
 ## v1.0.0
 
 ### Packaging

--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -313,39 +313,6 @@ struct NavigationEventDetails: EventDetails {
     }
 }
 
-extension RouteLegProgress: Encodable {
-    private enum CodingKeys: String, CodingKey {
-        case upcomingInstruction
-        case upcomingType
-        case upcomingModifier
-        case upcomingName
-        case previousInstruction
-        case previousType
-        case previousModifier
-        case previousName
-        case distance
-        case duration
-        case distanceRemaining
-        case durationRemaining
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encodeIfPresent(upcomingStep?.instructions, forKey: .upcomingInstruction)
-        try container.encodeIfPresent(upcomingStep?.maneuverType, forKey: .upcomingType)
-        try container.encodeIfPresent(upcomingStep?.maneuverDirection, forKey: .upcomingModifier)
-        try container.encodeIfPresent(upcomingStep?.names?.joined(separator: ";"), forKey: .upcomingName)
-        try container.encodeIfPresent(currentStep.instructions, forKey: .previousInstruction)
-        try container.encode(currentStep.maneuverType, forKey: .previousType)
-        try container.encode(currentStep.maneuverDirection, forKey: .previousModifier)
-        try container.encode(currentStep.names?.joined(separator: ";"), forKey: .previousName)
-        try container.encode(Int(currentStep.distance), forKey: .distance)
-        try container.encode(Int(currentStep.expectedTravelTime), forKey: .duration)
-        try container.encode(Int(currentStepProgress.distanceRemaining), forKey: .distanceRemaining)
-        try container.encode(Int(currentStepProgress.durationRemaining), forKey: .durationRemaining)
-    }
-}
-
 enum EventDetailsError: Error {
     case EncodingError(String)
 }

--- a/MapboxCoreNavigation/RouteLegProgress.swift
+++ b/MapboxCoreNavigation/RouteLegProgress.swift
@@ -1,0 +1,255 @@
+
+import Foundation
+import MapboxDirections
+
+/**
+ `RouteLegProgress` stores the user’s progress along a route leg.
+ */
+open class RouteLegProgress: Codable {
+    /**
+     Returns the current `RouteLeg`.
+     */
+    public let leg: RouteLeg
+
+    /**
+     Index representing the current step.
+     */
+    public var stepIndex: Int {
+        didSet {
+            assert(stepIndex >= 0 && stepIndex < leg.steps.endIndex)
+            currentStepProgress = RouteStepProgress(step: currentStep)
+        }
+    }
+
+    /**
+     The remaining steps for user to complete.
+     */
+    public var remainingSteps: [RouteStep] {
+        return Array(leg.steps.suffix(from: stepIndex + 1))
+    }
+
+    /**
+     Total distance traveled in meters along current leg.
+     */
+    public var distanceTraveled: CLLocationDistance {
+        return leg.steps.prefix(upTo: stepIndex).map { $0.distance }.reduce(0, +) + currentStepProgress.distanceTraveled
+    }
+
+    /**
+     Duration remaining in seconds on current leg.
+     */
+    public var durationRemaining: TimeInterval {
+        return remainingSteps.map { $0.expectedTravelTime }.reduce(0, +) + currentStepProgress.durationRemaining
+    }
+
+    /**
+     Distance remaining on the current leg.
+     */
+    public var distanceRemaining: CLLocationDistance {
+        return remainingSteps.map { $0.distance }.reduce(0, +) + currentStepProgress.distanceRemaining
+    }
+
+    /**
+     Number between 0 and 1 representing how far along the current leg the user has traveled.
+     */
+    public var fractionTraveled: Double {
+        return distanceTraveled / leg.distance
+    }
+
+    public var userHasArrivedAtWaypoint = false
+
+    /**
+     Returns the `RouteStep` before a given step. Returns `nil` if there is no step prior.
+     */
+    public func stepBefore(_ step: RouteStep) -> RouteStep? {
+        guard let index = leg.steps.firstIndex(of: step) else {
+            return nil
+        }
+        if index > 0 {
+            return leg.steps[index-1]
+        }
+        return nil
+    }
+
+    /**
+     Returns the `RouteStep` after a given step. Returns `nil` if there is not a step after.
+     */
+    public func stepAfter(_ step: RouteStep) -> RouteStep? {
+        guard let index = leg.steps.firstIndex(of: step) else {
+            return nil
+        }
+        if index+1 < leg.steps.endIndex {
+            return leg.steps[index+1]
+        }
+        return nil
+    }
+
+    /**
+     Returns the `RouteStep` before the current step.
+
+     If there is no `priorStep`, nil is returned.
+     */
+    public var priorStep: RouteStep? {
+        guard stepIndex - 1 >= 0 else {
+            return nil
+        }
+        return leg.steps[stepIndex - 1]
+    }
+
+    /**
+     Returns the current `RouteStep` for the leg the user is on.
+     */
+    public var currentStep: RouteStep {
+        return leg.steps[stepIndex]
+    }
+
+    /**
+     Returns the upcoming `RouteStep`.
+
+     If there is no `upcomingStep`, nil is returned.
+     */
+    @available(swift, obsoleted: 0.1, renamed: "upcomingStep")
+    public var upComingStep: RouteStep? {
+        fatalError()
+    }
+    
+    public var upcomingStep: RouteStep? {
+        guard stepIndex + 1 < leg.steps.endIndex else {
+            return nil
+        }
+        return leg.steps[stepIndex + 1]
+    }
+
+    /**
+     Returns step 2 steps ahead.
+
+     If there is no `followOnStep`, nil is returned.
+     */
+    public var followOnStep: RouteStep? {
+        guard stepIndex + 2 < leg.steps.endIndex else {
+            return nil
+        }
+        return leg.steps[stepIndex + 2]
+    }
+
+    /**
+     Return bool whether step provided is the current `RouteStep` the user is on.
+     */
+    public func isCurrentStep(_ step: RouteStep) -> Bool {
+        return step == currentStep
+    }
+
+    /**
+     Returns the progress along the current `RouteStep`.
+     */
+    public var currentStepProgress: RouteStepProgress
+
+    /**
+     Intializes a new `RouteLegProgress`.
+
+     - parameter leg: Leg on a `Route`.
+     - parameter stepIndex: Current step the user is on.
+     */
+    public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0) {
+        self.leg = leg
+        self.stepIndex = stepIndex
+        
+        precondition(leg.steps.indices.contains(stepIndex), "It's not possible to create RouteLegProgress without any steps or when stepIndex is higher than steps count.")
+        
+        currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
+    }
+
+    typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)
+
+    func closestStep(to coordinate: CLLocationCoordinate2D) -> StepIndexDistance? {
+        var currentClosest: StepIndexDistance?
+        let remainingSteps = leg.steps.suffix(from: stepIndex)
+
+        for (currentStepIndex, step) in remainingSteps.enumerated() {
+            guard let shape = step.shape else { continue }
+            guard let closestCoordOnStep = shape.closestCoordinate(to: coordinate) else { continue }
+            let closesCoordOnStepDistance = closestCoordOnStep.coordinate.distance(to: coordinate)
+            let foundIndex = currentStepIndex + stepIndex
+
+            // First time around, currentClosest will be `nil`.
+            guard let currentClosestDistance = currentClosest?.distance else {
+                currentClosest = (index: foundIndex, distance: closesCoordOnStepDistance)
+                continue
+            }
+
+            if closesCoordOnStepDistance < currentClosestDistance {
+                currentClosest = (index: foundIndex, distance: closesCoordOnStepDistance)
+            }
+        }
+
+        return currentClosest
+    }
+    
+    /**
+     The waypoints remaining on the current leg, not including the leg’s destination.
+     */
+    func remainingWaypoints(among waypoints: [Waypoint]) -> [Waypoint] {
+        guard waypoints.count > 1 else {
+            // The leg has only a source and no via points. Save ourselves a call to RouteLeg.coordinates, which can be expensive.
+            return []
+        }
+        let legPolyline = leg.shape
+        guard let userCoordinateIndex = legPolyline.indexedCoordinateFromStart(distance: distanceTraveled)?.index else {
+            // The leg is empty, so none of the waypoints are meaningful.
+            return []
+        }
+        var slice = legPolyline
+        var accumulatedCoordinates = 0
+        return Array(waypoints.drop { (waypoint) -> Bool in
+            let newSlice = slice.sliced(from: waypoint.coordinate)!
+            accumulatedCoordinates += slice.coordinates.count - newSlice.coordinates.count
+            slice = newSlice
+            return accumulatedCoordinates <= userCoordinateIndex
+        })
+    }
+
+    /**
+     Returns the SpeedLimit for the current position along the route. Returns SpeedLimit.invalid if the speed limit is unknown or missing.
+     
+     The maximum speed may be an advisory speed limit for segments where legal limits are not posted, such as highway entrance and exit ramps. If the speed limit along a particular segment is unknown, it is set to `nil`. If the speed is unregulated along the segment, such as on the German _Autobahn_ system, it is represented by a measurement whose value is `Double.infinity`.
+     
+     Speed limit data is available in [a number of countries and territories worldwide](https://docs.mapbox.com/help/how-mapbox-works/directions/).
+     */
+    public var currentSpeedLimit: Measurement<UnitSpeed>? {
+        guard let segmentMaximumSpeedLimits = leg.segmentMaximumSpeedLimits else {
+            return nil
+        }
+        
+        let distanceTraveled = currentStepProgress.distanceTraveled
+        guard var index = currentStep.shape?.indexedCoordinateFromStart(distance: distanceTraveled)?.index else {
+            return nil
+        }
+        
+        var range = leg.segmentRangesByStep[stepIndex]
+        
+        // indexedCoordinateFromStart(distance:) can return a coordinate indexed to the last coordinate of the step, which is past any segment on the current step.
+        if index == range.count && upcomingStep != nil {
+            range = leg.segmentRangesByStep[stepIndex.advanced(by: 1)]
+            index = 0
+        }
+        guard index < range.count && range.upperBound <= segmentMaximumSpeedLimits.endIndex else {
+            return nil
+        }
+        
+        let speedLimit = segmentMaximumSpeedLimits[range][range.lowerBound.advanced(by: index)]
+        if let speedUnit = currentStep.speedLimitUnit {
+            return speedLimit?.converted(to: speedUnit)
+        } else {
+            return speedLimit
+        }
+    }
+    
+    // MARK: - Codable implementation
+    
+    private enum CodingKeys: String, CodingKey {
+        case leg
+        case stepIndex
+        case userHasArrivedAtWaypoint
+        case currentStepProgress
+    }
+}

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -5,7 +5,7 @@ import Turf
 /**
  `RouteProgress` stores the user’s progress along a route.
  */
-open class RouteProgress {
+open class RouteProgress: Codable {
     private static let reroutingAccuracy: CLLocationAccuracy = 90
     
     var indexedRoute: IndexedRoute
@@ -296,401 +296,68 @@ open class RouteProgress {
         
         calculateLegsCongestion()
     }
-}
-
-/**
- `RouteLegProgress` stores the user’s progress along a route leg.
- */
-open class RouteLegProgress {
-    /**
-     Returns the current `RouteLeg`.
-     */
-    public let leg: RouteLeg
-
-    /**
-     Index representing the current step.
-     */
-    public var stepIndex: Int {
-        didSet {
-            assert(stepIndex >= 0 && stepIndex < leg.steps.endIndex)
-            currentStepProgress = RouteStepProgress(step: currentStep)
-        }
-    }
-
-    /**
-     The remaining steps for user to complete.
-     */
-    public var remainingSteps: [RouteStep] {
-        return Array(leg.steps.suffix(from: stepIndex + 1))
-    }
-
-    /**
-     Total distance traveled in meters along current leg.
-     */
-    public var distanceTraveled: CLLocationDistance {
-        return leg.steps.prefix(upTo: stepIndex).map { $0.distance }.reduce(0, +) + currentStepProgress.distanceTraveled
-    }
-
-    /**
-     Duration remaining in seconds on current leg.
-     */
-    public var durationRemaining: TimeInterval {
-        return remainingSteps.map { $0.expectedTravelTime }.reduce(0, +) + currentStepProgress.durationRemaining
-    }
-
-    /**
-     Distance remaining on the current leg.
-     */
-    public var distanceRemaining: CLLocationDistance {
-        return remainingSteps.map { $0.distance }.reduce(0, +) + currentStepProgress.distanceRemaining
-    }
-
-    /**
-     Number between 0 and 1 representing how far along the current leg the user has traveled.
-     */
-    public var fractionTraveled: Double {
-        return distanceTraveled / leg.distance
-    }
-
-    public var userHasArrivedAtWaypoint = false
-
-    /**
-     Returns the `RouteStep` before a given step. Returns `nil` if there is no step prior.
-     */
-    public func stepBefore(_ step: RouteStep) -> RouteStep? {
-        guard let index = leg.steps.firstIndex(of: step) else {
-            return nil
-        }
-        if index > 0 {
-            return leg.steps[index-1]
-        }
-        return nil
-    }
-
-    /**
-     Returns the `RouteStep` after a given step. Returns `nil` if there is not a step after.
-     */
-    public func stepAfter(_ step: RouteStep) -> RouteStep? {
-        guard let index = leg.steps.firstIndex(of: step) else {
-            return nil
-        }
-        if index+1 < leg.steps.endIndex {
-            return leg.steps[index+1]
-        }
-        return nil
-    }
-
-    /**
-     Returns the `RouteStep` before the current step.
-
-     If there is no `priorStep`, nil is returned.
-     */
-    public var priorStep: RouteStep? {
-        guard stepIndex - 1 >= 0 else {
-            return nil
-        }
-        return leg.steps[stepIndex - 1]
-    }
-
-    /**
-     Returns the current `RouteStep` for the leg the user is on.
-     */
-    public var currentStep: RouteStep {
-        return leg.steps[stepIndex]
-    }
-
-    /**
-     Returns the upcoming `RouteStep`.
-
-     If there is no `upcomingStep`, nil is returned.
-     */
-    @available(swift, obsoleted: 0.1, renamed: "upcomingStep")
-    public var upComingStep: RouteStep? {
-        fatalError()
+    
+    // MARK: - Codable implementation
+    
+    private enum CodingKeys: String, CodingKey {
+        case indexedRoute
+        case indexedRouteIndex
+        case routeOptions
+        case legIndex
+        case currentLegProgress
+        case congestionTravelTimesSegmentsByStep
+        case congestionTimesPerStep
     }
     
-    public var upcomingStep: RouteStep? {
-        guard stepIndex + 1 < leg.steps.endIndex else {
-            return nil
-        }
-        return leg.steps[stepIndex + 1]
+    private struct TimedCongestionLevelCodable: Codable {
+        var congestionLevel: CongestionLevel
+        var travelTime: TimeInterval
     }
-
-    /**
-     Returns step 2 steps ahead.
-
-     If there is no `followOnStep`, nil is returned.
-     */
-    public var followOnStep: RouteStep? {
-        guard stepIndex + 2 < leg.steps.endIndex else {
-            return nil
-        }
-        return leg.steps[stepIndex + 2]
-    }
-
-    /**
-     Return bool whether step provided is the current `RouteStep` the user is on.
-     */
-    public func isCurrentStep(_ step: RouteStep) -> Bool {
-        return step == currentStep
-    }
-
-    /**
-     Returns the progress along the current `RouteStep`.
-     */
-    public var currentStepProgress: RouteStepProgress
-
-    /**
-     Intializes a new `RouteLegProgress`.
-
-     - parameter leg: Leg on a `Route`.
-     - parameter stepIndex: Current step the user is on.
-     */
-    public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0) {
-        self.leg = leg
-        self.stepIndex = stepIndex
-        
-        precondition(leg.steps.indices.contains(stepIndex), "It's not possible to create RouteLegProgress without any steps or when stepIndex is higher than steps count.")
-        
-        currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
-    }
-
-    typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)
-
-    func closestStep(to coordinate: CLLocationCoordinate2D) -> StepIndexDistance? {
-        var currentClosest: StepIndexDistance?
-        let remainingSteps = leg.steps.suffix(from: stepIndex)
-
-        for (currentStepIndex, step) in remainingSteps.enumerated() {
-            guard let shape = step.shape else { continue }
-            guard let closestCoordOnStep = shape.closestCoordinate(to: coordinate) else { continue }
-            let closesCoordOnStepDistance = closestCoordOnStep.coordinate.distance(to: coordinate)
-            let foundIndex = currentStepIndex + stepIndex
-
-            // First time around, currentClosest will be `nil`.
-            guard let currentClosestDistance = currentClosest?.distance else {
-                currentClosest = (index: foundIndex, distance: closesCoordOnStepDistance)
-                continue
-            }
-
-            if closesCoordOnStepDistance < currentClosestDistance {
-                currentClosest = (index: foundIndex, distance: closesCoordOnStepDistance)
+    
+    private func decodeCongestion(_ decodable: [[[TimedCongestionLevelCodable]]]) -> [[[TimedCongestionLevel]]] {
+        return decodable.map {
+            return $0.map {
+                return $0.map {
+                    return ($0.congestionLevel, $0.travelTime)
+                }
             }
         }
-
-        return currentClosest
     }
     
-    /**
-     The waypoints remaining on the current leg, not including the leg’s destination.
-     */
-    func remainingWaypoints(among waypoints: [Waypoint]) -> [Waypoint] {
-        guard waypoints.count > 1 else {
-            // The leg has only a source and no via points. Save ourselves a call to RouteLeg.coordinates, which can be expensive.
-            return []
-        }
-        let legPolyline = leg.shape
-        guard let userCoordinateIndex = legPolyline.indexedCoordinateFromStart(distance: distanceTraveled)?.index else {
-            // The leg is empty, so none of the waypoints are meaningful.
-            return []
-        }
-        var slice = legPolyline
-        var accumulatedCoordinates = 0
-        return Array(waypoints.drop { (waypoint) -> Bool in
-            let newSlice = slice.sliced(from: waypoint.coordinate)!
-            accumulatedCoordinates += slice.coordinates.count - newSlice.coordinates.count
-            slice = newSlice
-            return accumulatedCoordinates <= userCoordinateIndex
-        })
-    }
-
-    /**
-     Returns the SpeedLimit for the current position along the route. Returns SpeedLimit.invalid if the speed limit is unknown or missing.
-     
-     The maximum speed may be an advisory speed limit for segments where legal limits are not posted, such as highway entrance and exit ramps. If the speed limit along a particular segment is unknown, it is set to `nil`. If the speed is unregulated along the segment, such as on the German _Autobahn_ system, it is represented by a measurement whose value is `Double.infinity`.
-     
-     Speed limit data is available in [a number of countries and territories worldwide](https://docs.mapbox.com/help/how-mapbox-works/directions/).
-     */
-    public var currentSpeedLimit: Measurement<UnitSpeed>? {
-        guard let segmentMaximumSpeedLimits = leg.segmentMaximumSpeedLimits else {
-            return nil
-        }
-        
-        let distanceTraveled = currentStepProgress.distanceTraveled
-        guard var index = currentStep.shape?.indexedCoordinateFromStart(distance: distanceTraveled)?.index else {
-            return nil
-        }
-        
-        var range = leg.segmentRangesByStep[stepIndex]
-        
-        // indexedCoordinateFromStart(distance:) can return a coordinate indexed to the last coordinate of the step, which is past any segment on the current step.
-        if index == range.count && upcomingStep != nil {
-            range = leg.segmentRangesByStep[stepIndex.advanced(by: 1)]
-            index = 0
-        }
-        guard index < range.count && range.upperBound <= segmentMaximumSpeedLimits.endIndex else {
-            return nil
-        }
-        
-        let speedLimit = segmentMaximumSpeedLimits[range][range.lowerBound.advanced(by: index)]
-        if let speedUnit = currentStep.speedLimitUnit {
-            return speedLimit?.converted(to: speedUnit)
-        } else {
-            return speedLimit
+    private func encodeCongestion(_ encodable: [[[TimedCongestionLevel]]]) -> [[[TimedCongestionLevelCodable]]] {
+        return encodable.map {
+            return $0.map {
+                return $0.map {
+                    return TimedCongestionLevelCodable(congestionLevel: $0.0,
+                                                       travelTime: $0.1)
+                }
+            }
         }
     }
-}
-
-/**
- `RouteStepProgress` stores the user’s progress along a route step.
- */
-open class RouteStepProgress {
-    /**
-     Returns the current `RouteStep`.
-     */
-    public let step: RouteStep
-
-    /**
-     Returns distance user has traveled along current step.
-     */
-    public var distanceTraveled: CLLocationDistance = 0
-
-    /**
-     Returns distance from user to end of step.
-     */
-    public var userDistanceToManeuverLocation: CLLocationDistance
-
-    /**
-     Total distance in meters remaining on current step.
-     */
-    public var distanceRemaining: CLLocationDistance {
-        return step.distance - distanceTraveled
-    }
-
-    /**
-     Number between 0 and 1 representing fraction of current step traveled.
-     */
-    public var fractionTraveled: Double {
-        guard step.distance > 0 else { return 1 }
-        return distanceTraveled / step.distance
-    }
-
-    /**
-     Number of seconds remaining on current step.
-     */
-    public var durationRemaining: TimeInterval {
-        return (1 - fractionTraveled) * step.expectedTravelTime
+        
+    required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let route = try container.decode(Route.self, forKey: .indexedRoute)
+        let routeIndex = try container.decode(Int.self, forKey: .indexedRouteIndex)
+        self.indexedRoute = (route, routeIndex)
+        self.routeOptions = try container.decode(RouteOptions.self, forKey: .routeOptions)
+        self.legIndex = try container.decode(Int.self, forKey: .legIndex)
+        self.currentLegProgress = try container.decode(RouteLegProgress.self, forKey: .currentLegProgress)
+        self.congestionTravelTimesSegmentsByStep = decodeCongestion(try container.decode([[[TimedCongestionLevelCodable]]].self,
+                                                                                         forKey: .congestionTravelTimesSegmentsByStep))
+        self.congestionTimesPerStep = try container.decode([[[CongestionLevel: TimeInterval]]].self, forKey: .congestionTimesPerStep)
     }
     
-    /**
-     Intializes a new `RouteStepProgress`.
-
-     - parameter step: Step on a `RouteLeg`.
-     */
-    public init(step: RouteStep, spokenInstructionIndex: Int = 0) {
-        self.step = step
-        self.userDistanceToManeuverLocation = step.distance
-        self.intersectionIndex = 0
-        self.spokenInstructionIndex = spokenInstructionIndex
-    }
-
-    /**
-     All intersections on the current `RouteStep` and also the first intersection on the upcoming `RouteStep`.
-
-     The upcoming `RouteStep` first `Intersection` is added because it is omitted from the current step.
-     */
-    public var intersectionsIncludingUpcomingManeuverIntersection: [Intersection]?
-
-    /**
-     The next intersection the user will travel through.
-
-     The step must contain `intersectionsIncludingUpcomingManeuverIntersection` otherwise this property will be `nil`.
-     */
-    public var upcomingIntersection: Intersection? {
-        guard let intersections = intersectionsIncludingUpcomingManeuverIntersection, intersections.startIndex..<intersections.endIndex-1 ~= intersectionIndex else {
-            return nil
-        }
-
-        return intersections[intersections.index(after: intersectionIndex)]
-    }
-
-    /**
-     Index representing the current intersection.
-     */
-    public var intersectionIndex: Int = 0
-
-    /**
-     The current intersection the user will travel through.
-
-     The step must contain `intersectionsIncludingUpcomingManeuverIntersection` otherwise this property will be `nil`.
-     */
-    public var currentIntersection: Intersection? {
-        guard let intersections = intersectionsIncludingUpcomingManeuverIntersection, intersections.startIndex..<intersections.endIndex ~= intersectionIndex else {
-            return nil
-        }
-
-        return intersections[intersectionIndex]
-    }
-
-    /**
-     Returns an array of the calculated distances from the current intersection to the next intersection on the current step.
-     */
-    public var intersectionDistances: Array<CLLocationDistance>?
-
-    /**
-     The distance in meters the user is to the next intersection they will pass through.
-     */
-    public var userDistanceToUpcomingIntersection: CLLocationDistance?
-
-    /**
-     Index into `step.instructionsDisplayedAlongStep` representing the current visual instruction for the step.
-     */
-    public var visualInstructionIndex: Int = 0
-
-    /**
-     An `Array` of remaining `VisualInstruction` for a step.
-     */
-    public var remainingVisualInstructions: [VisualInstructionBanner]? {
-        guard let visualInstructions = step.instructionsDisplayedAlongStep else { return nil }
-        return Array(visualInstructions.suffix(from: visualInstructionIndex))
-    }
-
-    /**
-     Index into `step.instructionsSpokenAlongStep` representing the current spoken instruction.
-     */
-    public var spokenInstructionIndex: Int = 0
-
-    /**
-     An `Array` of remaining `SpokenInstruction` for a step.
-     */
-    public var remainingSpokenInstructions: [SpokenInstruction]? {
-        guard let instructions = step.instructionsSpokenAlongStep else { return nil }
-        return Array(instructions.suffix(from: spokenInstructionIndex))
-    }
-
-    /**
-     Current spoken instruction for the user's progress along a step.
-     */
-    public var currentSpokenInstruction: SpokenInstruction? {
-        guard let instructionsSpokenAlongStep = step.instructionsSpokenAlongStep else { return nil }
-        guard spokenInstructionIndex < instructionsSpokenAlongStep.count else { return nil }
-        return instructionsSpokenAlongStep[spokenInstructionIndex]
-    }
-
-    /**
-     Current visual instruction for the user's progress along a step.
-     */
-    public var currentVisualInstruction: VisualInstructionBanner? {
-        guard let instructionsDisplayedAlongStep = step.instructionsDisplayedAlongStep else { return nil }
-        guard visualInstructionIndex < instructionsDisplayedAlongStep.count else { return nil }
-        return instructionsDisplayedAlongStep[visualInstructionIndex]
-    }
-    
-    public var keyPathsAffectingValueForRemainingVisualInstructions: Set<String> {
-        return ["step.instructionsDisplayedAlongStep", "visualInstructionIndex"]
-    }
-    
-    public var keyPathsAffectingValueForRemainingSpokenInstructions: Set<String> {
-        return ["step.instructionsDisplayedAlongStep", "spokenInstructionIndex"]
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(indexedRoute.0, forKey: .indexedRoute)
+        try container.encode(indexedRoute.1, forKey: .indexedRouteIndex)
+        try container.encode(routeOptions, forKey: .routeOptions)
+        try container.encode(legIndex, forKey: .legIndex)
+        try container.encode(currentLegProgress, forKey: .currentLegProgress)
+        try container.encode(encodeCongestion(congestionTravelTimesSegmentsByStep), forKey: .congestionTravelTimesSegmentsByStep)
+        try container.encode(congestionTimesPerStep, forKey: .congestionTimesPerStep)
     }
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -305,34 +305,6 @@ open class RouteProgress: Codable {
         case routeOptions
         case legIndex
         case currentLegProgress
-        case congestionTravelTimesSegmentsByStep
-        case congestionTimesPerStep
-    }
-    
-    private struct TimedCongestionLevelCodable: Codable {
-        var congestionLevel: CongestionLevel
-        var travelTime: TimeInterval
-    }
-    
-    private func decodeCongestion(_ decodable: [[[TimedCongestionLevelCodable]]]) -> [[[TimedCongestionLevel]]] {
-        return decodable.map {
-            return $0.map {
-                return $0.map {
-                    return ($0.congestionLevel, $0.travelTime)
-                }
-            }
-        }
-    }
-    
-    private func encodeCongestion(_ encodable: [[[TimedCongestionLevel]]]) -> [[[TimedCongestionLevelCodable]]] {
-        return encodable.map {
-            return $0.map {
-                return $0.map {
-                    return TimedCongestionLevelCodable(congestionLevel: $0.0,
-                                                       travelTime: $0.1)
-                }
-            }
-        }
     }
         
     required public init(from decoder: Decoder) throws {
@@ -344,9 +316,8 @@ open class RouteProgress: Codable {
         self.routeOptions = try container.decode(RouteOptions.self, forKey: .routeOptions)
         self.legIndex = try container.decode(Int.self, forKey: .legIndex)
         self.currentLegProgress = try container.decode(RouteLegProgress.self, forKey: .currentLegProgress)
-        self.congestionTravelTimesSegmentsByStep = decodeCongestion(try container.decode([[[TimedCongestionLevelCodable]]].self,
-                                                                                         forKey: .congestionTravelTimesSegmentsByStep))
-        self.congestionTimesPerStep = try container.decode([[[CongestionLevel: TimeInterval]]].self, forKey: .congestionTimesPerStep)
+        
+        calculateLegsCongestion()
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -357,7 +328,5 @@ open class RouteProgress: Codable {
         try container.encode(routeOptions, forKey: .routeOptions)
         try container.encode(legIndex, forKey: .legIndex)
         try container.encode(currentLegProgress, forKey: .currentLegProgress)
-        try container.encode(encodeCongestion(congestionTravelTimesSegmentsByStep), forKey: .congestionTravelTimesSegmentsByStep)
-        try container.encode(congestionTimesPerStep, forKey: .congestionTimesPerStep)
     }
 }

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -167,12 +167,12 @@ open class RouteProgress: Codable {
     /**
      If the route contains both `segmentCongestionLevels` and `expectedSegmentTravelTimes`, this property is set to a deeply nested array of `TimeCongestionLevels` per segment per step per leg.
      */
-    public var congestionTravelTimesSegmentsByStep: [[[TimedCongestionLevel]]] = []
+    public private(set) var congestionTravelTimesSegmentsByStep: [[[TimedCongestionLevel]]] = []
 
     /**
      An dictionary containing a `TimeInterval` total per `CongestionLevel`. Only `CongestionLevel` founnd on that step will present. Broken up by leg and then step.
      */
-    public var congestionTimesPerStep: [[[CongestionLevel: TimeInterval]]]  = [[[:]]]
+    public private(set) var congestionTimesPerStep: [[[CongestionLevel: TimeInterval]]]  = [[[:]]]
 
     /**
      Intializes a new `RouteProgress`.

--- a/MapboxCoreNavigation/RouteStepProgress.swift
+++ b/MapboxCoreNavigation/RouteStepProgress.swift
@@ -1,0 +1,170 @@
+
+import Foundation
+import MapboxDirections
+
+/**
+ `RouteStepProgress` stores the user’s progress along a route step.
+ */
+open class RouteStepProgress: Codable {
+    /**
+     Returns the current `RouteStep`.
+     */
+    public let step: RouteStep
+
+    /**
+     Returns distance user has traveled along current step.
+     */
+    public var distanceTraveled: CLLocationDistance = 0
+
+    /**
+     Returns distance from user to end of step.
+     */
+    public var userDistanceToManeuverLocation: CLLocationDistance
+
+    /**
+     Total distance in meters remaining on current step.
+     */
+    public var distanceRemaining: CLLocationDistance {
+        return step.distance - distanceTraveled
+    }
+
+    /**
+     Number between 0 and 1 representing fraction of current step traveled.
+     */
+    public var fractionTraveled: Double {
+        guard step.distance > 0 else { return 1 }
+        return distanceTraveled / step.distance
+    }
+
+    /**
+     Number of seconds remaining on current step.
+     */
+    public var durationRemaining: TimeInterval {
+        return (1 - fractionTraveled) * step.expectedTravelTime
+    }
+    
+    /**
+     Intializes a new `RouteStepProgress`.
+
+     - parameter step: Step on a `RouteLeg`.
+     */
+    public init(step: RouteStep, spokenInstructionIndex: Int = 0) {
+        self.step = step
+        self.userDistanceToManeuverLocation = step.distance
+        self.intersectionIndex = 0
+        self.spokenInstructionIndex = spokenInstructionIndex
+    }
+
+    /**
+     All intersections on the current `RouteStep` and also the first intersection on the upcoming `RouteStep`.
+
+     The upcoming `RouteStep` first `Intersection` is added because it is omitted from the current step.
+     */
+    public var intersectionsIncludingUpcomingManeuverIntersection: [Intersection]?
+
+    /**
+     The next intersection the user will travel through.
+
+     The step must contain `intersectionsIncludingUpcomingManeuverIntersection` otherwise this property will be `nil`.
+     */
+    public var upcomingIntersection: Intersection? {
+        guard let intersections = intersectionsIncludingUpcomingManeuverIntersection, intersections.startIndex..<intersections.endIndex-1 ~= intersectionIndex else {
+            return nil
+        }
+
+        return intersections[intersections.index(after: intersectionIndex)]
+    }
+
+    /**
+     Index representing the current intersection.
+     */
+    public var intersectionIndex: Int = 0
+
+    /**
+     The current intersection the user will travel through.
+
+     The step must contain `intersectionsIncludingUpcomingManeuverIntersection` otherwise this property will be `nil`.
+     */
+    public var currentIntersection: Intersection? {
+        guard let intersections = intersectionsIncludingUpcomingManeuverIntersection, intersections.startIndex..<intersections.endIndex ~= intersectionIndex else {
+            return nil
+        }
+
+        return intersections[intersectionIndex]
+    }
+
+    /**
+     Returns an array of the calculated distances from the current intersection to the next intersection on the current step.
+     */
+    public var intersectionDistances: Array<CLLocationDistance>?
+
+    /**
+     The distance in meters the user is to the next intersection they will pass through.
+     */
+    public var userDistanceToUpcomingIntersection: CLLocationDistance?
+
+    /**
+     Index into `step.instructionsDisplayedAlongStep` representing the current visual instruction for the step.
+     */
+    public var visualInstructionIndex: Int = 0
+
+    /**
+     An `Array` of remaining `VisualInstruction` for a step.
+     */
+    public var remainingVisualInstructions: [VisualInstructionBanner]? {
+        guard let visualInstructions = step.instructionsDisplayedAlongStep else { return nil }
+        return Array(visualInstructions.suffix(from: visualInstructionIndex))
+    }
+
+    /**
+     Index into `step.instructionsSpokenAlongStep` representing the current spoken instruction.
+     */
+    public var spokenInstructionIndex: Int = 0
+
+    /**
+     An `Array` of remaining `SpokenInstruction` for a step.
+     */
+    public var remainingSpokenInstructions: [SpokenInstruction]? {
+        guard let instructions = step.instructionsSpokenAlongStep else { return nil }
+        return Array(instructions.suffix(from: spokenInstructionIndex))
+    }
+
+    /**
+     Current spoken instruction for the user's progress along a step.
+     */
+    public var currentSpokenInstruction: SpokenInstruction? {
+        guard let instructionsSpokenAlongStep = step.instructionsSpokenAlongStep else { return nil }
+        guard spokenInstructionIndex < instructionsSpokenAlongStep.count else { return nil }
+        return instructionsSpokenAlongStep[spokenInstructionIndex]
+    }
+
+    /**
+     Current visual instruction for the user's progress along a step.
+     */
+    public var currentVisualInstruction: VisualInstructionBanner? {
+        guard let instructionsDisplayedAlongStep = step.instructionsDisplayedAlongStep else { return nil }
+        guard visualInstructionIndex < instructionsDisplayedAlongStep.count else { return nil }
+        return instructionsDisplayedAlongStep[visualInstructionIndex]
+    }
+    
+    public var keyPathsAffectingValueForRemainingVisualInstructions: Set<String> {
+        return ["step.instructionsDisplayedAlongStep", "visualInstructionIndex"]
+    }
+    
+    public var keyPathsAffectingValueForRemainingSpokenInstructions: Set<String> {
+        return ["step.instructionsDisplayedAlongStep", "spokenInstructionIndex"]
+    }
+    
+    // MARK: - Codable implementation
+    
+    private enum CodingKeys: String, CodingKey {
+        case step
+        case userDistanceToManeuverLocation
+        case intersectionsIncludingUpcomingManeuverIntersection
+        case intersectionIndex
+        case intersectionDistances
+        case userDistanceToUpcomingIntersection
+        case visualInstructionIndex
+        case spokenInstructionIndex
+    }
+}

--- a/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -272,4 +272,74 @@ class RouteProgressTests: XCTestCase {
         legProgress.currentStepProgress.distanceTraveled = lineString.distance(to: coordinates[5])! + (lineString.distance()! - lineString.distance(to: coordinates[5])!) / 2.0
         XCTAssertTrue(legProgress.currentSpeedLimit?.value.isInfinite ?? false)
     }
+    
+    func testRouteProggressCodable() {
+        let routeProgress = RouteProgress(route: route, routeIndex: 0, options: routeOptions)
+
+        let encoder = JSONEncoder()
+        encoder.userInfo[.options] = routeOptions
+        let data = try! encoder.encode(routeProgress)
+        let decoder = JSONDecoder()
+        decoder.userInfo[.options] = routeOptions
+        let decoded = try! decoder.decode(RouteProgress.self, from: data)
+
+        XCTAssertEqual(routeProgress.indexedRoute.0.shape?.coordinates, decoded.indexedRoute.0.shape?.coordinates)
+        XCTAssertEqual(routeProgress.indexedRoute.0.expectedTravelTime, decoded.indexedRoute.0.expectedTravelTime)
+        XCTAssertEqual(routeProgress.indexedRoute.0.routeIdentifier, decoded.indexedRoute.0.routeIdentifier)
+        XCTAssertEqual(routeProgress.indexedRoute.1, decoded.indexedRoute.1)
+        XCTAssertEqual(routeProgress.routeOptions, decoded.routeOptions)
+        XCTAssertEqual(routeProgress.legIndex, decoded.legIndex)
+        XCTAssertEqual(routeProgress.currentLegProgress.leg.source, decoded.currentLegProgress.leg.source)
+        XCTAssertEqual(routeProgress.currentLegProgress.leg.destination, decoded.currentLegProgress.leg.destination)
+        XCTAssertEqual(routeProgress.currentLegProgress.leg.name, decoded.currentLegProgress.leg.name)
+        XCTAssertEqual(routeProgress.currentLegProgress.leg.distance, decoded.currentLegProgress.leg.distance)
+        XCTAssertEqual(routeProgress.currentLegProgress.leg.source, decoded.currentLegProgress.leg.source)
+        XCTAssertEqual(routeProgress.congestionTravelTimesSegmentsByStep.count, decoded.congestionTravelTimesSegmentsByStep.count)
+        XCTAssertEqual(routeProgress.congestionTimesPerStep, decoded.congestionTimesPerStep)
+    }
+    
+    func testRouteLegProgressCodable() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 2, longitude: 3),
+            CLLocationCoordinate2D(latitude: 4, longitude: 6),
+            CLLocationCoordinate2D(latitude: 6, longitude: 9),
+            CLLocationCoordinate2D(latitude: 8, longitude: 12),
+            CLLocationCoordinate2D(latitude: 10, longitude: 15),
+            CLLocationCoordinate2D(latitude: 12, longitude: 18),
+        ]
+        let options = RouteOptions(coordinates: [coordinates.first!, coordinates.last!])
+        let legProgress = routeLegProgress(options: options, routeCoordinates: coordinates)
+        
+        let data = try! JSONEncoder().encode(legProgress)
+        let decoded = try! JSONDecoder().decode(RouteLegProgress.self, from: data)
+        
+        XCTAssertEqual(legProgress.leg, decoded.leg)
+        XCTAssertEqual(legProgress.stepIndex, decoded.stepIndex)
+        XCTAssertEqual(legProgress.userHasArrivedAtWaypoint, decoded.userHasArrivedAtWaypoint)
+        XCTAssertEqual(legProgress.currentStepProgress.step, decoded.currentStepProgress.step)
+        XCTAssertEqual(legProgress.currentStepProgress.distanceTraveled, decoded.currentStepProgress.distanceTraveled)
+    }
+    
+    func testRouteStepProgressCodable() {
+        let stepProgress = RouteStepProgress(step: RouteStep(transportType: .automobile,
+                                                             maneuverLocation: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                                                             maneuverType: .arrive,
+                                                             instructions: "instructions",
+                                                             drivingSide: .right,
+                                                             distance: 13.3,
+                                                             expectedTravelTime: 0.7))
+        
+        let data = try! JSONEncoder().encode(stepProgress)
+        let decoded = try! JSONDecoder().decode(RouteStepProgress.self, from: data)
+        
+        XCTAssertEqual(stepProgress.step, decoded.step)
+        XCTAssertEqual(stepProgress.userDistanceToManeuverLocation, decoded.userDistanceToManeuverLocation)
+        XCTAssertEqual(stepProgress.intersectionsIncludingUpcomingManeuverIntersection, decoded.intersectionsIncludingUpcomingManeuverIntersection)
+        XCTAssertEqual(stepProgress.intersectionIndex, decoded.intersectionIndex)
+        XCTAssertEqual(stepProgress.intersectionDistances, decoded.intersectionDistances)
+        XCTAssertEqual(stepProgress.userDistanceToUpcomingIntersection, decoded.userDistanceToUpcomingIntersection)
+        XCTAssertEqual(stepProgress.visualInstructionIndex, decoded.visualInstructionIndex)
+        XCTAssertEqual(stepProgress.spokenInstructionIndex, decoded.spokenInstructionIndex)
+    }
 }

--- a/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -275,7 +275,7 @@ class RouteProgressTests: XCTestCase {
     
     func testRouteProggressCodable() {
         let routeProgress = RouteProgress(route: route, routeIndex: 0, options: routeOptions)
-
+        
         let encoder = JSONEncoder()
         encoder.userInfo[.options] = routeOptions
         let data = try! encoder.encode(routeProgress)
@@ -283,7 +283,9 @@ class RouteProgressTests: XCTestCase {
         decoder.userInfo[.options] = routeOptions
         let decoded = try! decoder.decode(RouteProgress.self, from: data)
 
-        XCTAssertEqual(routeProgress.indexedRoute.0.shape?.coordinates, decoded.indexedRoute.0.shape?.coordinates)
+        XCTAssertEqual(routeProgress.indexedRoute.0.distance, decoded.indexedRoute.0.distance)
+        XCTAssertEqual(routeProgress.indexedRoute.0.speechLocale, decoded.indexedRoute.0.speechLocale)
+        XCTAssertEqual(routeProgress.indexedRoute.0.shape, decoded.indexedRoute.0.shape)
         XCTAssertEqual(routeProgress.indexedRoute.0.expectedTravelTime, decoded.indexedRoute.0.expectedTravelTime)
         XCTAssertEqual(routeProgress.indexedRoute.0.routeIdentifier, decoded.indexedRoute.0.routeIdentifier)
         XCTAssertEqual(routeProgress.indexedRoute.1, decoded.indexedRoute.1)

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		2B8098432411447E00FED452 /* MultiplexedSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8098422411447E00FED452 /* MultiplexedSpeechSynthesizer.swift */; };
 		2B81EC28241A237E00145086 /* SpeechSynthesizersControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B81EC27241A237E00145086 /* SpeechSynthesizersControllerTests.swift */; };
 		2B91C9B12416357700E532A5 /* MapboxSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B91C9B02416357700E532A5 /* MapboxSpeechSynthesizer.swift */; };
+		2BBEEDA52508DB1700C8DA4A /* RouteLegProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBEEDA42508DB1700C8DA4A /* RouteLegProgress.swift */; };
+		2BBEEDA72508E1E300C8DA4A /* RouteStepProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBEEDA62508E1E300C8DA4A /* RouteStepProgress.swift */; };
 		35002D611E5F6ADB0090E733 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35002D5F1E5F6ADB0090E733 /* Assets.xcassets */; };
 		35002D691E5F6B2F0090E733 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 35002D661E5F6B1B0090E733 /* Main.storyboard */; };
 		3502231A205BC94E00E1449A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35022319205BC94E00E1449A /* Constants.swift */; };
@@ -657,6 +659,8 @@
 		2B8098422411447E00FED452 /* MultiplexedSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplexedSpeechSynthesizer.swift; sourceTree = "<group>"; };
 		2B81EC27241A237E00145086 /* SpeechSynthesizersControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechSynthesizersControllerTests.swift; sourceTree = "<group>"; };
 		2B91C9B02416357700E532A5 /* MapboxSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxSpeechSynthesizer.swift; sourceTree = "<group>"; };
+		2BBEEDA42508DB1700C8DA4A /* RouteLegProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteLegProgress.swift; sourceTree = "<group>"; };
+		2BBEEDA62508E1E300C8DA4A /* RouteStepProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStepProgress.swift; sourceTree = "<group>"; };
 		35002D5D1E5F6ABB0090E733 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		35002D5F1E5F6ADB0090E733 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		35002D671E5F6B1B0090E733 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -1765,6 +1769,8 @@
 				8D75F990212B5C7F00F99CF3 /* TunnelAuthority.swift */,
 				3582A25120EFA9680029C5DE /* RouterDelegate.swift */,
 				C5ADFBFB1DDCC9AD0011824B /* RouteProgress.swift */,
+				2BBEEDA42508DB1700C8DA4A /* RouteLegProgress.swift */,
+				2BBEEDA62508E1E300C8DA4A /* RouteStepProgress.swift */,
 				3582A24F20EEC46B0029C5DE /* Router.swift */,
 				353E69031EF0C4E5007B2AE5 /* SimulatedLocationManager.swift */,
 				35C98730212E02B500808B82 /* RouteController.swift */,
@@ -2675,8 +2681,10 @@
 				DA0A4B8124D1C9B200D6B4F8 /* Navigator.swift in Sources */,
 				5A3D212E24DADFA000EA652A /* SkuTokenProvider.swift in Sources */,
 				351927361F0FA072003A702D /* ScreenCapture.swift in Sources */,
+				2BBEEDA72508E1E300C8DA4A /* RouteStepProgress.swift in Sources */,
 				35F3387C2232AEBF0071DB5C /* MinimumEditDistance.swift in Sources */,
 				C5D9800F1EFBCDAD006DBF2E /* Date.swift in Sources */,
+				2BBEEDA52508DB1700C8DA4A /* RouteLegProgress.swift in Sources */,
 				35A43F77223BD632000CB367 /* RouteLeg.swift in Sources */,
 				4303A3992332CD6200B5737D /* UnimplementedLogging.swift in Sources */,
 				3A163AE3249901D000D66A0D /* FixLocation.swift in Sources */,


### PR DESCRIPTION
Resolves #1940 

Added `Codable` compliance to `RouteLegProgress`, `RouteStepProgress` and `RouteProgress` classes.

Due to some `tuple` properties ([`IndexedRoute`](https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxCoreNavigation/Router.swift#L18) and [`TimedCongestionLevel`](https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxCoreNavigation/RouteProgress.swift#L165)) in `RouteProgress` I had to implement custom `encode/decode` methods.