### PR TITLE
Match Android for Feedback event JSON keys and the sending of a single event per category

### DIFF
--- a/MapboxCoreNavigation/CoreFeedbackEvent.swift
+++ b/MapboxCoreNavigation/CoreFeedbackEvent.swift
@@ -26,6 +26,19 @@ class CoreFeedbackEvent: Hashable {
 class FeedbackEvent: CoreFeedbackEvent {
     func update(type: FeedbackType, source: FeedbackSource, description: String?) {
         eventDictionary["feedbackType"] = type.description
+
+        // if there is a subtype for this event then append the subtype description to our list for this type of feedback
+        if let subtypeDescription = type.subtypeDescription {
+            var subtypeList = [String]()
+            if let existingSubtypeList = eventDictionary["feedbackSubType"] as? [String] {
+                subtypeList.append(contentsOf: existingSubtypeList)
+            }
+
+            if !subtypeList.contains(subtypeDescription) {
+                subtypeList.append(subtypeDescription)
+            }
+            eventDictionary["feedbackSubType"] = subtypeList
+        }
         eventDictionary["source"] = source.description
         eventDictionary["description"] = description
     }

--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -352,9 +352,7 @@ enum EventDetailsError: Error {
 
 extension EventDetails {
     func asDictionary() throws -> [String: Any] {
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        let data = try encoder.encode(self)
+        let data = try JSONEncoder().encode(self)
         if let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] {
             return dictionary
         } else {

--- a/MapboxCoreNavigation/EventDetails.swift
+++ b/MapboxCoreNavigation/EventDetails.swift
@@ -352,7 +352,9 @@ enum EventDetailsError: Error {
 
 extension EventDetails {
     func asDictionary() throws -> [String: Any] {
-        let data = try JSONEncoder().encode(self)
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(self)
         if let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] {
             return dictionary
         } else {

--- a/MapboxCoreNavigation/Feedback.swift
+++ b/MapboxCoreNavigation/Feedback.swift
@@ -27,17 +27,29 @@ public enum FeedbackType: CustomStringConvertible {
     /// Indicates a problem with positioning the user
     case positioning(subtype: PositioningSubtype?)
 
-    /*
-      case streetPermanentlyBlockedOff
-      case roadMissingFromMap
-      case other
-     */
+    /// Description of the category for this type of feedback
     public var description: String {
         switch self {
         case .general:
             return "general"
-        case .incorrectVisual(subtype: .none):
-            return "incorrect_visual"
+        case .incorrectVisual(_):
+            return "incorrect_visual_guidance"
+        case .confusingAudio(_):
+            return "incorrect_audio_guidance"
+        case .routeQuality(_):
+            return "routing_error"
+        case .illegalRoute(_):
+            return "not_allowed"
+        case .roadClosure(_):
+            return "road_closed"
+        case .positioning(_):
+            return "positioning_issue"
+        }
+    }
+
+    /// Optional detailed description of the subtype of this feedback
+    public var subtypeDescription: String? {
+        switch self {
         case .incorrectVisual(subtype: .turnIconIncorrect):
             return "turn_icon_incorrect"
         case .incorrectVisual(subtype: .streetNameIncorrect):
@@ -54,10 +66,6 @@ public enum FeedbackType: CustomStringConvertible {
             return "lane_guidance_incorrect"
         case .incorrectVisual(subtype: .roadKnownByDifferentName):
             return "road_known_by_different_name"
-        case .incorrectVisual(subtype: .other):
-            return "incorrect_visual"
-        case .confusingAudio(subtype: .none):
-            return "confusing_audio"
         case .confusingAudio(subtype: .guidanceTooEarly):
             return "guidance_too_early"
         case .confusingAudio(subtype: .guidanceTooLate):
@@ -66,10 +74,6 @@ public enum FeedbackType: CustomStringConvertible {
             return "pronunciation_incorrect"
         case .confusingAudio(subtype: .roadNameRepeated):
             return "road_name_repeated"
-        case .confusingAudio(subtype: .other):
-            return "confusing_audio"
-        case .routeQuality(subtype: .none):
-            return "route_quality"
         case .routeQuality(subtype: .routeNonDrivable):
             return "route_not_driveable"
         case .routeQuality(subtype: .routeNotPreferred):
@@ -80,10 +84,6 @@ public enum FeedbackType: CustomStringConvertible {
             return "route_included_missing_roads"
         case .routeQuality(subtype: .routeHadRoadsTooNarrowToPass):
             return "route_had_roads_too_narrow_to_pass"
-        case .routeQuality(subtype: .other):
-            return "route_quality"
-        case .illegalRoute(subtype: .none):
-            return "illegal_route"
         case .illegalRoute(subtype: .routedDownAOneWay):
             return "routed_down_a_one_way"
         case .illegalRoute(subtype: .turnWasNotAllowed):
@@ -92,20 +92,14 @@ public enum FeedbackType: CustomStringConvertible {
             return "cars_not_allowed_on_street"
         case .illegalRoute(subtype: .turnAtIntersectionUnprotected):
             return "turn_at_intersection_was_unprotected"
-        case .illegalRoute(subtype: .other):
-            return "illegal_route"
-        case .roadClosure(subtype: .none):
-            return "road_closure"
         case .roadClosure(subtype: .streetPermanentlyBlockedOff):
             return "street_permanently_blocked_off"
         case .roadClosure(subtype: .roadMissingFromMap):
             return "road_is_missing_from_map"
-        case .roadClosure(subtype: .other):
-            return "road_closure"
-        case .positioning(subtype: .none):
-            return "positioning_issue"
         case .positioning(subtype: .userPosition):
             return "positioning_issue"
+        default:
+            return nil
         }
     }
 }

--- a/MapboxCoreNavigation/Feedback.swift
+++ b/MapboxCoreNavigation/Feedback.swift
@@ -26,22 +26,85 @@ public enum FeedbackType: CustomStringConvertible {
 
     /// Indicates a problem with positioning the user
     case positioning(subtype: PositioningSubtype?)
-    
+
+    /*
+      case streetPermanentlyBlockedOff
+      case roadMissingFromMap
+      case other
+     */
     public var description: String {
         switch self {
         case .general:
             return "general"
-        case .incorrectVisual(_):
+        case .incorrectVisual(subtype: .none):
             return "incorrect_visual"
-        case .confusingAudio(_):
+        case .incorrectVisual(subtype: .turnIconIncorrect):
+            return "turn_icon_incorrect"
+        case .incorrectVisual(subtype: .streetNameIncorrect):
+            return "street_name_incorrect"
+        case .incorrectVisual(subtype: .instructionUnnecessary):
+            return "instruction_unnecessary"
+        case .incorrectVisual(subtype: .instructionMissing):
+            return "instruction_missing"
+        case .incorrectVisual(subtype: .maneuverIncorrect):
+            return "maneuver_incorrect"
+        case .incorrectVisual(subtype: .exitInfoIncorrect):
+            return "exit_info_incorrect"
+        case .incorrectVisual(subtype: .laneGuidanceIncorrect):
+            return "lane_guidance_incorrect"
+        case .incorrectVisual(subtype: .roadKnownByDifferentName):
+            return "road_known_by_different_name"
+        case .incorrectVisual(subtype: .other):
+            return "incorrect_visual"
+        case .confusingAudio(subtype: .none):
             return "confusing_audio"
-        case .routeQuality(_):
+        case .confusingAudio(subtype: .guidanceTooEarly):
+            return "guidance_too_early"
+        case .confusingAudio(subtype: .guidanceTooLate):
+            return "guidance_too_late"
+        case .confusingAudio(subtype: .pronunciationIncorrect):
+            return "pronunciation_incorrect"
+        case .confusingAudio(subtype: .roadNameRepeated):
+            return "road_name_repeated"
+        case .confusingAudio(subtype: .other):
+            return "confusing_audio"
+        case .routeQuality(subtype: .none):
             return "route_quality"
-        case .illegalRoute(_):
+        case .routeQuality(subtype: .routeNonDrivable):
+            return "route_not_driveable"
+        case .routeQuality(subtype: .routeNotPreferred):
+            return "route_not_preferred"
+        case .routeQuality(subtype: .alternativeRouteNotExpected):
+            return "alternative_route_not_expected"
+        case .routeQuality(subtype: .routeIncludedMissingRoads):
+            return "route_included_missing_roads"
+        case .routeQuality(subtype: .routeHadRoadsTooNarrowToPass):
+            return "route_had_roads_too_narrow_to_pass"
+        case .routeQuality(subtype: .other):
+            return "route_quality"
+        case .illegalRoute(subtype: .none):
             return "illegal_route"
-        case .roadClosure(_):
+        case .illegalRoute(subtype: .routedDownAOneWay):
+            return "routed_down_a_one_way"
+        case .illegalRoute(subtype: .turnWasNotAllowed):
+            return "turn_was_not_allowed"
+        case .illegalRoute(subtype: .carsNotAllowedOnStreet):
+            return "cars_not_allowed_on_street"
+        case .illegalRoute(subtype: .turnAtIntersectionUnprotected):
+            return "turn_at_intersection_was_unprotected"
+        case .illegalRoute(subtype: .other):
+            return "illegal_route"
+        case .roadClosure(subtype: .none):
             return "road_closure"
-        case .positioning(_):
+        case .roadClosure(subtype: .streetPermanentlyBlockedOff):
+            return "street_permanently_blocked_off"
+        case .roadClosure(subtype: .roadMissingFromMap):
+            return "road_is_missing_from_map"
+        case .roadClosure(subtype: .other):
+            return "road_closure"
+        case .positioning(subtype: .none):
+            return "positioning_issue"
+        case .positioning(subtype: .userPosition):
             return "positioning_issue"
         }
     }

--- a/MapboxNavigation/FeedbackItem.swift
+++ b/MapboxNavigation/FeedbackItem.swift
@@ -84,7 +84,7 @@ public extension FeedbackType {
         case .positioning(.none):
             return NSLocalizedString("POSITIONING", bundle: .mapboxNavigation, value: "Positioning", comment: "General category of route feedback where user position is incorrect.")
         case .positioning(.userPosition):
-            return NSLocalizedString("POSITIONING", bundle: .mapboxNavigation, value: "User Position", comment: "Specific route feedback that user positioning is incorrect.")
+            return NSLocalizedString("POSITIONING_USER", bundle: .mapboxNavigation, value: "User Position", comment: "Specific route feedback that user positioning is incorrect.")
         }
     }
 

--- a/MapboxNavigation/FeedbackItem.swift
+++ b/MapboxNavigation/FeedbackItem.swift
@@ -84,7 +84,7 @@ public extension FeedbackType {
         case .positioning(.none):
             return NSLocalizedString("POSITIONING", bundle: .mapboxNavigation, value: "Positioning", comment: "General category of route feedback where user position is incorrect.")
         case .positioning(.userPosition):
-            return NSLocalizedString("POSITIONING_USER", bundle: .mapboxNavigation, value: "User Position", comment: "Specific route feedback that user positioning is incorrect.")
+            return NSLocalizedString("POSITIONING_USER", bundle: .mapboxNavigation, value: "Your position", comment: "Specific route feedback that user positioning is incorrect.")
         }
     }
 

--- a/MapboxNavigation/FeedbackSubtypeViewController.swift
+++ b/MapboxNavigation/FeedbackSubtypeViewController.swift
@@ -161,7 +161,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
     private func sendReport() {
         if selectedItems.count > 0 {
             if let uuid = self.uuid {
-                selectedItems.forEach { item in
+                for item in selectedItems {
                     delegate?.feedbackViewController(self, didSend: item, uuid: uuid)
                     eventsManager?.updateFeedback(uuid: uuid, type: item.feedbackType, source: .user, description: nil)
                 }

--- a/MapboxNavigation/FeedbackSubtypeViewController.swift
+++ b/MapboxNavigation/FeedbackSubtypeViewController.swift
@@ -160,8 +160,8 @@ class FeedbackSubtypeViewController: FeedbackViewController {
 
     private func sendReport() {
         if selectedItems.count > 0 {
-            selectedItems.forEach { item in
-                if let uuid = self.uuid {
+            if let uuid = self.uuid {
+                selectedItems.forEach { item in
                     delegate?.feedbackViewController(self, didSend: item, uuid: uuid)
                     eventsManager?.updateFeedback(uuid: uuid, type: item.feedbackType, source: .user, description: nil)
                 }

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -136,9 +136,11 @@
 /* Accessibility value of label indicating the absence of a rating */
 "NO_RATING" = "No rating set.";
 
-/* General category of route feedback where user position is incorrect.
-   Specific route feedback that user positioning is incorrect. */
+/* General category of route feedback where user position is incorrect. */
 "POSITIONING" = "Positioning";
+
+/* Specific route feedback that user positioning is incorrect. */
+"POSITIONING_USER" = "User Position";
 
 /* Rating Reset To Zero Accessability Hint */
 "RATING_ACCESSIBILITY_RESET" = "Tap to reset the rating to zero.";

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -140,7 +140,7 @@
 "POSITIONING" = "Positioning";
 
 /* Specific route feedback that user positioning is incorrect. */
-"POSITIONING_USER" = "User Position";
+"POSITIONING_USER" = "Your position";
 
 /* Rating Reset To Zero Accessability Hint */
 "RATING_ACCESSIBILITY_RESET" = "Tap to reset the rating to zero.";


### PR DESCRIPTION
Match Android feedback mechanism of sending a single event per category of feedback with an optional array of subtypes. Update JSON keys to match Android as well.