### PR TITLE
MIgrate nav docs script over ios-sdk repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Get up and running in a few minutes with our drop-in turn-by-turn navigation `Na
 
 ## [Documentation](https://docs.mapbox.com/ios/api/navigation/)
 
+After a release, follow these steps to generate and publish documentation and update the iOS site with the latest version number:
+
+1. Generate and publish the documentation.
+    - Run `./scripts/update-navigation.sh`. 
+    - This script will checkout the release branch, install dependencies, generate the documentation, and commit the generated documentation to a new branch.
+    - Create a pull request and set the base branch to `publisher-production`.
+2. Wait for new documentation to be live. 
+    - Once you merge the branch into `publisher-production`, the new version will be available within 10 minutes. 
+    - You can check the #publisher channel in Slack for a notification of when your commit has been published.
+3. Update the ios-sdk repository constants. 
+    - Complete the [Mapbox Navigation for iOS section](https://github.com/mapbox/ios-sdk#navigation-sdk-for-ios) in the ios-sdk repository README.
+
 ## Requirements
 
 The Mapbox Navigation SDK and Core Navigation are compatible with applications written in Swift 5 in Xcode 11.4.1 and above. The Mapbox Navigation and Mapbox Core Navigation frameworks run on iOS 10.0 and above.

--- a/scripts/update-navigation.sh
+++ b/scripts/update-navigation.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+OUTPUT="/tmp/`uuidgen`"
+RELEASE_BRANCH=${1:-master}
+
+step "Updating mapbox-navigation-ios…"
+git fetch --depth=1 --prune
+git fetch --tags
+git checkout $RELEASE_BRANCH
+VERSION=$( git describe --tags --match=v*.*.* --abbrev=0 | sed 's/^v//' )
+
+# I don't think mapbox-navigation-ios uses this branch naming convention
+# git checkout $VERSION
+
+step "Updating jazzy…"
+gem install jazzy
+
+step "Generating new docs for ${VERSION}…"
+OUTPUT=${OUTPUT} scripts/document.sh
+
+step "Moving new docs folder to ./$VERSION"
+rm -rf "./$VERSION"
+mkdir -p "./navigation/api/$VERSION"
+mv -v $OUTPUT/* "./navigation/api/$VERSION"
+
+step "Switching branch to publisher-production"
+git checkout origin/publisher-production
+step "Committing API docs for $VERSION"
+git add "./$VERSION"
+git commit -m "[navigation] Add Mapbox Directions for Swift API docs for $VERSION [ci skip]" --no-verify
+
+step "Finished updating documentation"

--- a/scripts/update-navigation.sh
+++ b/scripts/update-navigation.sh
@@ -12,7 +12,7 @@ OUTPUT="/tmp/`uuidgen`"
 RELEASE_BRANCH=${1:-master}
 
 step "Updating mapbox-navigation-ios…"
-git fetch --depth=1 --prune
+git fetch
 git fetch --tags
 git checkout $RELEASE_BRANCH
 VERSION=$( git describe --tags --match=v*.*.* --abbrev=0 | sed 's/^v//' )
@@ -28,13 +28,13 @@ OUTPUT=${OUTPUT} scripts/document.sh
 
 step "Moving new docs folder to ./$VERSION"
 rm -rf "./$VERSION"
-mkdir -p "./navigation/api/$VERSION"
+mkdir -p "./$VERSION"
 mv -v $OUTPUT/* "./navigation/api/$VERSION"
 
 step "Switching branch to publisher-production"
 git checkout origin/publisher-production
 step "Committing API docs for $VERSION"
 git add "./$VERSION"
-git commit -m "[navigation] Add Mapbox Directions for Swift API docs for $VERSION [ci skip]" --no-verify
+git commit -m "[navigation] Add Mapbox Navigation SDK for iOS docs for v$VERSION [ci skip]" --no-verify
 
 step "Finished updating documentation"

--- a/scripts/update-navigation.sh
+++ b/scripts/update-navigation.sh
@@ -17,9 +17,6 @@ git fetch --tags
 git checkout $RELEASE_BRANCH
 VERSION=$( git describe --tags --match=v*.*.* --abbrev=0 | sed 's/^v//' )
 
-# I don't think mapbox-navigation-ios uses this branch naming convention
-# git checkout $VERSION
-
 step "Updating jazzy…"
 gem install jazzy
 


### PR DESCRIPTION
Related: https://github.com/mapbox/mapbox-directions-swift/pull/467

This PR will move the [shell script for generating documentation](https://github.com/mapbox/ios-sdk/blob/publisher-production/scripts/update-navigation.sh) from /ios-sdk into this repo. The script will generate the documentation, switch and commit the new version on the publisher-production branch.

To do:
- [ ] Verify version branch naming convention
- [ ] Test script
- [ ] Document!

cc @katydecorah and @1ec5 

Ref mapbox/ios-sdk#980