### PR TITLE
Add workaround which allows to perform maneuver view redrawing in time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Other changes
 
 * Fixed an issue which was causing clear map button disappearance in the example app when selecting the route. ([#2718](https://github.com/mapbox/mapbox-navigation-ios/pull/2718))
+* Fixed an issue where maneuver icon was not shown after selecting specific step. ([#2722](https://github.com/mapbox/mapbox-navigation-ios/issues/2722))
 
 ## v1.1.0
 

--- a/MapboxNavigation/NavigationViewController.swift
+++ b/MapboxNavigation/NavigationViewController.swift
@@ -845,7 +845,11 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
         guard let upcomingStep = legProgress.upcomingStep else { return }
         
         let previewBanner: CompletionHandler = {
-            banner.preview(step: legProgress.currentStep, maneuverStep: upcomingStep, distance: legProgress.currentStep.distance, steps: remaining)
+            // Since Mapbox SDK v6.2.0-beta.1 `MGLMapView.setCenter(_:zoomLevel:direction:animated:completionHandler:)` method is calling `completionHandler`
+            // synchronously, this prevents from well-timed maneuver redrawing in `ManeuverView`. Workaround is to perform asynchronous redrawing on main queue.
+            DispatchQueue.main.async {
+                banner.preview(step: legProgress.currentStep, maneuverStep: upcomingStep, distance: legProgress.currentStep.distance, steps: remaining)
+            }
         }
         
         mapViewController?.center(on: upcomingStep, route: route, legIndex: legIndex, stepIndex: nextStepIndex, animated: animated, completion: previewBanner)


### PR DESCRIPTION
Closing #2722.

Current issue is considered as a regression after update to Maps SDK `v6.2.0-beta.1`.
Here's stack trace for `v6.2.0-beta.1` when calling UI updates on Navigation SDK for iOS side:

```
0   MapboxNavigation                    0x00000001026bb2cb $s16MapboxNavigation0B14ViewControllerC7preview4step2in9remaining5route8animatedy0A10Directions9RouteStepC_AA09TopBannercD0CSayALGAJ0L0CSbtFyycfU_ + 235
1   MapboxNavigation                    0x0000000102661e80 $sIeg_IeyB_TR + 48
2   Mapbox                              0x0000000104525e96 -[MGLMapView processPendingBlocks] + 261
3   Mapbox                              0x0000000104524b18 -[MGLMapView renderSync] + 743
4   Mapbox                              0x00000001044d969b -[MGLMapViewImplDelegate glkView:drawInRect:] + 43
5   GLKit                               0x00007fff25b6bf47 -[GLKView _display:] + 275
6   QuartzCore                          0x00007fff2b4c4e19 -[CALayer display] + 184
7   QuartzCore                          0x00007fff2b4d7d72 _ZN2CA5Layer28layout_and_display_if_neededEPNS_11TransactionE + 520
8   QuartzCore                          0x00007fff2b420c04 _ZN2CA7Context18commit_transactionEPNS_11TransactionEd + 324
9   QuartzCore                          0x00007fff2b4545ef _ZN2CA11Transaction6commitEv + 649
10  QuartzCore                          0x00007fff2b381645 _ZN2CA7Display11DisplayLink14dispatch_itemsEyyy + 921
11  QuartzCore                          0x00007fff2b4588f0 _ZL22display_timer_callbackP12__CFMachPortPvlS1_ + 299
12  CoreFoundation                      0x00007fff23d6187d __CFMachPortPerform + 157
13  CoreFoundation                      0x00007fff23da14e9 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 41
14  CoreFoundation                      0x00007fff23da0ae8 __CFRunLoopDoSource1 + 472
15  CoreFoundation                      0x00007fff23d9b514 __CFRunLoopRun + 2228
16  CoreFoundation                      0x00007fff23d9a944 CFRunLoopRunSpecific + 404
17  GraphicsServices                    0x00007fff38ba6c1a GSEventRunModal + 139
18  UIKitCore                           0x00007fff48c8b9ec UIApplicationMain + 1605
19  Example                             0x0000000102367c4b main + 75
20  libdyld.dylib                       0x00007fff51a231fd start + 1
21  ???                                 0x0000000000000001 0x0 + 1
```

For Maps SDK `v6.2.0-alpha.1` stack trace looks like this:
```
0   MapboxNavigation                    0x000000010a45f2cb $s16MapboxNavigation0B14ViewControllerC7preview4step2in9remaining5route8animatedy0A10Directions9RouteStepC_AA09TopBannercD0CSayALGAJ0L0CSbtFyycfU_ + 235
1   MapboxNavigation                    0x000000010a405e80 $sIeg_IeyB_TR + 48
2   Mapbox                              0x000000010c2bea9a -[MGLMapView processPendingBlocks] + 261
3   Mapbox                              0x000000010c2bedd9 -[MGLMapView updateFromDisplayLink:] + 413
4   QuartzCore                          0x00007fff2b3814c6 _ZN2CA7Display11DisplayLink14dispatch_itemsEyyy + 538
5   QuartzCore                          0x00007fff2b4588f0 _ZL22display_timer_callbackP12__CFMachPortPvlS1_ + 299
6   CoreFoundation                      0x00007fff23d6187d __CFMachPortPerform + 157
7   CoreFoundation                      0x00007fff23da14e9 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 41
8   CoreFoundation                      0x00007fff23da0ae8 __CFRunLoopDoSource1 + 472
9   CoreFoundation                      0x00007fff23d9b514 __CFRunLoopRun + 2228
10  CoreFoundation                      0x00007fff23d9a944 CFRunLoopRunSpecific + 404
11  GraphicsServices                    0x00007fff38ba6c1a GSEventRunModal + 139
12  UIKitCore                           0x00007fff48c8b9ec UIApplicationMain + 1605
13  Example                             0x000000010a10bc4b main + 75
14  libdyld.dylib                       0x00007fff51a231fd start + 1
15  ???                                 0x0000000000000001 0x0 + 1
```

As you can see in `v6.2.0-beta.1` `-[MGLMapViewImplDelegate glkView:drawInRect:]` and `-[MGLMapView renderSync]` are now present in stack trace, which seems to be causing issues when performing timely synchronous updates in `ManeuverView.draw(_:)` method. Dispatching redrawing in async manner resolves original issue.