### PR TITLE
Avoid reconfiguring passive navigator

### DIFF
--- a/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
+++ b/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
@@ -70,7 +70,9 @@ class PassiveLocationDataSourceTests: XCTestCase {
         wait(for: [startingExpectation], timeout: 2)
         
         // FIXME: Starting the location manager should automatically configure the navigator.
+        XCTAssertFalse(locationManager.isConfigured)
         XCTAssertNoThrow(try locationManager.configureNavigator(withTilesVersion: "1234"))
+        XCTAssertTrue(locationManager.isConfigured)
         
         let locationUpdateExpectation = expectation(description: "Location manager should respond to every manual location update")
         locationUpdateExpectation.expectedFulfillmentCount = 5


### PR DESCRIPTION
Avoid refetching offline routing tile versions and reconfiguring the passive location data source’s navigator’s router multiple times, because a router instance only expects to be configured once.

When we later upgrade to MapboxNavigationNative v20._x_, we’ll need to move this configuration logic into the code that initializes the navigator (currently in `PassiveLocationDataSource(directions:systemLocationManager:)`). That will be interesting to consider as part of unifying the navigators in #2593.

This is a speculative fix for #2632.

/cc @mapbox/navigation-ios @mapbox/navnative