### PR TITLE
Allow the use of multiple status banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * MapboxCoreNavigation can now be installed using Swift Package Manager. ([#2771](https://github.com/mapbox/mapbox-navigation-ios/pull/2771))
 * The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
 * Old versions of routing tiles are automatically deleted from the cache to save storage space. ([#2807](https://github.com/mapbox/mapbox-navigation-ios/pull/2807))
-* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809) 
+* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809))
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 * Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
-* Fixed an issue where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
+* Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 
 ## v1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## v1.3.0
 
 * MapboxCoreNavigation can now be installed using Swift Package Manager. ([#2771](https://github.com/mapbox/mapbox-navigation-ios/pull/2771))
-* The CarPlay guidance panel now shows lane guidance. ([#2798](https://github.com/mapbox/mapbox-navigation-ios/pull/2798))
+* The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
 * Old versions of routing tiles are automatically deleted from the cache to save storage space. ([#2807](https://github.com/mapbox/mapbox-navigation-ios/pull/2807))
-* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809))
+* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809) 
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 * Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
-* Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
+* `NavigationViewController` can now manage multiple status banners one after another. Renamed the `NavigationViewController.showStatus(title:spinner:duration:animated:interactive:)` method to `NavigationViewController.show(_:)` and added a corresponding `NavigationViewController.hide(_:)` method. Renamed the `NavigationStatusPresenter.showStatus(title:spinner:duration:animated:interactive:)` method to `NavigationStatusPresenter.show(_:)` and added a `NavigationStatusPresenter.hide(_:)` method. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
 
 ## v1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
-* Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
-* Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 * `NavigationViewController` can now manage multiple status banners one after another. Renamed the `NavigationViewController.showStatus(title:spinner:duration:animated:interactive:)` method to `NavigationViewController.show(_:)` and added a corresponding `NavigationViewController.hide(_:)` method. Renamed the `NavigationStatusPresenter.showStatus(title:spinner:duration:animated:interactive:)` method to `NavigationStatusPresenter.show(_:)` and added a `NavigationStatusPresenter.hide(_:)` method. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
 
 ## v1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
+* Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
 
 ## v1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 * Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
+* Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
 
 ## v1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 * Fixed swiping for right-to-left languages for the Guidance Card UI to be more intuitive. ([#2724](https://github.com/mapbox/mapbox-navigation-ios/pull/2724))
 * Refactored `StatusView.swift` to allow the to use of multilpe status banners. Statuses can be added with `addNewStatus(status:)` and hidden with `hideStatus(using:)`. ([#2747](https://github.com/mapbox/mapbox-navigation-ios/pull/2747))
+* Fixed an issue where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 
 ## v1.2.1
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -302,7 +302,7 @@
 		B430D2FA25534FDC0088CC23 /* UserHaloCourseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */; };
 		B48CEFC125796FD300696BB3 /* route-for-vanishing-route-line.json in Resources */ = {isa = PBXBuildFile; fileRef = B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */; };
 		B4F7631C2578751300177B33 /* VanishingRouteLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F7631B2578751300177B33 /* VanishingRouteLine.swift */; };
-		C3A17C60258283730078C98B /* StatusViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A17C5F258283730078C98B /* StatusViewTests.swift */; };
+		C3D225512587F411007DBCDF /* StatusViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D225502587F411007DBCDF /* StatusViewTests.swift */; };
 		C51511D120EAC89D00372A91 /* CPMapTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51511D020EAC89D00372A91 /* CPMapTemplate.swift */; };
 		C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51DF8651F38C31C006C6A15 /* Locale.swift */; };
 		C51FC31720F689F800400CE7 /* CustomStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51FC31620F689F800400CE7 /* CustomStyles.swift */; };
@@ -886,12 +886,16 @@
 		AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+GuidanceCards.swift"; path = "Example/ViewController+GuidanceCards.swift"; sourceTree = "<group>"; };
 		AEF2C8F12072B603007B061F /* routeWithTunnels_9thStreetDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithTunnels_9thStreetDC.json; sourceTree = "<group>"; };
 <<<<<<< HEAD
+<<<<<<< HEAD
 		B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
 		B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-for-vanishing-route-line.json"; sourceTree = "<group>"; };
 		B4F7631B2578751300177B33 /* VanishingRouteLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VanishingRouteLine.swift; sourceTree = "<group>"; };
 =======
 		C3A17C5F258283730078C98B /* StatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusViewTests.swift; sourceTree = "<group>"; };
 >>>>>>> 2ebefc72... reflect added test file
+=======
+		C3D225502587F411007DBCDF /* StatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusViewTests.swift; sourceTree = "<group>"; };
+>>>>>>> 12d09fe6... test cases pass as expected
 		C51511D020EAC89D00372A91 /* CPMapTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPMapTemplate.swift; sourceTree = "<group>"; };
 		C51DF8651F38C31C006C6A15 /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		C51FC31620F689F800400CE7 /* CustomStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomStyles.swift; path = Example/CustomStyles.swift; sourceTree = "<group>"; };
@@ -1374,6 +1378,7 @@
 		35B711D01E5E7AD2001EDA8D /* MapboxNavigationTests */ = {
 			isa = PBXGroup;
 			children = (
+				C3D225502587F411007DBCDF /* StatusViewTests.swift */,
 				16E11B53212B3D4700027CD3 /* Extensions and Categories */,
 				355DB5731EFA73410091BFB7 /* Fixtures */,
 				3527D2B61EC45FBD00C07FC9 /* Fixtures.xcassets */,
@@ -1410,7 +1415,6 @@
 				35BC7177226F6667003BB5F1 /* CompassViewTests.swift */,
 				35E5B962227B4B620033A124 /* CarPlayCompassViewTests.swift */,
 				355B469A22B902C9009CE634 /* SKUTests.swift */,
-				C3A17C5F258283730078C98B /* StatusViewTests.swift */,
 			);
 			name = MapboxNavigationTests;
 			path = Tests/MapboxNavigationTests;
@@ -2683,7 +2687,7 @@
 				8D9CD7FF20880581004DC4B3 /* XCTestCase.swift in Sources */,
 				35DC585D1FABC61100B5A956 /* InstructionsBannerViewIntegrationTests.swift in Sources */,
 				3502231A205BC94E00E1449A /* Constants.swift in Sources */,
-				C3A17C60258283730078C98B /* StatusViewTests.swift in Sources */,
+				C3D225512587F411007DBCDF /* StatusViewTests.swift in Sources */,
 				DA0557252155040700A1F2AA /* RouteTests.swift in Sources */,
 				C55C299920D2E2F600B0406C /* NavigationMapViewTests.swift in Sources */,
 				4341758423061666004264A9 /* SnapshotTest+Mapbox.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		B430D2FA25534FDC0088CC23 /* UserHaloCourseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */; };
 		B48CEFC125796FD300696BB3 /* route-for-vanishing-route-line.json in Resources */ = {isa = PBXBuildFile; fileRef = B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */; };
 		B4F7631C2578751300177B33 /* VanishingRouteLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F7631B2578751300177B33 /* VanishingRouteLine.swift */; };
+		C3A17C60258283730078C98B /* StatusViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A17C5F258283730078C98B /* StatusViewTests.swift */; };
 		C51511D120EAC89D00372A91 /* CPMapTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51511D020EAC89D00372A91 /* CPMapTemplate.swift */; };
 		C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51DF8651F38C31C006C6A15 /* Locale.swift */; };
 		C51FC31720F689F800400CE7 /* CustomStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51FC31620F689F800400CE7 /* CustomStyles.swift */; };
@@ -884,9 +885,13 @@
 		AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+GuidanceCards.swift"; path = "Example/ViewController+GuidanceCards.swift"; sourceTree = "<group>"; };
 		AEF2C8F12072B603007B061F /* routeWithTunnels_9thStreetDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithTunnels_9thStreetDC.json; sourceTree = "<group>"; };
+<<<<<<< HEAD
 		B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
 		B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-for-vanishing-route-line.json"; sourceTree = "<group>"; };
 		B4F7631B2578751300177B33 /* VanishingRouteLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VanishingRouteLine.swift; sourceTree = "<group>"; };
+=======
+		C3A17C5F258283730078C98B /* StatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusViewTests.swift; sourceTree = "<group>"; };
+>>>>>>> 2ebefc72... reflect added test file
 		C51511D020EAC89D00372A91 /* CPMapTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPMapTemplate.swift; sourceTree = "<group>"; };
 		C51DF8651F38C31C006C6A15 /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		C51FC31620F689F800400CE7 /* CustomStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomStyles.swift; path = Example/CustomStyles.swift; sourceTree = "<group>"; };
@@ -1405,6 +1410,7 @@
 				35BC7177226F6667003BB5F1 /* CompassViewTests.swift */,
 				35E5B962227B4B620033A124 /* CarPlayCompassViewTests.swift */,
 				355B469A22B902C9009CE634 /* SKUTests.swift */,
+				C3A17C5F258283730078C98B /* StatusViewTests.swift */,
 			);
 			name = MapboxNavigationTests;
 			path = Tests/MapboxNavigationTests;
@@ -2677,6 +2683,7 @@
 				8D9CD7FF20880581004DC4B3 /* XCTestCase.swift in Sources */,
 				35DC585D1FABC61100B5A956 /* InstructionsBannerViewIntegrationTests.swift in Sources */,
 				3502231A205BC94E00E1449A /* Constants.swift in Sources */,
+				C3A17C60258283730078C98B /* StatusViewTests.swift in Sources */,
 				DA0557252155040700A1F2AA /* RouteTests.swift in Sources */,
 				C55C299920D2E2F600B0406C /* NavigationMapViewTests.swift in Sources */,
 				4341758423061666004264A9 /* SnapshotTest+Mapbox.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -885,17 +885,10 @@
 		AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+GuidanceCards.swift"; path = "Example/ViewController+GuidanceCards.swift"; sourceTree = "<group>"; };
 		AEF2C8F12072B603007B061F /* routeWithTunnels_9thStreetDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithTunnels_9thStreetDC.json; sourceTree = "<group>"; };
-<<<<<<< HEAD
-<<<<<<< HEAD
-		B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
+        B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
 		B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-for-vanishing-route-line.json"; sourceTree = "<group>"; };
 		B4F7631B2578751300177B33 /* VanishingRouteLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VanishingRouteLine.swift; sourceTree = "<group>"; };
-=======
-		C3A17C5F258283730078C98B /* StatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusViewTests.swift; sourceTree = "<group>"; };
->>>>>>> 2ebefc72... reflect added test file
-=======
 		C3D225502587F411007DBCDF /* StatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusViewTests.swift; sourceTree = "<group>"; };
->>>>>>> 12d09fe6... test cases pass as expected
 		C51511D020EAC89D00372A91 /* CPMapTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPMapTemplate.swift; sourceTree = "<group>"; };
 		C51DF8651F38C31C006C6A15 /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		C51FC31620F689F800400CE7 /* CustomStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomStyles.swift; path = Example/CustomStyles.swift; sourceTree = "<group>"; };

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -39,7 +39,11 @@ public protocol NavigationStatusPresenter: class {
     /**
      Shows the status view for a specified amount of time.
      */
+    
+    // TODO: DELETE THIS METHOD
     func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool)
     
     func addNewStatus(status: StatusView.Status)
+    
+    func hideStatus(status: StatusView.Status)
 }

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -45,5 +45,5 @@ public protocol NavigationStatusPresenter: class {
     
     func addNewStatus(status: StatusView.Status)
     
-    func hideStatus(status: StatusView.Status)
+    func hideStatus(usingStatusId: String?, usingStatus: StatusView.Status?, delay: TimeInterval)
 }

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -40,4 +40,6 @@ public protocol NavigationStatusPresenter: class {
      Shows the status view for a specified amount of time.
      */
     func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool)
+    
+    func addNewStatus(status: StatusView.Status)
 }

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -39,8 +39,6 @@ public protocol NavigationStatusPresenter: class {
     /**
      Shows a Status for a specified amount of time.
      */
-    func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool)
-    
     func addNewStatus(status: StatusView.Status)
     
     func hideStatus(using: StatusView.Status)

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -39,7 +39,9 @@ public protocol NavigationStatusPresenter: class {
     /**
      Shows a Status for a specified amount of time.
      */
+    func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool)
+    
     func addNewStatus(status: StatusView.Status)
     
-    func hideStatus(usingStatusId: String?, usingStatus: StatusView.Status?)
+    func hideStatus(using: StatusView.Status)
 }

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -40,9 +40,6 @@ public protocol NavigationStatusPresenter: class {
      Shows the status view for a specified amount of time.
      */
     
-    // TODO: DELETE THIS METHOD
-    func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool)
-    
     func addNewStatus(status: StatusView.Status)
     
     func hideStatus(usingStatusId: String?, usingStatus: StatusView.Status?, delay: TimeInterval)

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -37,10 +37,9 @@ public protocol CarPlayConnectionObserver: class {
  */
 public protocol NavigationStatusPresenter: class {
     /**
-     Shows the status view for a specified amount of time.
+     Shows a Status for a specified amount of time.
      */
-    
     func addNewStatus(status: StatusView.Status)
     
-    func hideStatus(usingStatusId: String?, usingStatus: StatusView.Status?, delay: TimeInterval)
+    func hideStatus(usingStatusId: String?, usingStatus: StatusView.Status?)
 }

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -39,7 +39,17 @@ public protocol NavigationStatusPresenter: class {
     /**
      Shows a Status for a specified amount of time.
      */
-    func addNewStatus(status: StatusView.Status)
+    func show(_: StatusView.Status)
     
-    func hideStatus(using: StatusView.Status)
+    /**
+     Hides a given Status without hiding the status view.
+     */
+    func hide(_: StatusView.Status)
+    
+    /**
+     Shows the status view for a specified amount of time.
+     `showStatus()` uses a default value for priority and the title input as identifier. To use these variables, use `show(_:)`
+     */
+    @available(*, deprecated, message: "Add a status using show(_:) instead")
+    func showStatus(title: String, spinner spin: Bool, duration: TimeInterval, animated: Bool, interactive: Bool)
 }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -468,12 +468,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         UNUserNotificationCenter.current().add(notificationRequest, withCompletionHandler: nil)
     }
     
