### PR TITLE
Show junction view on main queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * MapboxCoreNavigation can now be installed using Swift Package Manager. ([#2771](https://github.com/mapbox/mapbox-navigation-ios/pull/2771))
 * The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
 * Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796)) 
+* Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 
 ## v1.2.1
 

--- a/Sources/MapboxNavigation/JunctionView.swift
+++ b/Sources/MapboxNavigation/JunctionView.swift
@@ -50,12 +50,13 @@ public class JunctionView: UIImageView {
                 let stringURL = baseURLString + "&access_token=" + accessToken
 
                 guard let guidanceViewImageURL = URL(string: stringURL) else { return }
-                imageRepository.imageWithURL(guidanceViewImageURL, cacheKey: guidanceView.cacheKey!) { [unowned self] (downloadedImage) in
-                    
-                    self.isCurrentlyVisible = true
-                    self.isHidden = !self.isCurrentlyVisible
-                    
+                imageRepository.imageWithURL(guidanceViewImageURL, cacheKey: guidanceView.cacheKey!) { [weak self] (downloadedImage) in
                     DispatchQueue.main.async {
+                        guard let self = self else { return }
+                        
+                        self.isCurrentlyVisible = true
+                        self.isHidden = !self.isCurrentlyVisible
+                        
                         self.image = downloadedImage
                         self.show(animated: true)
                     }


### PR DESCRIPTION
Fixed a crash that occurred when showing a junction view on the image download queue by moving that operation to the main queue.

Fixes #2804.

/cc @mapbox/navigation-ios @bamx23