### PR TITLE
Rewrite lane use diagram selection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * MapboxCoreNavigation can now be installed using Swift Package Manager. ([#2771](https://github.com/mapbox/mapbox-navigation-ios/pull/2771))
 * The CarPlay guidance panel now shows lane guidance. ([#1885](https://github.com/mapbox/mapbox-navigation-ios/pull/1885))
-* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796)) 
+* Fixed an issue where lane guidance icons would indicate the wrong arrow for certain maneuvers. ([#2796](https://github.com/mapbox/mapbox-navigation-ios/pull/2796), [#2809](https://github.com/mapbox/mapbox-navigation-ios/pull/2809) 
 * Fixed a crash showing a junction view. ([#2805](https://github.com/mapbox/mapbox-navigation-ios/pull/2805))
 
 ## v1.2.1

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -391,6 +391,7 @@
 		DA67EA5623CAF345001686EA /* MGLShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA67EA5523CAF345001686EA /* MGLShape.swift */; };
 		DA754E1823AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DA754E1623AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA754E1923AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA754E1723AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.m */; };
+		DA85D5EF25DB4AA4008A2AD4 /* LaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA85D5EE25DB4AA3008A2AD4 /* LaneViewTests.swift */; };
 		DA8805002316EAED00B54D87 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
 		DA8F3A7623B5D84900B56786 /* SpeedLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7523B5D84900B56786 /* SpeedLimitView.swift */; };
 		DA8F3A7823B5DB7900B56786 /* SpeedLimitStyleKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7723B5DB7900B56786 /* SpeedLimitStyleKit.swift */; };
@@ -1002,6 +1003,7 @@
 		DA754E1723AC56E5007E16B5 /* MBXAccounts+CoreNavigationAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "MBXAccounts+CoreNavigationAdditions.m"; path = "include/MBXAccounts+CoreNavigationAdditions.m"; sourceTree = "<group>"; };
 		DA8264851F2AAD8400454B24 /* zh-Hant */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Main.strings"; sourceTree = "<group>"; };
 		DA8264871F2AADC200454B24 /* zh-Hant */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Navigation.strings"; sourceTree = "<group>"; };
+		DA85D5EE25DB4AA3008A2AD4 /* LaneViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaneViewTests.swift; sourceTree = "<group>"; };
 		DA8F3A7523B5D84900B56786 /* SpeedLimitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedLimitView.swift; sourceTree = "<group>"; };
 		DA8F3A7723B5DB7900B56786 /* SpeedLimitStyleKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeedLimitStyleKit.swift; sourceTree = "<group>"; };
 		DA9059B0223B1347006E8B46 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = hu; path = Resources/hu.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1382,6 +1384,7 @@
 				8DFD949D221F66BE00152F45 /* BottomBannerSnapshotTests.swift */,
 				AE47A33622B27D8D0096458C /* InstructionsCardCollectionTests.swift */,
 				3510300E1F54B67000E3B7E7 /* LaneTests.swift */,
+				DA85D5EE25DB4AA3008A2AD4 /* LaneViewTests.swift */,
 				35B1AEBB20AD9B3C00C8544E /* LeaksSpec.swift */,
 				35B1AEBD20AD9C7800C8544E /* LeakTest.swift */,
 				3540514E1F73F3F300ED572D /* ManeuverViewTests.swift */,
@@ -2678,6 +2681,7 @@
 				355B469B22B902C9009CE634 /* SKUTests.swift in Sources */,
 				DAD17202214DB12B009C8161 /* CPMapTemplateTests.swift in Sources */,
 				35EFD009207CA5E800BF3873 /* ManeuverViewTests.swift in Sources */,
+				DA85D5EF25DB4AA4008A2AD4 /* LaneViewTests.swift in Sources */,
 				35A262B92050A5CD00AEFF6D /* InstructionsBannerViewSnapshotTests.swift in Sources */,
 				8D5CF3B0215054AF005592D6 /* FBSnapshotTestCase.swift in Sources */,
 				16AC9D11212E356200CECE44 /* CPMapTemplate+MBTestable.mm in Sources */,

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxNavigation.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO"
+      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -1,9 +1,145 @@
 import UIKit
 import MapboxDirections
 
+extension LaneIndication {
+    static let lefts: LaneIndication = [.sharpLeft, .left, .slightLeft]
+    static let rights: LaneIndication = [.sharpRight, .right, .slightRight]
+    
+    struct Ranking: Equatable {
+        let primary: LaneIndication
+        let secondary: LaneIndication?
+    }
+    
+    /**
+     Separates the indication into primary and secondary indications with a bias toward the given maneuver direction.
+     
+     The return values are influenced by the set of available drawing methods in LanesStyleKit.
+     */
+    func ranked(favoring maneuverDirection: ManeuverDirection?) -> Ranking {
+        var indications = self
+        
+        // There are only assets for the most common configurations, so prioritize the indication that matches the maneuver direction.
+        var primaryIndication: LaneIndication
+        // Prioritize matches with the maneuver direction.
+        if indications.contains(.straightAhead) && maneuverDirection ?? .straightAhead == .straightAhead {
+            primaryIndication = .straightAhead
+        } else if indications.contains(.slightLeft) && maneuverDirection ?? .slightLeft == .slightLeft {
+            primaryIndication = .slightLeft
+        } else if indications.contains(.slightRight) && maneuverDirection ?? .slightRight == .slightRight {
+            primaryIndication = .slightRight
+        } else if (indications.contains(.left) && maneuverDirection?.isLeft ?? true) ||
+                    // No assets for sharp turns; treat them as normal turns.
+                    (indications.contains(.sharpLeft) && maneuverDirection ?? .sharpLeft == .sharpLeft) {
+            primaryIndication = .left
+        } else if (indications.contains(.right) && maneuverDirection?.isRight ?? true) ||
+                    // No assets for sharp turns; treat them as normal turns.
+                    (indications.contains(.sharpRight) && maneuverDirection ?? .sharpRight == .sharpRight) {
+            primaryIndication = .right
+        } else if indications.contains(.uTurn) && maneuverDirection ?? .uTurn == .uTurn {
+            primaryIndication = .uTurn
+        } else {
+            // The lane doesn’t match the maneuver direction, so choose the least extreme indication.
+            // Most likely the lane will appear unhighlighted anyways.
+            if indications.contains(.straightAhead) {
+                primaryIndication = .straightAhead
+            } else if indications.contains(.slightLeft) {
+                primaryIndication = .slightLeft
+            } else if indications.contains(.slightRight) {
+                primaryIndication = .slightRight
+            } else if !indications.isDisjoint(with: .lefts) {
+                primaryIndication = .left
+            } else if !indications.isDisjoint(with: .rights) {
+                primaryIndication = .right
+            } else if indications.contains(.uTurn) {
+                primaryIndication = .uTurn
+            } else {
+                // No indications to draw.
+                return Ranking(primary: [], secondary: nil)
+            }
+        }
+        
+        indications.remove(primaryIndication)
+        
+        // Some dual-use configurations are supported.
+        let secondaryIndication: LaneIndication?
+        if !primaryIndication.isSubset(of: [.straightAhead, .uTurn]) && indications.contains(.straightAhead) {
+            secondaryIndication = .straightAhead
+            
+            // No asset for dual-use slight turn, so use normal turn instead.
+            if primaryIndication == .slightLeft {
+                primaryIndication = .left
+            } else if primaryIndication == .slightRight {
+                primaryIndication = .right
+            }
+        } else if primaryIndication == .straightAhead && !indications.isDisjoint(with: .lefts) {
+            secondaryIndication = .left
+        } else if primaryIndication == .straightAhead && !indications.isDisjoint(with: .rights) {
+            secondaryIndication = .right
+        } else {
+            secondaryIndication = nil
+        }
+        
+        return Ranking(primary: primaryIndication, secondary: secondaryIndication)
+    }
+}
+
+/**
+ A generalized representation of the drawing methods available in LanesStyleKit.
+ */
+enum LaneConfiguration: Equatable {
+    case straightOnly
+    case slightTurnOnly(side: DrivingSide)
+    case turnOnly(side: DrivingSide)
+    case uTurnOnly(side: DrivingSide)
+    
+    case straightOrTurn(side: DrivingSide, straight: Bool, turn: Bool)
+    
+    init?(rankedIndications: LaneIndication.Ranking, drivingSide: DrivingSide) {
+        switch (rankedIndications.primary, rankedIndications.secondary) {
+        // Single-use lanes
+        case (.straightAhead, .none):
+            self = .straightOnly
+        case (.slightLeft, .none):
+            self = .slightTurnOnly(side: .left)
+        case (.slightRight, .none):
+            self = .slightTurnOnly(side: .right)
+        case (.left, .none):
+            self = .turnOnly(side: .left)
+        case (.right, .none):
+            self = .turnOnly(side: .right)
+        case (.uTurn, .none):
+            // When you drive on the right, you U-turn to the left and vice versa.
+            self = .uTurnOnly(side: drivingSide == .right ? .left : .right)
+        
+        // Dual-use lanes
+        case (.straightAhead, .some(.left)):
+            self = .straightOrTurn(side: .left, straight: true, turn: false)
+        case (.straightAhead, .some(.right)):
+            self = .straightOrTurn(side: .right, straight: true, turn: false)
+        case (.left, .some(.straightAhead)):
+            self = .straightOrTurn(side: .left, straight: false, turn: true)
+        case (.right, .some(.straightAhead)):
+            self = .straightOrTurn(side: .right, straight: false, turn: true)
+            
+        default:
+            return nil
+        }
+    }
+}
+
+extension ManeuverDirection {
+    var isLeft: Bool {
+        return self == .sharpLeft || self == .left || self == .slightLeft
+    }
+    
+    var isRight: Bool {
+        return self == .sharpRight || self == .right || self == .slightRight
+    }
+}
+
 /// :nodoc:
 open class LaneView: UIView {
-    var indications: LaneIndication? {
+    var indications: LaneIndication {
         didSet {
             setNeedsDisplay()
         }
@@ -84,11 +220,13 @@ open class LaneView: UIView {
     }
 
     override init(frame: CGRect) {
+        indications = []
         super.init(frame: frame)
         commonInit()
     }
 
     @objc public required init?(coder aDecoder: NSCoder) {
+        indications = []
         super.init(coder: aDecoder)
         commonInit()
     }
@@ -98,127 +236,49 @@ open class LaneView: UIView {
         // This is needed to obtain correct compositing since we implement our own draw function that includes transparency.
         isOpaque = false
     }
-
+    
     override open func draw(_ rect: CGRect) {
         super.draw(rect)
         
-        let resizing: LanesStyleKit.ResizingBehavior = .aspectFit
-        
-        if let indications = indications {
-            if indications.isSuperset(of: [.straightAhead, .sharpRight]) || indications.isSuperset(of: [.straightAhead, .right]) || indications.isSuperset(of: [.straightAhead, .slightRight]) {
-                if !isValid {
-                    if indications == .slightRight {
-                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor)
-                    } else {
-                        LanesStyleKit.drawLaneStraightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor)
-                    }
-                } else if maneuverDirection == .straightAhead {
-                    LanesStyleKit.drawLaneStraightOnly(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor)
-                } else if maneuverDirection == .sharpLeft || maneuverDirection == .left || maneuverDirection == .slightLeft {
-                    if indications == .slightLeft {
-                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
-                    } else {
-                        LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
-                    }
-                } else {
-                    // pick the color of the two parts (straight & turn) depending on which direction is being suggested
-                    let turnArrowColor: UIColor
-                    let straightArrowColor: UIColor
-                    switch self.maneuverDirection {
-                    case .straightAhead:
-                        straightArrowColor = appropriatePrimaryColor
-                        turnArrowColor = appropriateSecondaryColor
-                    default:
-                        straightArrowColor = appropriateSecondaryColor
-                        turnArrowColor = appropriatePrimaryColor
-                    }
-
-                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, primaryColor: turnArrowColor, secondaryColor: straightArrowColor)
-                }
-            } else if indications.isSuperset(of: [.straightAhead, .sharpLeft]) || indications.isSuperset(of: [.straightAhead, .left]) || indications.isSuperset(of: [.straightAhead, .slightLeft]) {
-                if !isValid {
-                    if indications == .slightLeft {
-                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor, flipHorizontally: true)
-                    } else {
-                        LanesStyleKit.drawLaneStraightRight(frame: bounds, resizing: resizing, primaryColor: appropriateSecondaryColor, flipHorizontally: true)
-                    }
-                } else if maneuverDirection == .straightAhead {
-                    LanesStyleKit.drawLaneStraightOnly(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor, flipHorizontally: true)
-                } else if maneuverDirection == .sharpRight || maneuverDirection == .right {
-                    LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                } else if maneuverDirection == .slightRight {
-                    LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                } else {
-                    // pick the color of the two parts (straight & turn) depending on which direction is being suggested
-                    let turnArrowColor: UIColor
-                    let straightArrowColor: UIColor
-
-                    switch self.maneuverDirection {
-                    case .straightAhead:
-                        straightArrowColor = appropriatePrimaryColor
-                        turnArrowColor = appropriateSecondaryColor
-                    default:
-                        straightArrowColor = appropriateSecondaryColor
-                        turnArrowColor = appropriatePrimaryColor
-                    }
-
-                    LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing, primaryColor: turnArrowColor, secondaryColor: straightArrowColor, flipHorizontally: true)
-                }
-            } else if indications.description.components(separatedBy: ",").count >= 2 {
-                // Hack:
-                // Account for a configuation where there is no straight lane
-                // but there are at least 2 indications.
-                // In this situation, just draw a left/right arrow
-                if maneuverDirection == .sharpRight || maneuverDirection == .right {
-                    LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                } else if maneuverDirection == .slightRight {
-                    LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                } else {
-                    LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
-                }
-            } else if indications.isSuperset(of: [.sharpRight]) || indications.isSuperset(of: [.right]) || indications.isSuperset(of: [.slightRight]) {
-                if indications == .slightRight {
-                    LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                } else {
-                    LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                }
-            } else if indications.isSuperset(of: [.sharpLeft]) || indications.isSuperset(of: [.left]) || indications.isSuperset(of: [.slightLeft]) {
-                if indications == .slightLeft {
-                    LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
-                } else {
-                    LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
-                }
-            } else if indications.isSuperset(of: [.straightAhead]) {
-                LanesStyleKit.drawLaneStraight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-            } else if indications.isSuperset(of: [.uTurn]) {
-                let flip = !(drivingSide == .left)
-                LanesStyleKit.drawLaneUturn(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: flip)
-            } else if indications.isEmpty && isValid {
-                // If the lane indication is `none` and the maneuver modifier has a turn in it,
-                // show the turn in the lane image.
-                if maneuverDirection == .sharpRight || maneuverDirection == .right || maneuverDirection == .slightRight {
-                    if maneuverDirection == .slightRight {
-                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                    } else {
-                        LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                    }
-                } else if maneuverDirection == .sharpLeft || maneuverDirection == .left || maneuverDirection == .slightLeft {
-                    if maneuverDirection == .slightLeft {
-                        LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
-                    } else {
-                        LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor, flipHorizontally: true)
-                    }
-                } else {
-                    LanesStyleKit.drawLaneStraight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-                }
-            } else {
-                LanesStyleKit.drawLaneStraight(frame: bounds, resizing: resizing, primaryColor: appropriatePrimaryColor)
-            }
-        }
-        
         #if TARGET_INTERFACE_BUILDER
         isValid = true
