### PR TITLE
MapboxNavigationNative v29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Packaging
 
-* Increased the minimum versions of `MapboxNavigationNative` to v28.1, `MapboxCommon` to v9.1.0 and `MapboxDirections` to v1.2. ([#2694](https://github.com/mapbox/mapbox-navigation-ios/pull/2694), [#2770](https://github.com/mapbox/mapbox-navigation-ios/pull/2770))
+* Increased the minimum versions of `MapboxNavigationNative` to v29.0, `MapboxCommon` to v9.1.0 and `MapboxDirections` to v1.2. ([#2694](https://github.com/mapbox/mapbox-navigation-ios/pull/2694), [#2770](https://github.com/mapbox/mapbox-navigation-ios/pull/2770), [#2781](https://github.com/mapbox/mapbox-navigation-ios/pull/2781))
 * Installing MapboxCoreNavigation using CocoaPods no longer overrides the `EXCLUDED_ARCHS` build setting of your application’s target. Installing MapboxNavigation still overrides this setting. ([#2770](https://github.com/mapbox/mapbox-navigation-ios/pull/2770))
 * Added a Ukrainian localization. ([#2735](https://github.com/mapbox/mapbox-navigation-ios/pull/2735))
 
@@ -32,6 +32,8 @@
 
 * Fixed potential crashes when using `PassiveLocationManager` or `PassiveLocationDataSource`. ([#2694](https://github.com/mapbox/mapbox-navigation-ios/pull/2694))
 * Fixed repeated rerouting when traveling alongside a freeway off-ramp. ([#2694](https://github.com/mapbox/mapbox-navigation-ios/pull/2694))
+* Fixed repeated rerouting when starting a new leg while the user is too far from the new leg’s origin. ([#2781](https://github.com/mapbox/mapbox-navigation-ios/pull/2781))
+* `RouteController` more reliably detects when the user has gone off-route. ([#2781](https://github.com/mapbox/mapbox-navigation-ios/pull/2781))
 * Fixed an issue where `RouteController` snapped the user’s location to the opposite side of a divided highway. ([#2694](https://github.com/mapbox/mapbox-navigation-ios/pull/2694))
 * Fixed an issue where `RouteController` got stuck after making a U-turn. ([#2694](https://github.com/mapbox/mapbox-navigation-ios/pull/2694))
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" ~> 2.3.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" ~> 28.1
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" ~> 29.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" ~> 6.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" == 9.1.0
 github "mapbox/mapbox-directions-swift" ~> 1.2.0-alpha.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" "9.1.0"
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.3.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" "28.1.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" "29.0.0"
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.3.1"
 github "CedarBDD/Cedar" "v1.0"
 github "Quick/Nimble" "v8.1.2"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 28.1"
+  s.dependency "MapboxNavigationNative", "~> 29.0"
   s.dependency "MapboxAccounts", "~> 2.3.0"
   s.dependency "MapboxDirections", "~> 1.2.0-alpha.3"
   s.dependency "MapboxMobileEvents", "~> 0.10.2" # Always specify a patch release if pre-v1.0

--- a/MapboxCoreNavigation/Tunnel.swift
+++ b/MapboxCoreNavigation/Tunnel.swift
@@ -6,7 +6,10 @@ import MapboxNavigationNative
  `Tunnel` is used for naming incoming tunnels, together with route alerts.
  */
 public struct Tunnel {
-    public let name: String
+    /**
+     The name of the tunnel.
+     */
+    public let name: String?
     
     init(_ tunnelInfo: RouteAlertTunnelInfo) {
         name = tunnelInfo.name

--- a/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/MapboxCoreNavigationTests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - MapboxAccounts (~> 2.3.0)
     - MapboxDirections (~> 1.2.0-alpha.3)
     - MapboxMobileEvents (~> 0.10.2)
-    - MapboxNavigationNative (~> 28.1)
+    - MapboxNavigationNative (~> 29.0)
     - Turf (~> 1.0)
   - MapboxDirections (1.2.0-alpha.3):
     - Polyline (~> 5.0)
@@ -19,7 +19,7 @@ PODS:
     - MapboxMobileEvents (~> 0.10.2)
     - MapboxSpeech (~> 1.0)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (28.1.0):
+  - MapboxNavigationNative (29.0.0):
     - MapboxCommon (= 9.1.0)
   - MapboxSpeech (1.0.0)
   - Polyline (5.0.2)
@@ -53,11 +53,11 @@ SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 2563ed87ead6ec08f1c2090873977b8a7be335a8
   MapboxAccounts: e40ef575df5d8b7ef33d0504ff2d393f4fde0455
   MapboxCommon: 2de699add978635b5373f6e1ace3d10df12b8459
-  MapboxCoreNavigation: d654fb7013bbb014857b3d005408508a398f3c22
+  MapboxCoreNavigation: bac5f796b02ff04844fe39a737816aba0848cfe5
   MapboxDirections: 193dfc86136b599e9a20fc41d6a8d81ed239854d
   MapboxMobileEvents: d0a581dedd8f47411cc65ea520b965e83914316e
   MapboxNavigation: 4b4d416e67d734ffa58772954541e6cf58ab8190
-  MapboxNavigationNative: f201a0c623baca9a22245f41762653e8c6658e66
+  MapboxNavigationNative: 6a875fda10f89fdd48046abe5712494dba08855f
   MapboxSpeech: 4b3aea42e35d056fae1d7ad847a9fc0f412d911e
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "MapboxGeocoder.swift", "~> 0.10.0"
   s.dependency "Mapbox-iOS-SDK", "~> 6.0"
   s.dependency "MapboxMobileEvents", "~> 0.10.2"
-  s.dependency "MapboxNavigationNative", "~> 28.1"
+  s.dependency "MapboxNavigationNative", "~> 29.0"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 1.0"
   s.dependency "MapboxSpeech", "~> 1.0"


### PR DESCRIPTION
Upgraded the MapboxNavigationNative dependency to a minimum of v29.0, allowing v29._x_. Made `Tunnel.name` optional and public.

Fixes #2777.

/cc @mapbox/navigation-ios @avi-c