### PR TITLE
Right to Left Language instruction card swipe bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 * Fixed an issue which was preventing the ability to scroll between instructions cards on iOS 14 using workaround. ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
 * Fixed an instructions cards layout issue that arose when changing orientation (portrait to landscape). ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
 * Fixed swiping for right-to-left languages for the traditional top banner to be more intuitive. ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
+* Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
+* Fixed an issue which was returning incorrect card width after multiple rotations on iPads. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 * Fixed an instructions cards layout issue that arose when changing orientation (portrait to landscape). ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
 * Fixed swiping for right-to-left languages for the traditional top banner to be more intuitive. ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
-* Fixed an issue which was returning incorrect card width after multiple rotations on iPads. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
+* Fixed an issue which was returning incorrect card width after multiple rotations on iPads by adding `InstructionsCardViewController.viewWillTransition(to:with:)`. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809))
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
+* Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 
 ## v1.2.1
 
@@ -41,7 +42,6 @@
 * Fixed an issue which was preventing the ability to scroll between instructions cards on iOS 14 using workaround. ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
 * Fixed an instructions cards layout issue that arose when changing orientation (portrait to landscape). ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
 * Fixed swiping for right-to-left languages for the traditional top banner to be more intuitive. ([#2755](https://github.com/mapbox/mapbox-navigation-ios/pull/2755))
-* Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 * Fixed an issue which was returning incorrect card width after multiple rotations on iPads by adding `InstructionsCardViewController.viewWillTransition(to:with:)`. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 
 ### Location tracking

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -213,22 +213,20 @@ open class InstructionsCardViewController: UIViewController {
         
         print("!!! item count: \(itemCount)")
         let estimatedIndex: Int
-        let blah = currentStepIndex ?? 0
-        let sub = cardSize.width * CGFloat(itemCount - blah)
-        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
-            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.left) / (cardSize.width + 10.0)))
+        let size = CGFloat(itemCount) * cardSize.width
+        
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            estimatedIndex = Int(round((size - collectionView.contentOffset.x + collectionView.contentInset.right) / (cardSize.width + 10.0)))
         } else {
-            let blah = currentStepIndex ?? 0
-            let sub = cardSize.width * CGFloat(itemCount - blah)
-            estimatedIndex = abs(Int(round((collectionView.contentOffset.x - sub + collectionView.contentInset.right) / (cardSize.width + 10.0))))
+            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.left) / (cardSize.width + 10.0)))
         }
         let indexInBounds = max(0, min(itemCount - 1, estimatedIndex))
-        
-        print("!!! snappedIndexPath current step Index: \(String(describing: currentStepIndex))")
-        print("!!! snappedIndexPath estimated Index: \(estimatedIndex)")
-        print("!!! snappedIndexPath contentOffset.x: \(collectionView.contentOffset.x)")
-        print("!!! snappedIndexPath sub: \(sub)")
-        print("!!! snappedIndexPath contentOffset.x-sub: \(collectionView.contentOffset.x-sub)")
+        print("!!! current step Index: \(String(describing: currentStepIndex))")
+        print("!!! contentOffset.x: \(collectionView.contentOffset.x)")
+        print("!!! size: \(size)")
+        print("!!! size - contentOffset.x: \(size-collectionView.contentOffset.x)")
+        print("!!! estimated Index: \(estimatedIndex)")
+        print("!!! indexInBounds: \(indexInBounds)")
         return IndexPath(row: indexInBounds, section: 0)
     }
     
@@ -247,9 +245,10 @@ open class InstructionsCardViewController: UIViewController {
         if didSwipe {
             if hasVelocityToSlideToNext {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
+                print("!!! BOOO")
             } else if hasVelocityToSlidePrev, UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
-                print("!!! BLAHHHH")
+                print("!!! FOOO")
             } else {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row - 1, section: 0)
             }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -253,15 +253,21 @@ open class InstructionsCardViewController: UIViewController {
                 print("!!! BOOO")
             } else if hasVelocityToSlidePrev, UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
