### PR TITLE
Exclude arm64 simulator from CocoaPods-managed targets in Xcode 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,8 @@ step-library:
       run:
         name: Update Carthage version
         command: |
-          brew update && brew upgrade carthage
+          curl -OL "https://github.com/Carthage/Carthage/releases/download/0.36.0/Carthage.pkg"
+          sudo installer -pkg Carthage.pkg -target /
 
   - &verify-missing-localizable-strings
       run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,17 @@ workflows:
           test: false
           device: "iPhone 7 Plus"
       - pod-job:
+          name: "Xcode_12.0_iOS_14.0_CP_install"
+          update: false
+          xcode: "12.0.0"
+          iOS: "14.0"
+      - pod-job:
+          name: "Xcode_12.0_iOS_14.0_CP_update"
+          update: true
+          xcode: "12.0.0"
+          iOS: "14.0"
+          lint: true
+      - pod-job:
           name: "Xcode_11.4.1_iOS_12.2_CP_install"
           update: false
           xcode: "11.4.1"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -48,4 +48,13 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
+  # https://github.com/mapbox/mapbox-navigation-ios/issues/2665
+  s.user_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))',
+    'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200' => 'arm64 arm64e armv7 armv7s armv6 armv8'
+  }
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))',
+    'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200' => 'arm64 arm64e armv7 armv7s armv6 armv8'
+  }
 end

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -57,4 +57,13 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
+  # https://github.com/mapbox/mapbox-navigation-ios/issues/2665
+  s.user_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))',
+    'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200' => 'arm64 arm64e armv7 armv7s armv6 armv8'
+  }
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))',
+    'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200' => 'arm64 arm64e armv7 armv7s armv6 armv8'
+  }
 end

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -51,4 +51,9 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
+  # https://github.com/mapbox/mapbox-navigation-ios/issues/2665
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))',
+    'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200' => 'arm64 arm64e armv7 armv7s armv6 armv8'
+  }
 end


### PR DESCRIPTION
Temporarily modified the podspecs to exclude the arm64 simulator from the CocoaPods-generated target and application target, based on the workaround in https://github.com/CocoaPods/CocoaPods/issues/10065#issuecomment-694266259 https://github.com/CocoaPods/CocoaPods/issues/10104#issuecomment-700918704 but conditionalized for Xcode 12, just like the Carthage workaround in #2649. Unlike that workaround, this one isn’t sensitive to patch releases of Xcode, so we don’t need the extra case for Xcode 12.0.1 seen in #2663.

Unfortunately, this workaround automatically modifies the `EXCLUDED_ARCHS[sdk=iphonesimulator*]` and `EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200` build settings of the application target, which could eventually be incompatible with another pod if that other pod employs the same workaround. #2672 tracks removing this workaround.

~~This workaround apparently requires Xcode 11.7 and above to build from source, so I’ve also made that a minimum requirement for both CocoaPods and Carthage users for consistency.~~

Before merging:

* [x] Lint podspecs with Xcode 11
* [x] Lint podspecs with Xcode 12
* [x] Push test podspecs to CocoaPods trunk with Xcode 12
* [x] Build and run internal dogfooding application in Xcode 11
   * [x] Debug
      * [x] Simulators
      * [x] Devices
   * [x] Release
      * [x] Simulators
      * [x] Devices
* [x] Build and run internal dogfooding application in Xcode 12
   * [x] Debug
      * [x] Simulators
      * [x] Devices
   * [x] Release
      * [x] Simulators
      * [x] Devices

Fixes #2665.

/ref #2652
/cc @mapbox/navigation-ios