### PR TITLE
Add lane guidance to CarPlay. Fix incorrect coloring of dual-use lane icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## v1.3.0
 
 * MapboxCoreNavigation can now be installed using Swift Package Manager. ([#2771](https://github.com/mapbox/mapbox-navigation-ios/pull/2771))
+* The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
+* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796)) 
 
 ## v1.2.1
 
 * Increased the minimum versions of `MapboxNavigationNative` to v30.0 and `MapboxCommon` to v9.2.0. ([#2793](https://github.com/mapbox/mapbox-navigation-ios/pull/2793))
 * Fixed an issue that caused the App Store to reject some application submissions with error ITMS-90338. ([#2793](https://github.com/mapbox/mapbox-navigation-ios/pull/2793))
-* The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
-* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796)) 
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Increased the minimum versions of `MapboxNavigationNative` to v30.0 and `MapboxCommon` to v9.2.0. ([#2793](https://github.com/mapbox/mapbox-navigation-ios/pull/2793))
 * Fixed an issue that caused the App Store to reject some application submissions with error ITMS-90338. ([#2793](https://github.com/mapbox/mapbox-navigation-ios/pull/2793))
+* The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
+* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796)) 
 
 ## v1.2.0
 

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -663,6 +663,13 @@ extension CarPlayManager: CPMapTemplateDelegate {
             interfaceController.popToRootTemplate(animated: animated)
         }
     }
+
+    public func mapTemplate(_ mapTemplate: CPMapTemplate, displayStyleFor maneuver: CPManeuver) -> CPManeuverDisplayStyle {
+        if let visualInstruction = maneuver.userInfo as? VisualInstruction, visualInstruction.containsLaneIndications {
+            return .symbolOnly
+        }
+        return []
+    }
 }
 
 // MARK: CarPlayNavigationDelegate

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -433,11 +433,13 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
         
         var maneuvers: [CPManeuver] = [primaryManeuver]
         
-        // Add tertiary instructions, if available
+        // Add tertiary information, if available
         if let tertiaryInstruction = visualInstruction.tertiaryInstruction {
+            let tertiaryManeuver = CPManeuver()
             if tertiaryInstruction.containsLaneIndications {
                 // create lanes visual banner
-                let tertiaryManeuver = CPManeuver()
+                // The `lanesImageMaxSize` size is an estimate of the CarPlay Lane Configuration View
+                // The dimensions are specified in the CarPlay App Programming Guide - https://developer.apple.com/carplay/documentation/CarPlay-App-Programming-Guide.pdf
                 let lanesImageMaxSize = CGSize(width: 120, height: 18)
 
                 let lightUseableColor: UIColor
@@ -455,6 +457,7 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
                     darkUseableColor = LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).primaryColor.resolvedColor(with: darkTraitCollection)
                     darkUnuseableColor = LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).secondaryColor.resolvedColor(with: darkTraitCollection)
                 } else {
+                    // No light/dark traits are supported
                     lightUseableColor = LaneView.appearance().primaryColor
                     lightUnuseableColor = LaneView.appearance().secondaryColor
 
@@ -475,11 +478,9 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
                 if let image = lightLanesImage, let darkImage = darkLanesImage {
                     tertiaryManeuver.symbolSet = CPImageSet(lightContentImage: image, darkContentImage: darkImage)
                     tertiaryManeuver.userInfo = tertiaryInstruction
-                    maneuvers.append(tertiaryManeuver)
                 }
             } else {
                 // add tertiary maneuver text
-                let tertiaryManeuver = CPManeuver()
                 tertiaryManeuver.symbolSet = tertiaryInstruction.maneuverImageSet(side: visualInstruction.drivingSide)
 
                 if let text = tertiaryInstruction.text {
@@ -490,20 +491,13 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
                     attributedTertiary.canonicalizeAttachments(maximumImageSize: maximumImageSize, imageRendererFormat: imageRendererFormat)
                     tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]
                 }
-
-                if let upcomingStep = navigationService.routeProgress.currentLegProgress.upcomingStep {
-                    let distance = Measurement(distance: upcomingStep.distance).localized()
-                    tertiaryManeuver.initialTravelEstimates = CPTravelEstimates(distanceRemaining: distance, timeRemaining: upcomingStep.expectedTravelTime)
-                }
-
-                maneuvers.append(tertiaryManeuver)
             }
-            
+
             if let upcomingStep = navigationService.routeProgress.currentLegProgress.upcomingStep {
                 let distance = Measurement(distance: upcomingStep.distance).localized()
                 tertiaryManeuver.initialTravelEstimates = CPTravelEstimates(distanceRemaining: distance, timeRemaining: upcomingStep.expectedTravelTime)
             }
