### PR TITLE
Remove the outdated entry from the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## v1.1.0
 
-### Packaging
-
-* Upgraded to [Mapbox Maps SDK for iOS v6.1.0-beta.2](https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v6.1.0-beta.2). ([#2565](https://github.com/mapbox/mapbox-navigation-ios/pull/2565))
-
 ### Other changes
 
 * `RouteProgress`, `RouteLegProgress`, and `RouteStepProgress` now conform to the `Codable` protocol. ([#2615](https://github.com/mapbox/mapbox-navigation-ios/pull/2615))


### PR DESCRIPTION
As Maps dependency is configured to accept any v6.x since #2565, we need to remove the outdated entry in the changelog.