### PR TITLE
Add ability to port building highlighting feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Renamed public property `MBCurrentLegAttribute` to `CurrentLegAttribute`. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Renamed public property `MBCongestionAttribute` to `CongestionAttribute`. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * `NavigationViewController.mapView` was renamed to `NavigationViewController.navigationMapView`. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
+* `NavigationMapView.highlightBuildings(at:in3D:)` was renamed to `NavigationMapView.highlightBuildings(at:in3D:completion:)`. ([#2827](https://github.com/mapbox/mapbox-navigation-ios/pull/2827))
 
 ### Location tracking
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -23,6 +23,8 @@ class ViewController: UIViewController {
     typealias RouteRequestSuccess = ((RouteResponse) -> Void)
     typealias RouteRequestFailure = ((Error) -> Void)
     
+    private var foundAllBuildings = false
+
     var navigationMapView: NavigationMapView! {
         didSet {
             if let navigationMapView = oldValue {
@@ -132,7 +134,7 @@ class ViewController: UIViewController {
         clearMap.isHidden = true
         longPressHintView.isHidden = false
         
-        // TODO: Unhighlight buildings when clearing map.
+        navigationMapView.unhighlightBuildings()
         navigationMapView.removeRoutes()
         navigationMapView.removeWaypoints()
         waypoints.removeAll()
@@ -324,6 +326,10 @@ class ViewController: UIViewController {
         waypoint.targetCoordinate = destinationCoordinate
         waypoints.append(waypoint)
         
+        // Example of highlighting buildings in 3d and directly using the API on NavigationMapView.
+        let buildingHighlightCoordinates = waypoints.compactMap { $0.targetCoordinate }
+        navigationMapView.highlightBuildings(at: buildingHighlightCoordinates)
+
         requestRoute()
     }
     

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -290,6 +290,7 @@
 		AE87207E22CF97B900D7DAB7 /* InstructionsCardCollectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE87207D22CF97B900D7DAB7 /* InstructionsCardCollectionDelegate.swift */; };
 		AEC3AC9A2106703100A26F34 /* HighwayShield.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC3AC992106703100A26F34 /* HighwayShield.swift */; };
 		AED6285622CBE4CE00058A51 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
+		B419BFF225F00A9C0086639B /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = B419BFF125F00A9C0086639B /* Feature.swift */; };
 		B430D2FA25534FDC0088CC23 /* UserHaloCourseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */; };
 		B48CEFC125796FD300696BB3 /* route-for-vanishing-route-line.json in Resources */ = {isa = PBXBuildFile; fileRef = B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */; };
 		C51511D120EAC89D00372A91 /* CPMapTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51511D020EAC89D00372A91 /* CPMapTemplate.swift */; };
@@ -806,6 +807,7 @@
 		AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+GuidanceCards.swift"; path = "Example/ViewController+GuidanceCards.swift"; sourceTree = "<group>"; };
 		AEF2C8F12072B603007B061F /* routeWithTunnels_9thStreetDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithTunnels_9thStreetDC.json; sourceTree = "<group>"; };
+		B419BFF125F00A9C0086639B /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
 		B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-for-vanishing-route-line.json"; sourceTree = "<group>"; };
 		C51511D020EAC89D00372A91 /* CPMapTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPMapTemplate.swift; sourceTree = "<group>"; };
@@ -1584,6 +1586,7 @@
 				CFD47D8F20FD85EC00BC1E49 /* AccountManager.swift */,
 				8A17635A25CC89D800737520 /* Expression.swift */,
 				8A1763CF25CCC38C00737520 /* Double.swift */,
+				B419BFF125F00A9C0086639B /* Feature.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2386,6 +2389,7 @@
 				8D24A2FA20449B430098CBF8 /* Dictionary.swift in Sources */,
 				350E2C5F22707EB80014CEB3 /* UIScreen.swift in Sources */,
 				8DB45E90201698EB001EA6A3 /* UIStackView.swift in Sources */,
+				B419BFF225F00A9C0086639B /* Feature.swift in Sources */,
 				351BEBFC1E5BCC63006FE110 /* NavigationViewController.swift in Sources */,
 				AE7DE6C621A47A23002653D1 /* CarPlaySearchController+CPSearchTemplateDelegate.swift in Sources */,
 				8D8EA9BC20575CD80077F478 /* FeedbackCollectionViewCell.swift in Sources */,

--- a/Sources/MapboxNavigation/Expression.swift
+++ b/Sources/MapboxNavigation/Expression.swift
@@ -17,4 +17,17 @@ extension Expression {
             gradientStops
         }
     }
+    
+    static func buildingExtrusionHeightExpression(_ hightProperty: String) -> Expression {
+        return Exp(.interpolate) {
+            Exp(.linear)
+            Exp(.zoom)
+            13
+            0
+            13.25
+            Exp(.get) {
+                hightProperty
+            }
+        }
+    }
 }

