### PR TITLE
Skip shape annotations when inserting route line into style

### DIFF
--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -536,6 +536,14 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             var parentLayer: MGLStyleLayer? = nil
             for layer in style.layers.reversed() {
                 if !(layer is MGLSymbolStyleLayer) && !identifiers.contains(layer.identifier) {
+                    // MGLMapView automatically adds an MGLLineStyleLayer or MGLFillStyleLayer to the top of the layer stack when adding a polyline or polygon annotation, respectively. There’s no way to insert them lower in the layer stack, so they aren’t good indicators of where to insert the route line.
+                    // Detect and skip such a layer by checking if its source lacks a dedicated MGLSource subclass.
+                    if let vectorLayer = layer as? MGLVectorStyleLayer,
+                       let sourceIdentifier = vectorLayer.sourceIdentifier,
+                       let source = style.source(withIdentifier: sourceIdentifier), type(of: source) == MGLSource.self {
+                        continue
+                    }
+                    
                     parentLayer = layer
                     break
                 }


### PR DESCRIPTION
Detect and skip polyline and polygon annotation layers when scouring the style’s layers for the right layer to insert the route line above.

<img src="https://user-images.githubusercontent.com/1231218/94500007-f3bd2d80-01b2-11eb-9c97-13f4d5140f94.png" width="300" alt="overlap">

Fixes #2657.

/cc @mapbox/navigation-ios