-                print("!!! FOOO")
+                print("!!! COOO")
             } else {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row - 1, section: 0)
             }
         } else {
-            if scrollView.contentOffset.x - contentOffsetBeforeSwipe.x < -cardSize.width / 2 {
+            if scrollView.contentOffset.x - contentOffsetBeforeSwipe.x < -cardSize.width / 2, UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row - 1, section: 0)
-            } else if scrollView.contentOffset.x - contentOffsetBeforeSwipe.x > cardSize.width / 2 {
+            } else if scrollView.contentOffset.x - contentOffsetBeforeSwipe.x > cardSize.width / 2, UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
+            } else if contentOffsetBeforeSwipe.x - scrollView.contentOffset.x < -cardSize.width / 2, UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+                scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
+                print("DOOO")
+            } else if contentOffsetBeforeSwipe.x - scrollView.contentOffset.x > cardSize.width / 2, UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+                scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row - 1, section: 0)
+                print("FOOO")
             } else {
                 scrollTargetIndexPath = indexBeforeSwipe
             }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -213,12 +213,14 @@ open class InstructionsCardViewController: UIViewController {
         
         print("!!! item count: \(itemCount)")
         let estimatedIndex: Int
+        let blah = currentStepIndex ?? 0
+        let sub = cardSize.width * CGFloat(itemCount - blah)
         if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
             estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.left) / (cardSize.width + 10.0)))
         } else {
-            // let sub = cardSize.width * CGFloat(itemCount - currentStepIndex!)
-            collectionView.semanticContentAttribute = .forceRightToLeft
-            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.right) / (cardSize.width + 10.0)))
+            let blah = currentStepIndex ?? 0
+            let sub = cardSize.width * CGFloat(itemCount - blah)
+            estimatedIndex = abs(Int(round((collectionView.contentOffset.x - sub + collectionView.contentInset.right) / (cardSize.width + 10.0))))
         }
         let indexInBounds = max(0, min(itemCount - 1, estimatedIndex))
         return IndexPath(row: indexInBounds, section: 0)
