### PR TITLE
Add workaround which prevents UI lags because of excessive calls to `viewDidLayoutSubviews()` on iOS 14.

### DIFF
--- a/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -96,6 +96,9 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
     
     var styleObservation: NSKeyValueObservation?
     
+    private let contentInsetUpdateDelay = 10.0
+    private var shouldUpdateContentInset = true
+    
     /**
      Creates a new CarPlay navigation view controller for the given route controller and user interface.
      
@@ -213,9 +216,15 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
 
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        if (isOverviewingRoutes) { return } // Don't move content when overlays change.
-        guard let mapView = mapView else { return }
-        mapView.contentInset = contentInset(forOverviewing: false)
+        
+        if shouldUpdateContentInset {
+            shouldUpdateContentInset = false
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + contentInsetUpdateDelay, execute: {
+                self.shouldUpdateContentInset = true
+                self.mapView?.contentInset = self.contentInset(forOverviewing: self.isOverviewingRoutes)
+            })
+        }
     }
 
     func contentInset(forOverviewing overviewing: Bool) -> UIEdgeInsets {


### PR DESCRIPTION
Closing #2671. 

I don't really like current workaround as it only partly fixes original problem (there will still be UI lags every `10` seconds based on `contentInsetUpdateDelay` variable). Here's example (as you can see every 10 seconds there is still visible lag):

![output](https://user-images.githubusercontent.com/1496498/95373689-2db4c080-0892-11eb-8854-e65d56b23f59.gif)

I've also noticed that there are no drawbacks when we do not set `contentInset` on `MGLMapView` at all on iOS 14, so we might want to consider such approach as well.

Best way would be to address issue reported on Maps SDK [side](https://github.com/mapbox/mapbox-gl-native-ios/issues/500).