### PR TITLE
Add ability to override main and alternative route lines.

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -198,6 +198,8 @@
 		8A2DFA8626168A300034A87E /* NavigationCameraDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DFA8526168A300034A87E /* NavigationCameraDebugView.swift */; };
 		8A30113C25DDCC8A00CE192A /* NavigationCameraConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30113B25DDCC8A00CE192A /* NavigationCameraConstants.swift */; };
 		8A3A219025EEC00200EDA999 /* CoreNavigationNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3A218F25EEC00200EDA999 /* CoreNavigationNavigator.swift */; };
+		8A2081CB25E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2081C925E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift */; };
+		8A2081CC25E07CED00F9B8A6 /* RouteLineType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2081CA25E07CED00F9B8A6 /* RouteLineType.swift */; };
 		8A41F5B225BF61AE00BD6FCF /* CarPlayActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A41F5B125BF61AE00BD6FCF /* CarPlayActivity.swift */; };
 		8A41F5EC25BF624900BD6FCF /* MapOrnamentPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A41F5EB25BF624900BD6FCF /* MapOrnamentPosition.swift */; };
 		8A41F63C25BF631500BD6FCF /* NavigationMapView+VanishingRouteLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A41F63A25BF631500BD6FCF /* NavigationMapView+VanishingRouteLine.swift */; };
@@ -724,6 +726,8 @@
 		8A2DFA8526168A300034A87E /* NavigationCameraDebugView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationCameraDebugView.swift; sourceTree = "<group>"; };
 		8A30113B25DDCC8A00CE192A /* NavigationCameraConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCameraConstants.swift; sourceTree = "<group>"; };
 		8A3A218F25EEC00200EDA999 /* CoreNavigationNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreNavigationNavigator.swift; sourceTree = "<group>"; };
+		8A2081C925E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationMapViewIdentifiers.swift; sourceTree = "<group>"; };
+		8A2081CA25E07CED00F9B8A6 /* RouteLineType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteLineType.swift; sourceTree = "<group>"; };
 		8A41F5B125BF61AE00BD6FCF /* CarPlayActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarPlayActivity.swift; sourceTree = "<group>"; };
 		8A41F5EB25BF624900BD6FCF /* MapOrnamentPosition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapOrnamentPosition.swift; sourceTree = "<group>"; };
 		8A41F63A25BF631500BD6FCF /* NavigationMapView+VanishingRouteLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NavigationMapView+VanishingRouteLine.swift"; sourceTree = "<group>"; };
@@ -1435,6 +1439,8 @@
 		8A0E0A66257ADD3D00C2E924 /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
+				8A2081C925E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift */,
+				8A2081CA25E07CED00F9B8A6 /* RouteLineType.swift */,
 				8DCB4247218A540A00D6FCAD /* NavigationComponent.swift */,
 				8DDBFCA22205016E0064DEBB /* NavigationCustomizable.swift */,
 				C53208AA1E81FFB900910266 /* NavigationMapView.swift */,
@@ -2585,6 +2591,7 @@
 				8A446645260A7B24008BA55E /* BoundingBox.swift in Sources */,
 				8AD866F625CA1BF10019A638 /* NavigationCamera.swift in Sources */,
 				8D5DFFF1207C04840093765A /* NSAttributedString.swift in Sources */,
+				8A2081CB25E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift in Sources */,
 				35CF34B11F0A733200C2692E /* UIFont.swift in Sources */,
 				8AD866F925CA1BF10019A638 /* ViewportDataSource.swift in Sources */,
 				4316D95C24340555000DD8F8 /* Match.swift in Sources */,
@@ -2592,6 +2599,7 @@
 				359D283C1F9DC14F00FDE9C9 /* UICollectionView.swift in Sources */,
 				8A17635B25CC89D800737520 /* Expression.swift in Sources */,
 				F4C5A26F24EF1D16004ED0DD /* FeedbackSubtypeViewController.swift in Sources */,
+				8A2081CC25E07CED00F9B8A6 /* RouteLineType.swift in Sources */,
 				2B3ED38C2609FA7900861A84 /* ArrivalController.swift in Sources */,
 				8D24A2F820409A890098CBF8 /* CGSize.swift in Sources */,
 				35CB1E131F97DD740011CC44 /* FeedbackItem.swift in Sources */,

--- a/Sources/MapboxNavigation/Constants.swift
+++ b/Sources/MapboxNavigation/Constants.swift
@@ -2,12 +2,15 @@ import CoreLocation
 import Foundation
 import MapboxDirections
 
+/**
+ A tuple that pairs an array of coordinates with level of traffic congestion along these coordinates.
+ */
 typealias CongestionSegment = ([CLLocationCoordinate2D], CongestionLevel)
 
 /**
- A stop dictionary representing the default line widths of the route line by zoom level when `NavigationMapViewDelegate.navigationMapView(_:routeStyleLayerWithIdentifier:source:)` is undefined.
+ A stop dictionary representing the default line widths of the route line by zoom level when `NavigationMapViewDelegate.navigationMapView(_:routeLineLayerWithIdentifier:sourceIdentifier:)` is undefined.
  
- You may use this constant in your implementation of `NavigationMapViewDelegate.navigationMapView(_:routeStyleLayerWithIdentifier:source:)` if you want to keep the default line widths but customize other aspects of the route line.
+ You may use this constant in your implementation of `NavigationMapViewDelegate.navigationMapView(_:routeLineLayerWithIdentifier:sourceIdentifier:)` if you want to keep the default line widths but customize other aspects of the route line.
  */
 public var RouteLineWidthByZoomLevel: [Double: Double] = [
     10.0: 8.0,

--- a/Sources/MapboxNavigation/MapView.swift
+++ b/Sources/MapboxNavigation/MapView.swift
@@ -27,17 +27,6 @@ extension MapView {
      This array contains multiple entries for a composited source. This property is empty for non-Mapbox-hosted tile sets and sources with type other than `vector`.
      */
     func tileSetIdentifiers(_ sourceIdentifier: String, sourceType: String) -> [String] {
-//        do {
-//            if sourceType == "vector",
-//               let properties = try __map.getStyleSourceProperties(forSourceId: sourceIdentifier).value as? Dictionary<String, Any>,
-//               let url = properties["url"] as? String,
-//               let configurationURL = URL(string: url),
-//               configurationURL.scheme == "mapbox",
-//               let tileSetIdentifiers = configurationURL.host?.components(separatedBy: ",") {
-//                return tileSetIdentifiers
-//            }
-//        } catch {
-//            NSLog("Failed to get source properties with error: \(error.localizedDescription).")
         if sourceType == "vector",
            let properties = mapboxMap.__map.getStyleSourceProperties(forSourceId: sourceIdentifier).value as? Dictionary<String, Any>,
            let url = properties["url"] as? String,
@@ -146,6 +135,34 @@ extension MapView {
         }
         
         return datasets
+    }
+
+    var mainRouteLineParentLayerIdentifier: String? {
+        var parentLayer: String? = nil
+        let identifiers = [
+            NavigationMapView.LayerIdentifier.arrowLayer,
+            NavigationMapView.LayerIdentifier.arrowSymbolLayer,
+            NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer,
+            NavigationMapView.LayerIdentifier.arrowStrokeLayer,
+            NavigationMapView.LayerIdentifier.waypointCircleLayer,
+            NavigationMapView.LayerIdentifier.buildingExtrusionLayer
+        ]
+        
+        for layer in mapboxMap.__map.getStyleLayers().reversed() {
+            if !(layer.type == "symbol") && !identifiers.contains(layer.id) {
+                let sourceLayer = mapboxMap.__map.getStyleLayerProperty(forLayerId: layer.id, property: "source-layer").value as? String
+                
+                if let sourceLayer = sourceLayer,
+                   sourceLayer.isEmpty {
+                    continue
+                }
+                
+                parentLayer = layer.id
+                break
+            }
+        }
+        
+        return parentLayer
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
@@ -46,14 +46,14 @@ extension NavigationMapView {
      Removes the highlight from all buildings highlighted by `highlightBuildings(at:in3D:)`.
      */
     public func unhighlightBuildings() {
-        guard let _ = try? mapView.style.getLayer(with: IdentifierString.buildingExtrusionLayer, type: FillExtrusionLayer.self).get() else { return }
-        let _ = mapView.style.removeStyleLayer(forLayerId: IdentifierString.buildingExtrusionLayer)
+        guard let _ = try? mapView.style.getLayer(with: NavigationMapView.LayerIdentifier.buildingExtrusionLayer, type: FillExtrusionLayer.self).get() else { return }
+        let _ = mapView.style.removeStyleLayer(forLayerId: NavigationMapView.LayerIdentifier.buildingExtrusionLayer)
     }
 
     private func addBuildingsLayer(with identifiers: Set<Int64>, in3D: Bool = false, extrudeAll: Bool = false) {
-        let _ = mapView.style.removeStyleLayer(forLayerId: IdentifierString.buildingExtrusionLayer)
+        let _ = mapView.style.removeStyleLayer(forLayerId: NavigationMapView.LayerIdentifier.buildingExtrusionLayer)
         if identifiers.isEmpty { return }
-        var highlightedBuildingsLayer = FillExtrusionLayer(id: IdentifierString.buildingExtrusionLayer)
+        var highlightedBuildingsLayer = FillExtrusionLayer(id: NavigationMapView.LayerIdentifier.buildingExtrusionLayer)
         highlightedBuildingsLayer.source = "composite"
         highlightedBuildingsLayer.sourceLayer = "building"
 

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -177,8 +177,8 @@ extension NavigationMapView {
      - parameter routeProgress: Current route progress.
      */
     public func updateRoute(_ routeProgress: RouteProgress) {
-        guard let mainRouteLayerIdentifier = identifier(routes?.first, identifierType: .route),
-              let mainRouteCasingLayerIdentifier = identifier(routes?.first, identifierType: .routeCasing) else { return }
+        let mainRouteLayerIdentifier = routeProgress.route.identifier(.route(isMainRoute: true))
+        let mainRouteCasingLayerIdentifier = routeProgress.route.identifier(.routeCasing(isMainRoute: true))
         
         if fractionTraveled >= 1.0 {
             // In case if route was fully travelled - remove main route and its casing.
@@ -205,142 +205,130 @@ extension NavigationMapView {
                 timer.invalidate()
                 return
             }
+            
             let newFractionTraveled = self.preFractionTraveled + traveledDifference * timePassedInMilliseconds.truncatingRemainder(dividingBy: 1000) / 1000
             
-            if let mainRouteLayerGradient = self.routeLineGradient(routeProgress.route, fractionTraveled: newFractionTraveled) {
-                self.mapView.style.updateLayer(id: mainRouteLayerIdentifier, type: LineLayer.self) { (lineLayer) in
-                    lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient))
+            DispatchQueue.global().async {
+                let congestionSegments = self.congestionSegments
+                if routeProgress.route != self.routes?.first {
+                    self.congestionSegments = routeProgress.route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: self.roadClassesWithOverriddenCongestionLevels)
+                }
+                
+                let mainRouteLayerGradient = self.routeLineGradient(congestionSegments,
+                                                                    fractionTraveled: newFractionTraveled)
+                DispatchQueue.main.async {
+                    self.mapView.style.updateLayer(id: mainRouteLayerIdentifier, type: LineLayer.self) { (lineLayer) in
+                        lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient))
+                    }
                 }
             }
             
-            self.mapView.style.updateLayer(id: mainRouteCasingLayerIdentifier, type: LineLayer.self) { (lineLayer) in
-                let mainRouteCasingLayerGradient = self.routeCasingGradient(newFractionTraveled)
-                lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient))
+            DispatchQueue.global().async {
+                let mainRouteCasingLayerGradient = self.routeLineGradient(fractionTraveled: newFractionTraveled)
+                DispatchQueue.main.async {
+                    self.mapView.style.updateLayer(id: mainRouteCasingLayerIdentifier, type: LineLayer.self) { (lineLayer) in
+                        lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient))
+                    }
+                }
             }
         })
     }
     
