### PR TITLE
Document guidance cards, junction views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 * As the user approaches certain junctions, an enlarged illustration of the junction appears below the top banner to help the user understand a complex maneuver. These junction views only appear when the relevant data is available. Contact your Mapbox sales representative or [support team](https://support.mapbox.com/) for access to the junction views feature. ([#2408](https://github.com/mapbox/mapbox-navigation-ios/pull/2408))
 * Replaced `RouteVoiceController` and `MapboxVoiceController` with `MultiplexedSpeechSynthesizer`. `MultiplexedSpeechSynthesizer` coordinates multiple cascading speech synthesizers. By default, the controller still tries to speak instructions via the Mapbox Voice API (`MapboxSpeechSynthesizer`) before falling back to VoiceOver (`SystemSpeechSynthesizer`), but you can also provide your own speech synthesizer that conforms to the `SpeechSynthesizing` protocol. ([#2348](https://github.com/mapbox/mapbox-navigation-ios/pull/2348))
+* Added an alternative presentation for maneuver instructions that resembles swipeable user notification cards. To replace the conventional `TopBannerViewController` presentation with the cardlike presentation, create an instance of `InstructionsCardViewController` and pass it into the `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:)` method. ([#2149](https://github.com/mapbox/mapbox-navigation-ios/pull/2149), [#2296](https://github.com/mapbox/mapbox-navigation-ios/pull/2296), [#2627](https://github.com/mapbox/mapbox-navigation-ios/pull/2627))
 
 ### Feedback
 

--- a/Example/ViewController+GuidanceCards.swift
+++ b/Example/ViewController+GuidanceCards.swift
@@ -2,7 +2,6 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
-/// :nodoc:
 extension ViewController: InstructionsCardCollectionDelegate {
     public func instructionsCardCollection(_ instructionsCardCollection: InstructionsCardViewController, didPreview step: RouteStep) {
         guard let route = response?.routes?.first else { return }

--- a/MapboxNavigation/InstructionsCardContainerView.swift
+++ b/MapboxNavigation/InstructionsCardContainerView.swift
@@ -3,7 +3,6 @@ import MapboxDirections
 import MapboxCoreNavigation
 
 /**
- :nodoc:
  The `InstructionsCardContainerViewDelegate` protocol defines a method that allows an object to customize presented visual instructions within the instructions container view.
  */
 public protocol InstructionsCardContainerViewDelegate: VisualInstructionDelegate {
@@ -46,7 +45,9 @@ public extension InstructionsCardContainerViewDelegate {
     }
 }
 
-/// :nodoc:
+/**
+ A container view for the information currently displayed in `InstructionsCardViewController`.
+ */
 public class InstructionsCardContainerView: StylableView {
     lazy var informationStackView = UIStackView(orientation: .vertical, autoLayout: true)
     
@@ -280,7 +281,6 @@ public class InstructionsCardContainerView: StylableView {
     }
 }
 
-/// :nodoc:
 extension InstructionsCardContainerView: InstructionsCardContainerViewDelegate {
     public func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
         if let primaryLabel = label as? PrimaryLabel,

--- a/MapboxNavigation/InstructionsCardViewController.swift
+++ b/MapboxNavigation/InstructionsCardViewController.swift
@@ -1,7 +1,11 @@
 import MapboxDirections
 import MapboxCoreNavigation
 
-/// :nodoc:
+/**
+ A view controller that displays the current maneuver instruction as a “card” resembling a user notification. A subsequent maneuver is always partially visible on one side of the view; swiping to one side reveals the full maneuver.
+ 
+ This class is an alternative to the more traditional banner interface provided by the `TopBannerViewController` class. To use `InstructionsCardViewController`, create an instance of it and pass it into the `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:)` method.
+ */
 open class InstructionsCardViewController: UIViewController {
     typealias InstructionsCardCollectionLayout = UICollectionViewFlowLayout
     
@@ -234,7 +238,6 @@ open class InstructionsCardViewController: UIViewController {
     }
 }
 
-/// :nodoc:
 extension InstructionsCardViewController: UICollectionViewDelegate {
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         indexBeforeSwipe = snappedIndexPath()
@@ -256,7 +259,6 @@ extension InstructionsCardViewController: UICollectionViewDelegate {
     }
 }
 
-/// :nodoc:
 extension InstructionsCardViewController: UICollectionViewDataSource {
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return steps?.count ?? 0
@@ -280,14 +282,12 @@ extension InstructionsCardViewController: UICollectionViewDataSource {
     }
 }
 
-/// :nodoc:
 extension InstructionsCardViewController: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return cardSize
     }
 }
 
-/// :nodoc:
 extension InstructionsCardViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
         routeProgress = progress
@@ -307,7 +307,6 @@ extension InstructionsCardViewController: NavigationComponent {
     }
 }
 
-/// :nodoc:
 extension InstructionsCardViewController: InstructionsCardContainerViewDelegate {
     public func primaryLabel(_ primaryLabel: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
         return cardCollectionDelegate?.primaryLabel(primaryLabel, willPresent: instruction, as: presented)
@@ -318,7 +317,6 @@ extension InstructionsCardViewController: InstructionsCardContainerViewDelegate 
     }
 }
 
-/// :nodoc:
 extension InstructionsCardViewController: NavigationMapInteractionObserver {
     public func navigationViewController(didCenterOn location: CLLocation) {
         stopPreview()

--- a/MapboxNavigation/JunctionView.swift
+++ b/MapboxNavigation/JunctionView.swift
@@ -2,8 +2,11 @@ import UIKit
 import MapboxCoreNavigation
 import MapboxDirections
 
-
-/// :nodoc:
+/**
+ A junction view shows an image depicting the layout of a highway junction.
+ 
+ As the user approaches certain junctions, an enlarged illustration of the junction appears in this view to help the user understand a complex maneuver. A junction view only appears when the relevant data is available.
+ */
 public class JunctionView: UIImageView {
     var isCurrentlyVisible: Bool = false
     var imageRepository: ImageRepository = .shared

--- a/MapboxNavigation/TopBannerViewController.swift
+++ b/MapboxNavigation/TopBannerViewController.swift
@@ -42,6 +42,11 @@ public extension TopBannerViewControllerDelegate {
     }
 }
 
+/**
+ A view controller that displays the current maneuver instruction as a “banner” flush with the edges of the containing view. The user swipes to one side to preview a subsequent maneuver.
+ 
+ This class is the default top banner view controller used by `NavigationOptions` and `NavigationViewController`. `InstructionsCardViewController` provides an alternative, user notification–like interface.
+ */
 open class TopBannerViewController: UIViewController {
     weak var delegate: TopBannerViewControllerDelegate? = nil
     

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -89,14 +89,20 @@ custom_categories:
       - DistanceFormatter
   - name: UI Components
     children:
-      - ManeuverView
       - BottomBannerViewController
       - BottomBannerViewControllerDelegate
       - SpeedLimitView
       - UserPuckCourseView
       - CourseUpdatable
-      - GenericRouteShield
       - NavigationComponent
+  - name: Guidance Instruction UI
+      - TopBannerViewController
+      - InstructionsCardViewController
+      - InstructionsCardContainerView
+      - InstructionsCardContainerViewDelegate
+      - ManeuverView
+      - JunctionView
+      - GenericRouteShield
   - name: CarPlay
     children:
       - CarPlayManager


### PR DESCRIPTION
Added class documentation comments for the minimum set of types necessary to consider the guidance cards feature from #2149 and #2296 to be publicly available. With these changes, we can finally add a blurb to the changelog announcing the introduction of this feature, even though it has been in the codebase for quite some time. This PR also adds some documentation about junction views for styling purposes.

Guidance cards, represented by the `InstructionsCardViewController` class, is an alternative presentation of maneuver instructions that is intended to be better visually integrated with the map than the traditional presentation of banners flush with the edges of the screen, represented by the default `TopBannerViewController` class. To enable guidance cards, an application would pass an instance of `InstructionsCardViewController` into `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:)` when creating the NavigationViewController. Using guidance cards in a custom turn-by-turn navigation UI requires some additional setup and delegate method implementations.

Fixes most of #2519.

/cc @mapbox/navigation-ios @avi-c @d-prukop