@@ -240,6 +242,9 @@ open class InstructionsCardViewController: UIViewController {
         if didSwipe {
             if hasVelocityToSlideToNext {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
+            } else if hasVelocityToSlidePrev, UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+                scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
+                print("!!! BLAHHHH")
             } else {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row - 1, section: 0)
             }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -122,12 +122,9 @@ open class InstructionsCardViewController: UIViewController {
     
     @objc func orientationDidChange(_ notification: Notification) {
         instructionsCardLayout.invalidateLayout()
-        handlePagingforScrollToItem(indexPath: indexBeforeSwipe)
-//        guard let visibleCell = instructionsCardLayout.collectionView?.visibleCells.first else { return }
-//        guard let indexPath = instructionsCardLayout.collectionView?.indexPath(for: visibleCell) else { return }
-//        instructionsCardLayout.collectionView?.isPagingEnabled = false
-//        instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: .left, animated: true)
-//        instructionsCardLayout.collectionView?.isPagingEnabled = false
+        instructionsCardLayout.collectionView?.isPagingEnabled = false
+        instructionsCardLayout.collectionView?.scrollToItem(at: indexBeforeSwipe, at: .left, animated: true)
+        instructionsCardLayout.collectionView?.isPagingEnabled = true
     }
     
     func addSubviews() {

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -123,6 +123,11 @@ open class InstructionsCardViewController: UIViewController {
     @objc func orientationDidChange(_ notification: Notification) {
         instructionsCardLayout.invalidateLayout()
         handlePagingforScrollToItem(indexPath: indexBeforeSwipe)
+//        guard let visibleCell = instructionsCardLayout.collectionView?.visibleCells.first else { return }
+//        guard let indexPath = instructionsCardLayout.collectionView?.indexPath(for: visibleCell) else { return }
+//        instructionsCardLayout.collectionView?.isPagingEnabled = false
+//        instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: .left, animated: true)
+//        instructionsCardLayout.collectionView?.isPagingEnabled = false
     }
     
     func addSubviews() {
@@ -179,17 +184,9 @@ open class InstructionsCardViewController: UIViewController {
     
     func snapToIndexPath(_ indexPath: IndexPath) {
         guard let itemCount = steps?.count, itemCount >= 0 && indexPath.row < itemCount else { return }
-        handlePagingforScrollToItem(indexPath: indexPath)
-    }
-    
-    public func handlePagingforScrollToItem(indexPath: IndexPath) {
-        if #available(iOS 14.0, *) {
-            instructionsCardLayout.collectionView?.isPagingEnabled = false
-            instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: direction, animated: true)
-            instructionsCardLayout.collectionView?.isPagingEnabled = true
-            return
-        }
-        instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: direction, animated: true)
+        instructionsCardLayout.collectionView?.isPagingEnabled = false
+        instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: .left, animated: true)
+        instructionsCardLayout.collectionView?.isPagingEnabled = true
     }
     
     public func stopPreview() {
@@ -296,7 +293,7 @@ extension InstructionsCardViewController: UICollectionViewDataSource {
 
 extension InstructionsCardViewController: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
+        print("!!! cardSize from InstructionsCardViewController: \(cardSize)")
         return cardSize
     }
 }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -128,10 +128,11 @@ open class InstructionsCardViewController: UIViewController {
     @objc func orientationDidChange(_ notification: Notification) {
         instructionsCardLayout.invalidateLayout()
 
-        guard let visibleCell = instructionsCardLayout.collectionView?.visibleCells.first else { return }
-        guard let indexPath = instructionsCardLayout.collectionView?.indexPath(for: visibleCell) else { return }
-        guard let cell = instructionCollectionView.cellForItem(at: indexPath) else { return }
-        cellTransform(for: cell)
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            instructionsCardLayout.collectionView?.visibleCells.forEach { cell in guard let cell = cell as? UICollectionViewCell else { return }
+                cellTransform(for: cell)
+            }
+        }
     }
     
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -206,12 +207,6 @@ open class InstructionsCardViewController: UIViewController {
               cell.subviews.count > 1 else {
             return nil
         }
-        
-//        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-//            DispatchQueue.main.asyncAfter(deadline: .now()) {
-//                cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
-//            }
-//        }
         
         return cell.subviews[1] as? InstructionsCardContainerView
     }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -211,9 +211,16 @@ open class InstructionsCardViewController: UIViewController {
             return IndexPath(row: 0, section: 0)
         }
         
-        let estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.left) / (cardSize.width + 10.0)))
+        print("!!! item count: \(itemCount)")
+        let estimatedIndex: Int
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.left) / (cardSize.width + 10.0)))
+        } else {
+            // let sub = cardSize.width * CGFloat(itemCount - currentStepIndex!)
+            collectionView.semanticContentAttribute = .forceRightToLeft
+            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.right) / (cardSize.width + 10.0)))
+        }
         let indexInBounds = max(0, min(itemCount - 1, estimatedIndex))
-        
         return IndexPath(row: indexInBounds, section: 0)
     }
     

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -185,13 +185,15 @@ open class InstructionsCardViewController: UIViewController {
     func snapToIndexPath(_ indexPath: IndexPath) {
         guard let itemCount = steps?.count, itemCount >= 0 && indexPath.row < itemCount else { return }
         instructionsCardLayout.collectionView?.isPagingEnabled = false
-        instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: .left, animated: true)
+        let direction: UICollectionView.ScrollPosition = UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .left : .right
+        instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: direction, animated: true)
         instructionsCardLayout.collectionView?.isPagingEnabled = true
     }
     
     public func stopPreview() {
         guard isInPreview else { return }
-        instructionCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .left, animated: false)
+        let direction: UICollectionView.ScrollPosition = UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .left : .right
+        instructionCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: direction, animated: false)
         isInPreview = false
     }
     