-            
+
             maneuvers.append(tertiaryManeuver)
         }
         

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -437,48 +437,12 @@ public class CarPlayNavigationViewController: UIViewController, NavigationMapVie
         if let tertiaryInstruction = visualInstruction.tertiaryInstruction {
             let tertiaryManeuver = CPManeuver()
             if tertiaryInstruction.containsLaneIndications {
-                // create lanes visual banner
-                // The `lanesImageMaxSize` size is an estimate of the CarPlay Lane Configuration View
-                // The dimensions are specified in the CarPlay App Programming Guide - https://developer.apple.com/carplay/documentation/CarPlay-App-Programming-Guide.pdf
-                let lanesImageMaxSize = CGSize(width: 120, height: 18)
-
-                let lightUseableColor: UIColor
-                let lightUnuseableColor: UIColor
-                let darkUseableColor: UIColor
-                let darkUnuseableColor: UIColor
-
-                if #available(iOS 13.0, *) {
-                    let lightTraitCollection = UITraitCollection(userInterfaceStyle: .light)
-                    let darkTraitCollection = UITraitCollection(userInterfaceStyle: .dark)
-
-                    lightUseableColor = LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).primaryColor.resolvedColor(with: lightTraitCollection)
-                    lightUnuseableColor = LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).secondaryColor.resolvedColor(with: lightTraitCollection)
-
-                    darkUseableColor = LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).primaryColor.resolvedColor(with: darkTraitCollection)
-                    darkUnuseableColor = LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).secondaryColor.resolvedColor(with: darkTraitCollection)
-                } else {
-                    // No light/dark traits are supported
-                    lightUseableColor = LaneView.appearance().primaryColor
-                    lightUnuseableColor = LaneView.appearance().secondaryColor
-
-                    darkUseableColor = LaneView.appearance().primaryColor
-                    darkUnuseableColor = LaneView.appearance().secondaryColor
+                // add lanes visual banner
+                if let imageSet = visualInstruction.tertiaryInstruction?.lanesImageSet(side: visualInstruction.drivingSide, direction: visualInstruction.primaryInstruction.maneuverDirection, scale: (carPlayManager.carWindow?.screen ?? UIScreen.main).scale) {
+                    tertiaryManeuver.symbolSet = imageSet
                 }
 
-                var lightLanesImage = tertiaryInstruction.lanesImage(side: visualInstruction.drivingSide, direction: visualInstruction.primaryInstruction.maneuverDirection, useableColor: lightUseableColor, unuseableColor: lightUnuseableColor, size: CGSize(width: CGFloat(tertiaryInstruction.laneComponents.count) * lanesImageMaxSize.height, height: lanesImageMaxSize.height), scale: (carPlayManager.carWindow?.screen ?? UIScreen.main).scale)
-
-                var darkLanesImage = tertiaryInstruction.lanesImage(side: visualInstruction.drivingSide, direction: visualInstruction.primaryInstruction.maneuverDirection, useableColor: darkUseableColor, unuseableColor: darkUnuseableColor, size: CGSize(width: CGFloat(tertiaryInstruction.laneComponents.count) * lanesImageMaxSize.height, height: lanesImageMaxSize.height), scale: (carPlayManager.carWindow?.screen ?? UIScreen.main).scale)
-
-                if let image = lightLanesImage, let darkImage = darkLanesImage, image.size.width > lanesImageMaxSize.width {
-                    let aspectRatio = lanesImageMaxSize.width / image.size.width
-                    let scaledSize = CGSize(width: lanesImageMaxSize.width, height: lanesImageMaxSize.height * aspectRatio)
-                    lightLanesImage = image.scaled(scaledSize)
-                    darkLanesImage = darkImage.scaled(scaledSize)
-                }
-                if let image = lightLanesImage, let darkImage = darkLanesImage {
-                    tertiaryManeuver.symbolSet = CPImageSet(lightContentImage: image, darkContentImage: darkImage)
-                    tertiaryManeuver.userInfo = tertiaryInstruction
-                }
+                tertiaryManeuver.userInfo = tertiaryInstruction
             } else {
                 // add tertiary maneuver text
                 tertiaryManeuver.symbolSet = tertiaryInstruction.maneuverImageSet(side: visualInstruction.drivingSide)

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -18,6 +18,9 @@ extension UIColor {
     class var defaultLaneArrowSecondary: UIColor { get { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) } }
     class var defaultLaneArrowPrimaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
     class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
+
+    class var defaultLaneArrowPrimaryCarPlay: UIColor { get { return #colorLiteral(red: 0.7649999857, green: 0.7649999857, blue: 0.7570000291, alpha: 1) } }
+    class var defaultLaneArrowSecondaryCarPlay: UIColor { get { return #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1) } }
     
     class var trafficUnknown: UIColor { get { return defaultRouteLayer } }
     class var trafficLow: UIColor { get { return defaultRouteLayer } }
@@ -119,10 +122,12 @@ open class DayStyle: Style {
         InstructionsCardContainerView.appearance(whenContainedInInstancesOf: [InstructionsCardCell.self]).highlightedBackgroundColor = UIColor(red: 0.26, green: 0.39, blue: 0.98, alpha: 1.0)
         InstructionsCardContainerView.appearance(whenContainedInInstancesOf: [InstructionsCardCell.self]).clipsToBounds = true
         InstructionsCardContainerView.appearance(whenContainedInInstancesOf: [InstructionsCardCell.self]).cornerRadius = 20
-        LaneView.appearance().primaryColor = .defaultLaneArrowPrimary
-        LaneView.appearance().secondaryColor = .defaultLaneArrowSecondary
-        LaneView.appearance().primaryColorHighlighted = .defaultLaneArrowPrimaryHighlighted
-        LaneView.appearance().secondaryColorHighlighted = .defaultLaneArrowSecondaryHighlighted
+        LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).primaryColor = .defaultLaneArrowPrimaryCarPlay
+        LaneView.appearance(for: UITraitCollection(userInterfaceIdiom: .carPlay)).secondaryColor = .defaultLaneArrowSecondaryCarPlay
+        LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).primaryColor = .defaultLaneArrowPrimary
+        LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).secondaryColor = .defaultLaneArrowSecondary
+        LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).primaryColorHighlighted = .defaultLaneArrowPrimaryHighlighted
+        LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).secondaryColorHighlighted = .defaultLaneArrowSecondaryHighlighted
         LanesView.appearance().backgroundColor = #colorLiteral(red: 0.968627451, green: 0.968627451, blue: 0.968627451, alpha: 1)
         LineView.appearance().lineColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.1)
         ManeuverView.appearance().backgroundColor = .clear

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -13,11 +13,11 @@ extension UIColor {
     class var defaultTurnArrowPrimaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
     class var defaultTurnArrowSecondary: UIColor { get { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) } }
     class var defaultTurnArrowSecondaryHighlighted: UIColor { get { return UIColor.white.withAlphaComponent(0.4) } }
