### PR TITLE
Remove unused variable in FeedbackViewController

### DIFF
--- a/MapboxNavigation/FeedbackViewController.swift
+++ b/MapboxNavigation/FeedbackViewController.swift
@@ -308,8 +308,6 @@ extension FeedbackViewController: UICollectionViewDelegateFlowLayout {
         let width = traitCollection.verticalSizeClass == .compact
             ? floor(availableWidth / CGFloat(sections.count))
             : floor(availableWidth / CGFloat(sections.count / 2))
-        let item = sections[indexPath.row]
-        let titleHeight = item.title.height(constrainedTo: width, font: FeedbackCollectionViewCell.Constants.titleFont)
         let cellHeight: CGFloat = FeedbackCollectionViewCell.Constants.circleSize.height
             + FeedbackCollectionViewCell.Constants.padding
             + FeedbackCollectionViewCell.Constants.verticalPadding // top and bottom padding


### PR DESCRIPTION
Fixed a compiler warning about an unused variable that shows up in an application’s workspace when using CocoaPods.

Fixes #2639.

/cc @mapbox/navigation-ios @avi-c