--- a/Sources/MapboxNavigation/Feature.swift
+++ b/Sources/MapboxNavigation/Feature.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Turf
+
+extension Feature {
+
+    var featureIdentifier: Int64? {
+        guard let featureIdentifier = self.identifier else { return nil }
+        
+        switch featureIdentifier {
+        case .string(let identifier):
+            return Int64(identifier)
+        case .number(let identifier):
+            switch identifier {
+            case .double(let identifier):
+                return Int64(identifier)
+            case .int(let identifier):
+                return Int64(identifier)
+            }
+        }
+    }
+}

--- a/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
@@ -1,7 +1,7 @@
 import CoreLocation
 import MapboxMaps
+import Turf
 
-// TODO: Implement the ability to highlight/unhighlight buildings in 2D/3D.
 extension NavigationMapView {
     
     // MARK: - Building Extrusion Highlighting methods
@@ -11,17 +11,97 @@ extension NavigationMapView {
      
      - parameter coordinates: Coordinates which represent building locations.
      - parameter extrudesBuildings: Switch which allows to highlight buildings in either 2D or 3D. Defaults to true.
-     
-     - returns: Bool indicating if number of buildings found equals number of coordinates supplied.
+     - parameter completion: An escaping closure to be executed when the `MapView` feature querying for all `coordinates` ends. A single `Boolean` argument in closure indicates whether or not buildings were found for all coordinates.
      */
-    @discardableResult public func highlightBuildings(at coordinates: [CLLocationCoordinate2D], in3D extrudesBuildings: Bool = true) -> Bool {
-        return false
+    public func highlightBuildings(at coordinates: [CLLocationCoordinate2D],
+                                   in3D extrudesBuildings: Bool = true,
+                                   completion: ((_ foundAllBuildings: Bool) -> Void)? = nil) {
+        var foundBuildingIds = Set<Int64>()
+        let group = DispatchGroup()
+        guard let identifiers = try? mapView.__map.getStyleLayers().compactMap({ $0.id }).filter({ $0.contains("building") }) else {
+            completion?(false)
+            return
+        }
+        
+        coordinates.forEach {
+            group.enter()
+            let screenCoordinate = mapView.point(for: $0, in: self)
+            mapView.visibleFeatures(at: screenCoordinate,
+                                    styleLayers: Set(identifiers),
+                                    completion: { [weak self] result in
+                                        guard let _ = self else { return }
+                                        if case .success(let features) = result {
+                                            if let identifier = features.first?.featureIdentifier {
+                                                foundBuildingIds.insert(identifier)
+                                            }
+                                            group.leave()
+                                        }
+                                    })
+        }
+
+        group.notify(queue: DispatchQueue.main) {
+            self.addBuildingsLayer(with: foundBuildingIds, in3D: extrudesBuildings)
+            completion?(foundBuildingIds.count == coordinates.count)
+        }
     }
     
     /**
      Removes the highlight from all buildings highlighted by `highlightBuildings(at:in3D:)`.
      */
     public func unhighlightBuildings() {
-        
+        guard let _ = try? mapView.style.getLayer(with: IdentifierString.buildingExtrusionLayer, type: FillExtrusionLayer.self).get() else { return }
+        let _ = mapView.style.removeStyleLayer(forLayerId: IdentifierString.buildingExtrusionLayer)
     }
+
+    private func addBuildingsLayer(with identifiers: Set<Int64>, in3D: Bool = false, extrudeAll: Bool = false) {
+        let _ = mapView.style.removeStyleLayer(forLayerId: IdentifierString.buildingExtrusionLayer)
+        if identifiers.isEmpty { return }
+        var highlightedBuildingsLayer = FillExtrusionLayer(id: IdentifierString.buildingExtrusionLayer)
+        highlightedBuildingsLayer.source = "composite"
+        highlightedBuildingsLayer.sourceLayer = "building"
+
+        let extrudeExpression: Expression = Exp(.eq) {
+            Exp(.get) {
+                "extrude"
+            }
+            "true"
+        }
+
+        if extrudeAll {
+            highlightedBuildingsLayer.filter = extrudeExpression
+        } else {
+            highlightedBuildingsLayer.filter = Exp(.all) {
+                extrudeExpression
+                Exp(.inExpression) {
+                    Exp(.id)
+                    Exp(.literal) {
+                        identifiers.map({ Double($0) })
+                    }
+                }
+            }
+        }
+
+        if in3D {
+            highlightedBuildingsLayer.paint?.fillExtrusionHeight = .expression(Expression.buildingExtrusionHeightExpression("height"))
+        } else {
+            highlightedBuildingsLayer.paint?.fillExtrusionHeight = .constant(0.0)
+        }
+
+        highlightedBuildingsLayer.paint?.fillExtrusionBase = .expression(Expression.buildingExtrusionHeightExpression("min_height"))
+
+        highlightedBuildingsLayer.paint?.fillExtrusionOpacity = .expression(
+            Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                13; 0.5
+                17; 0.8
+            }
+        )
+
+        highlightedBuildingsLayer.paint?.fillExtrusionColor = .constant(.init(color: buildingHighlightColor))
+        highlightedBuildingsLayer.paint?.fillExtrusionHeightTransition = StyleTransition(duration: 0.8, delay: 0)
+        highlightedBuildingsLayer.paint?.fillExtrusionOpacityTransition = StyleTransition(duration: 0.8, delay: 0)
+        mapView.style.addLayer(layer: highlightedBuildingsLayer)
+    }
+
 }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -79,6 +79,7 @@ open class NavigationMapView: UIView {
         static let waypointSource = "\(identifier)_waypointSource"
         static let waypointCircle = "\(identifier)_waypointCircle"
         static let waypointSymbol = "\(identifier)_waypointSymbol"
+        static let buildingExtrusionLayer = "\(identifier)buildingExtrusionLayer"
     }
     
     @objc dynamic public var trafficUnknownColor: UIColor = .trafficUnknown
@@ -129,7 +130,7 @@ open class NavigationMapView: UIView {
     var fractionTraveled: Double = 0.0
     var preFractionTraveled: Double = 0.0
     var vanishingRouteLineUpdateTimer: Timer? = nil
-    
+
     var shouldPositionCourseViewFrameByFrame = false {
         didSet {
             if shouldPositionCourseViewFrameByFrame {

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -377,4 +377,28 @@ class NavigationMapViewTests: XCTestCase {
         
         XCTAssertEqual(navigationMapView.roadClassesWithOverriddenCongestionLevels?.count, 3)
     }
+    
+    func testHighlightBuildings() {
+        let featureQueryExpectation = XCTestExpectation(description: "Wait for building to be highlighted.")
+
+        let navigationMapView = NavigationMapView(frame: CGRect(origin: .zero, size: .iPhone6Plus))
+        let cameraOptions = CameraOptions(center: CLLocationCoordinate2D(latitude: 37.79060960181454, longitude: -122.39564506250244),
+                                          zoom: 17.0,
+                                          bearing: 0.0,
+                                          pitch: 0.0)
+        navigationMapView.cameraManager.setCamera(to: cameraOptions)
+        let buildingHighlightCoordinates: [CLLocationCoordinate2D] = [
+            CLLocationCoordinate2D(latitude: 37.79066471218174, longitude: -122.39581404166825),
+            CLLocationCoordinate2D(latitude: 37.78999490647732, longitude: -122.39485917526815)
+        ]
+        navigationMapView.highlightBuildings(at: buildingHighlightCoordinates, in3D: true, completion: { (result) -> Void in
+            if result == true  {
+                featureQueryExpectation.fulfill()
+            } else {
+                XCTFail("Building highlighted failed.")
+            }
+        })
+        
+        wait(for: [featureQueryExpectation], timeout: 5.0)
+    }
 }


### PR DESCRIPTION
### Description
This Pr is to add the ability to high light choose building after long press in 3D, solving the [#728](https://github.com/mapbox/navigation-sdks/issues/728) The opacity would be varied with zoom level. The building would also appear in certain zoom level. 

- [x] add building highlighting feature
- [x] allow a series of buildings to highlight after long press

### Implementation
Add the calling functions of `mapView.highlightBuildings(at:, in 3D:)` to highlight the chosen waypoint. Do query the feature at the waypoint on map view to find the id of the corresponding building. Then add one fillExtrusionLayer and filter the layer based on the building id. 

It would allow the building from 3D changing to 2D in `DayStyle` and `NightStyle`. The color of building would also change from blue to red when  `NightStyle` is chosen.

### Screenshots or Gifs
As the below .gif, it allow a series of long press to choose multiple buildings to highlight, the color of the building would change under different circumstances.
![highlighting](https://user-images.githubusercontent.com/48976398/108951397-bc956000-761c-11eb-8098-2eb693ea4b11.gif)

It also allow the end of route the puck located at the waypoint and change 3D to 2D, behavior same as the 1.x.
![building](https://user-images.githubusercontent.com/48976398/109551208-1c5c9280-7a85-11eb-934f-05bfd10cc3f9.gif)

