### PR TITLE
Flip U-Turn Maneuver view when driving side is right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
 * Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809) 
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
+* Fixed an issue where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 
 ## v1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
 * Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809) 
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
-* Fixed an issue where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
+* Fixed an issue with CarPlay visual instructions where U-Turn maneuver icons were not being flipped properly based on regional driving side ([#2803](https://github.com/mapbox/mapbox-navigation-ios/pull/2803)) 
 
 ## v1.2.1
 

--- a/Sources/MapboxNavigation/UIView.swift
+++ b/Sources/MapboxNavigation/UIView.swift
@@ -122,7 +122,11 @@ extension UIView {
         layer.render(in:currentContext)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return image
+
+        // Check the transform property to see if the view was flipped.
+        // If it was then we need to apply a flip transform here as well since layer.render() ignores the view's transform when it is rendered
+        let isFlipped = transform.a == -1
+        return isFlipped ? image?.withHorizontallyFlippedOrientation() : image
     }
 }
 

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -85,10 +85,11 @@ extension VisualInstruction {
     /// Returns whether the `VisualInstruction`’s maneuver image should be flipped according to the driving side.
     public func shouldFlipImage(side: DrivingSide) -> Bool {
         switch maneuverType ?? .turn {
+        case _ where maneuverDirection == .uTurn:
+            return side == .right
         case .takeRoundabout,
              .turnAtRoundabout,
-             .takeRotary,
-             _ where maneuverDirection == .uTurn:
+             .takeRotary:
             return side == .left
         default:
             return [.left, .slightLeft, .sharpLeft].contains(maneuverDirection ?? .straightAhead)

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -24,8 +24,12 @@ extension VisualInstruction {
         mv.backgroundColor = .clear
         mv.scale = UIScreen.main.scale
         mv.visualInstruction = self
+        mv.drivingSide = side
         let image = mv.imageRepresentation
-        return shouldFlipImage(side: side) ? image?.withHorizontallyFlippedOrientation() : image
+        // Check the ManeuverView's transform property to see if the image view was flipped due to the regional driving side.
+        // If it was then we need to apply a flip transform here as well since imageRepresentation ignores view's transforms when it is rendered
+        let viewIsFlippedHorizontally = mv.transform.a == -1
+        return viewIsFlippedHorizontally ? image?.withHorizontallyFlippedOrientation() : image
     }
 
     func laneImage(side: DrivingSide, indication: LaneIndication, maneuverDirection: ManeuverDirection?, isUsable: Bool, useableColor: UIColor, unuseableColor: UIColor, size: CGSize) -> UIImage? {
@@ -42,8 +46,13 @@ extension VisualInstruction {
         laneView.maneuverDirection = maneuverDirection
         laneView.indications = indication
         laneView.isValid = isUsable
+        laneView.drivingSide = side
         let image = laneView.imageRepresentation
-        return shouldFlipImage(side: side) ? image?.withHorizontallyFlippedOrientation() : image
+
+        // Check the LaneView's transform property to see if the view was flipped due to the driving side.
+        // If it was then we need to apply a flip transform here as well since imageRepresentation ignores view's transforms when it is rendered
+        let viewIsFlippedHorizontally = laneView.transform.a == -1
+        return viewIsFlippedHorizontally ? image?.withHorizontallyFlippedOrientation() : image
     }
 
     func lanesImage(side: DrivingSide, direction: ManeuverDirection?, useableColor: UIColor, unuseableColor: UIColor, size: CGSize, scale: CGFloat) -> UIImage? {

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -26,10 +26,7 @@ extension VisualInstruction {
         mv.visualInstruction = self
         mv.drivingSide = side
         let image = mv.imageRepresentation
-        // Check the ManeuverView's transform property to see if the image view was flipped due to the regional driving side.
-        // If it was then we need to apply a flip transform here as well since imageRepresentation ignores view's transforms when it is rendered
-        let viewIsFlippedHorizontally = mv.transform.a == -1
-        return viewIsFlippedHorizontally ? image?.withHorizontallyFlippedOrientation() : image
+        return image
     }
 
     func laneImage(side: DrivingSide, indication: LaneIndication, maneuverDirection: ManeuverDirection?, isUsable: Bool, useableColor: UIColor, unuseableColor: UIColor, size: CGSize) -> UIImage? {
@@ -49,10 +46,7 @@ extension VisualInstruction {
         laneView.drivingSide = side
         let image = laneView.imageRepresentation
 
-        // Check the LaneView's transform property to see if the view was flipped due to the driving side.
-        // If it was then we need to apply a flip transform here as well since imageRepresentation ignores view's transforms when it is rendered
-        let viewIsFlippedHorizontally = laneView.transform.a == -1
-        return viewIsFlippedHorizontally ? image?.withHorizontallyFlippedOrientation() : image
+        return image
     }
 
     func lanesImage(side: DrivingSide, direction: ManeuverDirection?, useableColor: UIColor, unuseableColor: UIColor, size: CGSize, scale: CGFloat) -> UIImage? {


### PR DESCRIPTION
Should not be flipped when driving side is left, only when it is right. Fixes #2802.