### PR TITLE
Cherry-pick of making RouteProgress Congestion data readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 ### Other changes
 
 * Deprecated `NavigationDirectionsCompletionHandler`, `OfflineRoutingError`, `UnpackProgressHandler`, `UnpackCompletionHandler`, `OfflineRouteCompletionHandler`, and `NavigationDirections`. Use `Directions` instead of `NavigationDirections` to calculate a route. ([#2509](https://github.com/mapbox/mapbox-navigation-ios/pull/2509))
+* The `RouteLegProgress.congestionTravelTimesSegmentsByStep` and `RouteLegProgress.congestionTimesPerStep` properties are now read-only. ([#2615](https://github.com/mapbox/mapbox-navigation-ios/pull/2615))
 
 ## v0.40.0
 

--- a/MapboxCoreNavigation/RouteProgress.swift
+++ b/MapboxCoreNavigation/RouteProgress.swift
@@ -167,12 +167,12 @@ open class RouteProgress {
     /**
      If the route contains both `segmentCongestionLevels` and `expectedSegmentTravelTimes`, this property is set to a deeply nested array of `TimeCongestionLevels` per segment per step per leg.
      */
-    public var congestionTravelTimesSegmentsByStep: [[[TimedCongestionLevel]]] = []
+    public private(set) var congestionTravelTimesSegmentsByStep: [[[TimedCongestionLevel]]] = []
 
     /**
      An dictionary containing a `TimeInterval` total per `CongestionLevel`. Only `CongestionLevel` founnd on that step will present. Broken up by leg and then step.
      */
-    public var congestionTimesPerStep: [[[CongestionLevel: TimeInterval]]]  = [[[:]]]
+    public private(set) var congestionTimesPerStep: [[[CongestionLevel: TimeInterval]]]  = [[[:]]]
 
     /**
      Intializes a new `RouteProgress`.


### PR DESCRIPTION
Cherry picking public API change, introduced in PR #2615 to have them in v`1.0.0` first.