### PR TITLE
MapboxNavigationNative v31.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * MapboxCoreNavigation can now be installed using Swift Package Manager. ([#2771](https://github.com/mapbox/mapbox-navigation-ios/pull/2771))
 * The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
+* Old versions of routing tiles are automatically deleted from the cache to save storage space. ([#2807](https://github.com/mapbox/mapbox-navigation-ios/pull/2807))
 * Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809) 
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" ~> 2.3.0
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" ~> 30.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" ~> 31.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" ~> 6.0
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" == 9.2.0
 github "mapbox/mapbox-directions-swift" ~> 1.2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon-ios.json" "9.2.0"
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.3.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" "30.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.json" "31.0.1"
 binary "https://www.mapbox.com/ios-sdk/MapboxAccounts.json" "2.3.1"
 github "CedarBDD/Cedar" "v1.0"
 github "Quick/Nimble" "v8.1.2"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 30.0"
+  s.dependency "MapboxNavigationNative", "~> 31.0"
   s.dependency "MapboxAccounts", "~> 2.3.0"
   s.dependency "MapboxDirections", "~> 1.2.0"
   s.dependency "MapboxMobileEvents", "~> 0.10.2" # Always specify a patch release if pre-v1.0

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "MapboxGeocoder.swift", "~> 0.10.0"
   s.dependency "Mapbox-iOS-SDK", "~> 6.0"
   s.dependency "MapboxMobileEvents", "~> 0.10.2"
-  s.dependency "MapboxNavigationNative", "~> 30.0"
+  s.dependency "MapboxNavigationNative", "~> 31.0"
   s.dependency "Solar", "~> 2.1"
   s.dependency "Turf", "~> 1.0"
   s.dependency "MapboxSpeech", "~> 1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "0e6e7fb00ef0f1bce48a9da2dbb6551ccb5b51e7",
-          "version": "30.0.0"
+          "revision": "5e37ae2ebe0d49a78ed064813791e56a81926c1e",
+          "version": "31.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "9.2.0"),
         .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "1.2.0"),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "0.10.6"),
-        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "30.0.0"),
+        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "31.0.0"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", from: "2.0.0"),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
     ],

--- a/Sources/MapboxCoreNavigation/OfflineDirections.swift
+++ b/Sources/MapboxCoreNavigation/OfflineDirections.swift
@@ -117,6 +117,7 @@ public class NavigationDirections: Directions {
         NavigationDirectionsConstants.offlineSerialQueue.sync {
             let tilesConfig = TilesConfig(tilesPath: tilesURL.path,
                                           inMemoryTileCache: nil,
+                                          onDiskTileCache: nil,
                                           mapMatchingSpatialCache: nil,
                                           threadsCount: nil,
                                           endpointConfig: nil)

--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -99,7 +99,7 @@ open class PassiveLocationDataSource: NSObject {
     }
 
     func configureNavigator(withURL tilesURL: URL, tilesVersion: String?) {
-        let endpointConfig = TileEndpointConfiguration(directions: directions, tilesVersion: tilesVersion, minimumDaysToPersistVersion: nil)
+        let endpointConfig = TileEndpointConfiguration(credentials: directions.credentials, tilesVersion: tilesVersion, minimumDaysToPersistVersion: nil)
         let tilesConfig = TilesConfig(tilesPath: tilesURL.path,
                                       inMemoryTileCache: nil,
                                       onDiskTileCache: nil,
@@ -184,18 +184,19 @@ public protocol PassiveLocationDataSourceDelegate: class {
 
 extension TileEndpointConfiguration {
     /**
-     Initializes an object that configures a navigator to obtain routing tiles of the given version from an endpoint, using credentials that are consistent with the given directions service.
+     Initializes an object that configures a navigator to obtain routing tiles of the given version from an endpoint, using the given credentials.
      
+     - parameter credentials: Credentials for accessing road network data.
      - parameter tilesVersion: Routing tile version.
      - parameter minimumDaysToPersistVersion: The minimum age in days that a tile version much reach before a new version can be requested from the tile endpoint.
      - parameter removesOldLocalVersions: Whether to automatically remove older versions from the cache. By default, older versions are automatically removed.
      */
-    convenience init(directions: Directions, tilesVersion: String?, minimumDaysToPersistVersion: Int?, removesOldLocalVersions: Bool = true) {
-        let host = directions.credentials.host.absoluteString
-        guard let accessToken = directions.credentials.accessToken, !accessToken.isEmpty else {
+    convenience init(credentials: DirectionsCredentials, tilesVersion: String?, minimumDaysToPersistVersion: Int?, removesOldLocalVersions: Bool = true) {
+        let host = credentials.host.absoluteString
+        guard let accessToken = credentials.accessToken, !accessToken.isEmpty else {
             preconditionFailure("No access token specified in Info.plist")
         }
-        let skuTokenProvider = SkuTokenProvider(with: directions.credentials)
+        let skuTokenProvider = SkuTokenProvider(with: credentials)
         self.init(host: host, version: tilesVersion ?? "", token: accessToken, userAgent: URLSession.userAgent, navigatorVersion: "", skuTokenSource: skuTokenProvider, minDiffInDaysToConsiderServerVersion: minimumDaysToPersistVersion as NSNumber?, disableCleanOlderLocalVersions: !removesOldLocalVersions)
     }
 }

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - MapboxAccounts (~> 2.3.0)
     - MapboxDirections (~> 1.2.0)
     - MapboxMobileEvents (~> 0.10.2)
-    - MapboxNavigationNative (~> 30.0)
+    - MapboxNavigationNative (~> 31.0)
     - Turf (~> 1.0)
   - MapboxDirections (1.2.0):
     - Polyline (~> 5.0)
@@ -19,7 +19,7 @@ PODS:
     - MapboxMobileEvents (~> 0.10.2)
     - MapboxSpeech (~> 1.0)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (30.0.0):
+  - MapboxNavigationNative (31.0.1):
     - MapboxCommon (= 9.2.0)
   - MapboxSpeech (1.0.0)
   - Polyline (5.0.2)
@@ -53,11 +53,11 @@ SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 2563ed87ead6ec08f1c2090873977b8a7be335a8
   MapboxAccounts: e40ef575df5d8b7ef33d0504ff2d393f4fde0455
   MapboxCommon: 2c4ef00c10cba35302835423f4d63c6f3dea4bc4
-  MapboxCoreNavigation: d2e4d98b12f78e38d7ea7bb17d98e7892b623b84
+  MapboxCoreNavigation: 4b15644ba5bed72df14be44e4d2566124f30ac00
   MapboxDirections: 383df0cd65784897c2269750a42d9654c832f0ce
   MapboxMobileEvents: d0a581dedd8f47411cc65ea520b965e83914316e
   MapboxNavigation: 3f2e34a79420c59b52f6a3b62073fd6e21a038d7
-  MapboxNavigationNative: ac20c0b74f14e88972c1e3da5445bf8ef97bc365
+  MapboxNavigationNative: 0bc54a7cf20a892a96eca07e1f05776f496491f5
   MapboxSpeech: 4b3aea42e35d056fae1d7ad847a9fc0f412d911e
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24


### PR DESCRIPTION
Upgraded to [MapboxNavigationNative v31.0.1](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/31.0.1).

Removed explicit routing tile version discovery now that the navigator can automatically choose the most recent version. Now MapboxNavigationNative automatically deletes old versions of routing tiles from the cache to save storage space. To do so, it needs access to the overall tile cache folder, not just the folder for an individual tile version.

/cc @mapbox/navigation-ios @mskurydin