### PR TITLE
create a halo view for reduced accuracy in userCourseView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the ability to provide more detailed `Speed limit incorrect` feedback during turn-by-turn navigation. ([#2725](https://github.com/mapbox/mapbox-navigation-ios/pull/2725))
 
 ### Other changes
+
 * Fixed an issue which was causing clear map button disappearance in the example app when selecting the route. ([#2718](https://github.com/mapbox/mapbox-navigation-ios/pull/2718))
 * Fixed an issue where maneuver icon was not shown after selecting specific step. ([#2722](https://github.com/mapbox/mapbox-navigation-ios/issues/2722))
 * Fixed an issue which was preventing the ability to customize the bottom banner height. ([#2705](https://github.com/mapbox/mapbox-navigation-ios/pull/2705))
@@ -23,6 +24,7 @@
 * MapboxNavigationNative dependency was updated to v22.0.5 and MapboxCommon to v7.1.2. ([#2648](https://github.com/mapbox/mapbox-navigation-ios/pull/2648))
 
 ### User location
+
 * Fixed issues which was causing unsmooth user puck updates on iOS and inability to zoom-in to current location at the start of navigation on CarPlay by updating to Mapbox Maps SDK for iOS v6.2.2. ([#2699](https://github.com/mapbox/mapbox-navigation-ios/pull/2699))
 * Added the `NavigationServiceDelegate.navigationService(_:didChangeAuthorizationFor:)` method and `Notification.Name.locationAuthorizationDidChange` to detect when the user changes the Location Services permissions for the current application, including for approximate location on iOS 14. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))
 * When approximate location is enabled on iOS 14, a banner appears reminding the user to disable approximate location to continue navigating. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 * Added Ukrainian localization. ([#2735](https://github.com/mapbox/mapbox-navigation-ios/pull/2735)
 
 ### User Location
+<<<<<<< HEAD
 * Created the `UserHaloCourseView` similar to `UserCourseView` for approximate location on iOS 14 during the navigation to represent user location. Allow the switch between `UserHaloCourseView` and `UserCourseView` when precise mode is changed. ([#2664](https://github.com/mapbox/mapbox-navigation-ios/pull/2664))
+
 
 ## v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,14 @@
 
 ### User Location
 <<<<<<< HEAD
+<<<<<<< HEAD
 * Created the `UserHaloCourseView` similar to `UserCourseView` for approximate location on iOS 14 during the navigation to represent user location. Allow the switch between `UserHaloCourseView` and `UserCourseView` when precise mode is changed. ([#2664](https://github.com/mapbox/mapbox-navigation-ios/pull/2664))
 
+=======
+* Created a `UserHaloCourseView` similar to `UserCourseView` for approximate location on iOS 14 during the navigation to represent user location. Allow the switch between `UserHaloCourseView` and `UserCourseView` when precise mode is changed. ([#2664](https://github.com/mapbox/mapbox-navigation-ios/pull/2664))
+* Added the `NavigationServiceDelegate.navigationService(_:didChangeAuthorizationFor:)` method and `Notification.Name.locationAuthorizationDidChange` to detect when the user changes the Location Services permissions for the current application, including for approximate location on iOS 14. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))
+* When approximate location is enabled on iOS 14, a banner appears reminding the user to disable approximate location to continue navigating. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))
+>>>>>>> b910962f... update changelog
 
 ## v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
 ## v1.2.0
+<<<<<<< HEAD
 
 ### Feedback
 
 * Added the ability to provide more detailed `Speed limit incorrect` feedback during turn-by-turn navigation. ([#2725](https://github.com/mapbox/mapbox-navigation-ios/pull/2725))
 
 ### Other changes
-
 * Fixed an issue which was causing clear map button disappearance in the example app when selecting the route. ([#2718](https://github.com/mapbox/mapbox-navigation-ios/pull/2718))
 * Fixed an issue where maneuver icon was not shown after selecting specific step. ([#2722](https://github.com/mapbox/mapbox-navigation-ios/issues/2722))
 * Fixed an issue which was preventing the ability to customize the bottom banner height. ([#2705](https://github.com/mapbox/mapbox-navigation-ios/pull/2705))
 * Added Ukrainian localization. ([#2735](https://github.com/mapbox/mapbox-navigation-ios/pull/2735)
+
+### User Location
+* Created the `UserHaloCourseView` similar to `UserCourseView` for approximate location on iOS 14 during the navigation to represent user location. Allow the switch between `UserHaloCourseView` and `UserCourseView` when precise mode is changed. ([#2664](https://github.com/mapbox/mapbox-navigation-ios/pull/2664))
 
 ## v1.1.0
 
@@ -20,7 +23,6 @@
 * MapboxNavigationNative dependency was updated to v22.0.5 and MapboxCommon to v7.1.2. ([#2648](https://github.com/mapbox/mapbox-navigation-ios/pull/2648))
 
 ### User location
-
 * Fixed issues which was causing unsmooth user puck updates on iOS and inability to zoom-in to current location at the start of navigation on CarPlay by updating to Mapbox Maps SDK for iOS v6.2.2. ([#2699](https://github.com/mapbox/mapbox-navigation-ios/pull/2699))
 * Added the `NavigationServiceDelegate.navigationService(_:didChangeAuthorizationFor:)` method and `Notification.Name.locationAuthorizationDidChange` to detect when the user changes the Location Services permissions for the current application, including for approximate location on iOS 14. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))
 * When approximate location is enabled on iOS 14, a banner appears reminding the user to disable approximate location to continue navigating. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
 ## v1.2.0
-<<<<<<< HEAD
 
 ### Feedback
 
@@ -14,15 +13,8 @@
 * Added Ukrainian localization. ([#2735](https://github.com/mapbox/mapbox-navigation-ios/pull/2735)
 
 ### User Location
-<<<<<<< HEAD
-<<<<<<< HEAD
 * Created the `UserHaloCourseView` similar to `UserCourseView` for approximate location on iOS 14 during the navigation to represent user location. Allow the switch between `UserHaloCourseView` and `UserCourseView` when precise mode is changed. ([#2664](https://github.com/mapbox/mapbox-navigation-ios/pull/2664))
 
-=======
-* Created a `UserHaloCourseView` similar to `UserCourseView` for approximate location on iOS 14 during the navigation to represent user location. Allow the switch between `UserHaloCourseView` and `UserCourseView` when precise mode is changed. ([#2664](https://github.com/mapbox/mapbox-navigation-ios/pull/2664))
-* Added the `NavigationServiceDelegate.navigationService(_:didChangeAuthorizationFor:)` method and `Notification.Name.locationAuthorizationDidChange` to detect when the user changes the Location Services permissions for the current application, including for approximate location on iOS 14. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))
-* When approximate location is enabled on iOS 14, a banner appears reminding the user to disable approximate location to continue navigating. ([#2693](https://github.com/mapbox/mapbox-navigation-ios/pull/2693))
->>>>>>> b910962f... update changelog
 
 ## v1.1.0
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		AE87207E22CF97B900D7DAB7 /* InstructionsCardCollectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE87207D22CF97B900D7DAB7 /* InstructionsCardCollectionDelegate.swift */; };
 		AEC3AC9A2106703100A26F34 /* HighwayShield.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC3AC992106703100A26F34 /* HighwayShield.swift */; };
 		AED6285622CBE4CE00058A51 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
+		B430D2FA25534FDC0088CC23 /* UserHaloCourseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */; };
 		C51511D120EAC89D00372A91 /* CPMapTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51511D020EAC89D00372A91 /* CPMapTemplate.swift */; };
 		C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51DF8651F38C31C006C6A15 /* Locale.swift */; };
 		C51FC31720F689F800400CE7 /* CustomStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51FC31620F689F800400CE7 /* CustomStyles.swift */; };
@@ -931,6 +932,7 @@
 		AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+GuidanceCards.swift"; path = "Example/ViewController+GuidanceCards.swift"; sourceTree = "<group>"; };
 		AEF2C8F12072B603007B061F /* routeWithTunnels_9thStreetDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithTunnels_9thStreetDC.json; sourceTree = "<group>"; };
+		B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
 		C51511D020EAC89D00372A91 /* CPMapTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPMapTemplate.swift; sourceTree = "<group>"; };
 		C51DF8651F38C31C006C6A15 /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		C51FC31620F689F800400CE7 /* CustomStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomStyles.swift; path = Example/CustomStyles.swift; sourceTree = "<group>"; };
@@ -1359,6 +1361,7 @@
 				F4BF512D24EAD7A50066A49B /* FeedbackSubtypeCollectionViewCell.swift */,
 				5A1C075724BDEB44000A6330 /* PassiveLocationManager.swift */,
 				F4C5A26E24EF1D16004ED0DD /* FeedbackSubtypeViewController.swift */,
+				B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */,
 			);
 			path = MapboxNavigation;
 			sourceTree = "<group>";
@@ -2445,6 +2448,7 @@
 				351BEBFC1E5BCC63006FE110 /* NavigationViewController.swift in Sources */,
 				AE7DE6C621A47A23002653D1 /* CarPlaySearchController+ CPSearchTemplateDelegate.swift in Sources */,
 				8D8EA9BC20575CD80077F478 /* FeedbackCollectionViewCell.swift in Sources */,
+				B430D2FA25534FDC0088CC23 /* UserHaloCourseView.swift in Sources */,
 				35E407681F5625FF00EFC814 /* StyleKitMarker.swift in Sources */,
 				C588C3C21F33882100520EF2 /* String.swift in Sources */,
 				C53208AB1E81FFB900910266 /* NavigationMapView.swift in Sources */,

--- a/MapboxNavigation/DayStyle.swift
+++ b/MapboxNavigation/DayStyle.swift
@@ -199,6 +199,9 @@ open class DayStyle: Style {
         TopBannerView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         UserPuckCourseView.appearance().puckColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 1)
         UserPuckCourseView.appearance().stalePuckColor = #colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1)
+        UserHaloCourseView.appearance().haloColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)
+        UserHaloCourseView.appearance().haloRingColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 0.3)
+        UserHaloCourseView.appearance().haloRadius = 100.0
         WayNameLabel.appearance().normalFont = UIFont.systemFont(ofSize:20, weight: .medium).adjustedFont
         WayNameLabel.appearance().normalTextColor = #colorLiteral(red: 0.968627451, green: 0.968627451, blue: 0.968627451, alpha: 1)
         WayNameView.appearance().backgroundColor = UIColor.defaultRouteLayer.withAlphaComponent(0.85)

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -119,6 +119,11 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     @objc dynamic public var maneuverArrowStrokeColor: UIColor = .defaultManeuverArrowStroke
     @objc dynamic public var buildingDefaultColor: UIColor = .defaultBuildingColor
     @objc dynamic public var buildingHighlightColor: UIColor = .defaultBuildingHighlightColor
+    @objc dynamic public var reducedAccuracyActivatedMode: Bool = false {
+            didSet {
+                userCourseView = reducedAccuracyActivatedMode ? UserHaloCourseView(frame: CGRect(origin: .zero, size: 75.0)) : UserPuckCourseView(frame: CGRect(origin: .zero, size: 75.0))
+            }
+    }
     
     var userLocationForCourseTracking: CLLocation?
     var animatesUserLocation: Bool = false

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -120,9 +120,9 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     @objc dynamic public var buildingDefaultColor: UIColor = .defaultBuildingColor
     @objc dynamic public var buildingHighlightColor: UIColor = .defaultBuildingHighlightColor
     @objc dynamic public var reducedAccuracyActivatedMode: Bool = false {
-            didSet {
-                userCourseView = reducedAccuracyActivatedMode ? UserHaloCourseView(frame: CGRect(origin: .zero, size: 75.0)) : UserPuckCourseView(frame: CGRect(origin: .zero, size: 75.0))
-            }
+        didSet {
+            userCourseView = reducedAccuracyActivatedMode ? UserHaloCourseView(frame: CGRect(origin: .zero, size: 75.0)) : UserPuckCourseView(frame: CGRect(origin: .zero, size: 75.0))
+        }
     }
     
     var userLocationForCourseTracking: CLLocation?

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -699,6 +699,7 @@ extension NavigationViewController: NavigationServiceDelegate {
             mapView?.reducedAccuracyActivatedMode = true
         } else {
             //Fallback on earlier versions
+            mapView?.reducedAccuracyActivatedMode = false
             return
         }
     }

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -696,6 +696,7 @@ extension NavigationViewController: NavigationServiceDelegate {
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
             showStatus(title: title, spinner: false, duration: 20, animated: true, interactive: false)
+            mapView?.reducedAccuracyActivatedMode = true
         } else {
             //Fallback on earlier versions
             return

--- a/MapboxNavigation/UserCourseView.swift
+++ b/MapboxNavigation/UserCourseView.swift
@@ -1,9 +1,9 @@
 import UIKit
 import Turf
 import Mapbox
+import MapboxCoreNavigation
 
 let PuckSize: CGFloat = 45
-
 /**
  A protocol that represents a `UIView` which tracks the user’s location and course on a `NavigationMapView`.
  */
@@ -35,10 +35,13 @@ public extension CourseUpdatable {
 /**
  A view representing the user’s location on screen.
  */
+
 public class UserPuckCourseView: UIView, CourseUpdatable {
     private var lastLocationUpdate: Date?
     private var staleTimer: Timer!
     
+    private var approximateModeActivated: Bool = false
+
     /// Time interval tick at which Puck view is transitioning into 'stale' state
     public var staleRefreshInterval: TimeInterval = 1 {
         didSet {
@@ -56,8 +59,20 @@ public class UserPuckCourseView: UIView, CourseUpdatable {
         let duration: TimeInterval = animated ? 1 : 0
         UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveLinear], animations: {
             let angle = tracksUserCourse ? 0 : CLLocationDegrees(direction - location.course)
+            let dataSource = PassiveLocationDataSource()
+            let locationManager = PassiveLocationManager(dataSource: dataSource)
+            if #available(iOS 14.0, *) {
+                if (locationManager.accuracyAuthorization() ==
+                    MBNavigationAccuracyAuthorization(rawValue: 1)) {
+                    self.approximateModeActivated = true
+                    // ToDo: switch the puckView to UserApproximateStyleKitView
+                } else {
+                     // ToDo: switch the puckView to UserPuckStyleKitView
+                }
+            } else {
+                // ToDo: switch the puckView to UserPuckStyleKitView
+            }
             self.puckView.layer.setAffineTransform(CGAffineTransform.identity.rotated(by: -CGFloat(angle.toRadians())))
-            
             var transform = CATransform3DRotate(CATransform3DIdentity, CGFloat(CLLocationDegrees(pitch).toRadians()), 1.0, 0, 0)
             transform = CATransform3DScale(transform, tracksUserCourse ? 1 : 0.5, tracksUserCourse ? 1 : 0.5, 1)
             transform.m34 = -1.0 / 1000 // (-1 / distance to projection plane)
@@ -68,6 +83,9 @@ public class UserPuckCourseView: UIView, CourseUpdatable {
     // Sets the color on the user puck
     @objc public dynamic var puckColor: UIColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 1) {
         didSet {
+            if approximateModeActivated {
+                puckColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+            }
             puckView.puckColor = puckColor
         }
     }
@@ -75,10 +93,13 @@ public class UserPuckCourseView: UIView, CourseUpdatable {
     // Sets the color on the user puck in 'stale' state. Puck will gradually transition the color as long as location updates are missing
     @objc public dynamic var stalePuckColor: UIColor = #colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1) {
         didSet {
+            if approximateModeActivated {
+                stalePuckColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+            }
             puckView.stalePuckColor = stalePuckColor
         }
     }
-    
+
     // Sets the fill color on the circle around the user puck
     @objc public dynamic var fillColor: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) {
         didSet {
@@ -92,6 +113,15 @@ public class UserPuckCourseView: UIView, CourseUpdatable {
             puckView.shadowColor = shadowColor
         }
     }
+    
+    /*
+     Todo: mapView could not be identified, used to calculate the haloView radius
+    func calculateHaloViewRadius(location: CLLocation) -> Double {
+        guard let mapView = mapView else { return 100.0 }
+        return round(2 * location.horizontalAccuracy / mapView.metersPerPoint(atLatitude: location.coordinate.latitude))
+    }
+     */
+    
     
     var puckView: UserPuckStyleKitView!
     
@@ -146,6 +176,51 @@ public class UserPuckCourseView: UIView, CourseUpdatable {
     }
 }
 
+class UserApproximateStyleKitView: UIView {
+    var puckColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)  {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    var stalePuckColor: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    var fillColor: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+    var shadowColor: UIColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 0.16)
+    var staleRatio: CGFloat = 0 {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    var opacity: CGFloat = 0.25
+    var boarderSize = 2.0
+    var radius = 100.0
+    
+    override func draw(_ rect: CGRect) {
+           super.draw(rect)
+           drawHaloView()
+       }
+    
+    func drawHaloView() {
+        let haloPath = UIBezierPath(arcCenter: center, radius: CGFloat(radius), startAngle: 0, endAngle: 2.0 * CGFloat.pi, clockwise: true)
+        
+        let haloLayer = CAShapeLayer()
+        haloLayer.path = haloPath.cgPath
+                
+        haloLayer.fillColor = puckColor.cgColor
+        haloLayer.strokeColor = stalePuckColor.cgColor
+        haloLayer.lineWidth = CGFloat(boarderSize)
+        haloLayer.shadowColor = shadowColor.cgColor
+        haloLayer.opacity = Float(opacity)
+        haloLayer.borderWidth = CGFloat(boarderSize)
+        layer.addSublayer(haloLayer)
+    }
+}
+
 class UserPuckStyleKitView: UIView {
     private typealias ColorComponents = (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat)
     
@@ -182,6 +257,7 @@ class UserPuckStyleKitView: UIView {
             setNeedsDisplay()
         }
     }
+    
     
     private func colorComponents(_ color: UIColor) -> ColorComponents {
         var hue: CGFloat = 0, saturation: CGFloat = 0, brightness: CGFloat = 0, alpha: CGFloat = 0

--- a/MapboxNavigation/UserHaloCourseView.swift
+++ b/MapboxNavigation/UserHaloCourseView.swift
@@ -1,6 +1,4 @@
 import UIKit
-import Turf
-import Mapbox
 
 /**
 A view representing the user’s reduced accuracy location on screen.
@@ -10,7 +8,7 @@ public class UserHaloCourseView: UIView, CourseUpdatable {
     private var lastLocationUpdate: Date?
 
     /**
-    Transforms the location of the user puck.
+    Transforms the location of the user halo.
     */
     public func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, tracksUserCourse: Bool) {
         let duration: TimeInterval = animated ? 1 : 0
@@ -25,19 +23,21 @@ public class UserHaloCourseView: UIView, CourseUpdatable {
     }
 
 
-    // Sets the color on the user puck
+    // Sets the inner fill color of the user halo
     @objc public dynamic var haloColor: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5) {
         didSet {
             haloView.haloColor = haloColor
         }
     }
 
+    // Sets the ring fill color of the circle around the user halo
     @objc public dynamic var haloRingColor: UIColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 0.3) {
         didSet {
             haloView.haloRingColor = haloRingColor
         }
     }
 
+    // Sets the ring size by the radius of the user halo
     @objc public dynamic var haloRadius: Double = 100.0 {
         didSet {
             haloView.haloRadius = haloRadius
@@ -56,18 +56,12 @@ public class UserHaloCourseView: UIView, CourseUpdatable {
         commonInit()
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self, name: .routeControllerProgressDidChange, object: nil)
-    }
-
     func commonInit() {
         isUserInteractionEnabled = false
         backgroundColor = .clear
         haloView = UserHaloStyleKitView(frame: bounds)
         haloView.backgroundColor = .clear
         addSubview(haloView)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(locationDidUpdate(_ :)), name: .routeControllerProgressDidChange, object: nil)
     }
 
 
@@ -100,8 +94,7 @@ class UserHaloStyleKitView: UIView {
         drawHaloView()
     }
 
-    //var opacity: CGFloat = 0.25
-    var boarderSize = 5.0
+    var borderSize = 5.0
 
     func drawHaloView() {
         let haloPath = UIBezierPath(arcCenter: center, radius: CGFloat(haloRadius), startAngle: 0, endAngle: 2.0 * CGFloat.pi, clockwise: true)
@@ -110,8 +103,8 @@ class UserHaloStyleKitView: UIView {
         haloLayer.path = haloPath.cgPath
         haloLayer.fillColor = haloColor.cgColor
         haloLayer.strokeColor = haloRingColor.cgColor
-        haloLayer.lineWidth = CGFloat(boarderSize)
-        haloLayer.borderWidth = CGFloat(boarderSize)
+        haloLayer.lineWidth = CGFloat(borderSize)
+        haloLayer.borderWidth = CGFloat(borderSize)
         layer.addSublayer(haloLayer)
     }
 }

--- a/MapboxNavigation/UserHaloCourseView.swift
+++ b/MapboxNavigation/UserHaloCourseView.swift
@@ -22,7 +22,6 @@ public class UserHaloCourseView: UIView, CourseUpdatable {
         }, completion: nil)
     }
 
-
     // Sets the inner fill color of the user halo
     @objc public dynamic var haloColor: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5) {
         didSet {
@@ -64,7 +63,6 @@ public class UserHaloCourseView: UIView, CourseUpdatable {
         addSubview(haloView)
     }
 
-
     @objc func locationDidUpdate(_ notification: NSNotification) {
         lastLocationUpdate = Date()
     }
@@ -94,17 +92,16 @@ class UserHaloStyleKitView: UIView {
         drawHaloView()
     }
 
-    var borderSize = 5.0
-
     func drawHaloView() {
+        let borderWidth = 5.0
         let haloPath = UIBezierPath(arcCenter: center, radius: CGFloat(haloRadius), startAngle: 0, endAngle: 2.0 * CGFloat.pi, clockwise: true)
-
         let haloLayer = CAShapeLayer()
+        
         haloLayer.path = haloPath.cgPath
         haloLayer.fillColor = haloColor.cgColor
         haloLayer.strokeColor = haloRingColor.cgColor
-        haloLayer.lineWidth = CGFloat(borderSize)
-        haloLayer.borderWidth = CGFloat(borderSize)
+        haloLayer.lineWidth = CGFloat(borderWidth)
+        haloLayer.borderWidth = CGFloat(borderWidth)
         layer.addSublayer(haloLayer)
     }
 }

--- a/MapboxNavigation/UserHaloCourseView.swift
+++ b/MapboxNavigation/UserHaloCourseView.swift
@@ -1,0 +1,117 @@
+import UIKit
+import Turf
+import Mapbox
+
+/**
+A view representing the user’s reduced accuracy location on screen.
+*/
+
+public class UserHaloCourseView: UIView, CourseUpdatable {
+    private var lastLocationUpdate: Date?
+
+    /**
+    Transforms the location of the user puck.
+    */
+    public func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, tracksUserCourse: Bool) {
+        let duration: TimeInterval = animated ? 1 : 0
+        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveLinear], animations: {
+            let angle = tracksUserCourse ? 0 : CLLocationDegrees(direction - location.course)
+            self.haloView.layer.setAffineTransform(CGAffineTransform.identity.rotated(by: -CGFloat(angle.toRadians())))
+            var transform = CATransform3DRotate(CATransform3DIdentity, CGFloat(CLLocationDegrees(pitch).toRadians()), 1.0, 0, 0)
+            transform = CATransform3DScale(transform, tracksUserCourse ? 1 : 0.5, tracksUserCourse ? 1 : 0.5, 1)
+            transform.m34 = -1.0 / 1000 // (-1 / distance to projection plane)
+            self.layer.sublayerTransform = transform
+        }, completion: nil)
+    }
+
+
+    // Sets the color on the user puck
+    @objc public dynamic var haloColor: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5) {
+        didSet {
+            haloView.haloColor = haloColor
+        }
+    }
+
+    @objc public dynamic var haloRingColor: UIColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 0.3) {
+        didSet {
+            haloView.haloRingColor = haloRingColor
+        }
+    }
+
+    @objc public dynamic var haloRadius: Double = 100.0 {
+        didSet {
+            haloView.haloRadius = haloRadius
+        }
+    }
+
+    var haloView: UserHaloStyleKitView!
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: .routeControllerProgressDidChange, object: nil)
+    }
+
+    func commonInit() {
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+        haloView = UserHaloStyleKitView(frame: bounds)
+        haloView.backgroundColor = .clear
+        addSubview(haloView)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(locationDidUpdate(_ :)), name: .routeControllerProgressDidChange, object: nil)
+    }
+
+
+    @objc func locationDidUpdate(_ notification: NSNotification) {
+        lastLocationUpdate = Date()
+    }
+}
+
+class UserHaloStyleKitView: UIView {
+    var haloColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)  {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    var haloRingColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 0.3) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    var haloRadius: Double = 100.0 {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        drawHaloView()
+    }
+
+    //var opacity: CGFloat = 0.25
+    var boarderSize = 5.0
+
+    func drawHaloView() {
+        let haloPath = UIBezierPath(arcCenter: center, radius: CGFloat(haloRadius), startAngle: 0, endAngle: 2.0 * CGFloat.pi, clockwise: true)
+
+        let haloLayer = CAShapeLayer()
+        haloLayer.path = haloPath.cgPath
+        haloLayer.fillColor = haloColor.cgColor
+        haloLayer.strokeColor = haloRingColor.cgColor
+        haloLayer.lineWidth = CGFloat(boarderSize)
+        haloLayer.borderWidth = CGFloat(boarderSize)
+        layer.addSublayer(haloLayer)
+    }
+}

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -94,6 +94,7 @@ custom_categories:
       - BottomBannerViewControllerDelegate
       - SpeedLimitView
       - UserPuckCourseView
+      - UserHaloCourseView
       - CourseUpdatable
       - NavigationComponent
   - name: Guidance Instruction UI


### PR DESCRIPTION
## Description
### Goal

This pr will create a halo view for the iOS 14 reduced Accuracy during the navigation, similar to mapbox/mapbox-gl-native-ios#381. To solve the issue to fix mapbox/mapbox-navigation-ios#2555 following #2693 

- [x] fix mapbox/mapbox-navigation-ios#2555
- [x] add `UserHaloCourseView` to public API , update jazzy.yml to contain new symbol
- [x] update changelog 

### Implementation

This pr create a `UserHaloCourseView` similar to `UserCourseView` following the same protocol. Add a property in `NavigationMapView` to control the swift between the two views. Using the `navigationServiceDidChangeAuthorization` to set the value of the property. 

## Testing

The following screenshot shows the new halo view during navigation under reduced location accuracy.
![haloView](https://user-images.githubusercontent.com/48976398/98171057-f42ca080-1ea3-11eb-8f93-56b799b078f8.png)


/cc @mapbox/navigation-ios 