### PR TITLE
Add speed limit feedback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v1.2.0
+
+### Feedback
+
+* Added the ability to provide more detailed `Speed limit incorrect` feedback during turn-by-turn navigation. ([#2725](https://github.com/mapbox/mapbox-navigation-ios/pull/2725))
+
 ## v1.1.0
 
 ### Packaging

--- a/MapboxCoreNavigation/Feedback.swift
+++ b/MapboxCoreNavigation/Feedback.swift
@@ -114,6 +114,7 @@ public enum IncorrectVisualSubtype: String {
     case exitInfoIncorrect
     case laneGuidanceIncorrect
     case roadKnownByDifferentName
+    case incorrectSpeedLimit
     case other
 }
 

--- a/MapboxNavigation/FeedbackItem.swift
+++ b/MapboxNavigation/FeedbackItem.swift
@@ -33,6 +33,8 @@ public extension FeedbackType {
             return NSLocalizedString("INCORRECT_VISUAL_LANE_GUIDANCE_INCORRECT_FEEDBACK", bundle: .mapboxNavigation, value: "Lane guidance incorrect", comment: "Specific route feedback that the wrong lane was specified.")
         case .incorrectVisual(.roadKnownByDifferentName):
             return NSLocalizedString("INCORRECT_VISUAL_ROAD_NAME_DIFFERENT_FEEDBACK", bundle: .mapboxNavigation, value: "Road known by different name", comment: "Specific route feedback that a road is known by another name.")
+        case .incorrectVisual(.incorrectSpeedLimit):
+            return NSLocalizedString("INCORRECT_SPEED_LIMIT", bundle: .mapboxNavigation, value: "Speed limit incorrect", comment: "Specific route feedback that a speed limit is incorrect.")
         case .incorrectVisual(.other):
             return NSLocalizedString("INCORRECT_VISUAL_OTHER_FEEDBACK", bundle: .mapboxNavigation, value: "Other", comment: "Specific route feedback that a visual instruction problem was encountered but not listed as a choice.")
         case .confusingAudio(.none):

--- a/MapboxNavigation/FeedbackSubtypeViewController.swift
+++ b/MapboxNavigation/FeedbackSubtypeViewController.swift
@@ -53,6 +53,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
                         FeedbackType.incorrectVisual(subtype: .exitInfoIncorrect),
                         FeedbackType.incorrectVisual(subtype: .laneGuidanceIncorrect),
                         FeedbackType.incorrectVisual(subtype: .roadKnownByDifferentName),
+                        FeedbackType.incorrectVisual(subtype: .incorrectSpeedLimit),
                         FeedbackType.incorrectVisual(subtype: .other)].map { $0.generateFeedbackItem() }
             case .confusingAudio(_):
                 return [FeedbackType.confusingAudio(subtype: .guidanceTooEarly),

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 /* Specific route feedback that a maneuver specified was incorrect. */
 "INCORRECT_VISUAL_MANEUVER_INCORRECT_FEEDBACK" = "Maneuver incorrect";
 
+/* Specific route feedback that a speed limit is incorrect. */
+"INCORRECT_SPEED_LIMIT" = "Speed limit incorrect";
+
 /* Specific route feedback that a visual instruction problem was encountered but not listed as a choice. */
 "INCORRECT_VISUAL_OTHER_FEEDBACK" = "Other";
 

--- a/MapboxNavigation/Resources/Base.lproj/Localizable.strings
+++ b/MapboxNavigation/Resources/Base.lproj/Localizable.strings
@@ -94,6 +94,9 @@
 /* Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased */
 "INAUDIBLE_INSTRUCTIONS_CTA" = "Adjust Volume to Hear Instructions";
 
+/* Specific route feedback that a speed limit is incorrect. */
+"INCORRECT_SPEED_LIMIT" = "Speed limit incorrect";
+
 /* Specific route feedback that an exit was incorrect. */
 "INCORRECT_VISUAL_EXIT_INFO_INCORRECT_FEEDBACK" = "Exit info incorrect";
 
@@ -111,9 +114,6 @@
 
 /* Specific route feedback that a maneuver specified was incorrect. */
 "INCORRECT_VISUAL_MANEUVER_INCORRECT_FEEDBACK" = "Maneuver incorrect";
-
-/* Specific route feedback that a speed limit is incorrect. */
-"INCORRECT_SPEED_LIMIT" = "Speed limit incorrect";
 
 /* Specific route feedback that a visual instruction problem was encountered but not listed as a choice. */
 "INCORRECT_VISUAL_OTHER_FEEDBACK" = "Other";


### PR DESCRIPTION
Added `Speed limit incorrect` feedback subcategory for `Incorrect visual` category. Translations for newly added category and other strings will be added in another PR.