@@ -221,6 +223,7 @@ open class InstructionsCardViewController: UIViewController {
         let itemCount = steps?.count ?? 0
         let velocityThreshold: CGFloat = 0.4
         
+        // TODO: FIX HARD-CODED LEFT AND RIGHT
         let hasVelocityToSlideToNext = indexBeforeSwipe.row + 1 < itemCount && velocity.x > velocityThreshold
         let hasVelocityToSlidePrev = indexBeforeSwipe.row - 1 >= 0 && velocity.x < -velocityThreshold
         let didSwipe = hasVelocityToSlideToNext || hasVelocityToSlidePrev

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -130,7 +130,7 @@ open class InstructionsCardViewController: UIViewController {
 
         if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
             instructionsCardLayout.collectionView?.visibleCells.forEach { cell in guard let cell = cell as? UICollectionViewCell else { return }
-                cellTransform(for: cell)
+                cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
             }
         }
     }
@@ -295,12 +295,6 @@ extension InstructionsCardViewController: UICollectionViewDataSource {
         }
         
         return cell
-    }
-    
-    func cellTransform(for cell: UICollectionViewCell) {
-        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-            cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
-        }
     }
 }
 

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -184,10 +184,15 @@ open class InstructionsCardViewController: UIViewController {
     
     func snapToIndexPath(_ indexPath: IndexPath) {
         guard let itemCount = steps?.count, itemCount >= 0 && indexPath.row < itemCount else { return }
-        instructionsCardLayout.collectionView?.isPagingEnabled = false
+        
         let direction: UICollectionView.ScrollPosition = UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .left : .right
+        if #available(iOS 14.0, *) {
+            instructionsCardLayout.collectionView?.isPagingEnabled = false
+            instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: direction, animated: true)
+            instructionsCardLayout.collectionView?.isPagingEnabled = true
+            return
+        }
         instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: direction, animated: true)
-        instructionsCardLayout.collectionView?.isPagingEnabled = true
     }
     
     public func stopPreview() {

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -127,11 +127,16 @@ open class InstructionsCardViewController: UIViewController {
     
     @objc func orientationDidChange(_ notification: Notification) {
         instructionsCardLayout.invalidateLayout()
-        
-//        guard let cell = instructionCollectionView.cellForItem(at: indexPath)
-//        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-//            cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
-//        }
+
+        guard let visibleCell = instructionsCardLayout.collectionView?.visibleCells.first else { return }
+        guard let indexPath = instructionsCardLayout.collectionView?.indexPath(for: visibleCell) else { return }
+        guard let cell = instructionCollectionView.cellForItem(at: indexPath) else { return }
+        cellTransform(for: cell)
+    }
+    
+    open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        instructionsCardLayout.invalidateLayout()
     }
     
     func addSubviews() {
@@ -202,10 +207,11 @@ open class InstructionsCardViewController: UIViewController {
             return nil
         }
         
-        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-            DispatchQueue.main.asyncAfter(deadline: .now())
-            cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
-        }
+//        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+//            DispatchQueue.main.asyncAfter(deadline: .now()) {
+//                cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
+//            }
+//        }
         
         return cell.subviews[1] as? InstructionsCardContainerView
     }
@@ -294,6 +300,12 @@ extension InstructionsCardViewController: UICollectionViewDataSource {
         }
         
         return cell
+    }
+    
+    func cellTransform(for cell: UICollectionViewCell) {
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
+        }
     }
 }
 

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -223,7 +223,6 @@ open class InstructionsCardViewController: UIViewController {
         if didSwipe {
             if hasVelocityToSlideToNext {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row + 1, section: 0)
-                print("!!! BOOO")
             } else {
                 scrollTargetIndexPath = IndexPath(row: indexBeforeSwipe.row - 1, section: 0)
             }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -221,6 +221,12 @@ open class InstructionsCardViewController: UIViewController {
             let blah = currentStepIndex ?? 0
             let sub = cardSize.width * CGFloat(itemCount - blah)
             estimatedIndex = abs(Int(round((collectionView.contentOffset.x - sub + collectionView.contentInset.right) / (cardSize.width + 10.0))))
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.left) / (cardSize.width + 10.0)))
+        } else {
+            // let sub = cardSize.width * CGFloat(itemCount - currentStepIndex!)
+            collectionView.semanticContentAttribute = .forceRightToLeft
+            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.right) / (cardSize.width + 10.0)))
         }
         let indexInBounds = max(0, min(itemCount - 1, estimatedIndex))
         return IndexPath(row: indexInBounds, section: 0)