-    func routeLineGradient(_ route: Route, fractionTraveled: Double, isMain: Bool = true) -> [Double: UIColor]? {
-        var gradientStops = [CGFloat: UIColor]()
-        
-        /**
-         We will keep track of this value as we iterate through
-         the various congestion segments.
-         */
+    func routeLineGradient(_ congestionFeatures: [Feature]? = nil, fractionTraveled: Double, isMain: Bool = true) -> [Double: UIColor] {
+        var gradientStops = [Double: UIColor]()
         var distanceTraveled = fractionTraveled
         
-        /**
-         Begin by calculating individual congestion segments associated
-         with a congestion level.
-         */
-        let congestionSegments = addCongestion(to: route, legIndex: 0)
-        
-        /**
-         To create the stops dictionary that represents the route line expressed
-         as gradients, for every congestion segment we need one pair of dictionary
-         entries to represent the color to be displayed between that range. Depending
-         on the index of the congestion segment, the pair's first or second key
-         will have a buffer value added or subtracted to make room for a gradient
-         transition between congestion segments.
-         
-         green       gradient       red
-         transition
-         |-----------|~~~~~~~~~~~~|----------|
-         0         0.499        0.501       1.0
-         */
-        
-        for (index, feature) in congestionSegments.enumerated() {
-            // Get congestion color for the stop.
+        if let congestionFeatures = congestionFeatures {
+            let routeDistance = congestionFeatures.compactMap({ ($0.geometry.value as? LineString)?.distance() }).reduce(0, +)
+            var minimumSegment: (CGFloat, UIColor) = (CGFloat.greatestFiniteMagnitude, .clear)
             
-            let congestionLevel = feature.properties?[CongestionAttribute] as? String
-            let associatedCongestionColor = congestionColor(for: congestionLevel, isMain: isMain)
-            
-            // Measure the line length of the traffic segment.
-            let lineString = feature.geometry.value as? LineString
-            guard let distance = lineString?.distance() else { return nil }
-            
-            /**
-             If this is the first congestion segment, then the starting
-             percentage point will be zero.
-             */
-            if index == congestionSegments.startIndex {
-                distanceTraveled = distanceTraveled + distance
-
-                let segmentEndPercentTraveled = CGFloat(distanceTraveled / route.distance)
-                gradientStops[segmentEndPercentTraveled.nextDown] = associatedCongestionColor
+            for (index, feature) in congestionFeatures.enumerated() {
+                let congestionLevel = feature.properties?[CongestionAttribute] as? String
+                let associatedCongestionColor = congestionColor(for: congestionLevel, isMain: isMain)
+                let lineString = feature.geometry.value as? LineString
+                guard let distance = lineString?.distance() else { return gradientStops }
                 
-                if index + 1 < congestionSegments.count {
-                    gradientStops[segmentEndPercentTraveled.nextUp] = congestionColor(for: congestionSegments[index + 1].properties?["congestion"] as? String, isMain: isMain)
+                if index == congestionFeatures.startIndex {
+                    distanceTraveled = distanceTraveled + distance
+                    
+                    let segmentEndPercentTraveled = CGFloat(distanceTraveled / routeDistance)
+                    if Double(segmentEndPercentTraveled.nextDown) >= fractionTraveled {
+                        gradientStops[Double(segmentEndPercentTraveled.nextDown)] = associatedCongestionColor
+                        
+                        if segmentEndPercentTraveled.nextDown < minimumSegment.0 {
+                            minimumSegment = (segmentEndPercentTraveled.nextDown, associatedCongestionColor)
+                        }
+                        
+                        if index + 1 < congestionFeatures.count {
+                            let color = congestionColor(for: congestionFeatures[index + 1].properties?["congestion"] as? String, isMain: isMain)
+                            gradientStops[Double(segmentEndPercentTraveled.nextUp)] = color
+                            
+                            if segmentEndPercentTraveled.nextUp < minimumSegment.0 {
+                                minimumSegment = (segmentEndPercentTraveled.nextUp, color)
+                            }
+                        }
+                    }
+                    
+                    continue
                 }
                 
-                continue
+                if index == congestionFeatures.endIndex - 1 {
+                    let lastGradientStop: CGFloat = 1.0
+                    gradientStops[Double(lastGradientStop)] = associatedCongestionColor
+                    
+                    if lastGradientStop < minimumSegment.0 {
+                        minimumSegment = (lastGradientStop, associatedCongestionColor)
+                    }
+                    
+                    continue
+                }
+                
+                let segmentStartPercentTraveled = CGFloat(distanceTraveled / routeDistance)
+                
+                if Double(segmentStartPercentTraveled.nextUp) >= fractionTraveled {
+                    gradientStops[Double(segmentStartPercentTraveled.nextUp)] = associatedCongestionColor
+                    
+                    if segmentStartPercentTraveled.nextUp < minimumSegment.0 {
+                        minimumSegment = (segmentStartPercentTraveled.nextUp, associatedCongestionColor)
+                    }
+                }
+                
+                distanceTraveled = distanceTraveled + distance
+                
+                let segmentEndPercentTraveled = CGFloat(distanceTraveled / routeDistance)
+                if Double(segmentEndPercentTraveled.nextDown) >= fractionTraveled {
+                    gradientStops[Double(segmentEndPercentTraveled.nextDown)] = associatedCongestionColor
+                    
+                    if segmentEndPercentTraveled.nextDown < minimumSegment.0 {
+                        minimumSegment = (segmentEndPercentTraveled.nextDown, associatedCongestionColor)
+                    }
+                }
+                
+                if index + 1 < congestionFeatures.count && Double(segmentEndPercentTraveled.nextUp) >= fractionTraveled {
+                    let color = congestionColor(for: congestionFeatures[index + 1].properties?["congestion"] as? String, isMain: isMain)
+                    gradientStops[Double(segmentEndPercentTraveled.nextUp)] = color
+                    
+                    if segmentEndPercentTraveled.nextUp < minimumSegment.0 {
+                        minimumSegment = (segmentEndPercentTraveled.nextUp, color)
+                    }
+                }
             }
             
-            /**
-             If this is the last congestion segment, then the ending
-             percentage point will be 1.0, to represent 100%.
-             */
-            if index == congestionSegments.endIndex - 1 {
-                let segmentEndPercentTraveled = CGFloat(1.0)
-                gradientStops[segmentEndPercentTraveled.nextDown] = associatedCongestionColor
-                continue
+            gradientStops[0.0] = traversedRouteColor
+            if Double(CGFloat(fractionTraveled).nextDown) >= 0.0 {
+                gradientStops[Double(CGFloat(fractionTraveled).nextDown)] = traversedRouteColor
             }
-            
-            /**
-             If this is not the first or last congestion segment, then
-             the starting and ending percent values traveled for this segment
-             will be a fractional amount more/less than the actual values.
-             */
-            let segmentStartPercentTraveled = CGFloat(distanceTraveled / route.distance)
-            gradientStops[segmentStartPercentTraveled.nextUp] = associatedCongestionColor
-            
-            distanceTraveled = distanceTraveled + distance
-            
-            let segmentEndPercentTraveled = CGFloat(distanceTraveled / route.distance)
-            gradientStops[segmentEndPercentTraveled.nextDown] = associatedCongestionColor
-            
-            if index + 1 < congestionSegments.count {
-                gradientStops[segmentEndPercentTraveled.nextUp] = congestionColor(for: congestionSegments[index + 1].properties?["congestion"] as? String, isMain: isMain)
+            gradientStops[fractionTraveled] = minimumSegment.1
+        } else {
+            let percentTraveled = CGFloat(fractionTraveled)
+            gradientStops[0.0] = traversedRouteColor
+            if percentTraveled.nextDown >= 0.0 {
+                gradientStops[Double(percentTraveled.nextDown)] = traversedRouteColor
             }
+            gradientStops[Double(percentTraveled)] = routeCasingColor
         }
         
-        let percentTraveled = CGFloat(fractionTraveled)
-        
-        // Filter out only the stops that are greater than or equal to the percent of the route traveled.
-        var filteredGradientStops = gradientStops.filter { key, value in
-            return key >= percentTraveled
-        }
-        
-        // Then, get the lowest value from the above and fade the range from zero that lowest value,
-        // which represents the % of the route traveled.
-        if let minStop = filteredGradientStops.min(by: { $0.0 < $1.0 }) {
-            filteredGradientStops[0.0] = traversedRouteColor
-            filteredGradientStops[percentTraveled.nextDown] = traversedRouteColor
-            filteredGradientStops[percentTraveled] = minStop.value
-        }
-        
-        var resultGradientStops = [Double: UIColor]()
-
-        filteredGradientStops.filter({ $0.0 >= 0.0 }).forEach {
-            resultGradientStops[Double($0.0)] = $0.1
-        }
-        
-        return resultGradientStops
-    }
-    
-    func routeCasingGradient(_ fractionTraveled: Double) -> [Double: UIColor] {
-        let percentTraveled = CGFloat(fractionTraveled)
-        var gradientStops = [CGFloat: UIColor]()
-        gradientStops[0.0] = traversedRouteColor
-        gradientStops[percentTraveled.nextDown] = traversedRouteColor
-        gradientStops[percentTraveled != 0.0 ? percentTraveled : 1.0] = routeCasingColor
-        
-        var resultGradientStops = [Double: UIColor]()
-        gradientStops.filter({ $0.0 >= 0.0 }).forEach {
-            resultGradientStops[Double($0.0)] = $0.1
-        }
-        
-        return resultGradientStops
+        return gradientStops
     }
     
     /**
@@ -359,100 +347,5 @@ extension NavigationMapView {
         default:
             return isMain ? trafficUnknownColor : alternativeTrafficUnknownColor
         }
-    }
-    
-    func addCongestion(to route: Route, legIndex: Int?) -> [Feature] {
-        guard let coordinates = route.shape?.coordinates, let shape = route.shape else { return [] }
-        
-        var features: [Feature] = []
-        
-        for (index, leg) in route.legs.enumerated() {
-            let legFeatures: [Feature]
-            
-            if let legCongestion = leg.segmentCongestionLevels, legCongestion.count < coordinates.count {
-                // The last coord of the preceding step, is shared with the first coord of the next step, we don't need both.
-                let legCoordinates: [CLLocationCoordinate2D] = leg.steps.enumerated().reduce([]) { allCoordinates, current in
-                    let index = current.offset
-                    let step = current.element
-                    let stepCoordinates = step.shape!.coordinates
-                    
-                    return index == 0 ? stepCoordinates : allCoordinates + stepCoordinates.suffix(from: 1)
-                }
-                
-                let mergedCongestionSegments = combine(legCoordinates,
-                                                       with: legCongestion,
-                                                       streetsRoadClasses: leg.streetsRoadClasses,
-                                                       roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
-                
-                legFeatures = mergedCongestionSegments.map { (congestionSegment: CongestionSegment) -> Feature in
-                    var feature = Feature(LineString(congestionSegment.0))
-                    feature.properties = [
-                        CongestionAttribute: String(describing: congestionSegment.1),
-                        "isAlternateRoute": false,
-                        CurrentLegAttribute: (legIndex != nil) ? index == legIndex : index == 0
-                    ]
-                    
-                    return feature
-                }
-            } else {
-                var feature = Feature(LineString(shape.coordinates))
-                feature.properties = [
-                    "isAlternateRoute": false,
-                    CurrentLegAttribute: (legIndex != nil) ? index == legIndex : index == 0
-                ]
-                legFeatures = [feature]
-            }
-            
-            features.append(contentsOf: legFeatures)
-        }
-        
-        return features
-    }
-    
-    /**
-     Returns an array of congestion segments by associating the given congestion levels with the coordinates of the respective line segments that they apply to.
-     
-     This method coalesces consecutive line segments that have the same congestion level.
-     
-     For each item in the`CongestionSegment` collection a `CongestionLevel` substitution will take place that has a streets road class contained in the `roadClassesWithOverriddenCongestionLevels` collection.
-     For each of these items the `CongestionLevel` for `.unknown` traffic congestion will be replaced with the `.low` traffic congestion.
-     
-     - parameter coordinates: The coordinates of a leg.
-     - parameter congestions: The congestion levels along a leg. There should be one fewer congestion levels than coordinates.
-     - parameter streetsRoadClasses: A collection of streets road classes for each geometry index in `Intersection`. There should be the same amount of `streetsRoadClasses` and `congestions`.
-     - parameter roadClassesWithOverriddenCongestionLevels: Streets road classes for which a `CongestionLevel` substitution should occur.
-     - returns: A list of `CongestionSegment` tuples with coordinate and congestion level.
-     */
-    func combine(_ coordinates: [CLLocationCoordinate2D],
-                 with congestions: [CongestionLevel],
-                 streetsRoadClasses: [MapboxStreetsRoadClass?]? = nil,
-                 roadClassesWithOverriddenCongestionLevels: Set<MapboxStreetsRoadClass>? = nil) -> [CongestionSegment] {
-        var segments: [CongestionSegment] = []
-        segments.reserveCapacity(congestions.count)
-        
-        var index = 0
-        for (firstSegment, congestionLevel) in zip(zip(coordinates, coordinates.suffix(from: 1)), congestions) {
-            let coordinates = [firstSegment.0, firstSegment.1]
-            
-            var overriddenCongestionLevel = congestionLevel
-            if let streetsRoadClasses = streetsRoadClasses,
-               let roadClassesWithOverriddenCongestionLevels = roadClassesWithOverriddenCongestionLevels,
-               streetsRoadClasses.indices.contains(index),
-               let streetsRoadClass = streetsRoadClasses[index],
-               congestionLevel == .unknown,
-               roadClassesWithOverriddenCongestionLevels.contains(streetsRoadClass) {
-                overriddenCongestionLevel = .low
-            }
-            
-            if segments.last?.1 == overriddenCongestionLevel {
-                segments[segments.count - 1].0 += coordinates
-            } else {
-                segments.append((coordinates, overriddenCongestionLevel))
-            }
-            
-            index += 1
-        }
-        
-        return segments
     }
 }

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -228,7 +228,7 @@ extension NavigationMapView {
         
         if let congestionFeatures = congestionFeatures {
             let routeDistance = congestionFeatures.compactMap({ ($0.geometry.value as? LineString)?.distance() }).reduce(0, +)
-            var minimumSegment: (CGFloat, UIColor) = (CGFloat.greatestFiniteMagnitude, .clear)
+            var minimumSegment: (Double, UIColor) = (Double.greatestFiniteMagnitude, .clear)
             
             for (index, feature) in congestionFeatures.enumerated() {
                 let congestionLevel = feature.properties?[CongestionAttribute] as? String
@@ -240,19 +240,21 @@ extension NavigationMapView {
                     distanceTraveled = distanceTraveled + distance
                     
                     let segmentEndPercentTraveled = CGFloat(distanceTraveled / routeDistance)
-                    if Double(segmentEndPercentTraveled.nextDown) >= fractionTraveled {
-                        gradientStops[Double(segmentEndPercentTraveled.nextDown)] = associatedCongestionColor
+                    let currentGradientStop = Double(segmentEndPercentTraveled.nextDown)
+                    if currentGradientStop >= fractionTraveled {
+                        gradientStops[currentGradientStop] = associatedCongestionColor
                         
-                        if segmentEndPercentTraveled.nextDown < minimumSegment.0 {
-                            minimumSegment = (segmentEndPercentTraveled.nextDown, associatedCongestionColor)
+                        if currentGradientStop < minimumSegment.0 {
+                            minimumSegment = (currentGradientStop, associatedCongestionColor)
                         }
                         
                         if index + 1 < congestionFeatures.count {
-                            let color = congestionColor(for: congestionFeatures[index + 1].properties?["congestion"] as? String, isMain: isMain)
-                            gradientStops[Double(segmentEndPercentTraveled.nextUp)] = color
+                            let currentGradientStop = Double(segmentEndPercentTraveled.nextUp)
+                            let currentColor = congestionColor(for: congestionFeatures[index + 1].properties?["congestion"] as? String, isMain: isMain)
+                            gradientStops[currentGradientStop] = currentColor
                             
-                            if segmentEndPercentTraveled.nextUp < minimumSegment.0 {
-                                minimumSegment = (segmentEndPercentTraveled.nextUp, color)
+                            if currentGradientStop < minimumSegment.0 {
+                                minimumSegment = (currentGradientStop, currentColor)
                             }
                         }
                     }
@@ -261,8 +263,8 @@ extension NavigationMapView {
                 }
                 
                 if index == congestionFeatures.endIndex - 1 {
-                    let lastGradientStop: CGFloat = 1.0
-                    gradientStops[Double(lastGradientStop)] = associatedCongestionColor
+                    let lastGradientStop: Double = 1.0
+                    gradientStops[lastGradientStop] = associatedCongestionColor
                     
                     if lastGradientStop < minimumSegment.0 {
                         minimumSegment = (lastGradientStop, associatedCongestionColor)
@@ -274,10 +276,11 @@ extension NavigationMapView {
                 let segmentStartPercentTraveled = CGFloat(distanceTraveled / routeDistance)
                 
                 if Double(segmentStartPercentTraveled.nextUp) >= fractionTraveled {
-                    gradientStops[Double(segmentStartPercentTraveled.nextUp)] = associatedCongestionColor
+                    let currentGradientStop = Double(segmentStartPercentTraveled.nextUp)
+                    gradientStops[currentGradientStop] = associatedCongestionColor
                     
-                    if segmentStartPercentTraveled.nextUp < minimumSegment.0 {
-                        minimumSegment = (segmentStartPercentTraveled.nextUp, associatedCongestionColor)
+                    if currentGradientStop < minimumSegment.0 {
+                        minimumSegment = (currentGradientStop, associatedCongestionColor)
                     }
                 }
                 
@@ -285,26 +288,29 @@ extension NavigationMapView {
                 
                 let segmentEndPercentTraveled = CGFloat(distanceTraveled / routeDistance)
                 if Double(segmentEndPercentTraveled.nextDown) >= fractionTraveled {
-                    gradientStops[Double(segmentEndPercentTraveled.nextDown)] = associatedCongestionColor
+                    let currentGradientStop = Double(segmentEndPercentTraveled.nextDown)
+                    gradientStops[currentGradientStop] = associatedCongestionColor
                     
-                    if segmentEndPercentTraveled.nextDown < minimumSegment.0 {
-                        minimumSegment = (segmentEndPercentTraveled.nextDown, associatedCongestionColor)
+                    if currentGradientStop < minimumSegment.0 {
+                        minimumSegment = (currentGradientStop, associatedCongestionColor)
                     }
                 }
                 
                 if index + 1 < congestionFeatures.count && Double(segmentEndPercentTraveled.nextUp) >= fractionTraveled {
-                    let color = congestionColor(for: congestionFeatures[index + 1].properties?["congestion"] as? String, isMain: isMain)
-                    gradientStops[Double(segmentEndPercentTraveled.nextUp)] = color
+                    let currentGradientStop = Double(segmentEndPercentTraveled.nextUp)
+                    let currentColor = congestionColor(for: congestionFeatures[index + 1].properties?["congestion"] as? String, isMain: isMain)
+                    gradientStops[currentGradientStop] = currentColor
                     
-                    if segmentEndPercentTraveled.nextUp < minimumSegment.0 {
-                        minimumSegment = (segmentEndPercentTraveled.nextUp, color)
+                    if currentGradientStop < minimumSegment.0 {
+                        minimumSegment = (currentGradientStop, currentColor)
                     }
                 }
             }
             
             gradientStops[0.0] = traversedRouteColor
-            if Double(CGFloat(fractionTraveled).nextDown) >= 0.0 {
-                gradientStops[Double(CGFloat(fractionTraveled).nextDown)] = traversedRouteColor
+            let currentGradientStop = Double(CGFloat(fractionTraveled).nextDown)
+            if currentGradientStop >= 0.0 {
+                gradientStops[currentGradientStop] = traversedRouteColor
             }
             gradientStops[fractionTraveled] = minimumSegment.1
         } else {

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -208,28 +208,16 @@ extension NavigationMapView {
             
             let newFractionTraveled = self.preFractionTraveled + traveledDifference * timePassedInMilliseconds.truncatingRemainder(dividingBy: 1000) / 1000
             
-            DispatchQueue.global().async {
-                let congestionSegments = self.congestionSegments
-                if routeProgress.route != self.routes?.first {
-                    self.congestionSegments = routeProgress.route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: self.roadClassesWithOverriddenCongestionLevels)
-                }
-                
-                let mainRouteLayerGradient = self.routeLineGradient(congestionSegments,
-                                                                    fractionTraveled: newFractionTraveled)
-                DispatchQueue.main.async {
-                    self.mapView.style.updateLayer(id: mainRouteLayerIdentifier, type: LineLayer.self) { (lineLayer) in
-                        lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient))
-                    }
-                }
+            let congestionSegments = routeProgress.route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: self.roadClassesWithOverriddenCongestionLevels)
+            let mainRouteLayerGradient = self.routeLineGradient(congestionSegments,
+                                                                fractionTraveled: newFractionTraveled)
+            self.mapView.style.updateLayer(id: mainRouteLayerIdentifier, type: LineLayer.self) { (lineLayer) in
+                lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient))
             }
             
-            DispatchQueue.global().async {
-                let mainRouteCasingLayerGradient = self.routeLineGradient(fractionTraveled: newFractionTraveled)
-                DispatchQueue.main.async {
-                    self.mapView.style.updateLayer(id: mainRouteCasingLayerIdentifier, type: LineLayer.self) { (lineLayer) in
-                        lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient))
-                    }
-                }
+            let mainRouteCasingLayerGradient = self.routeLineGradient(fractionTraveled: newFractionTraveled)
+            self.mapView.style.updateLayer(id: mainRouteCasingLayerIdentifier, type: LineLayer.self) { (lineLayer) in
+                lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient))
             }
         })
     }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -50,34 +50,7 @@ open class NavigationMapView: UIView {
      If `true` and there're multiple routes to choose, the alternative route lines would display the congestion levels at different colors, similar to the main route. To customize the congestion colors that represent different congestion levels, override the `alternativeTrafficUnknownColor`, `alternativeTrafficLowColor`, `alternativeTrafficModerateColor`, `alternativeTrafficHeavyColor`, `alternativeTrafficSevereColor` property for the `NavigationMapView.appearance()`.
      */
     public var showsCongestionForAlternativeRoutes: Bool = false
-    
-    enum IdentifierType: Int {
-        case source
-        
-        case route
-        
-        case routeCasing
-    }
-    
-    struct IdentifierString {
-        static let identifier = Bundle.mapboxNavigation.bundleIdentifier ?? ""
-        static let arrowImage = "triangle-tip-navigation"
-        static let arrowSource = "\(identifier)_arrowSource"
-        static let arrow = "\(identifier)_arrow"
-        static let arrowStrokeSource = "\(identifier)arrowStrokeSource"
-        static let arrowStroke = "\(identifier)_arrowStroke"
-        static let arrowSymbolSource = "\(identifier)_arrowSymbolSource"
-        static let arrowSymbol = "\(identifier)_arrowSymbol"
-        static let arrowCasingSymbol = "\(identifier)_arrowCasingSymbol"
-        static let instructionSource = "\(identifier)_instructionSource"
-        static let instructionLabel = "\(identifier)_instructionLabel"
-        static let instructionCircle = "\(identifier)_instructionCircle"
-        static let waypointSource = "\(identifier)_waypointSource"
-        static let waypointCircle = "\(identifier)_waypointCircle"
-        static let waypointSymbol = "\(identifier)_waypointSymbol"
-        static let buildingExtrusionLayer = "\(identifier)buildingExtrusionLayer"
-    }
-    
+
     @objc dynamic public var trafficUnknownColor: UIColor = .trafficUnknown
     @objc dynamic public var trafficLowColor: UIColor = .trafficLow
     @objc dynamic public var trafficModerateColor: UIColor = .trafficModerate
@@ -123,7 +96,14 @@ open class NavigationMapView: UIView {
      Most recent user location, which is used to place `UserCourseView`.
      */
     var mostRecentUserCourseViewLocation: CLLocation?
-    var routes: [Route]?
+    var congestionSegments: [Feature] = []
+    var routes: [Route]? {
+        didSet {
+            if let route = routes?.first {
+                congestionSegments = route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: self.roadClassesWithOverriddenCongestionLevels)
+            }
+        }
+    }
     var routePoints: RoutePoints?
     var routeLineGranularDistances: RouteLineGranularDistances?
     var routeRemainingDistancesIndex: Int?
@@ -134,8 +114,8 @@ open class NavigationMapView: UIView {
     
     var showsRoute: Bool {
         get {
-            guard let mainRouteLayerIdentifier = identifier(routes?.first, identifierType: .route),
-                  let mainRouteCasingLayerIdentifier = identifier(routes?.first, identifierType: .routeCasing) else { return false }
+            guard let mainRouteLayerIdentifier = routes?.first?.identifier(.route(isMainRoute: true)),
+                  let mainRouteCasingLayerIdentifier = routes?.first?.identifier(.routeCasing(isMainRoute: true)) else { return false }
             
             guard let _ = try? mapView.style.getLayer(with: mainRouteLayerIdentifier, type: LineLayer.self).get(),
                   let _ = try? mapView.style.getLayer(with: mainRouteCasingLayerIdentifier, type: LineLayer.self).get() else { return false }
@@ -322,6 +302,8 @@ open class NavigationMapView: UIView {
      
      This method accounts for the proximity to a maneuver and the current power source.
      It has no effect if `NavigationCameraState` is in `.following` mode.
+     
+     - parameter routeProgress: Object, which stores current progress along specific route.
      */
     public func updatePreferredFrameRate(for routeProgress: RouteProgress) {
         guard navigationCamera.state == .following else { return }
@@ -354,6 +336,9 @@ open class NavigationMapView: UIView {
     
     /**
      Updates `UserCourseView` to provided location.
+     
+     - parameter location: Location, where `UserCourseView` should be shown.
+     - parameter animated: Property, which determines whether `UserCourseView` transition to new location will be animated.
      */
     public func updateUserCourseView(_ location: CLLocation, animated: Bool = false) {
         guard CLLocationCoordinate2DIsValid(location.coordinate) else { return }
@@ -384,7 +369,7 @@ open class NavigationMapView: UIView {
     /**
      Showcases route array. Adds routes and waypoints to map, and sets camera to point encompassing the route.
      
-     - parameter routes: List of `Route` objects, which will be shown on `MapView.`
+     - parameter routes: List of `Route` objects, which will be shown on `MapView`.
      - parameter animated: Property, which determines whether camera movement will be animated while fitting first route.
      */
     public func showcase(_ routes: [Route], animated: Bool = false) {
@@ -403,6 +388,30 @@ open class NavigationMapView: UIView {
         fitCamera(to: activeRoute, animated: animated)
     }
     
+    /**
+     Adds main and alternative route lines and their casings on `MapView`. Prior to showing, previous
+     route lines and their casings will be removed.
+     
+     - parameter routes: List of `Route` objects, which will be shown on `MapView`.
+     - parameter legIndex: Index, which will be used to highlight specific `RouteLeg` on main route.
+     */
+    // TODO: Add ability to handle legIndex.
+    public func show(_ routes: [Route], legIndex: Int = 0) {
+        removeRoutes()
+        
+        self.routes = routes
+        
+        var parentLayerIdentifier: String? = nil
+        for (index, route) in routes.enumerated() {
+            if index == 0, routeLineTracksTraversal {
+                initPrimaryRoutePoints(route: route)
+            }
+            
+            parentLayerIdentifier = addRouteLayer(route, below: parentLayerIdentifier, isMainRoute: index == 0)
+            parentLayerIdentifier = addRouteCasingLayer(route, below: parentLayerIdentifier, isMainRoute: index == 0)
+        }
+    }
+    
     func fitCamera(to route: Route, animated: Bool = false) {
         guard let routeShape = route.shape, !routeShape.coordinates.isEmpty else { return }
         let edgeInsets = safeArea + UIEdgeInsets(top: 10.0, left: 20.0, bottom: 10.0, right: 20.0)
@@ -411,31 +420,7 @@ open class NavigationMapView: UIView {
             mapView?.camera.setCamera(to: cameraOptions, animated: animated)
         }
     }
-    
-    public func show(_ routes: [Route], legIndex: Int = 0) {
-        removeRoutes()
-        
-        self.routes = routes
-        
-        // TODO: Add ability to handle legIndex.
-        var parentLayerIdentifier: String? = nil
-        for (index, route) in routes.enumerated() {
-            if index == 0 {
-                parentLayerIdentifier = addMainRouteLayer(route)
-                parentLayerIdentifier = addMainRouteCasingLayer(route, below: parentLayerIdentifier)
-                
-                if routeLineTracksTraversal {
-                    initPrimaryRoutePoints(route: route)
-                }
-                
-                continue
-            }
-            
-            parentLayerIdentifier = addAlternativeRouteLayer(route,  below: parentLayerIdentifier)
-            addAlternativeRouteCasingLayer(route, below: parentLayerIdentifier)
-        }
-    }
-    
+
     /**
      Sets initial `CameraOptions` for specific coordinate.
      
@@ -452,143 +437,105 @@ open class NavigationMapView: UIView {
         mapView.cameraOptions = CameraOptions(center: coordinate, zoom: zoom)
         updateUserCourseView(CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude))
     }
-    
-    @discardableResult func addMainRouteLayer(_ route: Route) -> String? {
+
+    @discardableResult func addRouteLayer(_ route: Route, below parentLayerIndentifier: String? = nil, isMainRoute: Bool = true) -> String? {
         guard let shape = route.shape else { return nil }
         
-        var geoJSONSource = GeoJSONSource()
-        geoJSONSource.data = .geometry(.lineString(shape))
-        geoJSONSource.lineMetrics = true
-        
-        guard let sourceIdentifier = identifier(route, identifierType: .source) else { return nil }
+        let geoJSONSource = self.geoJSONSource(delegate?.navigationMapView(self, casingShapeFor: route) ?? shape)
+        let sourceIdentifier = route.identifier(.source(isMainRoute: isMainRoute, isSourceCasing: true))
         mapView.style.addSource(source: geoJSONSource, identifier: sourceIdentifier)
         
-        let fractionTraveledForStops = routeLineTracksTraversal ? fractionTraveled : 0.0
-        guard let layerIdentifier = identifier(route, identifierType: .route) else { return nil }
-        var lineLayer = LineLayer(id: layerIdentifier)
-        lineLayer.source = sourceIdentifier
-        lineLayer.paint?.lineWidth = .expression(Expression.routeLineWidthExpression())
-        lineLayer.layout?.lineJoin = .constant(.round)
-        lineLayer.layout?.lineCap = .constant(.round)
+        let layerIdentifier = route.identifier(.route(isMainRoute: isMainRoute))
+        var lineLayer = delegate?.navigationMapView(self,
+                                                    routeLineLayerWithIdentifier: layerIdentifier,
+                                                    sourceIdentifier: sourceIdentifier)
         
-        if let gradientStops = routeLineGradient(route, fractionTraveled: fractionTraveledForStops) {
-            lineLayer.paint?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops)))
-        }
-        
-        var parentLayer: String? {
-            var parentLayer: String? = nil
-            let identifiers = [
-                IdentifierString.arrow,
-                IdentifierString.arrowSymbol,
-                IdentifierString.arrowCasingSymbol,
-                IdentifierString.arrowStroke,
-                IdentifierString.waypointCircle,
-                IdentifierString.buildingExtrusionLayer
-            ]
+        if lineLayer == nil {
+            lineLayer = LineLayer(id: layerIdentifier)
+            lineLayer?.source = sourceIdentifier
+            lineLayer?.paint?.lineColor = .constant(.init(color: trafficUnknownColor))
+            lineLayer?.paint?.lineWidth = .expression(Expression.routeLineWidthExpression())
+            lineLayer?.layout?.lineJoin = .constant(.round)
+            lineLayer?.layout?.lineCap = .constant(.round)
             
-            for layer in mapView.mapboxMap.__map.getStyleLayers().reversed() {
-                if !(layer.type == "symbol") && !identifiers.contains(layer.id) {
-                    let sourceLayer = mapView.mapboxMap.__map.getStyleLayerProperty(forLayerId: layer.id, property: "source-layer").value as? String
-                    
-                    if let sourceLayer = sourceLayer,
-                       sourceLayer.isEmpty {
-                        continue
-                    }
-                    
-                    parentLayer = layer.id
-                    break
+            // TODO: Verify that `isAlternativeRoute` parameter usage is needed.
+            if isMainRoute {
+                let gradientStops = routeLineGradient(route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels),
+                                                      fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
+                lineLayer?.paint?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops)))
+            } else {
+                if showsCongestionForAlternativeRoutes {
+                    let gradientStops = routeLineGradient(route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels),
+                                                          fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0,
+                                                          isMain: false)
+                    lineLayer?.paint?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops)))
+                } else {
+                    lineLayer?.paint?.lineColor = .constant(.init(color: routeAlternateColor))
                 }
             }
+        }
+        
+        if let lineLayer = lineLayer {
+            mapView.style.addLayer(layer: lineLayer,
+                                   layerPosition: isMainRoute ?
+                                    LayerPosition(above: mapView.mainRouteLineParentLayerIdentifier) :
+                                    LayerPosition(below: parentLayerIndentifier))
+        }
+        
+        return layerIdentifier
+    }
+    
+    @discardableResult func addRouteCasingLayer(_ route: Route, below parentLayerIndentifier: String? = nil, isMainRoute: Bool = true) -> String? {
+        guard let shape = route.shape else { return nil }
+        
+        let geoJSONSource = self.geoJSONSource(delegate?.navigationMapView(self, shapeFor: route) ?? shape)
+        let sourceIdentifier = route.identifier(.source(isMainRoute: isMainRoute, isSourceCasing: isMainRoute))
+        mapView.style.addSource(source: geoJSONSource, identifier: sourceIdentifier)
+        
+        let layerIdentifier = route.identifier(.routeCasing(isMainRoute: isMainRoute))
+        var lineLayer = delegate?.navigationMapView(self,
+                                                    routeCasingLineLayerWithIdentifier: layerIdentifier,
+                                                    sourceIdentifier: sourceIdentifier)
+        
+        if lineLayer == nil {
+            lineLayer = LineLayer(id: layerIdentifier)
+            lineLayer?.source = sourceIdentifier
+            lineLayer?.paint?.lineColor = .constant(.init(color: routeCasingColor))
+            lineLayer?.paint?.lineWidth = .expression(Expression.routeLineWidthExpression(1.5))
+            lineLayer?.layout?.lineJoin = .constant(.round)
+            lineLayer?.layout?.lineCap = .constant(.round)
             
-            return parentLayer
+            if isMainRoute {
+                let gradientStops = routeLineGradient(fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
+                lineLayer?.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(gradientStops))
+            } else {
+                lineLayer?.paint?.lineColor = .constant(.init(color: routeAlternateCasingColor))
+            }
         }
         
-        mapView.style.addLayer(layer: lineLayer, layerPosition: LayerPosition(above: parentLayer))
-        
-        return layerIdentifier
-    }
-    
-    @discardableResult func addMainRouteCasingLayer(_ route: Route, below parentLayerIndentifier: String? = nil) -> String? {
-        guard let shape = route.shape else { return nil }
-        
-        var geoJSONSource = GeoJSONSource()
-        geoJSONSource.data = .geometry(.lineString(shape))
-        geoJSONSource.lineMetrics = true
-        
-        guard let sourceIdentifier = identifier(route, identifierType: .source, isMainRouteCasingSource: true) else { return nil }
-        mapView.style.addSource(source: geoJSONSource, identifier: sourceIdentifier)
-        
-        let fractionTraveledForStops = routeLineTracksTraversal ? fractionTraveled : 0.0
-        guard let layerIdentifier = identifier(route, identifierType: .routeCasing) else { return nil }
-        var lineLayer = LineLayer(id: layerIdentifier)
-        lineLayer.source = sourceIdentifier
-        lineLayer.paint?.lineColor = .constant(.init(color: routeCasingColor))
-        lineLayer.paint?.lineWidth = .expression(Expression.routeLineWidthExpression(1.5))
-        lineLayer.layout?.lineJoin = .constant(.round)
-        lineLayer.layout?.lineCap = .constant(.round)
-        
-        mapView.style.addLayer(layer: lineLayer, layerPosition: LayerPosition(below: parentLayerIndentifier))
-        
-        let gradientStops = routeCasingGradient(fractionTraveledForStops)
-        lineLayer.paint?.lineGradient = .expression(Expression.routeLineGradientExpression(gradientStops))
-
-        return layerIdentifier
-    }
-    
-    @discardableResult func addAlternativeRouteLayer(_ route: Route, below parentLayerIndentifier: String? = nil) -> String? {
-        guard let shape = route.shape else { return nil }
-        
-        var geoJSONSource = GeoJSONSource()
-        geoJSONSource.data = .geometry(.lineString(shape))
-        geoJSONSource.lineMetrics = true
-        
-        guard let sourceIdentifier = identifier(route, identifierType: .source) else { return nil }
-        mapView.style.addSource(source: geoJSONSource, identifier: sourceIdentifier)
-        
-        guard let layerIdentifier = identifier(route, identifierType: .route) else { return nil }
-        var lineLayer = LineLayer(id: layerIdentifier)
-        lineLayer.source = sourceIdentifier
-        lineLayer.paint?.lineColor = .constant(.init(color: routeAlternateColor))
-        lineLayer.paint?.lineWidth = .expression(Expression.routeLineWidthExpression())
-        lineLayer.layout?.lineJoin = .constant(.round)
-        lineLayer.layout?.lineCap = .constant(.round)
-
-        if showsCongestionForAlternativeRoutes, let gradientStops = routeLineGradient(route, fractionTraveled: 0.0, isMain: false) {
-            lineLayer.paint?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops)))
+        if let lineLayer = lineLayer {
+            mapView.style.addLayer(layer: lineLayer, layerPosition: LayerPosition(below: parentLayerIndentifier))
         }
-        mapView.style.addLayer(layer: lineLayer, layerPosition: LayerPosition(below: parentLayerIndentifier))
         
         return layerIdentifier
     }
     
-    @discardableResult func addAlternativeRouteCasingLayer(_ route: Route, below parentLayerIndentifier: String? = nil) -> String? {
-        guard let shape = route.shape else { return nil }
-        
+    func geoJSONSource(_ shape: LineString) -> GeoJSONSource {
         var geoJSONSource = GeoJSONSource()
         geoJSONSource.data = .geometry(.lineString(shape))
         geoJSONSource.lineMetrics = true
         
-        guard let sourceIdentifier = identifier(route, identifierType: .source) else { return nil }
-        mapView.style.addSource(source: geoJSONSource, identifier: sourceIdentifier)
-        
-        guard let layerIdentifier = identifier(route, identifierType: .routeCasing) else { return nil }
-        var lineLayer = LineLayer(id: layerIdentifier)
-        lineLayer.source = sourceIdentifier
-        lineLayer.paint?.lineColor = .constant(.init(color: routeAlternateCasingColor))
-        lineLayer.paint?.lineWidth = .expression(Expression.routeLineWidthExpression(1.5))
-        lineLayer.layout?.lineJoin = .constant(.round)
-        lineLayer.layout?.lineCap = .constant(.round)
-        
-        mapView.style.addLayer(layer: lineLayer, layerPosition: LayerPosition(below: parentLayerIndentifier))
-        
-        return layerIdentifier
+        return geoJSONSource
     }
     
     /**
      Adds the route waypoints to the map given the current leg index. Previous waypoints for completed legs will be omitted.
+     
+     - parameter route: `Route`, on which a certain `Waypoint` will be shown.
+     - parameter legIndex: Index, which determines for which `RouteLeg` `Waypoint` will be shown.
      */
     public func showWaypoints(on route: Route, legIndex: Int = 0) {
-        let waypoints: [Waypoint] = Array(route.legs.dropLast().compactMap({$0.destination}))
+        let waypoints: [Waypoint] = Array(route.legs.dropLast().compactMap({ $0.destination }))
 
         var features = [Feature]()
         for (waypointIndex, waypoint) in waypoints.enumerated() {
@@ -602,25 +549,31 @@ open class NavigationMapView: UIView {
         
         let shape = delegate?.navigationMapView(self, shapeFor: waypoints, legIndex: legIndex) ?? FeatureCollection(features: features)
 
-        if route.legs.count > 1 { // are we on a multipoint route?
+        if route.legs.count > 1 {
             routes = [route]
 
-            if let _ = try? mapView.style.getSource(identifier: IdentifierString.waypointSource, type: GeoJSONSource.self).get() {
-                let _ = mapView.style.updateGeoJSON(for: IdentifierString.waypointSource, with: shape)
+            if let _ = try? mapView.style.getSource(identifier: NavigationMapView.SourceIdentifier.waypointSource, type: GeoJSONSource.self).get() {
+                let _ = mapView.style.updateGeoJSON(for: NavigationMapView.SourceIdentifier.waypointSource, with: shape)
             } else {
                 var waypointSource = GeoJSONSource()
                 waypointSource.data = .featureCollection(shape)
-                mapView.style.addSource(source: waypointSource, identifier: IdentifierString.waypointSource)
+                mapView.style.addSource(source: waypointSource, identifier: NavigationMapView.SourceIdentifier.waypointSource)
 
-                let circles = delegate?.navigationMapView(self, waypointCircleLayerWithIdentifier: IdentifierString.waypointCircle, sourceIdentifier: IdentifierString.waypointSource) ?? defaultWaypointCircleLayer()
-                let symbols = delegate?.navigationMapView(self, waypointSymbolLayerWithIdentifier: IdentifierString.waypointSymbol, sourceIdentifier: IdentifierString.waypointSource) ?? defaultWaypointSymbolLayer()
+                let circles = delegate?.navigationMapView(self,
+                                                          waypointCircleLayerWithIdentifier: NavigationMapView.LayerIdentifier.waypointCircleLayer,
+                                                          sourceIdentifier: NavigationMapView.SourceIdentifier.waypointSource) ?? defaultWaypointCircleLayer()
 
-                if let arrows = try? mapView.style.getLayer(with: IdentifierString.arrowSymbol, type: LineLayer.self).get() {
+                if let arrows = try? mapView.style.getLayer(with: NavigationMapView.LayerIdentifier.arrowSymbolLayer, type: LineLayer.self).get() {
                     mapView.style.addLayer(layer: circles, layerPosition: LayerPosition(above: arrows.id))
                 } else {
-                    guard let layerIdentifier = identifier(route, identifierType: .route) else { return }
+                    let layerIdentifier = route.identifier(.route(isMainRoute: true))
                     mapView.style.addLayer(layer: circles, layerPosition: LayerPosition(above: layerIdentifier))
                 }
+                
+                let symbols = delegate?.navigationMapView(self,
+                                                          waypointSymbolLayerWithIdentifier: NavigationMapView.LayerIdentifier.waypointSymbolLayer,
+                                                          sourceIdentifier: NavigationMapView.SourceIdentifier.waypointSource) ?? defaultWaypointSymbolLayer()
+                
                 mapView.style.addLayer(layer: symbols, layerPosition: LayerPosition(above: circles.id))
             }
         }
@@ -635,8 +588,8 @@ open class NavigationMapView: UIView {
     }
     
     func defaultWaypointCircleLayer() -> CircleLayer {
-        var circles = CircleLayer(id: IdentifierString.waypointCircle)
-        circles.source = IdentifierString.waypointSource
+        var circleLayer = CircleLayer(id: NavigationMapView.LayerIdentifier.waypointCircleLayer)
+        circleLayer.source = NavigationMapView.SourceIdentifier.waypointSource
         let opacity = Exp(.switchCase) {
             Exp(.any) {
                 Exp(.get) {
@@ -646,25 +599,26 @@ open class NavigationMapView: UIView {
             0.5
             1
         }
-        circles.paint?.circleColor = .constant(.init(color: UIColor(red:0.9, green:0.9, blue:0.9, alpha:1.0)))
-        circles.paint?.circleOpacity = .expression(opacity)
-        circles.paint?.circleRadius = .constant(.init(10))
-        circles.paint?.circleStrokeColor = .constant(.init(color: UIColor.black))
-        circles.paint?.circleStrokeWidth = .constant(.init(1))
-        circles.paint?.circleStrokeOpacity = .expression(opacity)
-        return circles
+        circleLayer.paint?.circleColor = .constant(.init(color: UIColor(red:0.9, green:0.9, blue:0.9, alpha:1.0)))
+        circleLayer.paint?.circleOpacity = .expression(opacity)
+        circleLayer.paint?.circleRadius = .constant(.init(10))
+        circleLayer.paint?.circleStrokeColor = .constant(.init(color: UIColor.black))
+        circleLayer.paint?.circleStrokeWidth = .constant(.init(1))
+        circleLayer.paint?.circleStrokeOpacity = .expression(opacity)
+        
+        return circleLayer
     }
     
     func defaultWaypointSymbolLayer() -> SymbolLayer {
-        var symbols = SymbolLayer(id: IdentifierString.waypointSymbol)
-        symbols.source = IdentifierString.waypointSource
-        symbols.layout?.textField = .expression(Exp(.toString) {
+        var symbolLayer = SymbolLayer(id: NavigationMapView.LayerIdentifier.waypointSymbolLayer)
+        symbolLayer.source = NavigationMapView.SourceIdentifier.waypointSource
+        symbolLayer.layout?.textField = .expression(Exp(.toString) {
             Exp(.get) {
                 "name"
             }
         })
-        symbols.layout?.textSize = .constant(.init(10))
-        symbols.paint?.textOpacity = .expression(Exp(.switchCase) {
+        symbolLayer.layout?.textSize = .constant(.init(10))
+        symbolLayer.paint?.textOpacity = .expression(Exp(.switchCase) {
             Exp(.any) {
                 Exp(.get) {
                     "waypointCompleted"
@@ -673,30 +627,23 @@ open class NavigationMapView: UIView {
             0.5
             1
         })
-        symbols.paint?.textHaloWidth = .constant(.init(0.25))
-        symbols.paint?.textHaloColor = .constant(.init(color: UIColor.black))
-        return symbols
+        symbolLayer.paint?.textHaloWidth = .constant(.init(0.25))
+        symbolLayer.paint?.textHaloColor = .constant(.init(color: UIColor.black))
+        
+        return symbolLayer
     }
     
+    /**
+     Removes all existing `Route` objects from `MapView`, which were added by `NavigationMapView`.
+     */
     public func removeRoutes() {
         var sourceIdentifiers = Set<String>()
         var layerIdentifiers = Set<String>()
         routes?.enumerated().forEach {
-            if $0.offset == 0, let identifier = identifier($0.element, identifierType: .source, isMainRouteCasingSource: true) {
-                sourceIdentifiers.insert(identifier)
-            }
-            
-            if let identifier = identifier($0.element, identifierType: .source) {
-                sourceIdentifiers.insert(identifier)
-            }
-            
-            if let identifier = identifier($0.element, identifierType: .route) {
-                layerIdentifiers.insert(identifier)
-            }
-            
-            if let identifier = identifier($0.element, identifierType: .routeCasing) {
-                layerIdentifiers.insert(identifier)
-            }
+            sourceIdentifiers.insert($0.element.identifier(.source(isMainRoute: $0.offset == 0, isSourceCasing: true)))
+            sourceIdentifiers.insert($0.element.identifier(.source(isMainRoute: $0.offset == 0, isSourceCasing: false)))
+            layerIdentifiers.insert($0.element.identifier(.route(isMainRoute: $0.offset == 0)))
+            layerIdentifiers.insert($0.element.identifier(.routeCasing(isMainRoute: $0.offset == 0)))
         }
         
         mapView.style.removeLayers(layerIdentifiers)
@@ -707,33 +654,19 @@ open class NavigationMapView: UIView {
         routeLineGranularDistances = nil
     }
     
-    func identifier(_ route: Route?, identifierType: IdentifierType, isMainRouteCasingSource: Bool = false) -> String? {
-        guard let route = route else { return nil }
-        let identifier = Unmanaged.passUnretained(route).toOpaque()
-        
-        switch identifierType {
-        case .source:
-            if isMainRouteCasingSource {
-                return "\(identifier)_casing_source"
-            }
-            
-            return "\(identifier)_source"
-            
-        case .route:
-            return "\(identifier)_route"
-            
-        case .routeCasing:
-            return "\(identifier)_casing"
-        }
-    }
-    
+    /**
+     Removes all existing `Waypoint` objects from `MapView`, which were added by `NavigationMapView`.
+     */
     public func removeWaypoints() {
         mapView.annotations.removeAnnotations(annotationsToRemove())
         
-        let layerSet: Set = [IdentifierString.waypointCircle,
-                             IdentifierString.waypointSymbol]
-        mapView.style.removeLayers(layerSet)
-        mapView.style.removeSources([IdentifierString.waypointSource])
+        let layers: Set = [
+            NavigationMapView.LayerIdentifier.waypointCircleLayer,
+            NavigationMapView.LayerIdentifier.waypointSymbolLayer
+        ]
+        
+        mapView.style.removeLayers(layers)
+        mapView.style.removeSources([NavigationMapView.SourceIdentifier.waypointSource])
     }
     
     func annotationsToRemove() -> [Annotation] {
@@ -743,19 +676,19 @@ open class NavigationMapView: UIView {
     
     /**
      Shows the step arrow given the current `RouteProgress`.
+     
+     - parameter route: `Route` object, for which maneuver arrows will be shown.
+     - parameter legIndex: Zero-based index of the `RouteLeg` which contains the maneuver.
+     - parameter stepIndex: Zero-based index of the `RouteStep` which contains the maneuver.
      */
     public func addArrow(route: Route, legIndex: Int, stepIndex: Int) {
         guard route.legs.indices.contains(legIndex),
               route.legs[legIndex].steps.indices.contains(stepIndex),
-              let mainRouteLayerIdentifier = identifier(route, identifierType: .route),
               let triangleImage = Bundle.mapboxNavigation.image(named: "triangle")?.withRenderingMode(.alwaysTemplate) else { return }
         
-        let _ = mapView.style.setStyleImage(image: triangleImage, with: IdentifierString.arrowImage, scale: 1.0)
-        
-        let minimumZoomLevel: Double = 8.0
+        mapView.style.setStyleImage(image: triangleImage, with: NavigationMapView.ImageIdentifier.arrowImage, scale: 1.0)
         let step = route.legs[legIndex].steps[stepIndex]
         let maneuverCoordinate = step.maneuverLocation
-        
         guard step.maneuverType != .arrive else { return }
         
         // TODO: Implement ability to change `shaftLength` depending on zoom level.
@@ -763,113 +696,131 @@ open class NavigationMapView: UIView {
         let shaftPolyline = route.polylineAroundManeuver(legIndex: legIndex, stepIndex: stepIndex, distance: shaftLength)
         
         if shaftPolyline.coordinates.count > 1 {
+            let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
+            let minimumZoomLevel: Double = 8.0
             let shaftStrokeCoordinates = shaftPolyline.coordinates
             let shaftDirection = shaftStrokeCoordinates[shaftStrokeCoordinates.count - 2].direction(to: shaftStrokeCoordinates.last!)
             
             var arrowSource = GeoJSONSource()
             arrowSource.data = .feature(Feature(shaftPolyline))
-            var arrow = LineLayer(id: IdentifierString.arrow)
-            if let _ = try? mapView.style.getSource(identifier: IdentifierString.arrowSource, type: GeoJSONSource.self).get() {
+            var arrowLayer = LineLayer(id: NavigationMapView.LayerIdentifier.arrowLayer)
+            if let _ = try? mapView.style.getSource(identifier: NavigationMapView.SourceIdentifier.arrowSource, type: GeoJSONSource.self).get() {
                 let geoJSON = Feature(shaftPolyline)
-                let _ = mapView.style.updateGeoJSON(for: IdentifierString.arrowSource, with: geoJSON)
+                let _ = mapView.style.updateGeoJSON(for: NavigationMapView.SourceIdentifier.arrowSource, with: geoJSON)
             } else {
-                arrow.minZoom = Double(minimumZoomLevel)
-                arrow.layout?.lineCap = .constant(.butt)
-                arrow.layout?.lineJoin = .constant(.round)
-                arrow.paint?.lineWidth = .expression(Expression.routeLineWidthExpression(0.7))
-                arrow.paint?.lineColor = .constant(.init(color: maneuverArrowColor))
+                arrowLayer.minZoom = Double(minimumZoomLevel)
+                arrowLayer.layout?.lineCap = .constant(.butt)
+                arrowLayer.layout?.lineJoin = .constant(.round)
+                arrowLayer.paint?.lineWidth = .expression(Expression.routeLineWidthExpression(0.70))
+                arrowLayer.paint?.lineColor = .constant(.init(color: maneuverArrowColor))
                 
-                mapView.style.addSource(source: arrowSource, identifier: IdentifierString.arrowSource)
-                arrow.source = IdentifierString.arrowSource
-                mapView.style.addLayer(layer: arrow, layerPosition: LayerPosition(above: mainRouteLayerIdentifier))
+                mapView.style.addSource(source: arrowSource, identifier: NavigationMapView.SourceIdentifier.arrowSource)
+                arrowLayer.source = NavigationMapView.SourceIdentifier.arrowSource
+                
+                if let _ = try? mapView.style.getLayer(with: NavigationMapView.LayerIdentifier.waypointCircleLayer, type: LineLayer.self).get() {
+                    mapView.style.addLayer(layer: arrowLayer, layerPosition: LayerPosition(below: NavigationMapView.LayerIdentifier.waypointCircleLayer))
+                } else {
+                    mapView.style.addLayer(layer: arrowLayer)
+                }
             }
             
             var arrowStrokeSource = GeoJSONSource()
             arrowStrokeSource.data = .feature(Feature(shaftPolyline))
-            var arrowStroke = LineLayer(id: IdentifierString.arrowStroke)
-            if let _ = try? mapView.style.getSource(identifier: IdentifierString.arrowStrokeSource, type: GeoJSONSource.self).get() {
+            var arrowStrokeLayer = LineLayer(id: NavigationMapView.LayerIdentifier.arrowStrokeLayer)
+            if let _ = try? mapView.style.getSource(identifier: NavigationMapView.SourceIdentifier.arrowStrokeSource, type: GeoJSONSource.self).get() {
                 let geoJSON = Feature(shaftPolyline)
-                let _ = mapView.style.updateGeoJSON(for: IdentifierString.arrowStrokeSource, with: geoJSON)
+                let _ = mapView.style.updateGeoJSON(for: NavigationMapView.SourceIdentifier.arrowStrokeSource, with: geoJSON)
             } else {
-                arrowStroke.minZoom = arrow.minZoom
-                arrowStroke.layout?.lineCap = arrow.layout?.lineCap
-                arrowStroke.layout?.lineJoin = arrow.layout?.lineJoin
-                arrowStroke.paint?.lineWidth = .expression(Expression.routeLineWidthExpression(0.8))
-                arrowStroke.paint?.lineColor = .constant(.init(color: maneuverArrowStrokeColor))
+                arrowStrokeLayer.minZoom = arrowLayer.minZoom
+                arrowStrokeLayer.layout?.lineCap = arrowLayer.layout?.lineCap
+                arrowStrokeLayer.layout?.lineJoin = arrowLayer.layout?.lineJoin
+                arrowStrokeLayer.paint?.lineWidth = .expression(Expression.routeLineWidthExpression(0.80))
+                arrowStrokeLayer.paint?.lineColor = .constant(.init(color: maneuverArrowStrokeColor))
                 
-                mapView.style.addSource(source: arrowStrokeSource, identifier: IdentifierString.arrowStrokeSource)
-                arrowStroke.source = IdentifierString.arrowStrokeSource
-                mapView.style.addLayer(layer: arrowStroke, layerPosition: LayerPosition(above: mainRouteLayerIdentifier))
+                mapView.style.addSource(source: arrowStrokeSource, identifier: NavigationMapView.SourceIdentifier.arrowStrokeSource)
+                arrowStrokeLayer.source = NavigationMapView.SourceIdentifier.arrowStrokeSource
+                mapView.style.addLayer(layer: arrowStrokeLayer, layerPosition: LayerPosition(above: mainRouteLayerIdentifier))
             }
             
             let point = Point(shaftStrokeCoordinates.last!)
             var arrowSymbolSource = GeoJSONSource()
             arrowSymbolSource.data = .feature(Feature(point))
-            if let _ = try? mapView.style.getSource(identifier: IdentifierString.arrowSymbolSource, type: GeoJSONSource.self).get() {
+            if let _ = try? mapView.style.getSource(identifier: NavigationMapView.SourceIdentifier.arrowSymbolSource, type: GeoJSONSource.self).get() {
                 let geoJSON = Feature.init(geometry: Geometry.point(point))
-                let _ = mapView.style.updateGeoJSON(for: IdentifierString.arrowSymbolSource, with: geoJSON)
-                mapView.mapboxMap.__map.setStyleLayerPropertyForLayerId(IdentifierString.arrowSymbol, property: "icon-rotate", value: shaftDirection)
-                mapView.mapboxMap.__map.setStyleLayerPropertyForLayerId(IdentifierString.arrowCasingSymbol, property: "icon-rotate", value: shaftDirection)
+                let _ = mapView.style.updateGeoJSON(for: NavigationMapView.SourceIdentifier.arrowSymbolSource, with: geoJSON)
+                mapView.mapboxMap.__map.setStyleLayerPropertyForLayerId(NavigationMapView.LayerIdentifier.arrowSymbolLayer, property: "icon-rotate", value: shaftDirection)
+                mapView.mapboxMap.__map.setStyleLayerPropertyForLayerId(NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer, property: "icon-rotate", value: shaftDirection)
             } else {
-                var arrowSymbolLayer = SymbolLayer(id: IdentifierString.arrowSymbol)
+                var arrowSymbolLayer = SymbolLayer(id: NavigationMapView.LayerIdentifier.arrowSymbolLayer)
                 arrowSymbolLayer.minZoom = Double(minimumZoomLevel)
-                arrowSymbolLayer.layout?.iconImage = .constant(.name(IdentifierString.arrowImage))
+                arrowSymbolLayer.layout?.iconImage = .constant(.name(NavigationMapView.ImageIdentifier.arrowImage))
+                // FIXME: `iconColor` has no effect.
                 arrowSymbolLayer.paint?.iconColor = .constant(.init(color: maneuverArrowColor))
                 arrowSymbolLayer.layout?.iconRotationAlignment = .constant(.map)
                 arrowSymbolLayer.layout?.iconRotate = .constant(.init(shaftDirection))
                 arrowSymbolLayer.layout?.iconSize = .expression(Expression.routeLineWidthExpression(0.12))
                 arrowSymbolLayer.layout?.iconAllowOverlap = .constant(true)
                 
-                var arrowSymbolLayerCasing = SymbolLayer(id: IdentifierString.arrowCasingSymbol)
-                arrowSymbolLayerCasing.minZoom = arrowSymbolLayer.minZoom
-                arrowSymbolLayerCasing.layout?.iconImage = arrowSymbolLayer.layout?.iconImage
-                arrowSymbolLayerCasing.paint?.iconColor = .constant(.init(color: maneuverArrowStrokeColor))
-                arrowSymbolLayerCasing.layout?.iconRotationAlignment = arrowSymbolLayer.layout?.iconRotationAlignment
-                arrowSymbolLayerCasing.layout?.iconRotate = arrowSymbolLayer.layout?.iconRotate
-                arrowSymbolLayerCasing.layout?.iconSize = .expression(Expression.routeLineWidthExpression(0.14))
-                arrowSymbolLayerCasing.layout?.iconAllowOverlap = arrowSymbolLayer.layout?.iconAllowOverlap
+                var arrowSymbolCasingLayer = SymbolLayer(id: NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer)
+                arrowSymbolCasingLayer.minZoom = arrowSymbolLayer.minZoom
+                arrowSymbolCasingLayer.layout?.iconImage = arrowSymbolLayer.layout?.iconImage
+                // FIXME: `iconColor` has no effect.
+                arrowSymbolCasingLayer.paint?.iconColor = .constant(.init(color: maneuverArrowStrokeColor))
+                arrowSymbolCasingLayer.layout?.iconRotationAlignment = arrowSymbolLayer.layout?.iconRotationAlignment
+                arrowSymbolCasingLayer.layout?.iconRotate = arrowSymbolLayer.layout?.iconRotate
+                arrowSymbolCasingLayer.layout?.iconSize = .expression(Expression.routeLineWidthExpression(0.14))
+                arrowSymbolCasingLayer.layout?.iconAllowOverlap = arrowSymbolLayer.layout?.iconAllowOverlap
                 
-                mapView.style.addSource(source: arrowSymbolSource, identifier: IdentifierString.arrowSymbolSource)
-                arrowSymbolLayer.source = IdentifierString.arrowSymbolSource
-                arrowSymbolLayerCasing.source = IdentifierString.arrowSymbolSource
+                mapView.style.addSource(source: arrowSymbolSource, identifier: NavigationMapView.SourceIdentifier.arrowSymbolSource)
+                arrowSymbolLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
+                arrowSymbolCasingLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
+                
                 mapView.style.addLayer(layer: arrowSymbolLayer)
-                mapView.style.addLayer(layer: arrowSymbolLayerCasing, layerPosition: LayerPosition(below: IdentifierString.arrowSymbol))
+                mapView.style.addLayer(layer: arrowSymbolCasingLayer, layerPosition: LayerPosition(below: NavigationMapView.LayerIdentifier.arrowSymbolLayer))
             }
         }
     }
     
     /**
-     Removes the step arrow from the map.
+     Removes the `RouteStep` arrow from the `MapView`.
      */
     public func removeArrow() {
-        let layerSet: Set = [
-            IdentifierString.arrow,
-            IdentifierString.arrowStroke,
-            IdentifierString.arrowSymbol,
-            IdentifierString.arrowCasingSymbol
+        let layers: Set = [
+            NavigationMapView.LayerIdentifier.arrowLayer,
+            NavigationMapView.LayerIdentifier.arrowStrokeLayer,
+            NavigationMapView.LayerIdentifier.arrowSymbolLayer,
+            NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer
         ]
-        mapView.style.removeLayers(layerSet)
+        mapView.style.removeLayers(layers)
         
-        let sourceSet: Set = [
-            IdentifierString.arrowSource,
-            IdentifierString.arrowStrokeSource,
-            IdentifierString.arrowSymbolSource
+        let sources: Set = [
+            NavigationMapView.SourceIdentifier.arrowSource,
+            NavigationMapView.SourceIdentifier.arrowStrokeSource,
+            NavigationMapView.SourceIdentifier.arrowSymbolSource
         ]
-        mapView.style.removeSources(sourceSet)
+        mapView.style.removeSources(sources)
     }
     
     public func localizeLabels() {
         // TODO: Implement ability to localize road labels.
     }
     
+    /**
+     Shows voice instructions for specific `Route` object.
+     
+     - parameter route: `Route` object, along which voice instructions will be shown.
+     */
     public func showVoiceInstructionsOnMap(route: Route) {
         var featureCollection = FeatureCollection(features: [])
         
         for (legIndex, leg) in route.legs.enumerated() {
             for (stepIndex, step) in leg.steps.enumerated() {
-                for instruction in step.instructionsSpokenAlongStep! {
-                    let coordinate = LineString(route.legs[legIndex].steps[stepIndex].shape!.coordinates.reversed()).coordinateFromStart(distance: instruction.distanceAlongStep)!
-                    var feature = Feature(Point(coordinate))
+                guard let instructions = step.instructionsSpokenAlongStep else { continue }
+                for instruction in instructions {
+                    guard let shape = route.legs[legIndex].steps[stepIndex].shape,
+                          let coordinateFromStart = LineString(shape.coordinates.reversed()).coordinateFromStart(distance: instruction.distanceAlongStep) else { continue }
+                    
+                    var feature = Feature(Point(coordinateFromStart))
                     feature.properties = [
                         "instruction": instruction.text
                     ]
@@ -878,15 +829,15 @@ open class NavigationMapView: UIView {
             }
         }
 
-        if let _ = try? mapView.style.getSource(identifier: IdentifierString.instructionSource, type: GeoJSONSource.self).get() {
-            _ = mapView.style.updateGeoJSON(for: IdentifierString.instructionSource, with: featureCollection)
+        if let _ = try? mapView.style.getSource(identifier: NavigationMapView.SourceIdentifier.voiceInstructionSource, type: GeoJSONSource.self).get() {
+            _ = mapView.style.updateGeoJSON(for: NavigationMapView.SourceIdentifier.voiceInstructionSource, with: featureCollection)
         } else {
             var source = GeoJSONSource()
             source.data = .featureCollection(featureCollection)
-            mapView.style.addSource(source: source, identifier: IdentifierString.instructionSource)
+            mapView.style.addSource(source: source, identifier: NavigationMapView.SourceIdentifier.voiceInstructionSource)
             
-            var symbolLayer = SymbolLayer(id: IdentifierString.instructionLabel)
-            symbolLayer.source = IdentifierString.instructionSource
+            var symbolLayer = SymbolLayer(id: NavigationMapView.LayerIdentifier.voiceInstructionLabelLayer)
+            symbolLayer.source = NavigationMapView.SourceIdentifier.voiceInstructionSource
             
             let instruction = Exp(.toString) {
                 Exp(.get) {
@@ -903,8 +854,8 @@ open class NavigationMapView: UIView {
             symbolLayer.layout?.textJustify = .constant(.left)
             mapView.style.addLayer(layer: symbolLayer)
             
-            var circleLayer = CircleLayer(id: IdentifierString.instructionCircle)
-            circleLayer.source = IdentifierString.instructionSource
+            var circleLayer = CircleLayer(id: NavigationMapView.LayerIdentifier.voiceInstructionCircleLayer)
+            circleLayer.source = NavigationMapView.SourceIdentifier.voiceInstructionSource
             circleLayer.paint?.circleRadius = .constant(5)
             circleLayer.paint?.circleOpacity = .constant(0.75)
             circleLayer.paint?.circleColor = .constant(.init(color: .white))

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -96,14 +96,7 @@ open class NavigationMapView: UIView {
      Most recent user location, which is used to place `UserCourseView`.
      */
     var mostRecentUserCourseViewLocation: CLLocation?
-    var congestionSegments: [Feature] = []
-    var routes: [Route]? {
-        didSet {
-            if let route = routes?.first {
-                congestionSegments = route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: self.roadClassesWithOverriddenCongestionLevels)
-            }
-        }
-    }
+    var routes: [Route]?
     var routePoints: RoutePoints?
     var routeLineGranularDistances: RouteLineGranularDistances?
     var routeRemainingDistancesIndex: Int?

--- a/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -6,15 +6,59 @@ import MapboxMaps
 import Turf
 
 /**
- The `NavigationMapViewDelegate` provides methods for configuring the NavigationMapView, as well as responding to events triggered by the NavigationMapView.
+ The `NavigationMapViewDelegate` provides methods for configuring the `NavigationMapView`, as well as responding to events triggered by the `NavigationMapView`.
  */
 public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
+    
+    /**
+     Asks the receiver to return a `LineLayer` for the route line, given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter navigationMapView: The `NavigationMapView`.
+     - parameter identifier: The line layer identifier.
+     - parameter sourceIdentifier: The source identifier containing the route data that this method would style.
+     - returns: A `LineLayer` that is applied to the route line.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
+    
+    /**
+     Asks the receiver to return a `LineLayer` for the casing layer that surrounds route line, given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter navigationMapView: The NavigationMapView.
+     - parameter identifier: The line layer identifier.
+     - parameter sourceIdentifier: The source containing the route data that this method would style.
+     - returns: A `LineLayer` that is applied as a casing around the route line.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
+    
+    /**
+     Asks the receiver to return an `LineString` that describes the geometry of the route.
+     Resulting `LineString` will then be styled using `NavigationMapView.navigationMapView(_:routeLineLayerWithIdentifier:sourceIdentifier:)` provided style or a default congestion style if above delegate method was not implemented.
+     
+     - parameter navigationMapView: The `NavigationMapView`.
+     - parameter route: The route that the sender is asking about.
+     - returns: A `LineString` object that defines the shape of the route, or `nil` in case of default behavior.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, shapeFor route: Route) -> LineString?
+    
+    /**
+     Asks the receiver to return an `LineString` that describes the geometry of the route casing.
+     Resulting `LineString` will then be styled using `NavigationMapView.navigationMapView(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:)` provided style or a default style if above delegate method was not implemented.
+     
+     - parameter navigationMapView: The `NavigationMapView`.
+     - parameter route: The route that the sender is asking about.
+     - returns: A `LineString` object that defines the shape of the route casing, or `nil` in case of default behavior.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, casingShapeFor route: Route) -> LineString?
+    
     /**
      Asks the receiver to return a `CircleLayer` for waypoints, given an identifier and source.
      This method is invoked any time waypoints are added or shown.
+     
      - parameter navigationMapView: The `NavigationMapView`.
      - parameter identifier: The style identifier.
-     - parameter source: The Layer source containing the waypoint data that this method would style.
+     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
      - returns: A `CircleLayer` that the map applies to all waypoints.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, waypointCircleLayerWithIdentifier identifier: String, sourceIdentifier: String) -> CircleLayer?
@@ -22,15 +66,27 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
     /**
      Asks the receiver to return a `SymbolLayer` for waypoint symbols, given an identifier and source.
      This method is invoked any time waypoints are added or shown.
+     
      - parameter navigationMapView: The `NavigationMapView`.
      - parameter identifier: The style identifier.
-     - parameter source: The Layer source containing the waypoint data that this method would style.
+     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
      - returns: A `SymbolLayer` that the map applies to all waypoint symbols.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, waypointSymbolLayerWithIdentifier identifier: String, sourceIdentifier: String) -> SymbolLayer?
-
+    
+    /**
+     Asks the receiver to return a `FeatureCollection` that describes the geometry of the waypoint.
+     
+     - parameter navigationMapView: The `NavigationMapView`.
+     - parameter waypoints: The waypoints to be displayed on the map.
+     - parameter legIndex: Index, which determines for which `RouteLeg` `Waypoint` will be shown.
+     - returns: Optionally, a `FeatureCollection` that defines the shape of the waypoint, or `nil` to use default behavior.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection?
+    
     /**
      Tells the receiver that the user has selected a route by interacting with the map view.
+     
      - parameter navigationMapView: The `NavigationMapView`.
      - parameter route: The route that was selected.
      */
@@ -38,21 +94,46 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
     
     /**
      Tells the receiver that a waypoint was selected.
+     
      - parameter navigationMapView: The `NavigationMapView`.
      - parameter waypoint: The waypoint that was selected.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, didSelect waypoint: Waypoint)
-    
-    /**
-     Asks the receiver to return a `FeatureCollection` that describes the geometry of the waypoint.
-     - parameter navigationMapView: The `NavigationMapView`.
-     - parameter waypoints: The waypoints to be displayed on the map.
-     - returns: Optionally, a `FeatureCollection` that defines the shape of the waypoint, or `nil` to use default behavior.
-     */
-    func navigationMapView(_ navigationMapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection?
 }
 
 public extension NavigationMapViewDelegate {
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
+        return nil
+    }
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
+        return nil
+    }
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, shapeFor route: Route) -> LineString? {
+        logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
+        return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, casingShapeFor route: Route) -> LineString? {
+        logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
+        return nil
+    }
     
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
@@ -73,6 +154,14 @@ public extension NavigationMapViewDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
+    func navigationMapView(_ navigationMapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection? {
+        logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
+        return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationMapView(_ navigationMapView: NavigationMapView, didSelect route: Route) {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
     }
@@ -82,13 +171,5 @@ public extension NavigationMapViewDelegate {
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, didSelect waypoint: Waypoint) {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
-    }
-    
-    /**
-     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
-     */
-    func navigationMapView(_ navigationMapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection? {
-        logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
-        return nil
     }
 }

--- a/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -14,9 +14,9 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      Asks the receiver to return a `LineLayer` for the route line, given a layer identifier and a source identifier.
      This method is invoked when the map view loads and any time routes are added.
      
-     - parameter navigationMapView: The `NavigationMapView`.
-     - parameter identifier: The line layer identifier.
-     - parameter sourceIdentifier: The source identifier containing the route data that this method would style.
+     - parameter navigationMapView: The `NavigationMapView` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied to the route line.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
@@ -25,9 +25,9 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      Asks the receiver to return a `LineLayer` for the casing layer that surrounds route line, given a layer identifier and a source identifier.
      This method is invoked when the map view loads and any time routes are added.
      
-     - parameter navigationMapView: The NavigationMapView.
-     - parameter identifier: The line layer identifier.
-     - parameter sourceIdentifier: The source containing the route data that this method would style.
+     - parameter navigationMapView: The `NavigationMapView` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied as a casing around the route line.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
@@ -56,9 +56,9 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      Asks the receiver to return a `CircleLayer` for waypoints, given an identifier and source.
      This method is invoked any time waypoints are added or shown.
      
-     - parameter navigationMapView: The `NavigationMapView`.
-     - parameter identifier: The style identifier.
-     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
+     - parameter navigationMapView: The `NavigationMapView` object.
+     - parameter identifier: The `CircleLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the waypoint data that this method would style.
      - returns: A `CircleLayer` that the map applies to all waypoints.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, waypointCircleLayerWithIdentifier identifier: String, sourceIdentifier: String) -> CircleLayer?
@@ -67,9 +67,9 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      Asks the receiver to return a `SymbolLayer` for waypoint symbols, given an identifier and source.
      This method is invoked any time waypoints are added or shown.
      
-     - parameter navigationMapView: The `NavigationMapView`.
-     - parameter identifier: The style identifier.
-     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
+     - parameter navigationMapView: The `NavigationMapView` object.
+     - parameter identifier: The `SymbolLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the waypoint data that this method would style.
      - returns: A `SymbolLayer` that the map applies to all waypoint symbols.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, waypointSymbolLayerWithIdentifier identifier: String, sourceIdentifier: String) -> SymbolLayer?

--- a/Sources/MapboxNavigation/NavigationMapViewIdentifiers.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewIdentifiers.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension NavigationMapView {
+    
+    static let identifier = Bundle.mapboxNavigation.bundleIdentifier ?? ""
+    
+    struct LayerIdentifier {
+        static let arrowLayer = "\(identifier)_arrowLayer"
+        static let arrowStrokeLayer = "\(identifier)_arrowStrokeLayer"
+        static let arrowSymbolLayer = "\(identifier)_arrowSymbolLayer"
+        static let arrowSymbolCasingLayer = "\(identifier)_arrowSymbolCasingLayer"
+        static let voiceInstructionLabelLayer = "\(identifier)_voiceInstructionLabelLayer"
+        static let voiceInstructionCircleLayer = "\(identifier)_voiceInstructionCircleLayer"
+        static let waypointCircleLayer = "\(identifier)_waypointCircleLayer"
+        static let waypointSymbolLayer = "\(identifier)_waypointSymbolLayer"
+        static let buildingExtrusionLayer = "\(identifier)buildingExtrusionLayer"
+    }
+    
+    struct SourceIdentifier {
+        static let arrowSource = "\(identifier)_arrowSource"
+        static let arrowStrokeSource = "\(identifier)_arrowStrokeSource"
+        static let arrowSymbolSource = "\(identifier)_arrowSymbolSource"
+        static let voiceInstructionSource = "\(identifier)_instructionSource"
+        static let waypointSource = "\(identifier)_waypointSource"
+    }
+    
+    struct ImageIdentifier {
+        static let arrowImage = "triangle-tip-navigation"
+    }
+}

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -111,8 +111,8 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      If this method is not implemented, the navigation view controller’s map view draws the route line using default `LineLayer`.
      
      - parameter navigationViewController: The `NavigationViewController` object, on surface of which route line is drawn.
-     - parameter identifier: The line layer identifier.
-     - parameter sourceIdentifier: The source containing the route data that this method would style.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied to the route line.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
@@ -123,8 +123,8 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      If this method is not implemented, the navigation view controller’s map view draws the casing for the route line using default `LineLayer`.
      
      - parameter navigationViewController: The `NavigationViewController` object, on surface of which route line is drawn.
-     - parameter identifier: The line layer identifier.
-     - parameter sourceIdentifier: The source containing the route data that this method would style.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied as a casing around the route line.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
@@ -135,8 +135,8 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      If this method is unimplemented, the navigation view controller’s map view marks each destination waypoint with a circle.
      
      - parameter navigationViewController: The `NavigationViewController` object.
-     - parameter identifier: The style identifier.
-     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
+     - parameter identifier: The `CircleLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the waypoint data that this method would style.
      - returns: A `CircleLayer` that the map applies to all waypoints.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointCircleLayerWithIdentifier identifier: String, sourceIdentifier: String) -> CircleLayer?
@@ -147,8 +147,8 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      If this method is unimplemented, the navigation view controller’s map view labels each destination waypoint with a number, starting with 1 at the first destination, 2 at the second destination, and so on.
      
      - parameter navigationViewController: The `NavigationViewController` object.
-     - parameter identifier: The style identifier.
-     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
+     - parameter identifier: The `SymbolLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the waypoint data that this method would style.
      - returns: A `SymbolLayer` that the map applies to all waypoint symbols.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointSymbolLayerWithIdentifier identifier: String, sourceIdentifier: String) -> SymbolLayer?

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -104,38 +104,74 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      - parameter routeProgress: The updated route progress with the refreshed route.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didRefresh routeProgress: RouteProgress)
-
+    
+    /**
+     Returns an `LineLayer` that determines the appearance of the route line.
+     
+     If this method is not implemented, the navigation view controller’s map view draws the route line using default `LineLayer`.
+     
+     - parameter navigationViewController: The `NavigationViewController` object, on surface of which route line is drawn.
+     - parameter identifier: The line layer identifier.
+     - parameter sourceIdentifier: The source containing the route data that this method would style.
+     - returns: A `LineLayer` that is applied to the route line.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
+    
+    /**
+     Returns an `LineLayer` that determines the appearance of the casing around the route line.
+     
+     If this method is not implemented, the navigation view controller’s map view draws the casing for the route line using default `LineLayer`.
+     
+     - parameter navigationViewController: The `NavigationViewController` object, on surface of which route line is drawn.
+     - parameter identifier: The line layer identifier.
+     - parameter sourceIdentifier: The source containing the route data that this method would style.
+     - returns: A `LineLayer` that is applied as a casing around the route line.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
+    
     /**
      Returns an `CircleLayer` that marks the location of each destination along the route when there are multiple destinations. The returned layer is added to the map below the layer returned by `navigationViewController(_:waypointSymbolLayerWithIdentifier:sourceIdentifier:)`.
      
      If this method is unimplemented, the navigation view controller’s map view marks each destination waypoint with a circle.
+     
+     - parameter navigationViewController: The `NavigationViewController` object.
+     - parameter identifier: The style identifier.
+     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
+     - returns: A `CircleLayer` that the map applies to all waypoints.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointCircleLayerWithIdentifier identifier: String, sourceIdentifier: String) -> CircleLayer?
-
+    
     /**
      Returns a `SymbolLayer` that places an identifying symbol on each destination along the route when there are multiple destinations. The returned layer is added to the map above the layer returned by `navigationViewController(_:waypointCircleLayerWithIdentifier:sourceIdentifier:)`.
      
      If this method is unimplemented, the navigation view controller’s map view labels each destination waypoint with a number, starting with 1 at the first destination, 2 at the second destination, and so on.
+     
+     - parameter navigationViewController: The `NavigationViewController` object.
+     - parameter identifier: The style identifier.
+     - parameter sourceIdentifier: The Layer source containing the waypoint data that this method would style.
+     - returns: A `SymbolLayer` that the map applies to all waypoint symbols.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, waypointSymbolLayerWithIdentifier identifier: String, sourceIdentifier: String) -> SymbolLayer?
     
     /**
      Returns a `FeatureCollection` that represents the destination waypoints along the route (that is, excluding the origin).
      
-     If this method is unimplemented, the navigation view controller's map view draws the waypoints using default 'FeatureCollection`.
+     If this method is unimplemented, the navigation view controller's map view draws the waypoints using default `FeatureCollection`.
+     
+     - parameter navigationViewController: The `NavigationViewController` object.
+     - parameter waypoints: The waypoints to be displayed on the map.
+     - parameter legIndex: Index, which determines for which `RouteLeg` `Waypoint` will be shown.
+     - returns: Optionally, a `FeatureCollection` that defines the shape of the waypoint, or `nil` to use default behavior.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection?
+    
     /**
      Called when the user taps to select a route on the navigation view controller’s map view.
+     
      - parameter navigationViewController: The navigation view controller presenting the route that the user selected.
      - parameter route: The route on the map that the user selected.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didSelect route: Route)
-    
-    /**
-     Returns the center point of the user course view in screen coordinates relative to the map view.
-     */
-    func navigationViewController(_ navigationViewController: NavigationViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint
     
     /**
      Allows the delegate to decide whether to ignore a location update.
@@ -225,7 +261,23 @@ public extension NavigationViewControllerDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, didRefresh routeProgress: RouteProgress) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self, level: .debug)
     }
-
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+        return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+        return nil
+    }
+    
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
@@ -255,14 +307,6 @@ public extension NavigationViewControllerDelegate {
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didSelect route: Route) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
-    }
-    
-    /**
-     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
-     */
-    func navigationViewController(_ navigationViewController: NavigationViewController, mapViewUserAnchorPoint mapView: NavigationMapView) -> CGPoint {
-        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .info)
-        return .zero
     }
     
     /**

--- a/Sources/MapboxNavigation/RouteLineType.swift
+++ b/Sources/MapboxNavigation/RouteLineType.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum RouteLineType {
+    
+    case source(isMainRoute: Bool, isSourceCasing: Bool)
+    
+    case route(isMainRoute: Bool)
+    
+    case routeCasing(isMainRoute: Bool)
+}


### PR DESCRIPTION
### Description

Current PR implements functionality, which allows to override main and alternative route lines, along with refactoring which aims to simplify route line gradient generation.

<img width="225" alt="Screen Shot 2021-04-05 at 3 40 57 PM" src="https://user-images.githubusercontent.com/1496498/113635406-69ec9200-9625-11eb-904c-bc143598518f.png">

Also fixes https://github.com/mapbox/mapbox-navigation-ios/issues/2907 and https://github.com/mapbox/mapbox-navigation-ios/issues/2818.