-        LanesStyleKit.drawLaneRightOnly(primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor)
+        indications = [.straightAhead, .right]
+        maneuverDirection = .right
         #endif
+        
+        let resizing = LanesStyleKit.ResizingBehavior.aspectFit
+        let appropriateColor = isValid ? appropriatePrimaryColor : appropriateSecondaryColor
+        
+        let rankedIndications = indications.ranked(favoring: maneuverDirection)
+        guard let laneConfiguration = LaneConfiguration(rankedIndications: rankedIndications, drivingSide: drivingSide) else {
+            return
+        }
+        
+        switch laneConfiguration {
+        case .straightOnly:
+            LanesStyleKit.drawLaneStraight(frame: bounds, resizing: resizing, primaryColor: appropriateColor)
+        case .slightTurnOnly(side: let side):
+            LanesStyleKit.drawLaneSlightRight(frame: bounds, resizing: resizing, primaryColor: appropriateColor,
+                                              flipHorizontally: side == .left)
+        case .turnOnly(side: let side):
+            LanesStyleKit.drawLaneRight(frame: bounds, resizing: resizing, primaryColor: appropriateColor,
+                                        flipHorizontally: side == .left)
+        case .uTurnOnly(side: let side):
+            LanesStyleKit.drawLaneUturn(frame: bounds, resizing: resizing, primaryColor: appropriateColor,
+                                        flipHorizontally: side == .left)
+        case .straightOrTurn(side: let side, straight: let straight, turn: let turn):
+            if isValid && straight && !turn {
+                LanesStyleKit.drawLaneStraightOnly(frame: bounds, resizing: resizing,
+                                                   primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor,
+                                                   flipHorizontally: side == .left)
+            } else if isValid && !straight && turn {
+                LanesStyleKit.drawLaneRightOnly(frame: bounds, resizing: resizing,
+                                                primaryColor: appropriatePrimaryColor, secondaryColor: appropriateSecondaryColor,
+                                                flipHorizontally: side == .left)
+            } else {
+                LanesStyleKit.drawLaneStraightRight(frame: bounds, resizing: resizing, primaryColor: appropriateColor,
+                                                    flipHorizontally: side == .left)
+            }
+        }
     }
 }

