### PR TITLE
Improve performance of Wayname calculation

### DIFF
--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -687,10 +687,9 @@ extension RouteMapViewController: NavigationViewDelegate {
 
             if ![DirectionsProfileIdentifier.walking, DirectionsProfileIdentifier.cycling].contains( router.routeProgress.routeOptions.profileIdentifier) {
                 // filter out to road classes valid for motor transport
-                let roadPredicates = ["motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link", "street", "street_limited", "roundabout", "mini_roundabout"].compactMap { roadClass -> NSPredicate? in
-                    return NSPredicate(format: "%K == %@", "class", roadClass)
-                }
-                let compoundPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: roadPredicates)
+                let roadPredicates = ["motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link", "street", "street_limited", "roundabout"]
+
+                let compoundPredicate = NSPredicate(format: "class IN %@", roadPredicates)
                 streetLabelLayer.predicate = compoundPredicate
             }
             style.insertLayer(streetLabelLayer, at: 0)

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -684,6 +684,13 @@ extension RouteMapViewController: NavigationViewDelegate {
             streetLabelLayer.lineOpacity = NSExpression(forConstantValue: 1)
             streetLabelLayer.lineWidth = NSExpression(forConstantValue: 20)
             streetLabelLayer.lineColor = NSExpression(forConstantValue: UIColor.white)
+
+            // filter out to road classes valid for motor transport
+            let roadPredicates = ["motorway", "trunk", "primary", "secondary", "tertiary", "street"].compactMap { roadClass -> NSPredicate? in
+                return NSPredicate(format: "%K == %@", "class", roadClass)
+            }
+            let compoundPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: roadPredicates)
+            streetLabelLayer.predicate = compoundPredicate
             style.insertLayer(streetLabelLayer, at: 0)
         }
 
@@ -692,6 +699,7 @@ extension RouteMapViewController: NavigationViewDelegate {
         var smallestLabelDistance = Double.infinity
         var currentName: String?
         var currentShieldName: NSAttributedString?
+        let slicedLine = stepShape.sliced(from: closestCoordinate)!
 
         for feature in features {
             var allLines: [MGLPolyline] = []
@@ -706,7 +714,6 @@ extension RouteMapViewController: NavigationViewDelegate {
                 guard line.pointCount > 0 else { continue }
                 let featureCoordinates =  Array(UnsafeBufferPointer(start: line.coordinates, count: Int(line.pointCount)))
                 let featurePolyline = LineString(featureCoordinates)
-                let slicedLine = stepShape.sliced(from: closestCoordinate)!
 
                 let lookAheadDistance: CLLocationDistance = 10
                 guard let pointAheadFeature = featurePolyline.sliced(from: closestCoordinate)!.coordinateFromStart(distance: lookAheadDistance) else { continue }

--- a/MapboxNavigation/RouteMapViewController.swift
+++ b/MapboxNavigation/RouteMapViewController.swift
@@ -685,12 +685,14 @@ extension RouteMapViewController: NavigationViewDelegate {
             streetLabelLayer.lineWidth = NSExpression(forConstantValue: 20)
             streetLabelLayer.lineColor = NSExpression(forConstantValue: UIColor.white)
 
-            // filter out to road classes valid for motor transport
-            let roadPredicates = ["motorway", "trunk", "primary", "secondary", "tertiary", "street"].compactMap { roadClass -> NSPredicate? in
-                return NSPredicate(format: "%K == %@", "class", roadClass)
+            if ![DirectionsProfileIdentifier.walking, DirectionsProfileIdentifier.cycling].contains( router.routeProgress.routeOptions.profileIdentifier) {
+                // filter out to road classes valid for motor transport
+                let roadPredicates = ["motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link", "street", "street_limited", "roundabout", "mini_roundabout"].compactMap { roadClass -> NSPredicate? in
+                    return NSPredicate(format: "%K == %@", "class", roadClass)
+                }
+                let compoundPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: roadPredicates)
+                streetLabelLayer.predicate = compoundPredicate
             }
-            let compoundPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: roadPredicates)
-            streetLabelLayer.predicate = compoundPredicate
             style.insertLayer(streetLabelLayer, at: 0)
         }
 


### PR DESCRIPTION
Add a predicate filter for the road label MGLLineStyleLayer. Prevent the repeated recalculation of sliced current step line shape.

Fixes #2259.