-    public func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool) {
-        navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
-            $0.showStatus(title: title, spinner: spinner, duration: duration, animated: animated, interactive: interactive)
-        }
-    }
-    
     public func addNewStatus(status: StatusView.Status) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
             $0.addNewStatus(status: status)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -33,6 +33,7 @@ public enum MapOrnamentPosition {
  `CarPlayNavigationViewController` manages the corresponding user interface on a CarPlay screen.
  */
 open class NavigationViewController: UIViewController, NavigationStatusPresenter {
+    
     /**
      A `Route` object constructed by [MapboxDirections](https://docs.mapbox.com/ios/api/directions/) along with its index in a `RouteResponse`.
       
@@ -480,11 +481,12 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
     }
     
-    public func hideStatus(status: StatusView.Status) {
+    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil, delay: TimeInterval = 0) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
-            $0.hideStatus(status: status)
+            $0.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus, delay: 0)
         }
     }
+    
 }
 
 //MARK: - RouteMapViewControllerDelegate
@@ -748,16 +750,17 @@ extension NavigationViewController: NavigationServiceDelegate {
         guard let accuracyAuthorizationValue = locationManager.value(forKey: "accuracyAuthorization") as? Int else { return }
         let accuracyAuthorization = MBNavigationAccuracyAuthorization(rawValue: accuracyAuthorizationValue)
         let previousAuthorizationValue = 1 - accuracyAuthorizationValue
-                
+                        
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 1))
-                
+        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
+        
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = true
-        } else if #available(iOS 14.0, *), previousAuthorizationValue == 0 {
-            hideStatus(status: authorizationStatus)
+        } else if #available(iOS 14.0, *), previousAuthorizationValue == 1 {
+            print("!!! hide enable precise location banner")
+            hideStatus(usingStatus: authorizationStatus)
         } else {
             //Fallback on earlier versions
             mapView?.reducedAccuracyActivatedMode = false

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -755,7 +755,7 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: 10, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -401,6 +401,11 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         guard AVAudioSession.sharedInstance().outputVolume <= NavigationViewMinimumVolumeForWarning else { return }
         
         let title = NSLocalizedString("INAUDIBLE_INSTRUCTIONS_CTA", bundle: .mapboxNavigation, value: "Adjust Volume to Hear Instructions", comment: "Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased")
+        
+        // create low volume notification status and append to array of statuses
+        let lowVolumeStatus = StatusView.Status(id: title, duration: 3, animated: true, priority: StatusView.Priority(rawValue: 3))
+        StatusView().statuses.append(lowVolumeStatus)
+        
         showStatus(title: title, spinner: false, duration: 3, animated: true, interactive: false)
     }
     
@@ -732,6 +737,17 @@ extension NavigationViewController: NavigationServiceDelegate {
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
+            
+            // create authorization status and append to array of statuses
+            let authorizationStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 1))
+            
+            if let row = StatusView().statuses.firstIndex(where: {$0.id == title}) {
+                StatusView().statuses[row] = authorizationStatus
+            } else {
+                StatusView().statuses.append(authorizationStatus)
+            }
+            print("!!! statuses: \(StatusView().statuses)")
+            
             showStatus(title: title, spinner: false, duration: 20, animated: true, interactive: false)
             mapView?.reducedAccuracyActivatedMode = true
         } else {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -52,7 +52,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
     }
     
-    var authorizationChangeIsFirstCalled = true
+    var didChangeAuthorizationIsFirstCalled = true
     
     /**
      A `Route` object constructed by [MapboxDirections](https://docs.mapbox.com/ios/api/directions/).
@@ -760,14 +760,14 @@ extension NavigationViewController: NavigationServiceDelegate {
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = true
-        } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, authorizationChangeIsFirstCalled == false {
+        } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, didChangeAuthorizationIsFirstCalled == false {
             hideStatus(usingStatus: authorizationStatus)
         } else {
             //Fallback on earlier versions
             mapView?.reducedAccuracyActivatedMode = false
             return
         }
-        authorizationChangeIsFirstCalled = false
+        didChangeAuthorizationIsFirstCalled = false
     }
     
     // MARK: - Building Extrusion Highlighting

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -52,6 +52,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
     }
     
+    public var counter = 0
+    
     /**
      A `Route` object constructed by [MapboxDirections](https://docs.mapbox.com/ios/api/directions/).
      */
@@ -745,6 +747,8 @@ extension NavigationViewController: NavigationServiceDelegate {
         return navigationComponents.allSatisfy { $0.navigationServiceShouldDisableBatteryMonitoring(service) }
     }
     
+    // var isFirstCalled: Bool = false
+    
     public func navigationServiceDidChangeAuthorization(_ service: NavigationService, didChangeAuthorizationFor locationManager: CLLocationManager) {
         // CLLocationManager.accuracyAuthorization was introduced in the iOS 14 SDK in Xcode 12, so Xcode 11 doesn’t recognize it.
         guard let accuracyAuthorizationValue = locationManager.value(forKey: "accuracyAuthorization") as? Int else { return }
@@ -753,12 +757,12 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(id: title, duration: 5, priority: StatusView.Priority(rawValue: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = true
-        } else if #available(iOS 14.0, *), previousAuthorizationValue == 1 {
+        } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, counter != 0 {
             print("!!! hide enable precise location banner")
             hideStatus(usingStatus: authorizationStatus)
         } else {
@@ -766,7 +770,8 @@ extension NavigationViewController: NavigationServiceDelegate {
             mapView?.reducedAccuracyActivatedMode = false
             return
         }
-
+        // isFirstCalled = true
+        counter += 1
     }
     
     // MARK: - Building Extrusion Highlighting

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -746,7 +746,7 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(id: title, duration: 10, priority: StatusView.Priority(rawValue: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -52,7 +52,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
     }
     
-    public var counter = 0
+    var authorizationChangeIsFirstCalled = true
     
     /**
      A `Route` object constructed by [MapboxDirections](https://docs.mapbox.com/ios/api/directions/).
@@ -757,21 +757,19 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: 5, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = true
-        } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, counter != 0 {
-            print("!!! hide enable precise location banner")
+        } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, authorizationChangeIsFirstCalled == false {
             hideStatus(usingStatus: authorizationStatus)
         } else {
             //Fallback on earlier versions
             mapView?.reducedAccuracyActivatedMode = false
             return
         }
-        // isFirstCalled = true
-        counter += 1
+        authorizationChangeIsFirstCalled = false
     }
     
     // MARK: - Building Extrusion Highlighting

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -468,15 +468,21 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         UNUserNotificationCenter.current().add(notificationRequest, withCompletionHandler: nil)
     }
     
+    public func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool) {
+        navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
+            $0.showStatus(title: title, spinner: spinner, duration: duration, animated: animated, interactive: interactive)
+        }
+    }
+    
     public func addNewStatus(status: StatusView.Status) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
             $0.addNewStatus(status: status)
         }
     }
     
-    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil) {
+    public func hideStatus(using status: StatusView.Status) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
-            $0.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus)
+            $0.hideStatus(using: status)
         }
     }
     
@@ -746,13 +752,13 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: 10, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = true
         } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, didChangeAuthorizationIsFirstCalled == false {
-            hideStatus(usingStatus: authorizationStatus)
+            hideStatus(using: authorizationStatus)
         } else {
             //Fallback on earlier versions
             mapView?.reducedAccuracyActivatedMode = false

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -404,9 +404,9 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         // create low volume notification status and append to array of statuses
         let lowVolumeStatus = StatusView.Status(id: title, duration: 3, animated: true, priority: StatusView.Priority(rawValue: 3))
-        StatusView.statuses.append(lowVolumeStatus)
+        addNewStatus(status: lowVolumeStatus)
         
-        showStatus(title: title, spinner: false, duration: 3, animated: true, interactive: false)
+        // showStatus(title: title, spinner: false, duration: 3, animated: true, interactive: false)
     }
     
     
@@ -470,6 +470,12 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     public func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
             $0.showStatus(title: title, spinner: spinner, duration: duration, animated: animated, interactive: interactive)
+        }
+    }
+    
+    public func addNewStatus(status: StatusView.Status) {
+        navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
+            $0.addNewStatus(status: status)
         }
     }
 }
@@ -738,20 +744,11 @@ extension NavigationViewController: NavigationServiceDelegate {
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
             
-            // create authorization status and append to array of statuses
+            // create authorization status
             let authorizationStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 1))
-            
-            if let row = StatusView.statuses.firstIndex(where: {$0.id == title}) {
-                StatusView.statuses[row] = authorizationStatus
-            } else {
-                StatusView.statuses.append(authorizationStatus)
-            }
-            print("!!! statuses: \(StatusView.statuses)")
-            
+            addNewStatus(status: authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = true
-            StatusView().manageStatuses()
-            
-            // showStatus(title: title, spinner: false, duration: 20, animated: true, interactive: false)
+            // TODO: automatically hide banner when precise location is switched on
         } else {
             //Fallback on earlier versions
             mapView?.reducedAccuracyActivatedMode = false

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -408,8 +408,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         // create low volume notification status and append to array of statuses
         let lowVolumeStatus = StatusView.Status(id: title, duration: 3, animated: true, priority: StatusView.Priority(rawValue: 3))
         addNewStatus(status: lowVolumeStatus)
-        
-        // showStatus(title: title, spinner: false, duration: 3, animated: true, interactive: false)
     }
     
     
@@ -468,13 +466,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         let notificationRequest = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(notificationRequest, withCompletionHandler: nil)
-    }
-    
-    // TODO: DELETE THIS METHOD
-    public func showStatus(title: String, spinner: Bool, duration: TimeInterval, animated: Bool, interactive: Bool) {
-        navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
-            $0.showStatus(title: title, spinner: spinner, duration: duration, animated: animated, interactive: interactive)
-        }
     }
     
     public func addNewStatus(status: StatusView.Status) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -404,7 +404,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         // create low volume notification status and append to array of statuses
         let lowVolumeStatus = StatusView.Status(id: title, duration: 3, animated: true, priority: StatusView.Priority(rawValue: 3))
-        StatusView().statuses.append(lowVolumeStatus)
+        StatusView.statuses.append(lowVolumeStatus)
         
         showStatus(title: title, spinner: false, duration: 3, animated: true, interactive: false)
     }
@@ -741,12 +741,12 @@ extension NavigationViewController: NavigationServiceDelegate {
             // create authorization status and append to array of statuses
             let authorizationStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 1))
             
-            if let row = StatusView().statuses.firstIndex(where: {$0.id == title}) {
-                StatusView().statuses[row] = authorizationStatus
+            if let row = StatusView.statuses.firstIndex(where: {$0.id == title}) {
+                StatusView.statuses[row] = authorizationStatus
             } else {
-                StatusView().statuses.append(authorizationStatus)
+                StatusView.statuses.append(authorizationStatus)
             }
-            print("!!! statuses: \(StatusView().statuses)")
+            print("!!! statuses: \(StatusView.statuses)")
             
             showStatus(title: title, spinner: false, duration: 20, animated: true, interactive: false)
             mapView?.reducedAccuracyActivatedMode = true

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -474,9 +474,9 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
     }
     
-    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil, delay: TimeInterval = 0) {
+    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
-            $0.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus, delay: 0)
+            $0.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus)
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -753,6 +753,7 @@ extension NavigationViewController: NavigationServiceDelegate {
             mapView?.reducedAccuracyActivatedMode = true
         } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, didChangeAuthorizationIsFirstCalled == false {
             hideStatus(using: authorizationStatus)
+            mapView?.reducedAccuracyActivatedMode = false
         } else {
             //Fallback on earlier versions
             mapView?.reducedAccuracyActivatedMode = false

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -746,9 +746,7 @@ extension NavigationViewController: NavigationServiceDelegate {
     public func navigationServiceShouldDisableBatteryMonitoring(_ service: NavigationService) -> Bool {
         return navigationComponents.allSatisfy { $0.navigationServiceShouldDisableBatteryMonitoring(service) }
     }
-    
-    // var isFirstCalled: Bool = false
-    
+        
     public func navigationServiceDidChangeAuthorization(_ service: NavigationService, didChangeAuthorizationFor locationManager: CLLocationManager) {
         // CLLocationManager.accuracyAuthorization was introduced in the iOS 14 SDK in Xcode 12, so Xcode 11 doesn’t recognize it.
         guard let accuracyAuthorizationValue = locationManager.value(forKey: "accuracyAuthorization") as? Int else { return }
@@ -757,7 +755,7 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(id: title, duration: 10, priority: StatusView.Priority(rawValue: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             addNewStatus(status: authorizationStatus)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -748,8 +748,10 @@ extension NavigationViewController: NavigationServiceDelegate {
             }
             print("!!! statuses: \(StatusView.statuses)")
             
-            showStatus(title: title, spinner: false, duration: 20, animated: true, interactive: false)
             mapView?.reducedAccuracyActivatedMode = true
+            StatusView().manageStatuses()
+            
+            // showStatus(title: title, spinner: false, duration: 20, animated: true, interactive: false)
         } else {
             //Fallback on earlier versions
             mapView?.reducedAccuracyActivatedMode = false

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -406,7 +406,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         let title = NSLocalizedString("INAUDIBLE_INSTRUCTIONS_CTA", bundle: .mapboxNavigation, value: "Adjust Volume to Hear Instructions", comment: "Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased")
         
         // create low volume notification status and append to array of statuses
-        let lowVolumeStatus = StatusView.Status(identifier: "INAUDIBLE_INSTRUCTIONS_CTA", title: title, duration: 3, animated: true, priority: StatusView.Priority(rawValue: 3))
+        let lowVolumeStatus = StatusView.Status(identifier: "INAUDIBLE_INSTRUCTIONS_CTA", title: title, duration: 3, animated: true, priority: StatusView.Priority(3))
         show(lowVolumeStatus)
     }
     
@@ -758,7 +758,7 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION", title: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION", title: title, duration: .infinity, priority: StatusView.Priority(1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             show(authorizationStatus)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -406,7 +406,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         let title = NSLocalizedString("INAUDIBLE_INSTRUCTIONS_CTA", bundle: .mapboxNavigation, value: "Adjust Volume to Hear Instructions", comment: "Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased")
         
         // create low volume notification status and append to array of statuses
-        let lowVolumeStatus = StatusView.Status(identifier: "INAUDIBLE_INSTRUCTIONS_CTA", title: title, duration: 3, animated: true, priority: StatusView.Priority(value: 3))
+        let lowVolumeStatus = StatusView.Status(identifier: "INAUDIBLE_INSTRUCTIONS_CTA", title: title, duration: 3, animated: true, priority: 3)
         show(lowVolumeStatus)
     }
     
@@ -758,7 +758,7 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION", title: title, duration: .infinity, priority: StatusView.Priority(value: 1))
+        let authorizationStatus = StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION", title: title, duration: .infinity, priority: 1)
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             show(authorizationStatus)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -406,7 +406,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         let title = NSLocalizedString("INAUDIBLE_INSTRUCTIONS_CTA", bundle: .mapboxNavigation, value: "Adjust Volume to Hear Instructions", comment: "Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased")
         
         // create low volume notification status and append to array of statuses
-        let lowVolumeStatus = StatusView.Status(identifier: "INAUDIBLE_INSTRUCTIONS_CTA", title: title, duration: 3, animated: true, priority: StatusView.Priority(3))
+        let lowVolumeStatus = StatusView.Status(identifier: "INAUDIBLE_INSTRUCTIONS_CTA", title: title, duration: 3, animated: true, priority: StatusView.Priority(value: 3))
         show(lowVolumeStatus)
     }
     
@@ -758,7 +758,7 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION", title: title, duration: .infinity, priority: StatusView.Priority(1))
+        let authorizationStatus = StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION", title: title, duration: .infinity, priority: StatusView.Priority(value: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
             show(authorizationStatus)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -406,8 +406,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         let title = NSLocalizedString("INAUDIBLE_INSTRUCTIONS_CTA", bundle: .mapboxNavigation, value: "Adjust Volume to Hear Instructions", comment: "Label indicating the device volume is too low to hear spoken instructions and needs to be manually increased")
         
         // create low volume notification status and append to array of statuses
-        let lowVolumeStatus = StatusView.Status(id: title, duration: 3, animated: true, priority: StatusView.Priority(rawValue: 3))
-        addNewStatus(status: lowVolumeStatus)
+        let lowVolumeStatus = StatusView.Status(identifier: "INAUDIBLE_INSTRUCTIONS_CTA", title: title, duration: 3, animated: true, priority: StatusView.Priority(rawValue: 3))
+        show(lowVolumeStatus)
     }
     
     
@@ -468,18 +468,30 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         UNUserNotificationCenter.current().add(notificationRequest, withCompletionHandler: nil)
     }
     
-    public func addNewStatus(status: StatusView.Status) {
+    /**
+     Shows a Status for a specified amount of time.
+     */
+    public func show(_ status: StatusView.Status) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
-            $0.addNewStatus(status: status)
+            $0.show(status)
         }
     }
     
-    public func hideStatus(using status: StatusView.Status) {
+    /**
+     Hides a given Status without hiding the status view.
+     */
+    public func hide(_ status: StatusView.Status) {
         navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
-            $0.hideStatus(using: status)
+            $0.hide(status)
         }
     }
     
+    @available(*, deprecated, message: "Add a status using show(_:) instead")
+    public func showStatus(title: String, spinner spin: Bool, duration: TimeInterval, animated: Bool, interactive: Bool) {
+        navigationComponents.compactMap({ $0 as? NavigationStatusPresenter }).forEach {
+            $0.showStatus(title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive)
+        }
+    }
 }
 
 //MARK: - RouteMapViewControllerDelegate
@@ -746,13 +758,13 @@ extension NavigationViewController: NavigationServiceDelegate {
                         
         // create authorization status
         let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
-        let authorizationStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
+        let authorizationStatus = StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION", title: title, duration: .infinity, priority: StatusView.Priority(rawValue: 1))
         
         if #available(iOS 14.0, *), accuracyAuthorization == .reducedAccuracy {
-            addNewStatus(status: authorizationStatus)
+            show(authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = true
         } else if #available(iOS 14.0, *), previousAuthorizationValue == 1, didChangeAuthorizationIsFirstCalled == false {
-            hideStatus(using: authorizationStatus)
+            hide(authorizationStatus)
             mapView?.reducedAccuracyActivatedMode = false
         } else {
             //Fallback on earlier versions

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -153,8 +153,7 @@ public class StatusView: UIControl {
     
     // fix (method to deal with hiding/showing status banners and updating statuses array)
     func manageStatuses(status: Status? = nil) {
-        // print("!!! current label: \(String(describing: self.textLabel.text))")
-
+        
         // if we hide a Status and there are no Statuses left in the statuses array, hide the status view entirely
         if statuses.isEmpty {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
@@ -163,14 +162,29 @@ public class StatusView: UIControl {
             // find status with "highest" priority
             guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
             // check what banner is currently visible, if it's the highestPriorityStatus already, then we don't do anything
-            
-            
-            // SHOW STATUS
+            // ^ is this a case we'll ever run into?
+            print("!!! highest priority status: \(highestPriorityStatus)")
+            if highestPriorityStatus.id == self.textLabel.text {
+                return
+            } else {
+                // show status by updating the label for the specified duration
+                updateLabel(status: highestPriorityStatus)
+                show(status: highestPriorityStatus)
+                // guard highestPriorityStatus.duration < .infinity else { return }
+                hideStatus(usingStatus: highestPriorityStatus)
+            }
         }
     }
     
-    func hideStatus(status: Status) {
-        guard let row = statuses.firstIndex(where: {$0.id == status.id}) else { return }
+    // "hides" current status label by updating to a new label
+    func updateLabel(status: Status) {
+        textLabel.text = status.id
+    }
+    
+    // hide a status using either the status id or the status itself
+    func hideStatus(usingStatusId: String? = "", usingStatus: Status? = nil, delay: TimeInterval = 0) {
+        guard let firstWord = usingStatusId?.components(separatedBy: " ").first else { return }
+        guard let row = statuses.firstIndex(where: {$0.id == usingStatus?.id || $0.id.contains(firstWord)}) else { return }
         let removedStatus = statuses.remove(at: row)
         manageStatuses(status: removedStatus)
     }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -153,7 +153,7 @@ public class StatusView: UIControl {
     
     // fix (method to deal with hiding/showing status banners and updating statuses array)
     func manageStatuses(status: Status? = nil) {
-        
+        print("statuses: \(statuses)")
         // if we hide a Status and there are no Statuses left in the statuses array, hide the status view entirely
         if statuses.isEmpty {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -159,7 +159,6 @@ public class StatusView: UIControl {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
         } else {
             // if we hide a Status and there are Statuses left in the statuses array, show the Status with the highest priority
-            // find status with "highest" priority
             guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
             // check what banner is currently visible, if it's the highestPriorityStatus already, then we don't do anything
             // ^ is this a case we'll ever run into?
@@ -168,17 +167,11 @@ public class StatusView: UIControl {
                 return
             } else {
                 // show status by updating the label for the specified duration
-                updateLabel(status: highestPriorityStatus)
                 show(status: highestPriorityStatus)
-                // guard highestPriorityStatus.duration < .infinity else { return }
-                hideStatus(usingStatus: highestPriorityStatus)
+                // hideStatus(usingStatus: highestPriorityStatus)
+                hide(delay: highestPriorityStatus.duration)
             }
         }
-    }
-    
-    // "hides" current status label by updating to a new label
-    func updateLabel(status: Status) {
-        textLabel.text = status.id
     }
     
     // hide a status using either the status id or the status itself
@@ -200,7 +193,7 @@ public class StatusView: UIControl {
         let title = String.localizedStringWithFormat(format, NumberFormatter.localizedString(from: speed as NSNumber, number: .decimal))
         
         // create simulation status
-        let simulationStatus = Status(id: title, duration: 1000, interactive: true, priority: StatusView.Priority(rawValue: 2))
+        let simulationStatus = Status(id: title, duration: .infinity, interactive: true, priority: StatusView.Priority(rawValue: 2))
         addNewStatus(status: simulationStatus)
     }
     

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -174,6 +174,14 @@ public class StatusView: UIControl {
         }
     }
     
+    func highestPriority(status: Status) {
+        if status.duration != .infinity {
+            hideStatus(usingStatus: status)
+        } else {
+            
+        }
+    }
+    
     // hide a status using either the status id or the status itself
     func hideStatus(usingStatusId: String? = "", usingStatus: Status? = nil, delay: TimeInterval = 0) {
         guard let firstWord = usingStatusId?.components(separatedBy: " ").first else { return }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -151,30 +151,26 @@ public class StatusView: UIControl {
         manageStatuses()
     }
     
-    // fix name (method to deal with hiding/showing status banners and updating statuses array)
+    // fix (method to deal with hiding/showing status banners and updating statuses array)
     func manageStatuses(status: Status? = nil) {
-        
-        print("!!! current label: \(String(describing: self.textLabel.text))")
-        
-        print("!!! statuses: \(statuses)")
+        // print("!!! current label: \(String(describing: self.textLabel.text))")
 
-        // if we hide a Status and there are no Statuses left in the statuses array, we want to hide the status view entirely
+        // if we hide a Status and there are no Statuses left in the statuses array, hide the status view entirely
         if statuses.isEmpty {
-            print("!!! statuses is empty")
-            // HIDE STATUS VIEW ENTIRELY
+            hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
         } else {
-            // if we hide a Status and there are Statuses left in the statuses array, we want to show the Status with the highest priority
+            // if we hide a Status and there are Statuses left in the statuses array, show the Status with the highest priority
             // find status with "highest" priority
-
             guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
-            print("!!! \(String(describing: highestPriorityStatus))")
+            // check what banner is currently visible, if it's the highestPriorityStatus already, then we don't do anything
+            
             
             // SHOW STATUS
         }
     }
     
-    func hideStatus(banner: Status) {
-        guard let row = statuses.firstIndex(where: {$0.id == banner.id}) else { return }
+    func hideStatus(status: Status) {
+        guard let row = statuses.firstIndex(where: {$0.id == status.id}) else { return }
         let removedStatus = statuses.remove(at: row)
         manageStatuses(status: removedStatus)
     }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -46,8 +46,8 @@ public class StatusView: UIControl {
         }
     }
     
-    var statuses: [StatusView.Status] = []
-    
+    static var statuses: [StatusView.Status] = []
+
     public struct Status: Identifiable {
         public var id: String
 //        let title: String
@@ -100,6 +100,7 @@ public class StatusView: UIControl {
         
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(StatusView.tap(_:)))
         addGestureRecognizer(tapRecognizer)
+        
     }
     
     @objc func pan(_ sender: UIPanGestureRecognizer) {
@@ -137,7 +138,7 @@ public class StatusView: UIControl {
     func manageStatuses(showSpinner: Bool) {
         
         
-        if statuses.isEmpty {
+        if StatusView.statuses.isEmpty {
             let hide = {
                 self.isHidden = true
                 self.textLabel.alpha = 0
@@ -145,7 +146,7 @@ public class StatusView: UIControl {
             }
         } else {
             // find status with "highest" priority
-            
+            let highestPriorityStatus = StatusView.statuses.max(by: {$0.priority.rawValue < $1.priority.rawValue})
             
             let show = {
                 self.isHidden = false
@@ -157,9 +158,9 @@ public class StatusView: UIControl {
     }
     
     func hideStatus(banner: Status) {
-        guard let row = statuses.firstIndex(where: {$0.id == banner.id}) else { return }
+        guard let row = StatusView.statuses.firstIndex(where: {$0.id == banner.id}) else { return }
+        StatusView.statuses.remove(at: row)
         manageStatuses(showSpinner: true)
-        statuses.remove(at: row)
     }
     
     public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
@@ -174,13 +175,13 @@ public class StatusView: UIControl {
         
         // create simulation status and append to array of statuses
         let simulationStatus = Status(id: title, duration: .infinity, interactive: true, priority: StatusView.Priority(rawValue: 2))
-        if let row = statuses.firstIndex(where: {$0.id.contains("Simulating Navigation")}) {
-            statuses[row] = simulationStatus
+        if let row = StatusView.statuses.firstIndex(where: {$0.id.contains("Simulating Navigation")}) {
+            StatusView.statuses[row] = simulationStatus
         } else {
-            statuses.append(simulationStatus)
+            StatusView.statuses.append(simulationStatus)
         }
                 
-        print("!!! statuses in StatusView.showSimulationStatus: \(statuses)")
+        print("!!! statuses in StatusView.showSimulationStatus: \(StatusView.statuses)")
         
         showStatus(title: title, duration: .infinity, interactive: true)
     }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -151,31 +151,30 @@ public class StatusView: UIControl {
         manageStatuses()
     }
     
-    // fix (method to deal with hiding/showing status banners and updating statuses array)
+    /**
+     Manages showing and hiding Statuses and the status view.
+     */
     func manageStatuses(status: Status? = nil) {
         print("statuses: \(statuses)")
         // if we hide a Status and there are no Statuses left in the statuses array, hide the status view entirely
         if statuses.isEmpty {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
         } else {
-            // if we hide a Status and there are Statuses left in the statuses array, show the Status with the highest priority
+            // if we hide a Status and there are Statuses left in the statuses array, show the Status with highest priority
             guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
-            // check what banner is currently visible, if it's the highestPriorityStatus already, then we don't do anything
-            // ^ is this a case we'll ever run into?
             print("!!! highest priority status: \(highestPriorityStatus)")
-            if highestPriorityStatus.id == self.textLabel.text {
-                return
-            } else {
-                // show status by updating the label for the specified duration
-                show(status: highestPriorityStatus)
-                DispatchQueue.main.asyncAfter(deadline: .now() + highestPriorityStatus.duration) {
-                    self.hideStatus(usingStatus: highestPriorityStatus)
-                }
+            // show status by updating the label for the specified duration
+            // ADD conditional: is highestPriorityStatus == currentStatus??
+            show(status: highestPriorityStatus)
+            DispatchQueue.main.asyncAfter(deadline: .now() + highestPriorityStatus.duration) {
+                self.hideStatus(usingStatus: highestPriorityStatus)
             }
         }
     }
-
-    // hide a status using either the status id or the status itself
+    
+    /**
+     Hides a given Status without hiding the status view.
+     */
     func hideStatus(usingStatusId: String? = "", usingStatus: Status? = nil) {
         guard let firstWord = usingStatusId?.components(separatedBy: " ").first else { return }
         guard let row = statuses.firstIndex(where: {$0.id == usingStatus?.id || $0.id.contains(firstWord)}) else { return }
@@ -186,8 +185,6 @@ public class StatusView: UIControl {
     func showSimulationStatus(speed: Int) {
         let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %@×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
         let title = String.localizedStringWithFormat(format, NumberFormatter.localizedString(from: speed as NSNumber, number: .decimal))
-        
-        // create simulation status
         let simulationStatus = Status(id: title, duration: .infinity, interactive: true, priority: StatusView.Priority(rawValue: 2))
         addNewStatus(status: simulationStatus)
     }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -58,7 +58,7 @@ public class StatusView: UIControl {
         var priority: Priority
     }
     
-    struct Priority: RawRepresentable {
+    public struct Priority: RawRepresentable {
         public var rawValue: Int
 //        — Highest Priority —
 //            rerouting (rawValue = 0)

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -159,10 +159,7 @@ public class StatusView: UIControl {
             // if we hide a Status and there are Statuses left in the statuses array, show the Status with highest priority
             guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
             show(status: highestPriorityStatus)
-//            DispatchQueue.main.asyncAfter(deadline: .now() + highestPriorityStatus.duration) {
-                print("!!! triggered async to hide status")
-                self.hide(with: highestPriorityStatus)
-//            }
+            hide(with: highestPriorityStatus, delay: highestPriorityStatus.duration)
         }
     }
     

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -174,27 +174,13 @@ public class StatusView: UIControl {
             }
         }
     }
-    
-    func highestPriority(status: Status) {
-        if status.duration != .infinity {
-            hideStatus(usingStatus: status)
-        } else {
-            
-        }
-    }
-    
+
     // hide a status using either the status id or the status itself
-    func hideStatus(usingStatusId: String? = "", usingStatus: Status? = nil, delay: TimeInterval = 0) {
+    func hideStatus(usingStatusId: String? = "", usingStatus: Status? = nil) {
         guard let firstWord = usingStatusId?.components(separatedBy: " ").first else { return }
         guard let row = statuses.firstIndex(where: {$0.id == usingStatus?.id || $0.id.contains(firstWord)}) else { return }
         let removedStatus = statuses.remove(at: row)
         manageStatuses(status: removedStatus)
-    }
-    
-    public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
-        // show(title, showSpinner: spin, interactive: interactive)
-        guard duration < .infinity else { return }
-        hide(delay: duration, animated: animated)
     }
     
     func showSimulationStatus(speed: Int) {

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -216,7 +216,6 @@ public class StatusView: UIControl {
      Hides the status view.
      */
     public func hide(with status: Status? = nil, delay: TimeInterval = 0, animated: Bool = true) {
-        print("!!! status to hide: \(String(describing: status))")
         let hide = {
             if status == nil {
                 self.isHidden = true
@@ -231,7 +230,6 @@ public class StatusView: UIControl {
             let fireTime = DispatchTime.now() + delay
             DispatchQueue.main.asyncAfter(deadline: fireTime, execute: {
                 if status == nil {
-                    print("!!! HIDE STATUS VIEW ENTIRELY")
                     guard !self.isHidden, self.isCurrentlyVisible else { return }
                     
                     self.activityIndicatorView.stopAnimating()
@@ -239,7 +237,6 @@ public class StatusView: UIControl {
                         self.isCurrentlyVisible = false
                     })
                 } else {
-                    print("!!! HIDE STATUS ITSELF")
                     self.hideStatus(using: status)
                 }
             })

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -147,7 +147,6 @@ public class StatusView: UIControl {
     
     @available(*, deprecated, message: "Add a status using addNewStatus instead")
     public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
-        // show(title, showSpinner: spin, interactive: interactive)
         guard duration < .infinity else { return }
         hide(delay: duration, animated: animated)
     }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -168,9 +168,8 @@ public class StatusView: UIControl {
             } else {
                 // show status by updating the label for the specified duration
                 show(status: highestPriorityStatus)
-                // hideStatus(usingStatus: highestPriorityStatus)
-                hide(delay: highestPriorityStatus.duration)
-            }
+                
+                hideStatus(usingStatus: highestPriorityStatus)            }
         }
     }
     

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -159,10 +159,10 @@ public class StatusView: UIControl {
             // if we hide a Status and there are Statuses left in the statuses array, show the Status with highest priority
             guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
             show(status: highestPriorityStatus)
-            DispatchQueue.main.asyncAfter(deadline: .now() + highestPriorityStatus.duration) {
+//            DispatchQueue.main.asyncAfter(deadline: .now() + highestPriorityStatus.duration) {
                 print("!!! triggered async to hide status")
-                self.hideStatus(usingStatus: highestPriorityStatus)
-            }
+                self.hide(with: highestPriorityStatus)
+//            }
         }
     }
     
@@ -213,28 +213,29 @@ public class StatusView: UIControl {
      */
     public func hide(with status: Status? = nil, delay: TimeInterval = 0, animated: Bool = true) {
         
-        var boolFlag = true
-        var alpha = 0
-        if status != nil {
-            boolFlag = false
-            alpha = 1
-        }
-        
         let hide = {
-            self.isHidden = boolFlag
-            self.textLabel.alpha = CGFloat(alpha)
-            self.activityIndicatorView.isHidden = boolFlag
+            if status == nil {
+                self.isHidden = true
+                self.textLabel.alpha = 0
+                self.activityIndicatorView.isHidden = true
+            } else {
+                self.hideStatus(usingStatus: status)
+            }
         }
         
         let animate = {
             let fireTime = DispatchTime.now() + delay
             DispatchQueue.main.asyncAfter(deadline: fireTime, execute: {
-                guard !self.isHidden, self.isCurrentlyVisible else { return }
-                
-                self.activityIndicatorView.stopAnimating()
-                UIView.defaultAnimation(0.3, delay: 0, animations: hide, completion: { _ in
-                    self.isCurrentlyVisible = false
-                })
+                if status == nil {
+                    guard !self.isHidden, self.isCurrentlyVisible else { return }
+                    
+                    self.activityIndicatorView.stopAnimating()
+                    UIView.defaultAnimation(0.3, delay: 0, animations: hide, completion: { _ in
+                        self.isCurrentlyVisible = false
+                    })
+                } else {
+                    self.hideStatus(usingStatus: status)
+                }
             })
         }
         

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -139,6 +139,13 @@ public class StatusView: UIControl {
         }
     }
     
+    @available(*, deprecated, message: "Add a status using addNewStatus instead")
+    public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
+        // show(title, showSpinner: spin, interactive: interactive)
+        guard duration < .infinity else { return }
+        hide(delay: duration, animated: animated)
+    }
+    
     func addNewStatus(status: Status) {
         guard let firstWord = status.id.components(separatedBy: " ").first else { return }
         if let row = statuses.firstIndex(where: {$0.id.contains(firstWord)}) {
@@ -166,9 +173,9 @@ public class StatusView: UIControl {
     /**
      Hides a given Status without hiding the status view.
      */
-    func hideStatus(usingStatusId: String? = "", usingStatus: Status? = nil) {
-        guard let firstWord = usingStatusId?.components(separatedBy: " ").first else { return }
-        guard let row = statuses.firstIndex(where: {$0.id == usingStatus?.id || $0.id.contains(firstWord)}) else { return }
+    func hideStatus(using status: Status?) {
+        guard let firstWord = status?.id.components(separatedBy: " ").first else { return }
+        guard let row = statuses.firstIndex(where: {$0.id.contains(firstWord)}) else { return }
         let removedStatus = statuses.remove(at: row)
         manageStatuses(status: removedStatus)
     }
@@ -209,14 +216,14 @@ public class StatusView: UIControl {
      Hides the status view.
      */
     public func hide(with status: Status? = nil, delay: TimeInterval = 0, animated: Bool = true) {
-        
+        print("!!! status to hide: \(String(describing: status))")
         let hide = {
             if status == nil {
                 self.isHidden = true
                 self.textLabel.alpha = 0
                 self.activityIndicatorView.isHidden = true
             } else {
-                self.hideStatus(usingStatus: status)
+                self.hideStatus(using: status)
             }
         }
         
@@ -224,6 +231,7 @@ public class StatusView: UIControl {
             let fireTime = DispatchTime.now() + delay
             DispatchQueue.main.asyncAfter(deadline: fireTime, execute: {
                 if status == nil {
+                    print("!!! HIDE STATUS VIEW ENTIRELY")
                     guard !self.isHidden, self.isCurrentlyVisible else { return }
                     
                     self.activityIndicatorView.stopAnimating()
@@ -231,7 +239,8 @@ public class StatusView: UIControl {
                         self.isCurrentlyVisible = false
                     })
                 } else {
-                    self.hideStatus(usingStatus: status)
+                    print("!!! HIDE STATUS ITSELF")
+                    self.hideStatus(using: status)
                 }
             })
         }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -39,7 +39,6 @@ public class StatusView: UIControl {
         fatalError()
     }
     
-    // TODO: find a way to handle values attached to Statuses
     var value: Double = 0 {
         didSet {
             sendActions(for: .valueChanged)
@@ -59,7 +58,6 @@ public class StatusView: UIControl {
         var priority: Priority
     }
     
-    // TODO: define set of constants for priority
     struct Priority: RawRepresentable {
         public var rawValue: Int
 //        — Highest Priority —
@@ -155,18 +153,14 @@ public class StatusView: UIControl {
      Manages showing and hiding Statuses and the status view.
      */
     func manageStatuses(status: Status? = nil) {
-        print("statuses: \(statuses)")
-        // if we hide a Status and there are no Statuses left in the statuses array, hide the status view entirely
         if statuses.isEmpty {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
         } else {
             // if we hide a Status and there are Statuses left in the statuses array, show the Status with highest priority
             guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
-            print("!!! highest priority status: \(highestPriorityStatus)")
-            // show status by updating the label for the specified duration
-            // ADD conditional: is highestPriorityStatus == currentStatus??
             show(status: highestPriorityStatus)
             DispatchQueue.main.asyncAfter(deadline: .now() + highestPriorityStatus.duration) {
+                print("!!! triggered async to hide status")
                 self.hideStatus(usingStatus: highestPriorityStatus)
             }
         }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -168,8 +168,10 @@ public class StatusView: UIControl {
             } else {
                 // show status by updating the label for the specified duration
                 show(status: highestPriorityStatus)
-                
-                hideStatus(usingStatus: highestPriorityStatus)            }
+                DispatchQueue.main.asyncAfter(deadline: .now() + highestPriorityStatus.duration) {
+                    self.hideStatus(usingStatus: highestPriorityStatus)
+                }
+            }
         }
     }
     

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -59,7 +59,13 @@ public class StatusView: UIControl {
     }
     
     public struct Priority: RawRepresentable {
+        public typealias RawValue = Int
+
         public var rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
 //        — Highest Priority —
 //            rerouting (rawValue = 0)
 //            enable precise location (rawValue = 1)
@@ -146,6 +152,9 @@ public class StatusView: UIControl {
         hide(delay: duration, animated: animated)
     }
     
+    /**
+     Adds a new status to statuses array.
+     */
     func addNewStatus(status: Status) {
         guard let firstWord = status.id.components(separatedBy: " ").first else { return }
         if let row = statuses.firstIndex(where: {$0.id.contains(firstWord)}) {
@@ -157,7 +166,7 @@ public class StatusView: UIControl {
     }
     
     /**
-     Manages showing and hiding Statuses and the status view.
+     Manages showing and hiding Statuses and the status view itself.
      */
     func manageStatuses(status: Status? = nil) {
         if statuses.isEmpty {

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -211,11 +211,19 @@ public class StatusView: UIControl {
     /**
      Hides the status view.
      */
-    public func hide(delay: TimeInterval = 0, animated: Bool = true) {
+    public func hide(with status: Status? = nil, delay: TimeInterval = 0, animated: Bool = true) {
+        
+        var boolFlag = true
+        var alpha = 0
+        if status != nil {
+            boolFlag = false
+            alpha = 1
+        }
+        
         let hide = {
-            self.isHidden = true
-            self.textLabel.alpha = 0
-            self.activityIndicatorView.isHidden = true
+            self.isHidden = boolFlag
+            self.textLabel.alpha = CGFloat(alpha)
+            self.activityIndicatorView.isHidden = boolFlag
         }
         
         let animate = {

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -48,9 +48,12 @@ public class StatusView: UIControl {
     
     var statuses: [Status] = []
 
-    public struct Status: Identifiable {
-        public var id: String
-//        let title: String
+    /**
+    `Status` is a struct which stores information to be displayed by the `StatusView`
+     */
+    public struct Status {
+        public var identifier: String
+        let title: String
         var spinner: Bool = false
         let duration: TimeInterval
         var animated: Bool = true
@@ -58,6 +61,9 @@ public class StatusView: UIControl {
         var priority: Priority
     }
     
+    /**
+     `Priority` is used to display `Status`es by importance
+     */
     public struct Priority: RawRepresentable {
         public typealias RawValue = Int
 
@@ -145,18 +151,21 @@ public class StatusView: UIControl {
         }
     }
     
-    @available(*, deprecated, message: "Add a status using addNewStatus instead")
+    /**
+     Shows the status view for a specified amount of time.
+     `showStatus()` uses a default value for priority and the title input as identifier. To use these variables, use `show(_:)`
+     */
+    @available(*, deprecated, message: "Add a status using show(_:) instead")
     public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
-        guard duration < .infinity else { return }
-        hide(delay: duration, animated: animated)
+        let status = Status(identifier: title, title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive, priority: StatusView.Priority(rawValue: 1))
+        show(status)
     }
     
     /**
      Adds a new status to statuses array.
      */
-    func addNewStatus(status: Status) {
-        guard let firstWord = status.id.components(separatedBy: " ").first else { return }
-        if let row = statuses.firstIndex(where: {$0.id.contains(firstWord)}) {
+    func show(_ status: Status) {
+        if let row = statuses.firstIndex(where: {$0.identifier.contains(status.identifier)}) {
             statuses[row] = status
         } else {
             statuses.append(status)
@@ -181,9 +190,9 @@ public class StatusView: UIControl {
     /**
      Hides a given Status without hiding the status view.
      */
-    func hideStatus(using status: Status?) {
-        guard let firstWord = status?.id.components(separatedBy: " ").first else { return }
-        guard let row = statuses.firstIndex(where: {$0.id.contains(firstWord)}) else { return }
+    func hide(_ status: Status?) {
+        guard let identifier = status?.identifier else { return }
+        guard let row = statuses.firstIndex(where: {$0.identifier.contains(identifier)}) else { return }
         let removedStatus = statuses.remove(at: row)
         manageStatuses(status: removedStatus)
     }
@@ -191,8 +200,8 @@ public class StatusView: UIControl {
     func showSimulationStatus(speed: Int) {
         let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %@×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
         let title = String.localizedStringWithFormat(format, NumberFormatter.localizedString(from: speed as NSNumber, number: .decimal))
-        let simulationStatus = Status(id: title, duration: .infinity, interactive: true, priority: StatusView.Priority(rawValue: 2))
-        addNewStatus(status: simulationStatus)
+        let simulationStatus = Status(identifier: "USER_IN_SIMULATION_MODE", title: title, duration: .infinity, interactive: true, priority: StatusView.Priority(rawValue: 2))
+        show(simulationStatus)
     }
     
     /**
@@ -200,7 +209,7 @@ public class StatusView: UIControl {
      */
     public func show(status: Status) {
         isEnabled = status.interactive
-        textLabel.text = status.id
+        textLabel.text = status.title
         activityIndicatorView.hidesWhenStopped = true
         if (!status.spinner) { activityIndicatorView.stopAnimating() }
 
@@ -230,7 +239,7 @@ public class StatusView: UIControl {
                 self.textLabel.alpha = 0
                 self.activityIndicatorView.isHidden = true
             } else {
-                self.hideStatus(using: status)
+                self.hide(status)
             }
         }
         
@@ -245,7 +254,7 @@ public class StatusView: UIControl {
                         self.isCurrentlyVisible = false
                     })
                 } else {
-                    self.hideStatus(using: status)
+                    self.hide(status)
                 }
             })
         }

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -53,35 +53,35 @@ public class StatusView: UIControl {
      */
     public struct Status {
         /**
-        `identifier` is a unique string identifier for a `Status`
+        A string that uniquely identifies the `Status`
          */
         public var identifier: String
         /**
-        `title` is the text that will appear on the `Status`
+        The text that will appear on the `Status`
          */
         public let title: String
         /**
-        `spinner` indicates whether a spinner should be shown during animations
+         A boolean that indicates whether a `spinner` should be shown during animations
          set to `false` by default
          */
         public var spinner: Bool = false
         /**
-        `duration` designates the length of time a `Status` will be displayed in seconds
-         To display a `Status` indefinitely, set `duration` to `.infinity`
+         A TimeInterval that designates the length of time the `Status` will be displayed in seconds
+         To display the `Status` indefinitely, set `duration` to `.infinity`
          */
         public let duration: TimeInterval
         /**
-        `animated` indicates whether showing and hiding of the `Status` should be animated
+         A boolean that indicates whether showing and hiding of the `Status` should be animated
          set to `true` by default
          */
         public var animated: Bool = true
         /**
-        `interactive` indicates whether the `Status` should respond to touch events
+         A boolean that indicates whether the `Status` should respond to touch events
          set to `false` by default
          */
         public var interactive: Bool = false
         /**
-        `priority` is a struct which is used to rank a `Status` by importance
+         A typealias which is used to rank a `Status` by importance
          A lower `priority` value corresponds to a higher priority
          */
         public var priority: Priority
@@ -91,20 +91,12 @@ public class StatusView: UIControl {
      `Priority` is used to display `Status`es by importance
      Lower values correspond to higher priority.
      */
-    public struct Priority {
-        public typealias Priority = Int
-
-        public var value: Int
-
-        public init(value: Int) {
-            self.value = value
-        }
+    public typealias Priority = Int
 //        — Highest Priority —
 //            rerouting (value = 0)
 //            enable precise location (value = 1)
 //            simulation banner (value = 2)
 //        — Lowest Priority —
-    }
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -184,7 +176,7 @@ public class StatusView: UIControl {
      */
     @available(*, deprecated, message: "Add a status using show(_:) instead")
     public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
-        let status = Status(identifier: title, title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive, priority: StatusView.Priority(value: 1))
+        let status = Status(identifier: title, title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive, priority: 1)
         show(status)
     }
     
@@ -208,7 +200,7 @@ public class StatusView: UIControl {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
         } else {
             // if we hide a Status and there are Statuses left in the statuses array, show the Status with highest priority
-            guard let highestPriorityStatus = statuses.min(by: {$0.priority.value < $1.priority.value}) else { return }
+            guard let highestPriorityStatus = statuses.min(by: {$0.priority < $1.priority}) else { return }
             show(status: highestPriorityStatus)
             hide(with: highestPriorityStatus, delay: highestPriorityStatus.duration)
         }
@@ -226,7 +218,7 @@ public class StatusView: UIControl {
     func showSimulationStatus(speed: Int) {
         let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %@×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
         let title = String.localizedStringWithFormat(format, NumberFormatter.localizedString(from: speed as NSNumber, number: .decimal))
-        let simulationStatus = Status(identifier: "USER_IN_SIMULATION_MODE", title: title, duration: .infinity, interactive: true, priority: StatusView.Priority(value: 2))
+        let simulationStatus = Status(identifier: "USER_IN_SIMULATION_MODE", title: title, duration: .infinity, interactive: true, priority: 2)
         show(simulationStatus)
     }
     

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -52,12 +52,38 @@ public class StatusView: UIControl {
     `Status` is a struct which stores information to be displayed by the `StatusView`
      */
     public struct Status {
+        /**
+        `identifier` is a unique string identifier for a `Status`
+         */
         public var identifier: String
+        /**
+        `title` is the text that will appear on the `Status`
+         */
         public let title: String
+        /**
+        `spinner` indicates whether a spinner should be shown during animations
+         set to `false` by default
+         */
         public var spinner: Bool = false
+        /**
+        `duration` designates the length of time a `Status` will be displayed in seconds
+         To display a `Status` indefinitely, set `duration` to `.infinity`
+         */
         public let duration: TimeInterval
+        /**
+        `animated` indicates whether showing and hiding of the `Status` should be animated
+         set to `true` by default
+         */
         public var animated: Bool = true
+        /**
+        `interactive` indicates whether the `Status` should respond to touch events
+         set to `false` by default
+         */
         public var interactive: Bool = false
+        /**
+        `priority` is a struct which is used to rank a `Status` by importance
+         A lower `priority` value corresponds to a higher priority
+         */
         public var priority: Priority
     }
     
@@ -68,15 +94,15 @@ public class StatusView: UIControl {
     public struct Priority {
         public typealias Priority = Int
 
-        public var priority: Int
+        public var value: Int
 
-//        public init(rawValue: Int) {
-//            self.rawValue = rawValue
-//        }
+        public init(value: Int) {
+            self.value = value
+        }
 //        — Highest Priority —
-//            rerouting (priority = 0)
-//            enable precise location (priority = 1)
-//            simulation banner (priority = 2)
+//            rerouting (value = 0)
+//            enable precise location (value = 1)
+//            simulation banner (value = 2)
 //        — Lowest Priority —
     }
     
@@ -158,7 +184,7 @@ public class StatusView: UIControl {
      */
     @available(*, deprecated, message: "Add a status using show(_:) instead")
     public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
-        let status = Status(identifier: title, title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive, priority: StatusView.Priority(1))
+        let status = Status(identifier: title, title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive, priority: StatusView.Priority(value: 1))
         show(status)
     }
     
@@ -182,7 +208,7 @@ public class StatusView: UIControl {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
         } else {
             // if we hide a Status and there are Statuses left in the statuses array, show the Status with highest priority
-            guard let highestPriorityStatus = statuses.min(by: {$0.priority < $1.priority}) else { return }
+            guard let highestPriorityStatus = statuses.min(by: {$0.priority.value < $1.priority.value}) else { return }
             show(status: highestPriorityStatus)
             hide(with: highestPriorityStatus, delay: highestPriorityStatus.duration)
         }
@@ -200,7 +226,7 @@ public class StatusView: UIControl {
     func showSimulationStatus(speed: Int) {
         let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %@×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
         let title = String.localizedStringWithFormat(format, NumberFormatter.localizedString(from: speed as NSNumber, number: .decimal))
-        let simulationStatus = Status(identifier: "USER_IN_SIMULATION_MODE", title: title, duration: .infinity, interactive: true, priority: StatusView.Priority(2))
+        let simulationStatus = Status(identifier: "USER_IN_SIMULATION_MODE", title: title, duration: .infinity, interactive: true, priority: StatusView.Priority(value: 2))
         show(simulationStatus)
     }
     

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -53,29 +53,30 @@ public class StatusView: UIControl {
      */
     public struct Status {
         public var identifier: String
-        let title: String
-        var spinner: Bool = false
-        let duration: TimeInterval
-        var animated: Bool = true
-        var interactive: Bool = false
-        var priority: Priority
+        public let title: String
+        public var spinner: Bool = false
+        public let duration: TimeInterval
+        public var animated: Bool = true
+        public var interactive: Bool = false
+        public var priority: Priority
     }
     
     /**
      `Priority` is used to display `Status`es by importance
+     Lower values correspond to higher priority.
      */
-    public struct Priority: RawRepresentable {
-        public typealias RawValue = Int
+    public struct Priority {
+        public typealias Priority = Int
 
-        public var rawValue: Int
+        public var priority: Int
 
-        public init(rawValue: Int) {
-            self.rawValue = rawValue
-        }
+//        public init(rawValue: Int) {
+//            self.rawValue = rawValue
+//        }
 //        — Highest Priority —
-//            rerouting (rawValue = 0)
-//            enable precise location (rawValue = 1)
-//            simulation banner (rawValue = 2)
+//            rerouting (priority = 0)
+//            enable precise location (priority = 1)
+//            simulation banner (priority = 2)
 //        — Lowest Priority —
     }
     
@@ -157,7 +158,7 @@ public class StatusView: UIControl {
      */
     @available(*, deprecated, message: "Add a status using show(_:) instead")
     public func showStatus(title: String, spinner spin: Bool = false, duration: TimeInterval, animated: Bool = true, interactive: Bool = false) {
-        let status = Status(identifier: title, title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive, priority: StatusView.Priority(rawValue: 1))
+        let status = Status(identifier: title, title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive, priority: StatusView.Priority(1))
         show(status)
     }
     
@@ -181,7 +182,7 @@ public class StatusView: UIControl {
             hide(delay: status?.duration ?? 0, animated: status?.animated ?? true)
         } else {
             // if we hide a Status and there are Statuses left in the statuses array, show the Status with highest priority
-            guard let highestPriorityStatus = statuses.min(by: {$0.priority.rawValue < $1.priority.rawValue}) else { return }
+            guard let highestPriorityStatus = statuses.min(by: {$0.priority < $1.priority}) else { return }
             show(status: highestPriorityStatus)
             hide(with: highestPriorityStatus, delay: highestPriorityStatus.duration)
         }
@@ -191,8 +192,7 @@ public class StatusView: UIControl {
      Hides a given Status without hiding the status view.
      */
     func hide(_ status: Status?) {
-        guard let identifier = status?.identifier else { return }
-        guard let row = statuses.firstIndex(where: {$0.identifier.contains(identifier)}) else { return }
+        guard let row = statuses.firstIndex(where: {$0.identifier == status?.identifier}) else { return }
         let removedStatus = statuses.remove(at: row)
         manageStatuses(status: removedStatus)
     }
@@ -200,7 +200,7 @@ public class StatusView: UIControl {
     func showSimulationStatus(speed: Int) {
         let format = NSLocalizedString("USER_IN_SIMULATION_MODE", bundle: .mapboxNavigation, value: "Simulating Navigation at %@×", comment: "The text of a banner that appears during turn-by-turn navigation when route simulation is enabled.")
         let title = String.localizedStringWithFormat(format, NumberFormatter.localizedString(from: speed as NSNumber, number: .decimal))
-        let simulationStatus = Status(identifier: "USER_IN_SIMULATION_MODE", title: title, duration: .infinity, interactive: true, priority: StatusView.Priority(rawValue: 2))
+        let simulationStatus = Status(identifier: "USER_IN_SIMULATION_MODE", title: title, duration: .infinity, interactive: true, priority: StatusView.Priority(2))
         show(simulationStatus)
     }
     

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -402,7 +402,7 @@ extension TopBannerViewController: NavigationComponent {
             
             // create faster route status and append to array of statuses
             let fasterRouteStatus = StatusView.Status(id: title, duration: 3, priority: StatusView.Priority(rawValue: 0))
-            StatusView().statuses.append(fasterRouteStatus)
+            StatusView.statuses.append(fasterRouteStatus)
             
             statusView.showStatus(title: title, spinner: true, duration: 3)
         }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -399,6 +399,7 @@ extension TopBannerViewController: NavigationComponent {
             statusView.showSimulationStatus(speed: Int(service.simulationSpeedMultiplier))
         } else {
             statusView.hide(delay: 2, animated: true)
+            // statusView.hideStatus("simulating")
         }
         
         if (proactive) {
@@ -418,6 +419,7 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
         guard reason == .manual else { return }
         statusView.hide(delay: 0, animated: true)
+        // statusView.hide("simulating")
     }
     
     private func embed(_ child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])? = nil) {
@@ -468,6 +470,10 @@ extension TopBannerViewController: CarPlayConnectionObserver {
 }
 
 extension TopBannerViewController: NavigationStatusPresenter {
+    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil, delay: TimeInterval = 0) {
+        statusView.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus, delay: delay)
+    }
+    
     public func showStatus(title: String, spinner spin: Bool, duration time: TimeInterval, animated: Bool, interactive: Bool) {
         statusView.showStatus(title: title, spinner: spin, duration: time, animated: animated, interactive: interactive)
     }
@@ -476,9 +482,6 @@ extension TopBannerViewController: NavigationStatusPresenter {
         statusView.addNewStatus(status: status)
     }
     
-    public func hideStatus(status: StatusView.Status) {
-        statusView.hideStatus(status: status)
-    }
 }
 
 extension TopBannerViewController: NavigationMapInteractionObserver {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -475,6 +475,10 @@ extension TopBannerViewController: NavigationStatusPresenter {
     public func addNewStatus(status: StatusView.Status) {
         statusView.addNewStatus(status: status)
     }
+    
+    public func hideStatus(status: StatusView.Status) {
+        statusView.hideStatus(status: status)
+    }
 }
 
 extension TopBannerViewController: NavigationMapInteractionObserver {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -384,7 +384,17 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
-        statusView.show(title, showSpinner: true)
+        // statusView.show(title, showSpinner: true)
+        
+        // create rerouting status and append to array of statuses
+        let reroutingStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 0))
+        if let row = StatusView.statuses.firstIndex(where: {$0.id == title}) {
+            StatusView.statuses[row] = reroutingStatus
+        } else {
+            StatusView.statuses.append(reroutingStatus)
+        }
+        print("!!! statuses: \(StatusView.statuses)")
+        StatusView().manageStatuses()
     }
     
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -399,6 +399,11 @@ extension TopBannerViewController: NavigationComponent {
         
         if (proactive) {
             let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
+            
+            // create faster route status and append to array of statuses
+            let fasterRouteStatus = StatusView.Status(id: title, duration: 3, priority: StatusView.Priority(rawValue: 0))
+            StatusView().statuses.append(fasterRouteStatus)
+            
             statusView.showStatus(title: title, spinner: true, duration: 3)
         }
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -388,13 +388,7 @@ extension TopBannerViewController: NavigationComponent {
         
         // create rerouting status and append to array of statuses
         let reroutingStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 0))
-        if let row = StatusView.statuses.firstIndex(where: {$0.id == title}) {
-            StatusView.statuses[row] = reroutingStatus
-        } else {
-            StatusView.statuses.append(reroutingStatus)
-        }
-        print("!!! statuses: \(StatusView.statuses)")
-        StatusView().manageStatuses()
+        addNewStatus(status: reroutingStatus)
     }
     
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
@@ -412,9 +406,7 @@ extension TopBannerViewController: NavigationComponent {
             
             // create faster route status and append to array of statuses
             let fasterRouteStatus = StatusView.Status(id: title, duration: 3, priority: StatusView.Priority(rawValue: 0))
-            StatusView.statuses.append(fasterRouteStatus)
-            
-            statusView.showStatus(title: title, spinner: true, duration: 3)
+            statusView.addNewStatus(status: fasterRouteStatus)
         }
     }
     
@@ -478,6 +470,10 @@ extension TopBannerViewController: CarPlayConnectionObserver {
 extension TopBannerViewController: NavigationStatusPresenter {
     public func showStatus(title: String, spinner spin: Bool, duration time: TimeInterval, animated: Bool, interactive: Bool) {
         statusView.showStatus(title: title, spinner: spin, duration: time, animated: animated, interactive: interactive)
+    }
+    
+    public func addNewStatus(status: StatusView.Status) {
+        statusView.addNewStatus(status: status)
     }
 }
 

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -469,10 +469,6 @@ extension TopBannerViewController: CarPlayConnectionObserver {
 }
 
 extension TopBannerViewController: NavigationStatusPresenter {
-    public func showStatus(title: String, spinner spin: Bool, duration time: TimeInterval, animated: Bool, interactive: Bool) {
-        statusView.showStatus(title: title, spinner: spin, duration: time, animated: animated, interactive: interactive)
-    }
-    
     public func hideStatus(using status: StatusView.Status) {
         statusView.hideStatus(using: status)
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -470,8 +470,12 @@ extension TopBannerViewController: CarPlayConnectionObserver {
 }
 
 extension TopBannerViewController: NavigationStatusPresenter {
-    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil) {
-        statusView.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus)
+    public func showStatus(title: String, spinner spin: Bool, duration time: TimeInterval, animated: Bool, interactive: Bool) {
+        statusView.showStatus(title: title, spinner: spin, duration: time, animated: animated, interactive: interactive)
+    }
+    
+    public func hideStatus(using status: StatusView.Status) {
+        statusView.hideStatus(using: status)
     }
     
     public func addNewStatus(status: StatusView.Status) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -384,9 +384,6 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
-        // statusView.show(title, showSpinner: true)
-        
-        // create rerouting status and append to array of statuses
         let reroutingStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 0))
         addNewStatus(status: reroutingStatus)
     }
@@ -418,7 +415,6 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
         guard reason == .manual else { return }
         statusView.hide(delay: 0, animated: true)
-        // statusView.hide("simulating")
     }
     
     private func embed(_ child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])? = nil) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -399,7 +399,6 @@ extension TopBannerViewController: NavigationComponent {
             statusView.showSimulationStatus(speed: Int(service.simulationSpeedMultiplier))
         } else {
             statusView.hide(delay: 2, animated: true)
-            // statusView.hideStatus("simulating")
         }
         
         if (proactive) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -470,12 +470,8 @@ extension TopBannerViewController: CarPlayConnectionObserver {
 }
 
 extension TopBannerViewController: NavigationStatusPresenter {
-    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil, delay: TimeInterval = 0) {
-        statusView.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus, delay: delay)
-    }
-    
-    public func showStatus(title: String, spinner spin: Bool, duration time: TimeInterval, animated: Bool, interactive: Bool) {
-        statusView.showStatus(title: title, spinner: spin, duration: time, animated: animated, interactive: interactive)
+    public func hideStatus(usingStatusId: String? = "", usingStatus: StatusView.Status? = nil) {
+        statusView.hideStatus(usingStatusId: usingStatusId, usingStatus: usingStatus)
     }
     
     public func addNewStatus(status: StatusView.Status) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -384,8 +384,8 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
-        let reroutingStatus = StatusView.Status(id: title, duration: 20, priority: StatusView.Priority(rawValue: 0))
-        addNewStatus(status: reroutingStatus)
+        let reroutingStatus = StatusView.Status(identifier: "REROUTING", title: title, duration: 20, priority: StatusView.Priority(rawValue: 0))
+        show(reroutingStatus)
     }
     
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
@@ -402,8 +402,8 @@ extension TopBannerViewController: NavigationComponent {
             let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
             
             // create faster route status and append to array of statuses
-            let fasterRouteStatus = StatusView.Status(id: title, duration: 3, priority: StatusView.Priority(rawValue: 0))
-            statusView.addNewStatus(status: fasterRouteStatus)
+            let fasterRouteStatus = StatusView.Status(identifier: "FASTER_ROUTE_FOUND", title: title, duration: 3, priority: StatusView.Priority(rawValue: 0))
+            statusView.show(fasterRouteStatus)
         }
     }
     
@@ -465,14 +465,24 @@ extension TopBannerViewController: CarPlayConnectionObserver {
 }
 
 extension TopBannerViewController: NavigationStatusPresenter {
-    public func hideStatus(using status: StatusView.Status) {
-        statusView.hideStatus(using: status)
+    /**
+     Shows a Status for a specified amount of time.
+     */
+    public func show(_ status: StatusView.Status) {
+        statusView.show(status)
     }
     
-    public func addNewStatus(status: StatusView.Status) {
-        statusView.addNewStatus(status: status)
+    /**
+     Hides a given Status without hiding the status view.
+     */
+    public func hide(_ status: StatusView.Status) {
+        statusView.hide(status)
     }
     
+    @available(*, deprecated, message: "Add a status using show(_:) instead")
+    public func showStatus(title: String, spinner spin: Bool, duration: TimeInterval, animated: Bool, interactive: Bool) {
+        statusView.showStatus(title: title, spinner: spin, duration: duration, animated: animated, interactive: interactive)
+    }
 }
 
 extension TopBannerViewController: NavigationMapInteractionObserver {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -384,7 +384,7 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
-        let reroutingStatus = StatusView.Status(identifier: "REROUTING", title: title, duration: 20, priority: StatusView.Priority(0))
+        let reroutingStatus = StatusView.Status(identifier: "REROUTING", title: title, duration: 20, priority: StatusView.Priority(value: 0))
         show(reroutingStatus)
     }
     
@@ -402,7 +402,7 @@ extension TopBannerViewController: NavigationComponent {
             let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
             
             // create faster route status and append to array of statuses
-            let fasterRouteStatus = StatusView.Status(identifier: "FASTER_ROUTE_FOUND", title: title, duration: 3, priority: StatusView.Priority(0))
+            let fasterRouteStatus = StatusView.Status(identifier: "FASTER_ROUTE_FOUND", title: title, duration: 3, priority: StatusView.Priority(value: 0))
             statusView.show(fasterRouteStatus)
         }
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -465,16 +465,10 @@ extension TopBannerViewController: CarPlayConnectionObserver {
 }
 
 extension TopBannerViewController: NavigationStatusPresenter {
-    /**
-     Shows a Status for a specified amount of time.
-     */
     public func show(_ status: StatusView.Status) {
         statusView.show(status)
     }
     
-    /**
-     Hides a given Status without hiding the status view.
-     */
     public func hide(_ status: StatusView.Status) {
         statusView.hide(status)
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -384,7 +384,7 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
-        let reroutingStatus = StatusView.Status(identifier: "REROUTING", title: title, duration: 20, priority: StatusView.Priority(rawValue: 0))
+        let reroutingStatus = StatusView.Status(identifier: "REROUTING", title: title, duration: 20, priority: StatusView.Priority(0))
         show(reroutingStatus)
     }
     
@@ -402,7 +402,7 @@ extension TopBannerViewController: NavigationComponent {
             let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
             
             // create faster route status and append to array of statuses
-            let fasterRouteStatus = StatusView.Status(identifier: "FASTER_ROUTE_FOUND", title: title, duration: 3, priority: StatusView.Priority(rawValue: 0))
+            let fasterRouteStatus = StatusView.Status(identifier: "FASTER_ROUTE_FOUND", title: title, duration: 3, priority: StatusView.Priority(0))
             statusView.show(fasterRouteStatus)
         }
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -384,7 +384,7 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         let title = NSLocalizedString("REROUTING", bundle: .mapboxNavigation, value: "Rerouting…", comment: "Indicates that rerouting is in progress")
         lanesView.hide()
-        let reroutingStatus = StatusView.Status(identifier: "REROUTING", title: title, duration: 20, priority: StatusView.Priority(value: 0))
+        let reroutingStatus = StatusView.Status(identifier: "REROUTING", title: title, duration: 20, priority: 0)
         show(reroutingStatus)
     }
     
@@ -402,7 +402,7 @@ extension TopBannerViewController: NavigationComponent {
             let title = NSLocalizedString("FASTER_ROUTE_FOUND", bundle: .mapboxNavigation, value: "Faster Route Found", comment: "Indicates a faster route was found")
             
             // create faster route status and append to array of statuses
-            let fasterRouteStatus = StatusView.Status(identifier: "FASTER_ROUTE_FOUND", title: title, duration: 3, priority: StatusView.Priority(value: 0))
+            let fasterRouteStatus = StatusView.Status(identifier: "FASTER_ROUTE_FOUND", title: title, duration: 3, priority: 0)
             statusView.show(fasterRouteStatus)
         }
     }

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 			buildConfigurationList = 352544F91E66623D004C8F1C /* Build configuration list for PBXNativeTarget "PodInstall" */;
 			buildPhases = (
 				FCAEDB6CF8C116409B047EA1 /* [CP] Check Pods Manifest.lock */,
+				C0CE5D7A671F38C9FBA189FB /* [CP] Prepare Artifacts */,
 				352544D81E66623D004C8F1C /* Sources */,
 				352544D91E66623D004C8F1C /* Frameworks */,
 				352544DA1E66623D004C8F1C /* Resources */,
@@ -231,11 +232,19 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/cocoapods-artifacts-${CONFIGURATION}.txt",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/8F3E82C3-52DF-39E5-809D-3389B6CBCAD4.bcsymbolmap",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/0DC8DAD8-C6D7-343B-ACBF-79B48068D7CC.bcsymbolmap",
+				"${PODS_ROOT}/MapboxAccounts/MapboxAccounts.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxDirections/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
+				"${PODS_ROOT}/MapboxNavigationNative/MapboxNavigationNative.framework",
+				"${PODS_ROOT}/MapboxNavigationNative/MapboxNavigationNative.framework.dSYM",
+				"${PODS_ROOT}/MapboxNavigationNative/4868A5C8-3179-3F0D-ABFC-0C941CC5D2E4.bcsymbolmap",
 				"${BUILT_PRODUCTS_DIR}/MapboxSpeech/MapboxSpeech.framework",
 				"${BUILT_PRODUCTS_DIR}/Polyline/Polyline.framework",
 				"${BUILT_PRODUCTS_DIR}/Solar/Solar.framework",
@@ -247,10 +256,17 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/8F3E82C3-52DF-39E5-809D-3389B6CBCAD4.bcsymbolmap",
+				"${BUILT_PRODUCTS_DIR}/0DC8DAD8-C6D7-343B-ACBF-79B48068D7CC.bcsymbolmap",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxAccounts.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxNavigationNative.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/MapboxNavigationNative.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/4868A5C8-3179-3F0D-ABFC-0C941CC5D2E4.bcsymbolmap",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxSpeech.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Polyline.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Solar.framework",
@@ -262,6 +278,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C0CE5D7A671F38C9FBA189FB /* [CP] Prepare Artifacts */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-artifacts.sh",
+				"${PODS_ROOT}/MapboxCommon/MapboxCommon.xcframework",
+			);
+			name = "[CP] Prepare Artifacts";
+			outputPaths = (
+				"${BUILT_PRODUCTS_DIR}/cocoapods-artifacts-${CONFIGURATION}.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-artifacts.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FCAEDB6CF8C116409B047EA1 /* [CP] Check Pods Manifest.lock */ = {

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 @testable import MapboxNavigation
 @testable import MapboxCoreNavigation
 
@@ -9,50 +10,58 @@ class StatusViewTests: XCTestCase {
         return view
     }()
 
-    func testWithSignificantDelay() {
+    func testWithDelayShorterThanDuration() {
         addNewStatus(status: firstStatus())
-        let seconds = 4.0
-        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
-            XCTAssertEqual(self.statusView.statuses.count, 0)
-        }
+//        let seconds = 4.0
+
+        XCTAssertEqual(self.statusView.statuses.count, 1)
     }
     
-    func testWithDurationDelay() {
+    func testWithDelayLongerThanDuration() {
+        let seconds = 10.0
+//        Thread.sleep(forTimeInterval: seconds)
+        XCTAssertTrue(statusView.isHidden)
         addNewStatus(status: firstStatus())
-        let seconds = firstStatus().duration
-        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
-            XCTAssertEqual(self.statusView.statuses.count, 0)
-        }
+        XCTAssertFalse(statusView.isHidden)
+        let path = #keyPath(UIView.isHidden)
+        let expectation = XCTKVOExpectation(keyPath: path, object: statusView, expectedValue: true)
+        self.wait(for: [expectation], timeout: seconds)
+        XCTAssertTrue(statusView.isHidden)
+        XCTAssertEqual(self.statusView.statuses.count, 0)
     }
-    
-    func testFirstAndSecond() {
-        addNewStatus(status: firstStatus())
-        XCTAssertEqual(statusView.statuses.count, 1)
-        addNewStatus(status: secondStatus())
-        XCTAssertEqual(statusView.statuses.count, 2)
-        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus().duration + secondStatus().duration) {
-            XCTAssertEqual(self.statusView.statuses.count, 0)
-        }
-    }
-    
-    func testFirstAndSecondWithDelay() {
-        addNewStatus(status: firstStatus())
-        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus().duration) {
-            self.addNewStatus(status: self.secondStatus())
-            XCTAssertEqual(self.statusView.statuses.count, 1)
-        }
-    }
-    
-    func testFirstAndThird() {
-        print("!!! statuses before reset: \(statusView.statuses)")
-        clearStatuses()
-        addNewStatus(status: firstStatus())
-        addNewStatus(status: thirdStatus())
-        XCTAssertEqual(self.statusView.statuses.count, 2)
-        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus().duration) {
-            XCTAssertEqual(self.statusView.statuses.count, 1)
-        }
-    }
+//
+//    func testWithDurationDelay() {
+//        addNewStatus(status: firstStatus())
+//        let seconds = firstStatus().duration
+//        Thread.sleep(forTimeInterval: seconds)
+//        XCTAssertEqual(self.statusView.statuses.count, 0)
+//    }
+//
+//    func testFirstAndSecond() {
+//        addNewStatus(status: firstStatus())
+//        XCTAssertEqual(statusView.statuses.count, 1)
+//        addNewStatus(status: secondStatus())
+//        XCTAssertEqual(statusView.statuses.count, 2)
+//        Thread.sleep(forTimeInterval: firstStatus().duration + secondStatus().duration)
+//        XCTAssertEqual(self.statusView.statuses.count, 0)
+//    }
+//
+//    func testFirstAndSecondWithDelay() {
+//        addNewStatus(status: firstStatus())
+//        Thread.sleep(forTimeInterval: firstStatus().duration)
+//        self.addNewStatus(status: self.secondStatus())
+//        XCTAssertEqual(self.statusView.statuses.count, 1)
+//    }
+//
+//    func testFirstAndThird() {
+//        print("!!! statuses before reset: \(statusView.statuses)")
+//        clearStatuses()
+//        addNewStatus(status: firstStatus())
+//        addNewStatus(status: thirdStatus())
+//        XCTAssertEqual(self.statusView.statuses.count, 2)
+//        Thread.sleep(forTimeInterval: firstStatus().duration)
+//        XCTAssertEqual(self.statusView.statuses.count, 1)
+//    }
 }
 
 extension StatusViewTests {
@@ -60,17 +69,22 @@ extension StatusViewTests {
     // define statuses
     func firstStatus() -> StatusView.Status {
         let title1 = NSLocalizedString("FIRST_TEST_STATUS", bundle: .mapboxNavigation, value: "first test status", comment: "the first status banner used for testing")
-        return StatusView.Status(id: title1, duration: 50, priority: StatusView.Priority(rawValue: 0))
+        return StatusView.Status(id: title1, duration: 5, priority: StatusView.Priority(rawValue: 0))
     }
     
     func secondStatus() -> StatusView.Status {
         let title2 = NSLocalizedString("SECOND_TEST_STATUS", bundle: .mapboxNavigation, value: "second test status", comment: "the second status banner used for testing")
-        return StatusView.Status(id: title2, duration: 100, priority: StatusView.Priority(rawValue: 1))
+        return StatusView.Status(id: title2, duration: 10, priority: StatusView.Priority(rawValue: 1))
     }
     
     func thirdStatus() -> StatusView.Status {
         let title3 = NSLocalizedString("THIRD_TEST_STATUS", bundle: .mapboxNavigation, value: "third test status", comment: "the third status banner used for testing")
         return StatusView.Status(id: title3, duration: .infinity, priority: StatusView.Priority(rawValue: 2))
+    }
+    
+    func fourthStatus() -> StatusView.Status {
+        let title4 = NSLocalizedString("FOURTH_TEST_STATUS", bundle: .mapboxNavigation, value: "fourth test status", comment: "the fourth status banner used for testing")
+        return StatusView.Status(id: title4, duration: 0.5, priority: StatusView.Priority(rawValue: 3))
     }
 
     func addNewStatus(status: StatusView.Status) {
@@ -84,5 +98,6 @@ extension StatusViewTests {
     func clearStatuses() {
         statusView.statuses.removeAll()
     }
+    
 }
 

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -19,7 +19,6 @@ class StatusViewTests: XCTestCase {
     
     func testWithDelayLongerThanDuration() {
         let seconds = 10.0
-//        Thread.sleep(forTimeInterval: seconds)
         XCTAssertTrue(statusView.isHidden)
         addNewStatus(status: firstStatus())
         XCTAssertFalse(statusView.isHidden)

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -38,7 +38,7 @@ class StatusViewTests: XCTestCase {
         XCTAssertTrue(statusView.isHidden)
         XCTAssertEqual(self.statusView.statuses.count, 0)
     }
-
+    
     func testFirstAndThird() {
         addNewStatus(status: firstStatus())
         addNewStatus(status: thirdStatus())

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -12,13 +12,11 @@ class StatusViewTests: XCTestCase {
 
     func testWithDelayShorterThanDuration() {
         addNewStatus(status: firstStatus())
-//        let seconds = 4.0
-
         XCTAssertEqual(self.statusView.statuses.count, 1)
     }
-    
+
     func testWithDelayLongerThanDuration() {
-        let seconds = 10.0
+        let seconds = 5.0
         XCTAssertTrue(statusView.isHidden)
         addNewStatus(status: firstStatus())
         XCTAssertFalse(statusView.isHidden)
@@ -28,39 +26,29 @@ class StatusViewTests: XCTestCase {
         XCTAssertTrue(statusView.isHidden)
         XCTAssertEqual(self.statusView.statuses.count, 0)
     }
-//
-//    func testWithDurationDelay() {
-//        addNewStatus(status: firstStatus())
-//        let seconds = firstStatus().duration
-//        Thread.sleep(forTimeInterval: seconds)
-//        XCTAssertEqual(self.statusView.statuses.count, 0)
-//    }
-//
-//    func testFirstAndSecond() {
-//        addNewStatus(status: firstStatus())
-//        XCTAssertEqual(statusView.statuses.count, 1)
-//        addNewStatus(status: secondStatus())
-//        XCTAssertEqual(statusView.statuses.count, 2)
-//        Thread.sleep(forTimeInterval: firstStatus().duration + secondStatus().duration)
-//        XCTAssertEqual(self.statusView.statuses.count, 0)
-//    }
-//
-//    func testFirstAndSecondWithDelay() {
-//        addNewStatus(status: firstStatus())
-//        Thread.sleep(forTimeInterval: firstStatus().duration)
-//        self.addNewStatus(status: self.secondStatus())
-//        XCTAssertEqual(self.statusView.statuses.count, 1)
-//    }
-//
-//    func testFirstAndThird() {
-//        print("!!! statuses before reset: \(statusView.statuses)")
-//        clearStatuses()
-//        addNewStatus(status: firstStatus())
-//        addNewStatus(status: thirdStatus())
-//        XCTAssertEqual(self.statusView.statuses.count, 2)
-//        Thread.sleep(forTimeInterval: firstStatus().duration)
-//        XCTAssertEqual(self.statusView.statuses.count, 1)
-//    }
+
+    func testFirstAndSecond() {
+        addNewStatus(status: firstStatus())
+        XCTAssertFalse(statusView.isHidden)
+        addNewStatus(status: secondStatus())
+        XCTAssertEqual(statusView.statuses.count, 2)
+        let path = #keyPath(UIView.isHidden)
+        let expectation = XCTKVOExpectation(keyPath: path, object: statusView, expectedValue: true)
+        self.wait(for: [expectation], timeout: secondStatus().duration + 10.0)
+        XCTAssertTrue(statusView.isHidden)
+        XCTAssertEqual(self.statusView.statuses.count, 0)
+    }
+
+    func testFirstAndThird() {
+        addNewStatus(status: firstStatus())
+        addNewStatus(status: thirdStatus())
+        XCTAssertEqual(self.statusView.statuses.count, 2)
+        let path = #keyPath(UIView.isHidden)
+        let expectation = XCTKVOExpectation(keyPath: path, object: statusView, expectedValue: true)
+        self.wait(for: [expectation], timeout: 15.0)
+        XCTAssertFalse(statusView.isHidden)
+        XCTAssertEqual(self.statusView.statuses.count, 1)
+    }
 }
 
 extension StatusViewTests {
@@ -68,35 +56,29 @@ extension StatusViewTests {
     // define statuses
     func firstStatus() -> StatusView.Status {
         let title1 = NSLocalizedString("FIRST_TEST_STATUS", bundle: .mapboxNavigation, value: "first test status", comment: "the first status banner used for testing")
-        return StatusView.Status(id: title1, duration: 5, priority: StatusView.Priority(rawValue: 0))
+        return StatusView.Status(id: title1, duration: 1, priority: StatusView.Priority(rawValue: 0))
     }
     
     func secondStatus() -> StatusView.Status {
         let title2 = NSLocalizedString("SECOND_TEST_STATUS", bundle: .mapboxNavigation, value: "second test status", comment: "the second status banner used for testing")
-        return StatusView.Status(id: title2, duration: 10, priority: StatusView.Priority(rawValue: 1))
+        return StatusView.Status(id: title2, duration: 5, priority: StatusView.Priority(rawValue: 1))
     }
     
     func thirdStatus() -> StatusView.Status {
         let title3 = NSLocalizedString("THIRD_TEST_STATUS", bundle: .mapboxNavigation, value: "third test status", comment: "the third status banner used for testing")
         return StatusView.Status(id: title3, duration: .infinity, priority: StatusView.Priority(rawValue: 2))
     }
-    
-    func fourthStatus() -> StatusView.Status {
-        let title4 = NSLocalizedString("FOURTH_TEST_STATUS", bundle: .mapboxNavigation, value: "fourth test status", comment: "the fourth status banner used for testing")
-        return StatusView.Status(id: title4, duration: 0.5, priority: StatusView.Priority(rawValue: 3))
-    }
 
     func addNewStatus(status: StatusView.Status) {
         statusView.addNewStatus(status: status)
     }
     
-    func hideStatus(status: StatusView.Status) {
-        statusView.hideStatus(usingStatus: status)
+    func hideStatus(with status: StatusView.Status) {
+        statusView.hideStatus(using: status)
     }
     
     func clearStatuses() {
         statusView.statuses.removeAll()
     }
-    
 }
 

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -39,13 +39,13 @@ class StatusViewTests: XCTestCase {
         XCTAssertEqual(self.statusView.statuses.count, 0)
     }
     
-    func testFirstAndThird() {
+    func testWithInfinite() {
         addNewStatus(status: firstStatus())
         addNewStatus(status: thirdStatus())
         XCTAssertEqual(self.statusView.statuses.count, 2)
         let path = #keyPath(UIView.isHidden)
         let expectation = XCTKVOExpectation(keyPath: path, object: statusView, expectedValue: true)
-        self.wait(for: [expectation], timeout: 15.0)
+        XCTWaiter.wait(for: [expectation], timeout: 15.0)
         XCTAssertFalse(statusView.isHidden)
         XCTAssertEqual(self.statusView.statuses.count, 1)
     }

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -2,63 +2,87 @@ import XCTest
 @testable import MapboxNavigation
 @testable import MapboxCoreNavigation
 
-class StatusViewTests {
+class StatusViewTests: XCTestCase {
     lazy var statusView: StatusView = {
         let view: StatusView = .forAutoLayout()
         view.isHidden = true
         return view
     }()
-    
-    
-    let title = NSLocalizedString("TEST_STATUS_1", bundle: .mapboxNavigation, value: "test status 1", comment: "the first status banner used for testing")
-    let firstStatus = StatusView.Status(id: title, duration: 0.5, priority: StatusView.Priority(rawValue: 0))
-    
-    let title = NSLocalizedString("TEST_STATUS_2", bundle: .mapboxNavigation, value: "test status 2", comment: "the second status banner used for testing")
-    let secondStatus = StatusView.Status(id: title, duration: 0.1, priority: StatusView.Priority(rawValue: 1))
-    
-    let title = NSLocalizedString("TEST_STATUS_3", bundle: .mapboxNavigation, value: "test status 3", comment: "the third status banner used for testing")
-    let thirdStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 2))
-    
+
     func testWithSignificantDelay() {
-        addNewStatus(status: firstStatus)
+        addNewStatus(status: firstStatus())
         let seconds = 4.0
-        Dispatch.Queue.main.asyncAfter(deadline: .now() + seconds) {
-            XCTAssertEqual(statusView.statuses.count, 0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
+            XCTAssertEqual(self.statusView.statuses.count, 0)
         }
     }
     
     func testWithDurationDelay() {
-        addNewStatus(status: firstStatus)
-        let seconds = firstStatus.duration
-        Dispatch.Queue.main.asyncAfter(deadline: .now() + seconds) {
-            XCTAssertEqual(statusView.statuses.count, 0)
+        addNewStatus(status: firstStatus())
+        let seconds = firstStatus().duration
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
+            XCTAssertEqual(self.statusView.statuses.count, 0)
         }
     }
     
     func testFirstAndSecond() {
-        addNewStatus(status: firstStatus)
-        addNewStatus(status: secondStatus)
+        addNewStatus(status: firstStatus())
+        XCTAssertEqual(statusView.statuses.count, 1)
+        addNewStatus(status: secondStatus())
         XCTAssertEqual(statusView.statuses.count, 2)
-        Dispatch.Queue.main.asyncAfter(deadline: .now() + firstStatus.duration + secondStatus.duration) {
-            XCTAssertEqual(statusView.statuses.count, 0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus().duration + secondStatus().duration) {
+            XCTAssertEqual(self.statusView.statuses.count, 0)
         }
     }
     
     func testFirstAndSecondWithDelay() {
-        addNewStatus(status: firstStatus)
-        Dispatch.Queue.main.asyncAfter(deadline: .now() + firstStatus.duration) {
-            addNewStatus(status: secondStatus)
-            XCTAssertEqual(statusView.statuses.count, 1)
+        addNewStatus(status: firstStatus())
+        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus().duration) {
+            self.addNewStatus(status: self.secondStatus())
+            XCTAssertEqual(self.statusView.statuses.count, 1)
         }
     }
     
     func testFirstAndThird() {
-        addNewStatus(status: firstStatus)
-        addNewStatus(status: thirdStatus)
-        XCTAssertEqual(statusView.status.count, 2)
-        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus.durationze) {
-            XCTAssertEqual(statusView.statuses.count, 1)
+        print("!!! statuses before reset: \(statusView.statuses)")
+        clearStatuses()
+        addNewStatus(status: firstStatus())
+        addNewStatus(status: thirdStatus())
+        XCTAssertEqual(self.statusView.statuses.count, 2)
+        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus().duration) {
+            XCTAssertEqual(self.statusView.statuses.count, 1)
         }
     }
-    
 }
+
+extension StatusViewTests {
+    
+    // define statuses
+    func firstStatus() -> StatusView.Status {
+        let title1 = NSLocalizedString("FIRST_TEST_STATUS", bundle: .mapboxNavigation, value: "first test status", comment: "the first status banner used for testing")
+        return StatusView.Status(id: title1, duration: 50, priority: StatusView.Priority(rawValue: 0))
+    }
+    
+    func secondStatus() -> StatusView.Status {
+        let title2 = NSLocalizedString("SECOND_TEST_STATUS", bundle: .mapboxNavigation, value: "second test status", comment: "the second status banner used for testing")
+        return StatusView.Status(id: title2, duration: 100, priority: StatusView.Priority(rawValue: 1))
+    }
+    
+    func thirdStatus() -> StatusView.Status {
+        let title3 = NSLocalizedString("THIRD_TEST_STATUS", bundle: .mapboxNavigation, value: "third test status", comment: "the third status banner used for testing")
+        return StatusView.Status(id: title3, duration: .infinity, priority: StatusView.Priority(rawValue: 2))
+    }
+
+    func addNewStatus(status: StatusView.Status) {
+        statusView.addNewStatus(status: status)
+    }
+    
+    func hideStatus(status: StatusView.Status) {
+        statusView.hideStatus(usingStatus: status)
+    }
+    
+    func clearStatuses() {
+        statusView.statuses.removeAll()
+    }
+}
+

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import MapboxNavigation
+@testable import MapboxCoreNavigation
+
+class StatusViewTests {
+    lazy var statusView: StatusView = {
+        let view: StatusView = .forAutoLayout()
+        view.isHidden = true
+        return view
+    }()
+    
+    
+    let title = NSLocalizedString("TEST_STATUS_1", bundle: .mapboxNavigation, value: "test status 1", comment: "the first status banner used for testing")
+    let firstStatus = StatusView.Status(id: title, duration: 0.5, priority: StatusView.Priority(rawValue: 0))
+    
+    let title = NSLocalizedString("TEST_STATUS_2", bundle: .mapboxNavigation, value: "test status 2", comment: "the second status banner used for testing")
+    let secondStatus = StatusView.Status(id: title, duration: 0.1, priority: StatusView.Priority(rawValue: 1))
+    
+    let title = NSLocalizedString("TEST_STATUS_3", bundle: .mapboxNavigation, value: "test status 3", comment: "the third status banner used for testing")
+    let thirdStatus = StatusView.Status(id: title, duration: .infinity, priority: StatusView.Priority(rawValue: 2))
+    
+    func testWithSignificantDelay() {
+        addNewStatus(status: firstStatus)
+        let seconds = 4.0
+        Dispatch.Queue.main.asyncAfter(deadline: .now() + seconds) {
+            XCTAssertEqual(statusView.statuses.count, 0)
+        }
+    }
+    
+    func testWithDurationDelay() {
+        addNewStatus(status: firstStatus)
+        let seconds = firstStatus.duration
+        Dispatch.Queue.main.asyncAfter(deadline: .now() + seconds) {
+            XCTAssertEqual(statusView.statuses.count, 0)
+        }
+    }
+    
+    func testFirstAndSecond() {
+        addNewStatus(status: firstStatus)
+        addNewStatus(status: secondStatus)
+        XCTAssertEqual(statusView.statuses.count, 2)
+        Dispatch.Queue.main.asyncAfter(deadline: .now() + firstStatus.duration + secondStatus.duration) {
+            XCTAssertEqual(statusView.statuses.count, 0)
+        }
+    }
+    
+    func testFirstAndSecondWithDelay() {
+        addNewStatus(status: firstStatus)
+        Dispatch.Queue.main.asyncAfter(deadline: .now() + firstStatus.duration) {
+            addNewStatus(status: secondStatus)
+            XCTAssertEqual(statusView.statuses.count, 1)
+        }
+    }
+    
+    func testFirstAndThird() {
+        addNewStatus(status: firstStatus)
+        addNewStatus(status: thirdStatus)
+        XCTAssertEqual(statusView.status.count, 2)
+        DispatchQueue.main.asyncAfter(deadline: .now() + firstStatus.durationze) {
+            XCTAssertEqual(statusView.statuses.count, 1)
+        }
+    }
+    
+}

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -55,15 +55,15 @@ extension StatusViewTests {
     
     // define statuses
     func firstStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "FIRST_TEST_STATUS", title: "first test status", duration: 1, priority: StatusView.Priority(rawValue: 0))
+        return StatusView.Status(identifier: "FIRST_TEST_STATUS", title: "first test status", duration: 1, priority: StatusView.Priority(0))
     }
     
     func secondStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "SECOND_TEST_STATUS", title: "second test status", duration: 5, priority: StatusView.Priority(rawValue: 1))
+        return StatusView.Status(identifier: "SECOND_TEST_STATUS", title: "second test status", duration: 5, priority: StatusView.Priority(1))
     }
     
     func thirdStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "THIRD_TEST_STATUS", title: "third test status", duration: .infinity, priority: StatusView.Priority(rawValue: 2))
+        return StatusView.Status(identifier: "THIRD_TEST_STATUS", title: "third test status", duration: .infinity, priority: StatusView.Priority(2))
     }
 
     func show(_ status: StatusView.Status) {

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -55,15 +55,15 @@ extension StatusViewTests {
     
     // define statuses
     func firstStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "FIRST_TEST_STATUS", title: "first test status", duration: 1, priority: StatusView.Priority(0))
+        return StatusView.Status(identifier: "FIRST_TEST_STATUS", title: "first test status", duration: 1, priority: StatusView.Priority(value: 0))
     }
     
     func secondStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "SECOND_TEST_STATUS", title: "second test status", duration: 5, priority: StatusView.Priority(1))
+        return StatusView.Status(identifier: "SECOND_TEST_STATUS", title: "second test status", duration: 5, priority: StatusView.Priority(value: 1))
     }
     
     func thirdStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "THIRD_TEST_STATUS", title: "third test status", duration: .infinity, priority: StatusView.Priority(2))
+        return StatusView.Status(identifier: "THIRD_TEST_STATUS", title: "third test status", duration: .infinity, priority: StatusView.Priority(value: 2))
     }
 
     func show(_ status: StatusView.Status) {

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -55,15 +55,15 @@ extension StatusViewTests {
     
     // define statuses
     func firstStatus() -> StatusView.Status {
-        return StatusView.Status(id: "first test status", duration: 1, priority: StatusView.Priority(rawValue: 0))
+        return StatusView.Status(identifier: "FIRST_TEST_STATUS", title: "first test status", duration: 1, priority: StatusView.Priority(rawValue: 0))
     }
     
     func secondStatus() -> StatusView.Status {
-        return StatusView.Status(id: "second test status", duration: 5, priority: StatusView.Priority(rawValue: 1))
+        return StatusView.Status(identifier: "SECOND_TEST_STATUS", title: "second test status", duration: 5, priority: StatusView.Priority(rawValue: 1))
     }
     
     func thirdStatus() -> StatusView.Status {
-        return StatusView.Status(id: "third test status", duration: .infinity, priority: StatusView.Priority(rawValue: 2))
+        return StatusView.Status(identifier: "THIRD_TEST_STATUS", title: "third test status", duration: .infinity, priority: StatusView.Priority(rawValue: 2))
     }
 
     func show(_ status: StatusView.Status) {

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -11,14 +11,14 @@ class StatusViewTests: XCTestCase {
     }()
 
     func testWithDelayShorterThanDuration() {
-        addNewStatus(status: firstStatus())
+        show(firstStatus())
         XCTAssertEqual(self.statusView.statuses.count, 1)
     }
 
     func testWithDelayLongerThanDuration() {
         let seconds = 5.0
         XCTAssertTrue(statusView.isHidden)
-        addNewStatus(status: firstStatus())
+        show(firstStatus())
         XCTAssertFalse(statusView.isHidden)
         let path = #keyPath(UIView.isHidden)
         let expectation = XCTKVOExpectation(keyPath: path, object: statusView, expectedValue: true)
@@ -28,9 +28,9 @@ class StatusViewTests: XCTestCase {
     }
 
     func testFirstAndSecond() {
-        addNewStatus(status: firstStatus())
+        show(firstStatus())
         XCTAssertFalse(statusView.isHidden)
-        addNewStatus(status: secondStatus())
+        show(secondStatus())
         XCTAssertEqual(statusView.statuses.count, 2)
         let path = #keyPath(UIView.isHidden)
         let expectation = XCTKVOExpectation(keyPath: path, object: statusView, expectedValue: true)
@@ -40,8 +40,8 @@ class StatusViewTests: XCTestCase {
     }
     
     func testWithInfinite() {
-        addNewStatus(status: firstStatus())
-        addNewStatus(status: thirdStatus())
+        show(firstStatus())
+        show(thirdStatus())
         XCTAssertEqual(self.statusView.statuses.count, 2)
         let path = #keyPath(UIView.isHidden)
         let expectation = XCTKVOExpectation(keyPath: path, object: statusView, expectedValue: true)
@@ -55,26 +55,23 @@ extension StatusViewTests {
     
     // define statuses
     func firstStatus() -> StatusView.Status {
-        let title1 = NSLocalizedString("FIRST_TEST_STATUS", bundle: .mapboxNavigation, value: "first test status", comment: "the first status banner used for testing")
-        return StatusView.Status(id: title1, duration: 1, priority: StatusView.Priority(rawValue: 0))
+        return StatusView.Status(id: "first test status", duration: 1, priority: StatusView.Priority(rawValue: 0))
     }
     
     func secondStatus() -> StatusView.Status {
-        let title2 = NSLocalizedString("SECOND_TEST_STATUS", bundle: .mapboxNavigation, value: "second test status", comment: "the second status banner used for testing")
-        return StatusView.Status(id: title2, duration: 5, priority: StatusView.Priority(rawValue: 1))
+        return StatusView.Status(id: "second test status", duration: 5, priority: StatusView.Priority(rawValue: 1))
     }
     
     func thirdStatus() -> StatusView.Status {
-        let title3 = NSLocalizedString("THIRD_TEST_STATUS", bundle: .mapboxNavigation, value: "third test status", comment: "the third status banner used for testing")
-        return StatusView.Status(id: title3, duration: .infinity, priority: StatusView.Priority(rawValue: 2))
+        return StatusView.Status(id: "third test status", duration: .infinity, priority: StatusView.Priority(rawValue: 2))
     }
 
-    func addNewStatus(status: StatusView.Status) {
-        statusView.addNewStatus(status: status)
+    func show(_ status: StatusView.Status) {
+        statusView.show(status)
     }
     
-    func hideStatus(with status: StatusView.Status) {
-        statusView.hideStatus(using: status)
+    func hide(_ status: StatusView.Status) {
+        statusView.hide(status)
     }
     
     func clearStatuses() {

--- a/Tests/MapboxNavigationTests/StatusViewTests.swift
+++ b/Tests/MapboxNavigationTests/StatusViewTests.swift
@@ -55,15 +55,15 @@ extension StatusViewTests {
     
     // define statuses
     func firstStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "FIRST_TEST_STATUS", title: "first test status", duration: 1, priority: StatusView.Priority(value: 0))
+        return StatusView.Status(identifier: "FIRST_TEST_STATUS", title: "first test status", duration: 1, priority: 0)
     }
     
     func secondStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "SECOND_TEST_STATUS", title: "second test status", duration: 5, priority: StatusView.Priority(value: 1))
+        return StatusView.Status(identifier: "SECOND_TEST_STATUS", title: "second test status", duration: 5, priority: 1)
     }
     
     func thirdStatus() -> StatusView.Status {
-        return StatusView.Status(identifier: "THIRD_TEST_STATUS", title: "third test status", duration: .infinity, priority: StatusView.Priority(value: 2))
+        return StatusView.Status(identifier: "THIRD_TEST_STATUS", title: "third test status", duration: .infinity, priority: 2)
     }
 
     func show(_ status: StatusView.Status) {


### PR DESCRIPTION
### Description
This PR allows the use of multiple status banners by refactoring `StatusView.swift` to manage the display statuses.
- [x] Create `Status` struct to represent a status, store them in a `statuses` array, and refactor as necessary
- [x] Refactor how statuses are shown and hidden by priority
- [x] How will we deal with special values associated with a `Status`? (e.g.: simulation status banner is interactive, allows for changes in simulation speed)
- [x] Fix [#2723 ](https://github.com/mapbox/mapbox-navigation-ios/issues/2723) (hide "enable precise location" banner when precise location is switched on)
- [x] Test (StatusViewTests.swift)
- [x] Update Changelog

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->


### Screenshots or Gifs



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->