--- a/Tests/MapboxNavigationTests/LaneTests.swift
+++ b/Tests/MapboxNavigationTests/LaneTests.swift
@@ -31,7 +31,7 @@ class LaneTests: FBSnapshotTestCase {
                 let groupView = UIStackView(orientation: .vertical, autoLayout: true)
                 groupView.alignment = .center
                 
-                let laneView = LaneView(indications: lane.indications, isUsable: true, direction: ManeuverDirection(rawValue: lane.indications.description))
+                let laneView = LaneView(indications: lane.indications, isUsable: true, direction: lane.maneuverDirection)
                 laneView.drivingSide = lane.drivingSide
                 
                 laneView.backgroundColor = .white
@@ -71,7 +71,7 @@ struct TestableLane {
         
         namedIndications = [
             ("Sharp Left, Straight Ahead",      [.sharpLeft, .straightAhead], .sharpLeft),
-            ("Straight Ahead, Sharp Left",      [.straightAhead, .sharpLeft], .straightAhead),
+            ("Straight Ahead, Sharp Left",      [.straightAhead, .sharpLeft], .sharpLeft),
             ("Left",                            [.left], .left),
             ("Slight Left",                     [.slightLeft], .slightLeft),
             ("Sharp Left",                      [.sharpLeft], .sharpLeft),
@@ -81,7 +81,7 @@ struct TestableLane {
             ("Slight Right",                    [.slightRight], .slightRight),
             ("Right",                           [.right], .right),
             ("Sharp Right, Straight Ahead",     [.sharpRight, .straightAhead], .sharpRight),
-            ("Straight Ahead, Sharp Right",     [.straightAhead, .sharpRight], .straightAhead),
+            ("Straight Ahead, Sharp Right",     [.straightAhead, .sharpRight], .sharpRight),
         ]
         
         return namedIndications.map { TestableLane(description: $0.0, indications: $0.1, drivingSide: drivingSide, maneuverDirection: $0.2) }

--- a/Tests/MapboxNavigationTests/LaneViewTests.swift
+++ b/Tests/MapboxNavigationTests/LaneViewTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+import MapboxDirections
+@testable import MapboxNavigation
+
+class LaneViewTests: XCTestCase {
+    func testRankedIndications() {
+        XCTAssertEqual(LaneIndication.straightAhead.ranked(favoring: nil),
+                       .init(primary: .straightAhead, secondary: nil))
+        XCTAssertEqual(LaneIndication.straightAhead.ranked(favoring: .straightAhead),
+                       .init(primary: .straightAhead, secondary: nil))
+        XCTAssertEqual(LaneIndication.straightAhead.ranked(favoring: .right),
+                       .init(primary: .straightAhead, secondary: nil))
+        XCTAssertEqual(LaneIndication.straightAhead.ranked(favoring: .uTurn),
+                       .init(primary: .straightAhead, secondary: nil))
+        
+        XCTAssertEqual(LaneIndication.uTurn.ranked(favoring: nil),
+                       .init(primary: .uTurn, secondary: nil))
+        XCTAssertEqual(LaneIndication.uTurn.ranked(favoring: .uTurn),
+                       .init(primary: .uTurn, secondary: nil))
+        XCTAssertEqual(LaneIndication.uTurn.ranked(favoring: .straightAhead),
+                       .init(primary: .uTurn, secondary: nil))
+        
+        XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: nil),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: .sharpLeft),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: .left),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: .right),
+                       .init(primary: .left, secondary: nil))
+        
+        XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: nil),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: .sharpRight),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: .right),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: .left),
+                       .init(primary: .right, secondary: nil))
+        
+        XCTAssertEqual(LaneIndication.left.ranked(favoring: nil),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(LaneIndication.left.ranked(favoring: .left),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(LaneIndication.left.ranked(favoring: .sharpLeft),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(LaneIndication.left.ranked(favoring: .slightLeft),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(LaneIndication.left.ranked(favoring: .straightAhead),
+                       .init(primary: .left, secondary: nil))
+        
+        XCTAssertEqual(LaneIndication.right.ranked(favoring: nil),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(LaneIndication.right.ranked(favoring: .right),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(LaneIndication.right.ranked(favoring: .sharpRight),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(LaneIndication.right.ranked(favoring: .slightRight),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(LaneIndication.right.ranked(favoring: .straightAhead),
+                       .init(primary: .right, secondary: nil))
+        
+        XCTAssertEqual(LaneIndication.slightLeft.ranked(favoring: nil),
+                       .init(primary: .slightLeft, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightLeft.ranked(favoring: .slightLeft),
+                       .init(primary: .slightLeft, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightLeft.ranked(favoring: .left),
+                       .init(primary: .slightLeft, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightLeft.ranked(favoring: .sharpLeft),
+                       .init(primary: .slightLeft, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightLeft.ranked(favoring: .uTurn),
+                       .init(primary: .slightLeft, secondary: nil))
+        
+        XCTAssertEqual(LaneIndication.slightRight.ranked(favoring: nil),
+                       .init(primary: .slightRight, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightRight.ranked(favoring: .slightRight),
+                       .init(primary: .slightRight, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightRight.ranked(favoring: .right),
+                       .init(primary: .slightRight, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightRight.ranked(favoring: .sharpRight),
+                       .init(primary: .slightRight, secondary: nil))
+        XCTAssertEqual(LaneIndication.slightRight.ranked(favoring: .uTurn),
+                       .init(primary: .slightRight, secondary: nil))
+        
+        XCTAssertEqual(([.straightAhead, .left] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .straightAhead, secondary: .left))
+        XCTAssertEqual(([.straightAhead, .left] as LaneIndication).ranked(favoring: .right),
+                       .init(primary: .straightAhead, secondary: .left))
+        XCTAssertEqual(([.straightAhead, .left] as LaneIndication).ranked(favoring: .left),
+                       .init(primary: .left, secondary: .straightAhead))
+        XCTAssertEqual(([.straightAhead, .left] as LaneIndication).ranked(favoring: .sharpLeft),
+                       .init(primary: .left, secondary: .straightAhead))
+        XCTAssertEqual(([.straightAhead, .left] as LaneIndication).ranked(favoring: .slightLeft),
+                       .init(primary: .left, secondary: .straightAhead))
+        
+        XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .straightAhead, secondary: .left))
+        XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .right),
+                       .init(primary: .straightAhead, secondary: .left))
+        XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .left),
+                       .init(primary: .straightAhead, secondary: .left))
+        XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .sharpLeft),
+                       .init(primary: .straightAhead, secondary: .left))
+        XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .slightLeft),
+                       .init(primary: .left, secondary: .straightAhead))
+        
+        XCTAssertEqual(([.straightAhead, .right] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .straightAhead, secondary: .right))
+        XCTAssertEqual(([.straightAhead, .right] as LaneIndication).ranked(favoring: .left),
+                       .init(primary: .straightAhead, secondary: .right))
+        XCTAssertEqual(([.straightAhead, .right] as LaneIndication).ranked(favoring: .right),
+                       .init(primary: .right, secondary: .straightAhead))
+        XCTAssertEqual(([.straightAhead, .right] as LaneIndication).ranked(favoring: .sharpRight),
+                       .init(primary: .right, secondary: .straightAhead))
+        XCTAssertEqual(([.straightAhead, .right] as LaneIndication).ranked(favoring: .slightRight),
+                       .init(primary: .right, secondary: .straightAhead))
+        
+        XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .straightAhead, secondary: .right))
+        XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .left),
+                       .init(primary: .straightAhead, secondary: .right))
+        XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .right),
+                       .init(primary: .straightAhead, secondary: .right))
+        XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .sharpRight),
+                       .init(primary: .straightAhead, secondary: .right))
+        XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .slightRight),
+                       .init(primary: .right, secondary: .straightAhead))
+        
+        XCTAssertEqual(([.left, .uTurn] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(([.left, .uTurn] as LaneIndication).ranked(favoring: .left),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(([.left, .uTurn] as LaneIndication).ranked(favoring: .uTurn),
+                       .init(primary: .uTurn, secondary: nil))
+        
+        XCTAssertEqual(([.straightAhead, .uTurn] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .straightAhead, secondary: nil))
+        XCTAssertEqual(([.straightAhead, .uTurn] as LaneIndication).ranked(favoring: .straightAhead),
+                       .init(primary: .straightAhead, secondary: nil))
+        XCTAssertEqual(([.straightAhead, .uTurn] as LaneIndication).ranked(favoring: .uTurn),
+                       .init(primary: .uTurn, secondary: nil))
+        
+        XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: .left),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: .right),
+                       .init(primary: .right, secondary: nil))
+        XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: .slightRight),
+                       .init(primary: .right, secondary: nil))
+        
+        XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: nil),
+                       .init(primary: .slightRight, secondary: nil))
+        XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: .left),
+                       .init(primary: .left, secondary: nil))
+        XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: .slightRight),
+                       .init(primary: .slightRight, secondary: nil))
+        XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: .right),
+                       .init(primary: .slightRight, secondary: nil))
+    }
+    
+    func testLaneConfiguration() {
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .uTurn, secondary: nil), drivingSide: .right),
+                       .uTurnOnly(side: .left))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .uTurn, secondary: nil), drivingSide: .left),
+                       .uTurnOnly(side: .right))
+        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .uTurn, secondary: .left), drivingSide: .right))
+        
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .straightAhead, secondary: nil), drivingSide: .right),
+                       .straightOnly)
+        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .straightAhead, secondary: .slightLeft), drivingSide: .right))
+        
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .slightLeft, secondary: nil), drivingSide: .right),
+                       .slightTurnOnly(side: .left))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .slightRight, secondary: nil), drivingSide: .right),
+                       .slightTurnOnly(side: .right))
+        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .slightLeft, secondary: .straightAhead), drivingSide: .right))
+        
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .left, secondary: nil), drivingSide: .right),
+                       .turnOnly(side: .left))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .right, secondary: nil), drivingSide: .right),
+                       .turnOnly(side: .right))
+        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .left, secondary: .right), drivingSide: .right))
+        
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .left, secondary: .straightAhead), drivingSide: .right),
+                       .straightOrTurn(side: .left, straight: false, turn: true))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .right, secondary: .straightAhead), drivingSide: .right),
+                       .straightOrTurn(side: .right, straight: false, turn: true))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .straightAhead, secondary: .left), drivingSide: .right),
+                       .straightOrTurn(side: .left, straight: true, turn: false))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .straightAhead, secondary: .right), drivingSide: .right),
+                       .straightOrTurn(side: .right, straight: true, turn: false))
+    }
+}


