### PR TITLE
Update to Maps SDK 6.2.2 and remove previous workaround to prevent excessive calls to `layoutSubviews()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 ## v1.0.1
 
 ### User location
-* Fixed [#2671](https://github.com/mapbox/mapbox-navigation-ios/issues/2671) and [#2660](https://github.com/mapbox/mapbox-navigation-ios/issues/2660) issues which were causing excessive calls to `layoutSubviews()` on iOS and CarPlay by updating to Mapbox Maps SDK for iOS v6.2.2. ([#2699](https://github.com/mapbox/mapbox-navigation-ios/pull/2699))
+
+* Fixed issues which was causing unsmooth user puck updates on iOS and inability to zoom-in to current location at the start of navigation on CarPlay by updating to Mapbox Maps SDK for iOS v6.2.2. ([#2699](https://github.com/mapbox/mapbox-navigation-ios/pull/2699))
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 * Fixed an issue where the route line flickered when refreshing. ([#2642](https://github.com/mapbox/mapbox-navigation-ios/pull/2642))
 * Fixed an issue where the End of route view UI is broken prior to iOS 11. ([#2690](https://github.com/mapbox/mapbox-navigation-ios/pull/2690))
 
+## v1.0.1
+
+### User location
+* Fixed [#2671](https://github.com/mapbox/mapbox-navigation-ios/issues/2671) and [#2660](https://github.com/mapbox/mapbox-navigation-ios/issues/2660) issues which were causing excessive calls to `layoutSubviews()` on iOS and CarPlay by updating to Mapbox Maps SDK for iOS v6.2.2. ([#2699](https://github.com/mapbox/mapbox-navigation-ios/pull/2699))
+
 ## v1.0.0
 
 ### Packaging

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.2.1"
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" "7.1.2"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.2.2"
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" "22.0.5"
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.3.0"
 github "CedarBDD/Cedar" "v1.0"

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Mapbox-iOS-SDK (6.2.1):
+  - Mapbox-iOS-SDK (6.2.2):
     - MapboxMobileEvents (~> 0.10.4)
   - MapboxAccounts (2.3.0)
   - MapboxCommon (7.1.2)
@@ -50,7 +50,7 @@ EXTERNAL SOURCES:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: c5a2ec3a3a0a77ee0ba78f91380e83898cb6aa41
+  Mapbox-iOS-SDK: 3f83697efa97f3c21ea7f65c1e75205e1dc030ee
   MapboxAccounts: 84abfdde95d9dc483f604c1b0fe1861edf691ce7
   MapboxCommon: e469f6c62de29e1906c37e0bce65f6826e7fb9ac
   MapboxCoreNavigation: 6de899b067714754670dca5c1fd507a085dcba49

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -271,13 +271,8 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         super.layoutSubviews()
         
         //If the map is in tracking mode, make sure we update the camera after the layout pass.
-        if (tracksUserCourse) {            
-            if #available(iOS 14.0, *) {
-                // Since layoutSubviews() is called too often on iOS 14.0, it leads to lags in `UserCourseView` animated updates.
-                // Workaround is to allow `UserCourseView` updates only on iOS versions lower than 14.0.
-            } else {
-                updateCourseTracking(location: userLocationForCourseTracking, camera:self.camera, animated: false)
-            }
+        if (tracksUserCourse) {
+            updateCourseTracking(location: userLocationForCourseTracking, camera:self.camera, animated: false)
         }
     }
     


### PR DESCRIPTION
Closing #2660.

This PR removes previous workaround, which was added in #2659 (since root cause of this issue is in Maps SDK, which was addressed in https://github.com/mapbox/mapbox-gl-native-ios/issues/500 and available in Maps SDK `6.2.2`).