### PR TITLE
Custom Route shape tailwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fixed an issue where completed waypoints remained on map after rerouting. ([#2378](https://github.com/mapbox/mapbox-navigation-ios/pull/2378))
 * Fixed an issue where positioning icon was not highlighted on CarPlay when using iOS 14.0. ([#2681](https://github.com/mapbox/mapbox-navigation-ios/issues/2681))
 * Fixed an issue where ETA label font was too small during turn-by-turn navigation. ([#2679](https://github.com/mapbox/mapbox-navigation-ios/pull/2679))
+* Fixed an issue with `NavigationMapViewDelegate.navigationMapView(_:shapeFor:)` and `NavigationMapViewDelegate.navigationMapView(_:simplifiedShapeFor:)` methods were not correctly called for route shape customization ([#2623](https://github.com/mapbox/mapbox-navigation-ios/pull/2623))
 
 ## v1.0.0
 

--- a/MapboxNavigation/NavigationMapView.swift
+++ b/MapboxNavigation/NavigationMapView.swift
@@ -1213,6 +1213,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             } else {
                 polyline.attributes[MBCurrentLegAttribute] = index == 0
             }
+            polyline.attributes["isAlternateRoute"] = false
             linesPerLeg.append(polyline)
         }
         


### PR DESCRIPTION
Tail fixes after [PR #2623 ](https://github.com/mapbox/mapbox-navigation-ios/pull/2623).
Fixed main route shape attribute setting, CHANGELOG updated.