### PR TITLE
Fix wrong format specifier of speed multiplier in simulation (Hebrew)

### DIFF
--- a/MapboxNavigation/Resources/he.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/he.lproj/Localizable.strings
@@ -47,7 +47,7 @@
 "RESUME" = "חזור";
 
 /* The text of a banner that appears during turn-by-turn navigation when route simulation is enabled. */
-"USER_IN_SIMULATION_MODE" = "הדמה ניווט ב %dx";
+"USER_IN_SIMULATION_MODE" = "הדמה ניווט ב %@x";
 
 /* Format for displaying destination and intermediate waypoints; 1 = source ; 2 = destinations */
 "WAYPOINT_DESTINATION_VIA_WAYPOINTS_FORMAT" = "%1$@ דרך, %2$@";


### PR DESCRIPTION
**Mapbox Navigation SDK version:** `v1.0.0-rc.5`

When in simulation mode, a small status banner indicating the simulation speed multiplier is displayed.

In Hebrew, an integer format specifier was used for the multiplier but a string is being passed to the formatter.
So instead of showing "Simulating navigation at 1x" (in Hebrew)
it would show "Simulating navigation at -1,103,473,346x"

The code for passing the string to the localized string is `showSimulationStatus(speed: Int)` in `StatusView.swift`

/cc @mapbox/navigation-ios