### PR DESCRIPTION
Rewrote the code in LaneView that selects the LanesStyleKit drawing method. The new implementation separates the business logic from the drawing code. (Some assumptions about the repertoire of available lane configurations remains in the business logic.) In cases where the available drawing methods cannot faithfully depict the lane configuration, the closest match is drawn, biased toward the maneuver direction. The code flow goes from LaneIndication to LaneIndication.Ranking to LaneConfiguration to LanesStyleKit.

This PR comes with a battery of unit tests that’s much more comprehensive and maintainable than the existing snapshot tests, taking advantage of the new code’s testability. Some inaccuracies in the existing snapshot tests have also been fixed. (As of #2798, two test configurations specified maneuver directions that mismatched the test fixtures. The test passed despite these inaccuracies because it didn’t pass the maneuver direction into LaneView. It’s unclear whether the code prior to #2798 was really behaving correctly in these cases.)

This refactoring paves the way for #2801, in which the maneuver direction will be replaced by the active maneuver direction specified by the Directions API. It would be desirable to expose the new LaneConfiguration logic publicly so that applications would have a much more convenient starting point for customizing LaneView’s look and feel. But before we can do that, we’d need to add more lane configurations to navigation-ui-resources so we can remove the assumptions about the available assets: #576.

/cc @mapbox/navigation-ios @avi-c @abhishek1508