### PR TITLE
Custom Route shapes fix

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -473,7 +473,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         let allRoutesShape = navigationMapViewDelegate?.navigationMapView(self, shapeFor: routes) ?? shape(for: routes, legIndex: legIndex)
         let allRoutesSource = addAllRoutesSource(style, shape: allRoutesShape)
         
-        let mainRouteCasingShape = navigationMapViewDelegate?.navigationMapView(self, shapeFor: [mainRoute]) ?? shape(for: [mainRoute], legIndex: legIndex)
+        let mainRouteCasingShape = navigationMapViewDelegate?.navigationMapView(self, simplifiedShapeFor: mainRoute) ?? shape(forCasingOf: mainRoute, legIndex: legIndex)
+        
         let mainRouteCasingSource = addMainRouteCasingSource(style, shape: mainRouteCasingShape)
         
         let mainRouteLayer = addMainRouteLayer(style, source: allRoutesSource, lineGradient: routeLineGradient(mainRoute, fractionTraveled: 0.0))

--- a/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -83,6 +83,8 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
     
     /**
      Asks the receiver to return an MGLShape that describes the geometry of the route.
+        
+     Resulting `MGLShape` will then be styled using `NavigationMapView.navigationMapView(_: mainRouteStyleLayerWithIdentifier: source:)` provided style or a default congestion style if above delegate method was not implemented. In latter case, consider modifing your custom `MGLShape` `attributes` to have 'isAlternateRoute' key set to 'false'. Otherwise style predicate condition will filter out the shape.
      - note: The returned value represents the route in full detail. For example, individual `MGLPolyline` objects in an `MGLShapeCollectionFeature` object can represent traffic congestion segments. For improved performance, you should also implement `navigationMapView(_:simplifiedShapeFor:)`, which defines the overall route as a single feature.
      - parameter mapView: The NavigationMapView.
      - parameter routes: The routes that the sender is asking about. The first route will always be rendered as the main route, while all subsequent routes will be rendered as alternative routes.
@@ -92,6 +94,8 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
     
     /**
      Asks the receiver to return an MGLShape that describes the geometry of the route at lower zoomlevels.
+     
+     Resulting `MGLShape` will then be styled using `NavigationMapView.navigationMapView(_: mainRouteCasingStyleLayerWithIdentifier: source:)` provided style or a default style if above delegate method was not implemented. In latter case, consider modifing your custom `MGLShape` `attributes` to have 'isAlternateRoute' key set to 'false'. Otherwise style predicate condition will filter out the shape.
      - note: The returned value represents the simplfied route. It is designed to be used with `navigationMapView(_:shapeFor:), and if used without its parent method, can cause unexpected behavior.
      - parameter mapView: The NavigationMapView.
      - parameter route: The route that the sender is asking about.


### PR DESCRIPTION
Fixes #2595 

Restored calling `NavigationMapViewDelegate.navigationMapView(_:simplifiedShapeFor:)` method for shape customization and verified that custom shapes mechanism works.

There is a discussion going on around these methods on how to improve the API and make customization easy and straightforward. Eventually we should remove these methods, but decided to leave them for now because there is no alternative ideas developed atm and some clients already use that API.