### PR TITLE
Predictive Caching Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 * Removed deprecated `InstructionsBannerViewDelegate.didDragInstructionsBanner(_:)` method. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Removed `NavigationViewController.origin` property, which was not used. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
-* Added optional Predictive Caching mechanism which pre-fetches tiles which may become needed during navigation if app goes offline at some point. ([#2830](https://github.com/mapbox/mapbox-navigation-ios/pull/2830))
+* Added `PredictiveCacheOptions` to allow enabling and configuring a Predictive Caching mechanism which pre-fetches tiles which may become needed during navigation if app goes offline at some point. This can be configure either by updating `NavigationOptions` passed to `NavigationViewController` or by manually calling `NavigationMapView.setupPredictiveCaching(_:)` ([#2830](https://github.com/mapbox/mapbox-navigation-ios/pull/2830))
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 * Removed deprecated `InstructionsBannerViewDelegate.didDragInstructionsBanner(_:)` method. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Removed `NavigationViewController.origin` property, which was not used. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
+* Added optional Predictive Caching mechanism which pre-fetches tiles which may become needed during navigation if app goes offline at some point. ([#2830](https://github.com/mapbox/mapbox-navigation-ios/pull/2830))
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 * Removed deprecated `InstructionsBannerViewDelegate.didDragInstructionsBanner(_:)` method. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Removed `NavigationViewController.origin` property, which was not used. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
-* Added `PredictiveCacheOptions` to allow enabling and configuring a Predictive Caching mechanism which pre-fetches tiles which may become needed during navigation if app goes offline at some point. This can be configure either by updating `NavigationOptions` passed to `NavigationViewController` or by manually calling `NavigationMapView.setupPredictiveCaching(_:)` ([#2830](https://github.com/mapbox/mapbox-navigation-ios/pull/2830))
+* A new predictive cache proactively fetches tiles which may become necessary if the device loses its Internet connection at some point during passive or active turn-by-turn navigation. Pass a `PredictiveCacheOptions` instance into the `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:predictiveCacheOptions:)` initializer as you configure a `NavigationViewController`, or manually call `NavigationMapView.enablePredictiveCaching(options:)`. ([#2830](https://github.com/mapbox/mapbox-navigation-ios/pull/2830))
 
 ## v1.3.0
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -199,7 +199,7 @@ class ViewController: UIViewController {
     func startNavigation(styles: [MapboxNavigation.Style]) {
         guard let response = response, let route = response.routes?.first, case let .route(routeOptions) = response.options else { return }
         
-        let options = NavigationOptions(styles: styles, navigationService: navigationService(route: route, routeIndex: 0, options: routeOptions))
+        let options = NavigationOptions(styles: styles, navigationService: navigationService(route: route, routeIndex: 0, options: routeOptions), predictiveCacheOptions: PredictiveCacheOptions())
         let navigationViewController = NavigationViewController(for: route, routeIndex: 0, routeOptions: routeOptions, navigationOptions: options)
         navigationViewController.delegate = self
         
@@ -248,7 +248,7 @@ class ViewController: UIViewController {
         guard let response = response, let route = response.routes?.first, case let .route(routeOptions) = response.options else { return }
 
         let styles = [CustomDayStyle(), CustomNightStyle()]
-        let options = NavigationOptions(styles: styles, navigationService: navigationService(route: route, routeIndex: 0, options: routeOptions))
+        let options = NavigationOptions(styles: styles, navigationService: navigationService(route: route, routeIndex: 0, options: routeOptions), predictiveCacheOptions: PredictiveCacheOptions())
         let navigationViewController = NavigationViewController(for: route, routeIndex: 0, routeOptions: routeOptions, navigationOptions: options)
         navigationViewController.delegate = self
 
@@ -261,7 +261,7 @@ class ViewController: UIViewController {
         let instructionsCardCollection = InstructionsCardViewController()
         instructionsCardCollection.cardCollectionDelegate = self
         
-        let options = NavigationOptions(navigationService: navigationService(route: route, routeIndex: 0, options: routeOptions), topBanner: instructionsCardCollection)
+        let options = NavigationOptions(navigationService: navigationService(route: route, routeIndex: 0, options: routeOptions), topBanner: instructionsCardCollection, predictiveCacheOptions: PredictiveCacheOptions())
         let navigationViewController = NavigationViewController(for: route, routeIndex: 0, routeOptions: routeOptions, navigationOptions: options)
         navigationViewController.delegate = self
         
@@ -391,8 +391,8 @@ class ViewController: UIViewController {
     }
     
     func navigationViewController(navigationService: NavigationService) -> NavigationViewController {
-        let navigationOptions = NavigationOptions(navigationService: navigationService)
-
+        let navigationOptions = NavigationOptions(navigationService: navigationService, predictiveCacheOptions: PredictiveCacheOptions())
+        
         let navigationViewController = NavigationViewController(for: navigationService.route,
                                                                 routeIndex: navigationService.indexedRoute.1,
                                                                 routeOptions: navigationService.routeProgress.routeOptions,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		2B5407EB24470B0A006C820B /* AVAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5407EA24470B0A006C820B /* AVAudioSession.swift */; };
 		2B72EC5E241276D10003B370 /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B72EC5D241276D10003B370 /* RouteVoiceController.swift */; };
 		2B72EC602412AA800003B370 /* SystemSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B72EC5F2412AA800003B370 /* SystemSpeechSynthesizer.swift */; };
+		2B7ACA9B25E3F84700B0ACFD /* PredictiveCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7ACA9925E3F84600B0ACFD /* PredictiveCacheManager.swift */; };
+		2B7ACA9C25E3F84700B0ACFD /* PredictiveCacheOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7ACA9A25E3F84600B0ACFD /* PredictiveCacheOptions.swift */; };
 		2B8098412411375700FED452 /* SpeechSynthesizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8098402411375700FED452 /* SpeechSynthesizing.swift */; };
 		2B8098432411447E00FED452 /* MultiplexedSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8098422411447E00FED452 /* MultiplexedSpeechSynthesizer.swift */; };
 		2B81EC28241A237E00145086 /* SpeechSynthesizersControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B81EC27241A237E00145086 /* SpeechSynthesizersControllerTests.swift */; };
@@ -507,6 +509,8 @@
 		2B5407EA24470B0A006C820B /* AVAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAudioSession.swift; sourceTree = "<group>"; };
 		2B72EC5D241276D10003B370 /* RouteVoiceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteVoiceController.swift; sourceTree = "<group>"; };
 		2B72EC5F2412AA800003B370 /* SystemSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSpeechSynthesizer.swift; sourceTree = "<group>"; };
+		2B7ACA9925E3F84600B0ACFD /* PredictiveCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheManager.swift; sourceTree = "<group>"; };
+		2B7ACA9A25E3F84600B0ACFD /* PredictiveCacheOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheOptions.swift; sourceTree = "<group>"; };
 		2B8098402411375700FED452 /* SpeechSynthesizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechSynthesizing.swift; sourceTree = "<group>"; };
 		2B8098422411447E00FED452 /* MultiplexedSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplexedSpeechSynthesizer.swift; sourceTree = "<group>"; };
 		2B81EC27241A237E00145086 /* SpeechSynthesizersControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechSynthesizersControllerTests.swift; sourceTree = "<group>"; };
@@ -1692,6 +1696,8 @@
 				4303A3982332CD6200B5737D /* UnimplementedLogging.swift */,
 				8D1A5CD1212DDFCD0059BA4A /* DispatchTimer.swift */,
 				8D75F990212B5C7F00F99CF3 /* TunnelAuthority.swift */,
+				2B7ACA9A25E3F84600B0ACFD /* PredictiveCacheOptions.swift */,
+				2B7ACA9925E3F84600B0ACFD /* PredictiveCacheManager.swift */,
 				3582A25120EFA9680029C5DE /* RouterDelegate.swift */,
 				C5ADFBFB1DDCC9AD0011824B /* RouteProgress.swift */,
 				2BBEEDA42508DB1700C8DA4A /* RouteLegProgress.swift */,
@@ -2638,6 +2644,7 @@
 				4303A3992332CD6200B5737D /* UnimplementedLogging.swift in Sources */,
 				3A163AE3249901D000D66A0D /* FixLocation.swift in Sources */,
 				8D2AA745211CDD4000EB7F72 /* NavigationService.swift in Sources */,
+				2B7ACA9C25E3F84700B0ACFD /* PredictiveCacheOptions.swift in Sources */,
 				35A5413B1EFC052700E49846 /* RouteOptions.swift in Sources */,
 				353E69041EF0C4E5007B2AE5 /* SimulatedLocationManager.swift in Sources */,
 				DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */,
@@ -2650,6 +2657,7 @@
 				64847A041F04629D003F3A69 /* Feedback.swift in Sources */,
 				2BE7016925371E3400F46E4E /* Incident.swift in Sources */,
 				C58D6BAD1DDCF2AE00387F53 /* CoreConstants.swift in Sources */,
+				2B7ACA9B25E3F84700B0ACFD /* PredictiveCacheManager.swift in Sources */,
 				35C77F621FE8219900338416 /* NavigationSettings.swift in Sources */,
 				C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */,
 			);

--- a/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
+++ b/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
@@ -2,9 +2,9 @@ import Foundation
 import MapboxNavigationNative
 
 /**
- `PredictiveCacheManager` is responsible for creating and retaining `Predictive Caching` related components.
+ Proactively fetches tiles which may become necessary if the device loses its Internet connection at some point during passive or active turn-by-turn navigation.
  
- Typical usage suggests initializing an instance of `PredictiveCacheManager` and retaining it as long as caching is required.
+ Typically, you initialize an instance of this class and retain it as long as caching is required.
  */
 public class PredictiveCacheManager {
     public typealias MapOptions = (tileStore: TileStore, styleSourcePaths: [String])
@@ -12,10 +12,10 @@ public class PredictiveCacheManager {
     private(set) var controllers: [PredictiveCacheController] = []
     
     /**
-     Default initializer
-     
-     - parameter predictiveCacheOptions: `PredictiveCacheOptions` which configures various caching parameters like radiuses of current and destination locations.
-     - parameter mapOptions: A `MapOptions` which contains info about `MapView` tiles like its location and tilesets to be cached. If set to `nil` - predictive caching won't be enbled for map tiles.
+     Initializes a predictive cache.
+    
+     - parameter predictiveCacheOptions: A configuration specifying various caching parameters, such as the radii of current and destination locations.
+     - parameter mapOptions: Information about `MapView` tiles such as the location and tilesets to cache. If this argument is set to `nil`, predictive caching is disabled for map tiles.
      */
     public init(predictiveCacheOptions: PredictiveCacheOptions, mapOptions: MapOptions?) {
         self.controllers.append(initNavigatorController(options: predictiveCacheOptions))

--- a/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
+++ b/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
@@ -1,0 +1,57 @@
+import Foundation
+import MapboxNavigationNative
+
+/**
+ `PredictiveCacheManager` is responsible for creating and retaining `Predictive Caching` related components.
+ 
+ Typical usage suggests initializing an instance of `PredictiveCacheManager` and retaining it as long as caching is required.
+ */
+public class PredictiveCacheManager {
+    public typealias MapOptions = (tileStore: TileStore, styleSourcePaths: [String])
+    
+    private(set) var controllers: [PredictiveCacheController] = []
+    
+    /**
+     Default initializer
+     
+     - parameter predictiveCacheOptions: `PredictiveCacheOptions` which configures various caching parameters like radiuses of current and destination locations.
+     - parameter mapOptions: A `MapOptions` which contains info about `MapView` tiles like its location and tilesets to be cached. If set to `nil` - predictive caching won't be enbled for map tiles.
+     */
+    public init(predictiveCacheOptions: PredictiveCacheOptions, mapOptions: MapOptions?) {
+        self.controllers.append(initNavigatorController(options: predictiveCacheOptions))
+        if let mapOptions = mapOptions {
+            self.controllers.append(contentsOf: initMapControllers(options: predictiveCacheOptions, mapOptions: mapOptions))
+        }
+    }
+    
+    private func initMapControllers(options: PredictiveCacheOptions,
+                                    mapOptions: MapOptions) -> [PredictiveCacheController] {
+        return mapOptions.styleSourcePaths.compactMap {
+            createPredictiveCacheController(options: options,
+                                            tileStore: mapOptions.tileStore,
+                                            dataset: $0)
+        }
+    }
+    
+    private func initNavigatorController(options: PredictiveCacheOptions) -> PredictiveCacheController {
+        return createPredictiveCacheController(options: options)!
+    }
+    
+    private func createPredictiveCacheController(options: PredictiveCacheOptions,
+                                                 tileStore: TileStore? = nil,
+                                                 version: String = "",
+                                                 dataset: String = "mapbox",
+                                                 maxConcurrentRequests: UInt32 = 2) -> PredictiveCacheController? {
+        let cacheOptions = PredictiveCacheControllerOptions(version: version,
+                                                            dataset: dataset,
+                                                            concurrency: maxConcurrentRequests)
+        let predictiveLocationTrackerOptions = PredictiveLocationTrackerOptions(options)
+        if let tileStore = tileStore {
+            return try! Navigator.shared.navigator.createPredictiveCacheController(for: tileStore,
+                                                                                   cacheOptions: cacheOptions,
+                                                                                   locationTrackerOptions: predictiveLocationTrackerOptions)
+        } else {
+            return try! Navigator.shared.navigator.createPredictiveCacheController(for: predictiveLocationTrackerOptions)
+        }
+    }
+}

--- a/Sources/MapboxCoreNavigation/PredictiveCacheOptions.swift
+++ b/Sources/MapboxCoreNavigation/PredictiveCacheOptions.swift
@@ -1,9 +1,11 @@
 import MapboxNavigationNative
 
 /**
- `PredictiveCacheOptions` controls various configurations for a `Predictive Caching` mechanic.
+ Specifies the content that a predictive cache fetches and how it fetches the content.
+ 
+ Pass an instance of this class into the `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:predictiveCacheOptions:)` initializer or `NavigationMapView.enablePredictiveCaching(options:)` method.
  */
-public class PredictiveCacheOptions {
+public struct PredictiveCacheOptions {
     
     /**
      How far around the user's location caching is going to be performed.
@@ -31,7 +33,7 @@ public class PredictiveCacheOptions {
      
      Defaults to 2 concurrent requests.
      */
-    public var maxConcurrentRequests: UInt32 = 2
+    public var maximumConcurrentRequests: UInt32 = 2
     
     public init() {
         // No-op

--- a/Sources/MapboxCoreNavigation/PredictiveCacheOptions.swift
+++ b/Sources/MapboxCoreNavigation/PredictiveCacheOptions.swift
@@ -1,0 +1,48 @@
+import MapboxNavigationNative
+
+/**
+ `PredictiveCacheOptions` controls various configurations for a `Predictive Caching` mechanic.
+ */
+public class PredictiveCacheOptions {
+    
+    /**
+     How far around the user's location caching is going to be performed.
+     
+     Defaults to 2000 meters.
+     */
+    public var currentLocationRadius: CLLocationDistance = 2000
+    
+    /**
+     How far around the active route caching is going to be performed (if route is set).
+     
+     Defaults to 500 meters.
+     */
+    public var routeBufferRadius: CLLocationDistance = 500
+    
+    /**
+     How far around the destination location caching is going to be performed (if route is set).
+     
+     Defaults to 5000 meters.
+     */
+    public var destinationLocationRadius: CLLocationDistance = 5000
+    
+    /**
+     Maxiumum amount of concurrent requests, which will be used for caching.
+     
+     Defaults to 2 concurrent requests.
+     */
+    public var maxConcurrentRequests: UInt32 = 2
+    
+    public init() {
+        // No-op
+    }
+}
+
+extension PredictiveLocationTrackerOptions {
+    
+    convenience init(_ predictiveCacheOptions: PredictiveCacheOptions) {
+        self.init(currentLocationRadius: UInt32(predictiveCacheOptions.currentLocationRadius),
+                  routeBufferRadius: UInt32(predictiveCacheOptions.routeBufferRadius),
+                  destinationLocationRadius: UInt32(predictiveCacheOptions.destinationLocationRadius))
+    }
+}

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -231,6 +231,11 @@ open class NavigationMapView: UIView {
         }
     }
     
+    /**
+     A manager object, used to init and maintain predictive caching.
+     */
+    private(set) var predictiveCacheManager: PredictiveCacheManager?
+    
     public override init(frame: CGRect) {
         altitude = defaultAltitude
         super.init(frame: frame)
@@ -287,6 +292,17 @@ open class NavigationMapView: UIView {
         let mapTapGesture = UITapGestureRecognizer(target: self, action: #selector(didRecieveTap(sender:)))
         mapTapGesture.requireFailure(of: gestures)
         mapView.addGestureRecognizer(mapTapGesture)
+    }
+    
+    public func setupPredictiveCaching(_ predictiveCacheOptions: PredictiveCacheOptions?) {
+        let mapTileSource = try? TileStoreManager.getTileStore(for: mapView.__map.getResourceOptions())
+        var mapOptions: PredictiveCacheManager.MapOptions?
+        if let tileStore = mapTileSource?.value as? TileStore {
+            mapOptions = PredictiveCacheManager.MapOptions(tileStore, mapView.styleSourceDatasets(["raster", "vector"]))
+        }
+        
+        predictiveCacheManager = PredictiveCacheManager(predictiveCacheOptions: predictiveCacheOptions,
+                                                        mapOptions: mapOptions)
     }
     
     // MARK: - Overridden methods

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -294,7 +294,14 @@ open class NavigationMapView: UIView {
         mapView.addGestureRecognizer(mapTapGesture)
     }
     
-    public func setupPredictiveCaching(_ predictiveCacheOptions: PredictiveCacheOptions) {
+    /**
+     Setups the Predictive Caching mechanism using provided Options.
+     
+     This will handle all the required manipulations to enable the feature and maintain it during the navigations. Once enabled, it will be present as long as `NavigationMapView` is retained.
+     
+     - parameter options: options, controlling caching parameters like area radius and concurrent downloading threads.
+     */
+    public func enablePredictiveCaching(options predictiveCacheOptions: PredictiveCacheOptions) {
         let mapTileSource = try? TileStoreManager.getTileStore(for: mapView.__map.getResourceOptions())
         var mapOptions: PredictiveCacheManager.MapOptions?
         if let tileStore = mapTileSource?.value as? TileStore {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -294,7 +294,7 @@ open class NavigationMapView: UIView {
         mapView.addGestureRecognizer(mapTapGesture)
     }
     
-    public func setupPredictiveCaching(_ predictiveCacheOptions: PredictiveCacheOptions?) {
+    public func setupPredictiveCaching(_ predictiveCacheOptions: PredictiveCacheOptions) {
         let mapTileSource = try? TileStoreManager.getTileStore(for: mapView.__map.getResourceOptions())
         var mapOptions: PredictiveCacheManager.MapOptions?
         if let tileStore = mapTileSource?.value as? TileStore {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -260,7 +260,10 @@ open class NavigationMapView: UIView {
             fatalError("Access token was not set.")
         }
         
-        mapView = MapView(with: frame, resourceOptions: ResourceOptions(accessToken: accessToken))
+        let options = ResourceOptions(accessToken: accessToken,
+                                      tileStorePath: Bundle.mapboxNavigation.suggestedTileURL?.path)
+        
+        mapView = MapView(with: frame, resourceOptions: options)
         mapView.translatesAutoresizingMaskIntoConstraints = false
         mapView.update {
             $0.ornaments.showsScale = false

--- a/Sources/MapboxNavigation/NavigationOptions.swift
+++ b/Sources/MapboxNavigation/NavigationOptions.swift
@@ -41,10 +41,9 @@ open class NavigationOptions: NavigationCustomizable {
     open var bottomBanner: ContainerViewController?
     
     /**
-     Configuration for the Predictive Caching.
+     Configuration for predictive caching.
      
-     These parameters control how navigation engine will try to predict and pre-load data related to the route.
-     `nil` value means disabling the feature.
+     These options control how the `PredictiveCacheManager` will try to proactively fetch data related to the route. A `nil` value disables the feature.
      */
     open var predictiveCacheOptions: PredictiveCacheOptions?
     
@@ -61,7 +60,7 @@ open class NavigationOptions: NavigationCustomizable {
      - parameter voiceController: The voice controller that vocalizes spoken instructions along the route at the appropriate times.
      - parameter topBanner: The container view controller that presents the top banner.
      - parameter bottomBanner: The container view controller that presents the bottom banner.
-     - parameter predictiveCacheOptions: Predictive Caching setup.
+     - parameter predictiveCacheOptions: Configuration for predictive caching. These options control how the `PredictiveCacheManager` will try to proactively fetch data related to the route. A `nil` value disables the feature.
      */
     public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil, predictiveCacheOptions: PredictiveCacheOptions? = nil) {
         self.init()

--- a/Sources/MapboxNavigation/NavigationOptions.swift
+++ b/Sources/MapboxNavigation/NavigationOptions.swift
@@ -40,6 +40,14 @@ open class NavigationOptions: NavigationCustomizable {
      */
     open var bottomBanner: ContainerViewController?
     
+    /**
+     Configuration for the Predictive Caching.
+     
+     These parameters control how navigation engine will try to predict and pre-load data related to the route.
+     `nil` value means disabling the feature.
+     */
+    open var predictiveCacheOptions: PredictiveCacheOptions?
+    
     // This makes the compiler happy.
     required public init() {
         // do nothing
@@ -53,14 +61,16 @@ open class NavigationOptions: NavigationCustomizable {
      - parameter voiceController: The voice controller that vocalizes spoken instructions along the route at the appropriate times.
      - parameter topBanner: The container view controller that presents the top banner.
      - parameter bottomBanner: The container view controller that presents the bottom banner.
+     - parameter predictiveCacheOptions: Predictive Caching setup.
      */
-    public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil) {
+    public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil, predictiveCacheOptions: PredictiveCacheOptions? = nil) {
         self.init()
         self.styles = styles
         self.navigationService = navigationService
         self.voiceController = voiceController
         self.topBanner = topBanner
         self.bottomBanner = bottomBanner
+        self.predictiveCacheOptions = predictiveCacheOptions
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -87,11 +87,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
     
     /**
-     A manager object, used to init and maintain predictive caching.
-     */
-    private(set) var predictiveCacheManager: PredictiveCacheManager?
-    
-    /**
      The `NavigationMapView` displayed inside the view controller.
      
      - note: Do not change `NavigationMapView.delegate` property; instead, implement the corresponding methods on `NavigationViewControllerDelegate`.
@@ -296,7 +291,10 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         addRouteMapViewController(navigationOptions)
         setupStyleManager(navigationOptions)
-        setupPredictiveCaching(navigationOptions)
+        
+        if let predictiveCacheOptions = navigationOptions?.predictiveCacheOptions {
+            navigationMapView?.setupPredictiveCaching(predictiveCacheOptions)
+        }
     }
     
     /**
@@ -328,21 +326,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         if let currentStyle = styleManager.currentStyle {
             updateMapStyle(currentStyle)
         }
-    }
-    
-    func setupPredictiveCaching(_ navigationOptions: NavigationOptions?) {
-        guard let predictiveCacheOptions = navigationOptions?.predictiveCacheOptions,
-              let mapView = mapViewController?.navigationMapView.mapView else {
-            return
-        }
-        let mapTileSource = try? TileStoreManager.getTileStore(for: mapView.__map.getResourceOptions())
-        var mapOptions: PredictiveCacheManager.MapOptions?
-        if let tileStore = mapTileSource?.value as? TileStore {
-            mapOptions = PredictiveCacheManager.MapOptions(tileStore, mapView.styleSourceDatasets(["raster", "vector"]))
-        }
-        
-        predictiveCacheManager = PredictiveCacheManager(predictiveCacheOptions: predictiveCacheOptions,
-                                                        mapOptions: mapOptions)
     }
     
     func addRouteMapViewController(_ navigationOptions: NavigationOptions?) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -293,7 +293,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         setupStyleManager(navigationOptions)
         
         if let predictiveCacheOptions = navigationOptions?.predictiveCacheOptions {
-            navigationMapView?.setupPredictiveCaching(predictiveCacheOptions)
+            navigationMapView?.enablePredictiveCaching(options: predictiveCacheOptions)
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -87,6 +87,11 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
     
     /**
+     A manager object, used to init and maintain predictive caching.
+     */
+    private(set) var predictiveCacheManager: PredictiveCacheManager?
+    
+    /**
      The `NavigationMapView` displayed inside the view controller.
      
      - note: Do not change `NavigationMapView.delegate` property; instead, implement the corresponding methods on `NavigationViewControllerDelegate`.
@@ -291,6 +296,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         addRouteMapViewController(navigationOptions)
         setupStyleManager(navigationOptions)
+        setupPredictiveCaching(navigationOptions)
     }
     
     /**
@@ -322,6 +328,21 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         if let currentStyle = styleManager.currentStyle {
             updateMapStyle(currentStyle)
         }
+    }
+    
+    func setupPredictiveCaching(_ navigationOptions: NavigationOptions?) {
+        guard let predictiveCacheOptions = navigationOptions?.predictiveCacheOptions,
+              let mapView = mapViewController?.navigationMapView.mapView else {
+            return
+        }
+        let mapTileSource = try? TileStoreManager.getTileStore(for: mapView.__map.getResourceOptions())
+        var mapOptions: PredictiveCacheManager.MapOptions?
+        if let tileStore = mapTileSource?.value as? TileStore {
+            mapOptions = PredictiveCacheManager.MapOptions(tileStore, mapView.styleSourceDatasets(["raster", "vector"]))
+        }
+        
+        predictiveCacheManager = PredictiveCacheManager(predictiveCacheOptions: predictiveCacheOptions,
+                                                        mapOptions: mapOptions)
     }
     
     func addRouteMapViewController(_ navigationOptions: NavigationOptions?) {


### PR DESCRIPTION
### Description
This PR adds predictive Caching mechanism integration. It provides a configurable setting which enables predictive caching for `Navigator` and/or `Map`.

### Implementation
The PR introduces `PredictiveCacheLocationOptions` as a part of `NavigationOptions` which enables and configures the feature. Creation of predictive cache controllers is encapsulated in `PredictiveCacheManager` which just needs to be retained during the session.


Currently there seems to be some issue with navigation tiles. Tiles seems to be downloading after navigation has began, but it does not handle reroute events. 
Also, subjectively, MapView now takes longer to render at first launch, when there are no tiles downloaded yet. This may be related to providing a custom TileStore path, but I am not sure how and why this would matter.