-    
+
     class var defaultLaneArrowPrimary: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) } }
     class var defaultLaneArrowSecondary: UIColor { get { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) } }
     class var defaultLaneArrowPrimaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
-    class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
+    class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return #colorLiteral(red: 0.501960814, green: 0.501960814, blue: 0.501960814, alpha: 1) } }
 
     class var defaultLaneArrowPrimaryCarPlay: UIColor { get { return #colorLiteral(red: 0.7649999857, green: 0.7649999857, blue: 0.7570000291, alpha: 1) } }
     class var defaultLaneArrowSecondaryCarPlay: UIColor { get { return #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1) } }

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -17,7 +17,7 @@ extension UIColor {
     class var defaultLaneArrowPrimary: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) } }
     class var defaultLaneArrowSecondary: UIColor { get { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) } }
     class var defaultLaneArrowPrimaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
-    class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return #colorLiteral(red: 0.501960814, green: 0.501960814, blue: 0.501960814, alpha: 1) } }
+    class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
 
     class var defaultLaneArrowPrimaryCarPlay: UIColor { get { return #colorLiteral(red: 0.7649999857, green: 0.7649999857, blue: 0.7570000291, alpha: 1) } }
     class var defaultLaneArrowSecondaryCarPlay: UIColor { get { return #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1) } }

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -17,7 +17,7 @@ extension UIColor {
     class var defaultLaneArrowPrimary: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) } }
     class var defaultLaneArrowSecondary: UIColor { get { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) } }
     class var defaultLaneArrowPrimaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
-    class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
+    class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return #colorLiteral(red: 0.4, green: 0.4, blue: 0.4, alpha: 1) } }
 
     class var defaultLaneArrowPrimaryCarPlay: UIColor { get { return #colorLiteral(red: 0.7649999857, green: 0.7649999857, blue: 0.7570000291, alpha: 1) } }
     class var defaultLaneArrowSecondaryCarPlay: UIColor { get { return #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1) } }

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -3,8 +3,7 @@ import MapboxDirections
 
 /// :nodoc:
 open class LaneView: UIView {
-    let invalidAlpha: CGFloat = 0.4
-    
+
     var indications: LaneIndication? {
         didSet {
             setNeedsDisplay()
@@ -77,11 +76,11 @@ open class LaneView: UIView {
     
     static let defaultFrame: CGRect = CGRect(origin: .zero, size: 30.0)
     
-    convenience init(indications: LaneIndication, isUsable: Bool) {
+    convenience init(indications: LaneIndication, isUsable: Bool, direction: ManeuverDirection?) {
         self.init(frame: LaneView.defaultFrame)
         backgroundColor = .clear
         self.indications = indications
-        maneuverDirection = ManeuverDirection(rawValue: indications.description)
+        maneuverDirection = direction ?? ManeuverDirection(rawValue: indications.description)
         isValid = isUsable
     }
 
@@ -110,11 +109,10 @@ open class LaneView: UIView {
             if indications.isSuperset(of: [.straightAhead, .sharpRight]) || indications.isSuperset(of: [.straightAhead, .right]) || indications.isSuperset(of: [.straightAhead, .slightRight]) {
                 if !isValid {
                     if indications == .slightRight {
-                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
+                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor)
                     } else {
-                        LanesStyleKit.drawLaneStraightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
+                        LanesStyleKit.drawLaneStraightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor)
                     }
-                    alpha = invalidAlpha
                 } else if maneuverDirection == .straightAhead {
                     LanesStyleKit.drawLaneStraightOnly(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor)
                 } else if maneuverDirection == .sharpLeft || maneuverDirection == .left || maneuverDirection == .slightLeft {
@@ -124,17 +122,18 @@ open class LaneView: UIView {
                         LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
                     }
                 } else {
-                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor)
+                    // pick the color of the two parts (straight & turn) depending on which direction is being suggested
+                    let turnArrowColor = (self.maneuverDirection != ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
+                    let straightArrowColor = (self.maneuverDirection == ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
+                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, turnArrowColor: turnArrowColor, straightArrowColor: straightArrowColor)
                 }
             } else if indications.isSuperset(of: [.straightAhead, .sharpLeft]) || indications.isSuperset(of: [.straightAhead, .left]) || indications.isSuperset(of: [.straightAhead, .slightLeft]) {
                 if !isValid {
                     if indications == .slightLeft {
-                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
+                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor, flipHorizontally: true)
                     } else {
-                        LanesStyleKit.drawLaneStraightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
+                        LanesStyleKit.drawLaneStraightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor, flipHorizontally: true)
                     }
-                    
-                    alpha = invalidAlpha
                 } else if maneuverDirection == .straightAhead {
                     LanesStyleKit.drawLaneStraightOnly(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor, flipHorizontally: true)
                 } else if maneuverDirection == .sharpRight || maneuverDirection == .right {
@@ -142,7 +141,10 @@ open class LaneView: UIView {
                 } else if maneuverDirection == .slightRight {
                     LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
                 } else {
-                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor, flipHorizontally: true)
+                    // pick the color of the two parts (straight & turn) depending on which direction is being suggested
+                    let turnArrowColor = (self.maneuverDirection != ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
+                    let straightArrowColor = (self.maneuverDirection == ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
+                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, turnArrowColor: turnArrowColor, straightArrowColor: straightArrowColor, flipHorizontally: true)
                 }
             } else if indications.description.components(separatedBy: ",").count >= 2 {
                 // Hack:
@@ -156,28 +158,23 @@ open class LaneView: UIView {
                 } else {
                     LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
                 }
-                alpha = isValid ? 1 : invalidAlpha
             } else if indications.isSuperset(of: [.sharpRight]) || indications.isSuperset(of: [.right]) || indications.isSuperset(of: [.slightRight]) {
                 if indications == .slightRight {
                     LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
                 } else {
                     LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
                 }
-                alpha = isValid ? 1 : invalidAlpha
             } else if indications.isSuperset(of: [.sharpLeft]) || indications.isSuperset(of: [.left]) || indications.isSuperset(of: [.slightLeft]) {
                 if indications == .slightLeft {
                     LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
                 } else {
                     LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
                 }
-                alpha = isValid ? 1 : invalidAlpha
             } else if indications.isSuperset(of: [.straightAhead]) {
                 LanesStyleKit.drawLaneStraight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                alpha = isValid ? 1 : invalidAlpha
             } else if indications.isSuperset(of: [.uTurn]) {
                 let flip = !(drivingSide == .left)
                 LanesStyleKit.drawLaneUturn(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: flip)
-                alpha = isValid ? 1 : invalidAlpha
             } else if indications.isEmpty && isValid {
                 // If the lane indication is `none` and the maneuver modifier has a turn in it,
                 // show the turn in the lane image.
@@ -198,13 +195,12 @@ open class LaneView: UIView {
                 }
             } else {
                 LanesStyleKit.drawLaneStraight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                alpha = isValid ? 1 : invalidAlpha
             }
         }
         
         #if TARGET_INTERFACE_BUILDER
         isValid = true
-        LanesStyleKit.drawLaneRightOnly(primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor)
+        LanesStyleKit.drawLaneRightOnly(turnArrowColor: appropriatePrimaryColor, straightArrowColor: appropriateSecondaryColor)
         #endif
     }
 }

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -3,7 +3,6 @@ import MapboxDirections
 
 /// :nodoc:
 open class LaneView: UIView {
-
     var indications: LaneIndication? {
         didSet {
             setNeedsDisplay()

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -122,8 +122,17 @@ open class LaneView: UIView {
                     }
                 } else {
                     // pick the color of the two parts (straight & turn) depending on which direction is being suggested
-                    let turnArrowColor = (self.maneuverDirection != ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
-                    let straightArrowColor = (self.maneuverDirection == ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
+                    let turnArrowColor: UIColor
+                    let straightArrowColor: UIColor
+                    switch self.maneuverDirection {
+                    case .straightAhead:
+                        straightArrowColor = appropriatePrimaryColor
+                        turnArrowColor = appropriateSecondaryColor
+                    default:
+                        straightArrowColor = appropriateSecondaryColor
+                        turnArrowColor = appropriatePrimaryColor
+                    }
+
                     LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, turnArrowColor: turnArrowColor, straightArrowColor: straightArrowColor)
                 }
             } else if indications.isSuperset(of: [.straightAhead, .sharpLeft]) || indications.isSuperset(of: [.straightAhead, .left]) || indications.isSuperset(of: [.straightAhead, .slightLeft]) {
@@ -141,8 +150,18 @@ open class LaneView: UIView {
                     LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
                 } else {
                     // pick the color of the two parts (straight & turn) depending on which direction is being suggested
-                    let turnArrowColor = (self.maneuverDirection != ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
-                    let straightArrowColor = (self.maneuverDirection == ManeuverDirection.straightAhead) ? appropriatePrimaryColor : appropriateSecondaryColor
+                    let turnArrowColor: UIColor
+                    let straightArrowColor: UIColor
+
+                    switch self.maneuverDirection {
+                    case .straightAhead:
+                        straightArrowColor = appropriatePrimaryColor
+                        turnArrowColor = appropriateSecondaryColor
+                    default:
+                        straightArrowColor = appropriateSecondaryColor
+                        turnArrowColor = appropriatePrimaryColor
+                    }
+
                     LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, turnArrowColor: turnArrowColor, straightArrowColor: straightArrowColor, flipHorizontally: true)
                 }
             } else if indications.description.components(separatedBy: ",").count >= 2 {

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -133,7 +133,7 @@ open class LaneView: UIView {
                         turnArrowColor = appropriatePrimaryColor
                     }
 
-                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, turnArrowColor: turnArrowColor, straightArrowColor: straightArrowColor)
+                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, primaryColor: turnArrowColor, secondaryColor: straightArrowColor)
                 }
             } else if indications.isSuperset(of: [.straightAhead, .sharpLeft]) || indications.isSuperset(of: [.straightAhead, .left]) || indications.isSuperset(of: [.straightAhead, .slightLeft]) {
                 if !isValid {
@@ -162,7 +162,7 @@ open class LaneView: UIView {
                         turnArrowColor = appropriatePrimaryColor
                     }
 
-                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, turnArrowColor: turnArrowColor, straightArrowColor: straightArrowColor, flipHorizontally: true)
+                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, primaryColor: turnArrowColor, secondaryColor: straightArrowColor, flipHorizontally: true)
                 }
             } else if indications.description.components(separatedBy: ",").count >= 2 {
                 // Hack:
@@ -218,7 +218,7 @@ open class LaneView: UIView {
         
         #if TARGET_INTERFACE_BUILDER
         isValid = true
-        LanesStyleKit.drawLaneRightOnly(turnArrowColor: appropriatePrimaryColor, straightArrowColor: appropriateSecondaryColor)
+        LanesStyleKit.drawLaneRightOnly(primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor)
         #endif
     }
 }

--- a/Sources/MapboxNavigation/LanesStyleKit.swift
+++ b/Sources/MapboxNavigation/LanesStyleKit.swift
@@ -21,7 +21,7 @@ public class LanesStyleKit : NSObject {
     @objc dynamic public class func drawLaneStraightRight(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         //// Resize to Target Frame
         context.saveGState()
         let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 30, height: 30), target: targetFrame)
@@ -132,7 +132,7 @@ public class LanesStyleKit : NSObject {
     @objc dynamic public class func drawLaneStraightOnly(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), secondaryColor: UIColor = UIColor(red: 0.618, green: 0.618, blue: 0.618, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         //// Resize to Target Frame
         context.saveGState()
         let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 30, height: 30), target: targetFrame)
@@ -243,7 +243,7 @@ public class LanesStyleKit : NSObject {
     @objc dynamic public class func drawLaneRight(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         //// Resize to Target Frame
         context.saveGState()
         let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 30, height: 30), target: targetFrame)
@@ -310,10 +310,10 @@ public class LanesStyleKit : NSObject {
 
     }
 
-    @objc dynamic public class func drawLaneRightOnly(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), secondaryColor: UIColor = UIColor(red: 0.618, green: 0.618, blue: 0.618, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
+    @objc dynamic public class func drawLaneRightOnly(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, turnArrowColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), straightArrowColor: UIColor = UIColor(red: 0.618, green: 0.618, blue: 0.618, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         //// Resize to Target Frame
         context.saveGState()
         let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 30, height: 30), target: targetFrame)
@@ -338,7 +338,7 @@ public class LanesStyleKit : NSObject {
 
         //// Rectangle Drawing
         let rectanglePath = UIBezierPath(rect: CGRect(x: -5.98, y: -3.42, width: 4, height: 16))
-        secondaryColor.setFill()
+        straightArrowColor.setFill()
         rectanglePath.fill()
 
 
@@ -364,7 +364,7 @@ public class LanesStyleKit : NSObject {
         bezierPath.addCurve(to: CGPoint(x: -3.96, y: -12.42), controlPoint1: CGPoint(x: -9.7, y: -4.52), controlPoint2: CGPoint(x: -4.01, y: -12.36))
         bezierPath.addLine(to: CGPoint(x: -3.96, y: -12.42))
         bezierPath.close()
-        secondaryColor.setFill()
+        straightArrowColor.setFill()
         bezierPath.fill()
 
 
@@ -398,7 +398,7 @@ public class LanesStyleKit : NSObject {
         bezier2Path.addLine(to: CGPoint(x: 4.27, y: 4.16))
         bezier2Path.addLine(to: CGPoint(x: 3.01, y: 4.16))
         bezier2Path.usesEvenOddFillRule = true
-        primaryColor.setFill()
+        turnArrowColor.setFill()
         bezier2Path.fill()
 
 
@@ -409,7 +409,7 @@ public class LanesStyleKit : NSObject {
         bezier3Path.addCurve(to: CGPoint(x: -1.98, y: 4.19), controlPoint1: CGPoint(x: -3.95, y: 6.81), controlPoint2: CGPoint(x: -3.25, y: 5.23))
         bezier3Path.addCurve(to: CGPoint(x: 2.86, y: 2.19), controlPoint1: CGPoint(x: -0.75, y: 3.19), controlPoint2: CGPoint(x: 0.95, y: 2.19))
         bezier3Path.addLine(to: CGPoint(x: 5.05, y: 2.19))
-        primaryColor.setStroke()
+        turnArrowColor.setStroke()
         bezier3Path.lineWidth = 4
         bezier3Path.stroke()
 
@@ -424,7 +424,7 @@ public class LanesStyleKit : NSObject {
     @objc dynamic public class func drawLaneStraight(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32)) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         //// Resize to Target Frame
         context.saveGState()
         let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 30, height: 30), target: targetFrame)
@@ -483,7 +483,7 @@ public class LanesStyleKit : NSObject {
     @objc dynamic public class func drawLaneUturn(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         //// Resize to Target Frame
         context.saveGState()
         let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 30, height: 30), target: targetFrame)
@@ -556,7 +556,7 @@ public class LanesStyleKit : NSObject {
     @objc dynamic public class func drawLaneSlightRight(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         //// Resize to Target Frame
         context.saveGState()
         let resizedFrame: CGRect = resizing.apply(rect: CGRect(x: 0, y: 0, width: 30, height: 30), target: targetFrame)

--- a/Sources/MapboxNavigation/LanesStyleKit.swift
+++ b/Sources/MapboxNavigation/LanesStyleKit.swift
@@ -310,7 +310,7 @@ public class LanesStyleKit : NSObject {
 
     }
 
-    @objc dynamic public class func drawLaneRightOnly(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, turnArrowColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), straightArrowColor: UIColor = UIColor(red: 0.618, green: 0.618, blue: 0.618, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
+    @objc dynamic public class func drawLaneRightOnly(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 30, height: 30), resizing: ResizingBehavior = .aspectFit, primaryColor: UIColor = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha: 1.000), secondaryColor: UIColor = UIColor(red: 0.618, green: 0.618, blue: 0.618, alpha: 1.000), size: CGSize = CGSize(width: 32, height: 32), flipHorizontally: Bool = false) {
         //// General Declarations
         let context = UIGraphicsGetCurrentContext()!
 
@@ -338,7 +338,7 @@ public class LanesStyleKit : NSObject {
 
         //// Rectangle Drawing
         let rectanglePath = UIBezierPath(rect: CGRect(x: -5.98, y: -3.42, width: 4, height: 16))
-        straightArrowColor.setFill()
+        secondaryColor.setFill()
         rectanglePath.fill()
 
 
@@ -364,7 +364,7 @@ public class LanesStyleKit : NSObject {
         bezierPath.addCurve(to: CGPoint(x: -3.96, y: -12.42), controlPoint1: CGPoint(x: -9.7, y: -4.52), controlPoint2: CGPoint(x: -4.01, y: -12.36))
         bezierPath.addLine(to: CGPoint(x: -3.96, y: -12.42))
         bezierPath.close()
-        straightArrowColor.setFill()
+        secondaryColor.setFill()
         bezierPath.fill()
 
 
@@ -398,7 +398,7 @@ public class LanesStyleKit : NSObject {
         bezier2Path.addLine(to: CGPoint(x: 4.27, y: 4.16))
         bezier2Path.addLine(to: CGPoint(x: 3.01, y: 4.16))
         bezier2Path.usesEvenOddFillRule = true
-        turnArrowColor.setFill()
+        primaryColor.setFill()
         bezier2Path.fill()
 
 
@@ -409,7 +409,7 @@ public class LanesStyleKit : NSObject {
         bezier3Path.addCurve(to: CGPoint(x: -1.98, y: 4.19), controlPoint1: CGPoint(x: -3.95, y: 6.81), controlPoint2: CGPoint(x: -3.25, y: 5.23))
         bezier3Path.addCurve(to: CGPoint(x: 2.86, y: 2.19), controlPoint1: CGPoint(x: -0.75, y: 3.19), controlPoint2: CGPoint(x: 0.95, y: 2.19))
         bezier3Path.addLine(to: CGPoint(x: 5.05, y: 2.19))
-        turnArrowColor.setStroke()
+        primaryColor.setStroke()
         bezier3Path.lineWidth = 4
         bezier3Path.stroke()
 

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -83,7 +83,8 @@ open class LanesView: UIView, NavigationComponent {
         
         let subviews = tertiaryInstruction.components.compactMap { (component) -> LaneView? in
             if case let .lane(indications: indications, isUsable: isUsable) = component {
-                return LaneView(indications: indications, isUsable: isUsable)
+                let maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection ?? ManeuverDirection(rawValue: indications.description)
+                return LaneView(indications: indications, isUsable: isUsable, direction: maneuverDirection)
             } else {
                 return nil
             }

--- a/Sources/MapboxNavigation/UIImage.swift
+++ b/Sources/MapboxNavigation/UIImage.swift
@@ -33,4 +33,14 @@ extension UIImage {
             (text as NSString).draw(in: rect.offsetBy(dx: 0, dy: (constrainedSize.height - font.lineHeight) / 2).integral, withAttributes: textFontAttributes)
         }
     }
+
+    func scaled(_ size: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        self.draw(in: CGRect(origin: .zero, size: size))
+
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return scaledImage
+    }
 }

--- a/Sources/MapboxNavigation/UIImage.swift
+++ b/Sources/MapboxNavigation/UIImage.swift
@@ -34,7 +34,7 @@ extension UIImage {
         }
     }
 
-    func scaled(_ size: CGSize) -> UIImage? {
+    func scaled(to: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
         self.draw(in: CGRect(origin: .zero, size: size))
 

--- a/Sources/MapboxNavigation/UIView.swift
+++ b/Sources/MapboxNavigation/UIView.swift
@@ -117,7 +117,7 @@ extension UIView {
     
     var imageRepresentation: UIImage? {
         let size = CGSize(width: frame.size.width, height: frame.size.height)
-        UIGraphicsBeginImageContextWithOptions(size, false, UIScreen.main.scale)
+        UIGraphicsBeginImageContextWithOptions(size, false, (window?.screen ?? UIScreen.main).scale)
         guard let currentContext = UIGraphicsGetCurrentContext() else { return nil }
         layer.render(in:currentContext)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -12,7 +12,11 @@ extension VisualInstruction {
             return false
         }
     }
-    
+
+    var containsLaneIndications: Bool {
+        return laneComponents.count > 0
+    }
+
     func maneuverImage(side: DrivingSide, color: UIColor, size: CGSize) -> UIImage? {
         let mv = ManeuverView()
         mv.frame = CGRect(origin: .zero, size: size)

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -127,7 +127,7 @@ extension VisualInstruction {
     public func lanesImageSet(side: DrivingSide, direction: ManeuverDirection?, scale: CGFloat)  -> CPImageSet? {
         // create lanes visual banner
         // The `lanesImageMaxSize` size is an estimate of the CarPlay Lane Configuration View
-        // The dimensions are specified in the CarPlay App Programming Guide - https://developer.apple.com/carplay/documentation/CarPlay-App-Programming-Guide.pdf
+        // The dimensions are specified in the CarPlay App Programming Guide - https://developer.apple.com/carplay/documentation/CarPlay-App-Programming-Guide.pdf#page=38
         let lanesImageMaxSize = CGSize(width: 120, height: 18)
 
         let lightUsableColor: UIColor

--- a/Tests/MapboxNavigationTests/LaneTests.swift
+++ b/Tests/MapboxNavigationTests/LaneTests.swift
@@ -31,7 +31,7 @@ class LaneTests: FBSnapshotTestCase {
                 let groupView = UIStackView(orientation: .vertical, autoLayout: true)
                 groupView.alignment = .center
                 
-                let laneView = LaneView(indications: lane.indications, isUsable: true)
+                let laneView = LaneView(indications: lane.indications, isUsable: true, direction: ManeuverDirection(rawValue: lane.indications.description))
                 laneView.drivingSide = lane.drivingSide
                 
                 laneView.backgroundColor = .white

--- a/Tests/MapboxNavigationTests/LaneTests.swift
+++ b/Tests/MapboxNavigationTests/LaneTests.swift
@@ -64,26 +64,27 @@ struct TestableLane {
     var description: String
     var indications: LaneIndication
     var drivingSide: DrivingSide
+    var maneuverDirection: ManeuverDirection
     
     static func testableLanes(drivingSide: DrivingSide) -> [TestableLane] {
-        let namedIndications: [(String, LaneIndication)]
+        let namedIndications: [(String, LaneIndication, ManeuverDirection)]
         
         namedIndications = [
-            ("Sharp Left, Straight Ahead",      [.sharpLeft, .straightAhead]),
-            ("Straight Ahead, Sharp Left",      [.straightAhead, .sharpLeft]),
-            ("Left",                            [.left]),
-            ("Slight Left",                     [.slightLeft]),
-            ("Sharp Left",                      [.sharpLeft]),
-            ("Straight Ahead",                  [.straightAhead]),
-            ("u-Turn",                          [.uTurn]),
-            ("Sharp Right",                     [.sharpRight]),
-            ("Slight Right",                    [.slightRight]),
-            ("Right",                           [.right]),
-            ("Sharp Right, Straight Ahead",     [.sharpRight, .straightAhead]),
-            ("Straight Ahead, Sharp Right",     [.straightAhead, .sharpRight]),
+            ("Sharp Left, Straight Ahead",      [.sharpLeft, .straightAhead], .sharpLeft),
+            ("Straight Ahead, Sharp Left",      [.straightAhead, .sharpLeft], .straightAhead),
+            ("Left",                            [.left], .left),
+            ("Slight Left",                     [.slightLeft], .slightLeft),
+            ("Sharp Left",                      [.sharpLeft], .sharpLeft),
+            ("Straight Ahead",                  [.straightAhead], .straightAhead),
+            ("u-Turn",                          [.uTurn], .uTurn),
+            ("Sharp Right",                     [.sharpRight], .sharpRight),
+            ("Slight Right",                    [.slightRight], .slightRight),
+            ("Right",                           [.right], .right),
+            ("Sharp Right, Straight Ahead",     [.sharpRight, .straightAhead], .sharpRight),
+            ("Straight Ahead, Sharp Right",     [.straightAhead, .sharpRight], .straightAhead),
         ]
         
-        return namedIndications.map { TestableLane(description: $0.0, indications: $0.1, drivingSide: drivingSide) }
+        return namedIndications.map { TestableLane(description: $0.0, indications: $0.1, drivingSide: drivingSide, maneuverDirection: $0.2) }
     }
 }
 


### PR DESCRIPTION
### Description

Add support for visual lane guidance instructions in CarPlay. Addresses #1885 
Fix regression that occurred during Swift migration whereby dual use lane icons were not correctly indicating which direction to follow. Fixes #2796  

### Implementation
I used a slightly different approach for adding the Lane views than that which is outlines in #1885. Instead of drawing a snapshot of the `LanesView`, I instead form my own new lane image out of images of each lane.

For the lane coloring, I altered how the lanes are colored to use the Appearance proxy mechanism for the various colors. It no longer hardcodes that `invalid` or unusable lanes are colored with an alpha of 0.4. Instead they use whatever color is specified in the appearance proxy for the LaneView. This gives the client app more control over the visual appearance.

### Screenshots or Gifs
![Simulator Screen Shot - iPhone 11 - 2021-02-04 at 15 08 58](https://user-images.githubusercontent.com/10037825/106967126-74f57580-66fb-11eb-9074-7d6252cc56a3.png)
![Simulator Screen Shot - iPhone 11 - 2021-02-04 at 15 09 00](https://user-images.githubusercontent.com/10037825/106967138-77f06600-66fb-11eb-8646-3edbf33f3683.png)


![Simulator Screen Shot - iPhone 11 - 2021-02-04 at 15 14 33](https://user-images.githubusercontent.com/10037825/106967302-ca318700-66fb-11eb-98f4-c98d93f593d2.png)
![Simulator Screen Shot - iPhone 11 - 2021-02-04 at 15 14 38](https://user-images.githubusercontent.com/10037825/106967308-cd2c7780-66fb-11eb-9a61-d5b1a997afdc.png)