@@ -228,7 +234,6 @@ open class InstructionsCardViewController: UIViewController {
     
     fileprivate func scrollTargetIndexPath(for scrollView: UIScrollView, with velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) -> IndexPath {
         targetContentOffset.pointee = scrollView.contentOffset
-        
         let itemCount = steps?.count ?? 0
         let velocityThreshold: CGFloat = 0.4
         

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -303,7 +303,8 @@ extension UICollectionViewFlowLayout {
 
 extension InstructionsCardViewController: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return cardSize
+        
+        return CGSize(width: cardSize.width, height: cardSize.height - 10)
     }
 }
 

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -221,14 +221,14 @@ open class InstructionsCardViewController: UIViewController {
             let blah = currentStepIndex ?? 0
             let sub = cardSize.width * CGFloat(itemCount - blah)
             estimatedIndex = abs(Int(round((collectionView.contentOffset.x - sub + collectionView.contentInset.right) / (cardSize.width + 10.0))))
-        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
-            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.left) / (cardSize.width + 10.0)))
-        } else {
-            // let sub = cardSize.width * CGFloat(itemCount - currentStepIndex!)
-            collectionView.semanticContentAttribute = .forceRightToLeft
-            estimatedIndex = Int(round((collectionView.contentOffset.x + collectionView.contentInset.right) / (cardSize.width + 10.0)))
         }
         let indexInBounds = max(0, min(itemCount - 1, estimatedIndex))
+        
+        print("!!! snappedIndexPath current step Index: \(String(describing: currentStepIndex))")
+        print("!!! snappedIndexPath estimated Index: \(estimatedIndex)")
+        print("!!! snappedIndexPath contentOffset.x: \(collectionView.contentOffset.x)")
+        print("!!! snappedIndexPath sub: \(sub)")
+        print("!!! snappedIndexPath contentOffset.x-sub: \(collectionView.contentOffset.x-sub)")
         return IndexPath(row: indexInBounds, section: 0)
     }
     

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -127,6 +127,11 @@ open class InstructionsCardViewController: UIViewController {
     
     @objc func orientationDidChange(_ notification: Notification) {
         instructionsCardLayout.invalidateLayout()
+        
+//        guard let cell = instructionCollectionView.cellForItem(at: indexPath)
+//        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+//            cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
+//        }
     }
     
     func addSubviews() {
@@ -195,6 +200,11 @@ open class InstructionsCardViewController: UIViewController {
         guard let cell = instructionCollectionView.cellForItem(at: indexPath),
               cell.subviews.count > 1 else {
             return nil
+        }
+        
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            DispatchQueue.main.asyncAfter(deadline: .now())
+            cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
         }
         
         return cell.subviews[1] as? InstructionsCardContainerView


### PR DESCRIPTION
### Description
This PR is to fix top banner swiping not being mirrored for right-to-left languages for instructions cards #2626.
I attempted to fix this issue, but the code was starting to look messy/hard to read with a bunch of cases to check whether the language was right to left. A higher-level abstraction should be able to fix this issue.
- [x] Find and implement abstraction/workaround
- [x] Fix issue which was return incorrect card width after multiple rotations on iPad.
- [x] Update Changelog

### Implementation
Added `UICollectionViewFlowLayout` extension to override `flipsHorizontallyInOppositeLayoutDirection`.

To fix the iPad issue, I added `InstructionsCardViewController.viewWillTransition(to:with:)`.

### Screenshots or Gifs
![ezgif-1-a0f73e8d4da4](https://user-images.githubusercontent.com/43434254/102799996-40af3b00-4381-11eb-8a24-14dda66e2673.gif)
