### PR TITLE
Use custom CocoaPods version for all build jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,16 @@ step-library:
         keys:
           - nav-cache-pod-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock" }}
           - nav-cache-pod-v1
+
+  - &install-cocoapods
+      steps:
+        - restore_cache:
+            key: 1-gems-{{ checksum "Gemfile.lock" }}
+        - run: bundle check || bundle install --path vendor/bundle --clean
+        - save_cache:
+            key: 1-gems-{{ checksum "Gemfile.lock" }}
+            paths:
+              - vendor/bundle
   
   - &save-cache-cocoapods
       save_cache:
@@ -122,6 +132,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
+      - *install-cocoapods
       - *prepare-mapbox-file
       - *prepare-netrc-file
       - *update-carthage-version
@@ -130,17 +141,17 @@ jobs:
       - when:
           condition: << parameters.update >>
           steps:
-            - run: cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall && pod update --repo-update
+            - run: cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall && bundle exec pod update --repo-update
       - unless:
           condition: << parameters.update >>
           steps:
-            - run: cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall && pod install --repo-update
+            - run: cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall && bundle exec pod install --repo-update
       - run: cd MapboxCoreNavigationTests/CocoaPodsTest/PodInstall && xcodebuild -workspace PodInstall.xcworkspace -scheme PodInstall -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=iPhone 8 Plus' clean build | xcpretty
       - when:
           condition: << parameters.lint >>
           steps:
             - run: find . -path '*.podspec' -exec perl -pi -e 's/.+\.social_media_url.+//' {} \;
-            - run: pod lib lint MapboxCoreNavigation.podspec
+            - run: bundle exec pod lib lint MapboxCoreNavigation.podspec
       - *save-cache-podmaster
       - *save-cache-cocoapods
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,18 @@ step-library:
           - nav-cache-pod-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock" }}
           - nav-cache-pod-v1
 
-  - &install-cocoapods
+  - &restore-cache-cocoapods-installation
       restore_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-      run: bundle check || bundle install --path vendor/bundle --clean
+        keys:
+          - 1-gems-{{ checksum "Gemfile.lock" }}
+
+  - &install-cocoapods-installation
+      run:
+        name: Install cocoapods
+        command: |
+          bundle check || bundle install --path vendor/bundle --clean
+
+  - &save-cache-cocoapods-installation
       save_cache:
           key: 1-gems-{{ checksum "Gemfile.lock" }}
           paths:
@@ -131,12 +139,12 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
-      - *install-cocoapods
+      - *install-cocoapods-installation
       - *prepare-mapbox-file
       - *prepare-netrc-file
       - *update-carthage-version
       - *restore-cache-podmaster
-      - *restore-cache-cocoapods
+      - *restore-cache-cocoapods-installation
       - when:
           condition: << parameters.update >>
           steps:
@@ -153,6 +161,7 @@ jobs:
             - run: bundle exec pod lib lint MapboxCoreNavigation.podspec
       - *save-cache-podmaster
       - *save-cache-cocoapods
+      - *save-cache-cocoapods-installation
 
   build-job:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,13 @@ step-library:
           - nav-cache-pod-v1
 
   - &install-cocoapods
-      steps:
-        - restore_cache:
-            key: 1-gems-{{ checksum "Gemfile.lock" }}
-        - run: bundle check || bundle install --path vendor/bundle --clean
-        - save_cache:
-            key: 1-gems-{{ checksum "Gemfile.lock" }}
-            paths:
-              - vendor/bundle
+      restore_cache:
+          key: 1-gems-{{ checksum "Gemfile.lock" }}
+      run: bundle check || bundle install --path vendor/bundle --clean
+      save_cache:
+          key: 1-gems-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
   
   - &save-cache-cocoapods
       save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
       - *update-carthage-version
       - *restore-cache-podmaster
       - *restore-cache-cocoapods-installation
+      - *restore-cache-cocoapods
       - when:
           condition: << parameters.update >>
           steps:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem 'fastlane'
 gem 'snapshot'
-gem 'cocoapods', '= 1.10.0'
+gem 'cocoapods', '~> 1.10'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'fastlane'
 gem 'snapshot'
+gem 'cocoapods', '= 1.10.0'


### PR DESCRIPTION
### Description
Fixes build failures related to different CocoaPods versions being used for different environments on CircleCI. E.g.:
- `Xcode 12.2` uses CocoaPods `1.10.0`
- `Xcode 12.0.1` uses CocoaPods `1.10.0.rc.1`
- `Xcode 11.4.1` uses CocoaPods `1.9.1`

I'm not deeply familiar with CircleCI rules/syntax. Feel free to propose better appraches.