### PR TITLE
Implement support for CPTemplateApplicationSceneDelegate UIScene-based CarPlay on iOS 13 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added an optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method to determine which part of the view hierarchy is affected by a change to a different `Style`. ([#2897](https://github.com/mapbox/mapbox-navigation-ios/pull/2897))
 * Added the `NavigationViewController.styleManager`, `StyleManager.currentStyleType`, and `StyleManager.currentStyle` properties and the `StyleManager.applyStyle(type:)` method to manually change the UI style at any time. ([#2888](https://github.com/mapbox/mapbox-navigation-ios/pull/2888))
 * Fixed crash when switching between day / night modes ([#2896](https://github.com/mapbox/mapbox-navigation-ios/pull/2896))
+* Add support for iOS 13's UIScene based CarPlay API ([#2832](https://github.com/mapbox/mapbox-navigation-ios/pull/2832))
 
 ## v1.3.0
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -188,4 +188,41 @@ extension AppDelegate: CPListTemplateDelegate {
         completionHandler()
     }
 }
+
+@available(iOS 13.0, *)
+extension AppDelegate: UIWindowSceneDelegate {
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+
+        if connectingSceneSession.role == .carTemplateApplication {
+            return UISceneConfiguration(name: "ExampleCarPlayApplicationConfiguration", sessionRole: connectingSceneSession.role)
+        }
+        return UISceneConfiguration(name: "ExampleAppConfiguration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+
+    }
+}
+
+@available(iOS 13.0, *)
+class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
+
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
+                                  didConnect interfaceController: CPInterfaceController, to window: CPWindow) {
+
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        appDelegate.carPlayManager.delegate = appDelegate
+        appDelegate.carPlaySearchController.delegate = appDelegate
+        appDelegate.carPlayManager.templateApplicationScene(templateApplicationScene, didConnectCarInterfaceController: interfaceController, to: window)
+    }
+
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
+                                  didDisconnect interfaceController: CPInterfaceController, from window: CPWindow) {
+
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        appDelegate.carPlayManager.templateApplicationScene(templateApplicationScene, didDisconnectCarInterfaceController: interfaceController, from: window)
+    }
+}
+
 #endif

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -147,6 +147,10 @@ extension AppDelegate: CarPlayManagerDelegate {
             return nil
         }
     }
+
+    func carPlayManager(_ carPlayManager: CarPlayManager, didPresent navigationViewController: CarPlayNavigationViewController) {
+        // no-op
+    }
 }
 
 @available(iOS 12.0, *)

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -190,22 +190,6 @@ extension AppDelegate: CPListTemplateDelegate {
 }
 
 @available(iOS 13.0, *)
-extension AppDelegate: UIWindowSceneDelegate {
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-
-        if connectingSceneSession.role == .carTemplateApplication {
-            return UISceneConfiguration(name: "ExampleCarPlayApplicationConfiguration", sessionRole: connectingSceneSession.role)
-        }
-        return UISceneConfiguration(name: "ExampleAppConfiguration", sessionRole: connectingSceneSession.role)
-    }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-
-    }
-}
-
-@available(iOS 13.0, *)
 class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -1,6 +1,5 @@
 import UIKit
 import MapboxNavigation
-#if canImport(CarPlay)
 import CarPlay
 import MapboxCoreNavigation
 import MapboxDirections
@@ -208,5 +207,3 @@ class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
         appDelegate.carPlayManager.templateApplicationScene(templateApplicationScene, didDisconnectCarInterfaceController: interfaceController, from: window)
     }
 }
-
-#endif

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -54,3 +54,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 }
+
+@available(iOS 13.0, *)
+extension AppDelegate: UIWindowSceneDelegate {
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+
+        if connectingSceneSession.role == .carTemplateApplication {
+            return UISceneConfiguration(name: "ExampleCarPlayApplicationConfiguration", sessionRole: connectingSceneSession.role)
+        }
+        return UISceneConfiguration(name: "ExampleAppConfiguration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+
+    }
+}

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -1,8 +1,6 @@
 import UIKit
 import MapboxNavigation
-#if canImport(CarPlay)
 import CarPlay
-#endif
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     @available(iOS 12.0, *)
     lazy var carPlaySearchController: CarPlaySearchController = CarPlaySearchController()
 
-    #if canImport(CarPlay)
     @available(iOS 12.0, *)
     lazy var interfaceController: CPInterfaceController? = nil
 
@@ -24,7 +21,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     @available(iOS 12.0, *)
     lazy var sessionConfiguration: CPSessionConfiguration? = nil
-    #endif
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         if isRunningTests() {

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -1,5 +1,8 @@
 import UIKit
 import MapboxNavigation
+#if canImport(CarPlay)
+import CarPlay
+#endif
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -11,6 +14,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     @available(iOS 12.0, *)
     lazy var carPlaySearchController: CarPlaySearchController = CarPlaySearchController()
+
+    #if canImport(CarPlay)
+    @available(iOS 12.0, *)
+    lazy var interfaceController: CPInterfaceController? = nil
+
+    @available(iOS 12.0, *)
+    lazy var carWindow: CPWindow? = nil
+
+    @available(iOS 12.0, *)
+    lazy var sessionConfiguration: CPSessionConfiguration? = nil
+    #endif
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         if isRunningTests() {

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -28,6 +28,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         if isRunningTests() {
+            if window == nil {
+                window = UIWindow(frame: UIScreen.main.bounds)
+            }
             window!.rootViewController = UIViewController()
         }
         

--- a/Example/FavoritesList.swift
+++ b/Example/FavoritesList.swift
@@ -1,6 +1,4 @@
-#if canImport(CarPlay)
 import CarPlay
-#endif
 import CoreLocation
 
 public enum FavoritesList {
@@ -48,11 +46,9 @@ public enum FavoritesList {
             }
         }
         
-        #if canImport(CarPlay)
         @available(iOS 12.0, *)
         func listItem() -> CPListItem {
             return CPListItem(text: rawValue, detailText: subTitle, image: nil, showsDisclosureIndicator: true)
         }
-        #endif
     }
 }

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -32,6 +32,38 @@
 	<string>Get user location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Get user location</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>CPSupportsDashboardNavigationScene</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>ExampleCarPlayApplicationConfiguration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>Example_CarPlay.CarPlaySceneDelegate</string>
+				</dict>
+			</array>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>ExampleAppConfiguration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>Example_CarPlay.AppDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -46,7 +46,7 @@
 					<key>UISceneConfigurationName</key>
 					<string>ExampleCarPlayApplicationConfiguration</string>
 					<key>UISceneDelegateClassName</key>
-					<string>Example_CarPlay.CarPlaySceneDelegate</string>
+					<string>Example.CarPlaySceneDelegate</string>
 				</dict>
 			</array>
 			<key>UIWindowSceneSessionRoleApplication</key>

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -57,7 +57,7 @@
 					<key>UISceneConfigurationName</key>
 					<string>ExampleAppConfiguration</string>
 					<key>UISceneDelegateClassName</key>
-					<string>Example_CarPlay.AppDelegate</string>
+					<string>$(EXECUTABLE_NAME).AppDelegate</string>
 					<key>UISceneStoryboardFile</key>
 					<string>Main</string>
 				</dict>

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -905,7 +905,7 @@
 		C53C19751F38EADE008DB406 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C53C19771F38EAE4008DB406 /* ca */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C53C197A1F38EAEA008DB406 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C53F2F0720EBC95600D9798F /* Example-CarPlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-CarPlay.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C53F2F0720EBC95600D9798F /* Example_CarPlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example_CarPlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C549F8311F17F2C5001A0A2D /* MapboxMobileEvents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapboxMobileEvents.framework; path = Carthage/Build/iOS/MapboxMobileEvents.framework; sourceTree = "<group>"; };
 		C54C655120336F2600D338E0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C551B0E520D42222009A986F /* NavigationLocationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationManagerTests.swift; sourceTree = "<group>"; };
@@ -1779,7 +1779,7 @@
 				351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */,
 				358D14631E5E3B7700ADE590 /* Example.app */,
 				35B711CF1E5E7AD2001EDA8D /* MapboxNavigationTests.xctest */,
-				C53F2F0720EBC95600D9798F /* Example-CarPlay.app */,
+				C53F2F0720EBC95600D9798F /* Example_CarPlay.app */,
 				35CDA80621908F2F0072B675 /* Bench.app */,
 				35CDA81921908F320072B675 /* BenchTests.xctest */,
 				35CDA85E2190F2A30072B675 /* TestHelper.framework */,
@@ -2026,9 +2026,9 @@
 			productReference = 35CDA85E2190F2A30072B675 /* TestHelper.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		C53F2EDE20EBC95600D9798F /* Example-CarPlay */ = {
+		C53F2EDE20EBC95600D9798F /* Example_CarPlay */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example-CarPlay" */;
+			buildConfigurationList = C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example_CarPlay" */;
 			buildPhases = (
 				C53F2EE320EBC95600D9798F /* Sources */,
 				C53F2EE920EBC95600D9798F /* Frameworks */,
@@ -2043,9 +2043,9 @@
 				C53F2EDF20EBC95600D9798F /* PBXTargetDependency */,
 				C53F2EE120EBC95600D9798F /* PBXTargetDependency */,
 			);
-			name = "Example-CarPlay";
+			name = Example_CarPlay;
 			productName = "Example-Swift";
-			productReference = C53F2F0720EBC95600D9798F /* Example-CarPlay.app */;
+			productReference = C53F2F0720EBC95600D9798F /* Example_CarPlay.app */;
 			productType = "com.apple.product-type.application";
 		};
 		C5ADFBC81DDCC7840011824B /* MapboxCoreNavigation */ = {
@@ -2202,7 +2202,7 @@
 			projectRoot = "";
 			targets = (
 				358D14621E5E3B7700ADE590 /* Example */,
-				C53F2EDE20EBC95600D9798F /* Example-CarPlay */,
+				C53F2EDE20EBC95600D9798F /* Example_CarPlay */,
 				C5ADFBC81DDCC7840011824B /* MapboxCoreNavigation */,
 				351BEBD61E5BCC28006FE110 /* MapboxNavigation */,
 				35CDA85D2190F2A30072B675 /* TestHelper */,
@@ -3847,7 +3847,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example-CarPlay" */ = {
+		C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example_CarPlay" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C53F2F0520EBC95600D9798F /* Debug */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -905,7 +905,7 @@
 		C53C19751F38EADE008DB406 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C53C19771F38EAE4008DB406 /* ca */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C53C197A1F38EAEA008DB406 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C53F2F0720EBC95600D9798F /* Example_CarPlay.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example_CarPlay.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C53F2F0720EBC95600D9798F /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C549F8311F17F2C5001A0A2D /* MapboxMobileEvents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapboxMobileEvents.framework; path = Carthage/Build/iOS/MapboxMobileEvents.framework; sourceTree = "<group>"; };
 		C54C655120336F2600D338E0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C551B0E520D42222009A986F /* NavigationLocationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationManagerTests.swift; sourceTree = "<group>"; };
@@ -1779,7 +1779,7 @@
 				351BEBD71E5BCC28006FE110 /* MapboxNavigation.framework */,
 				358D14631E5E3B7700ADE590 /* Example.app */,
 				35B711CF1E5E7AD2001EDA8D /* MapboxNavigationTests.xctest */,
-				C53F2F0720EBC95600D9798F /* Example_CarPlay.app */,
+				C53F2F0720EBC95600D9798F /* Example.app */,
 				35CDA80621908F2F0072B675 /* Bench.app */,
 				35CDA81921908F320072B675 /* BenchTests.xctest */,
 				35CDA85E2190F2A30072B675 /* TestHelper.framework */,
@@ -2026,9 +2026,9 @@
 			productReference = 35CDA85E2190F2A30072B675 /* TestHelper.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		C53F2EDE20EBC95600D9798F /* Example_CarPlay */ = {
+		C53F2EDE20EBC95600D9798F /* Example-CarPlay */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example_CarPlay" */;
+			buildConfigurationList = C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example-CarPlay" */;
 			buildPhases = (
 				C53F2EE320EBC95600D9798F /* Sources */,
 				C53F2EE920EBC95600D9798F /* Frameworks */,
@@ -2043,9 +2043,9 @@
 				C53F2EDF20EBC95600D9798F /* PBXTargetDependency */,
 				C53F2EE120EBC95600D9798F /* PBXTargetDependency */,
 			);
-			name = Example_CarPlay;
+			name = "Example-CarPlay";
 			productName = "Example-Swift";
-			productReference = C53F2F0720EBC95600D9798F /* Example_CarPlay.app */;
+			productReference = C53F2F0720EBC95600D9798F /* Example.app */;
 			productType = "com.apple.product-type.application";
 		};
 		C5ADFBC81DDCC7840011824B /* MapboxCoreNavigation */ = {
@@ -2202,7 +2202,7 @@
 			projectRoot = "";
 			targets = (
 				358D14621E5E3B7700ADE590 /* Example */,
-				C53F2EDE20EBC95600D9798F /* Example_CarPlay */,
+				C53F2EDE20EBC95600D9798F /* Example-CarPlay */,
 				C5ADFBC81DDCC7840011824B /* MapboxCoreNavigation */,
 				351BEBD61E5BCC28006FE110 /* MapboxNavigation */,
 				35CDA85D2190F2A30072B675 /* TestHelper */,
@@ -3521,7 +3521,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.Example-CarPlay";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = Example;
 				PROVISIONING_PROFILE = "69c90fd8-c53b-41a4-ac73-5bc11068a49a";
 				PROVISIONING_PROFILE_SPECIFIER = "Navigation Example";
 				SWIFT_OBJC_BRIDGING_HEADER = "Example/Example-Swift-BridgingHeader.h";
@@ -3550,7 +3550,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.Example-CarPlay";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = Example;
 				PROVISIONING_PROFILE = "69c90fd8-c53b-41a4-ac73-5bc11068a49a";
 				PROVISIONING_PROFILE_SPECIFIER = "Navigation Example";
 				SWIFT_OBJC_BRIDGING_HEADER = "Example/Example-Swift-BridgingHeader.h";
@@ -3847,7 +3847,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example_CarPlay" */ = {
+		C53F2F0420EBC95600D9798F /* Build configuration list for PBXNativeTarget "Example-CarPlay" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C53F2F0520EBC95600D9798F /* Debug */,

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-CarPlay.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-CarPlay.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-               BuildableName = "Example-CarPlay.app"
-               BlueprintName = "Example-CarPlay"
+               BuildableName = "Example_CarPlay.app"
+               BlueprintName = "Example_CarPlay"
                ReferencedContainer = "container:MapboxNavigation.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -31,8 +31,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-            BuildableName = "Example-CarPlay.app"
-            BlueprintName = "Example-CarPlay"
+            BuildableName = "Example_CarPlay.app"
+            BlueprintName = "Example_CarPlay"
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -54,8 +54,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-            BuildableName = "Example-CarPlay.app"
-            BlueprintName = "Example-CarPlay"
+            BuildableName = "Example_CarPlay.app"
+            BlueprintName = "Example_CarPlay"
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -71,8 +71,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-            BuildableName = "Example-CarPlay.app"
-            BlueprintName = "Example-CarPlay"
+            BuildableName = "Example_CarPlay.app"
+            BlueprintName = "Example_CarPlay"
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-CarPlay.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/Example-CarPlay.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-               BuildableName = "Example_CarPlay.app"
-               BlueprintName = "Example_CarPlay"
+               BuildableName = "Example-CarPlay.app"
+               BlueprintName = "Example-CarPlay"
                ReferencedContainer = "container:MapboxNavigation.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -31,8 +31,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-            BuildableName = "Example_CarPlay.app"
-            BlueprintName = "Example_CarPlay"
+            BuildableName = "Example-CarPlay.app"
+            BlueprintName = "Example-CarPlay"
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -54,8 +54,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-            BuildableName = "Example_CarPlay.app"
-            BlueprintName = "Example_CarPlay"
+            BuildableName = "Example-CarPlay.app"
+            BlueprintName = "Example-CarPlay"
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -71,8 +71,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C53F2EDE20EBC95600D9798F"
-            BuildableName = "Example_CarPlay.app"
-            BlueprintName = "Example_CarPlay"
+            BuildableName = "Example-CarPlay.app"
+            BlueprintName = "Example-CarPlay"
             ReferencedContainer = "container:MapboxNavigation.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Sources/MapboxNavigation/CPMapTemplate.swift
+++ b/Sources/MapboxNavigation/CPMapTemplate.swift
@@ -1,6 +1,5 @@
 import Foundation
 import MapboxDirections
-#if canImport(CarPlay)
 import CarPlay
 
 @available(iOS 12.0, *)
@@ -32,5 +31,4 @@ extension CLLocationDirection {
         self = heading.wrap(min: 0, max: 360)
     }
 }
-#endif
 

--- a/Sources/MapboxNavigation/CPTrip.swift
+++ b/Sources/MapboxNavigation/CPTrip.swift
@@ -1,7 +1,5 @@
 import MapboxDirections
-#if canImport(CarPlay)
 import CarPlay
-#endif
 
 @available(iOS 12.0, *)
 extension CPTrip {

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -493,7 +493,10 @@ extension CarPlayManager: CPMapTemplateDelegate {
         currentNavigator = navigationViewController
 
         carPlayMapViewController.isOverviewingRoutes = false
-        carPlayMapViewController.present(navigationViewController, animated: true, completion: nil)
+        navigationViewController.modalPresentationStyle = .fullScreen
+        carPlayMapViewController.present(navigationViewController, animated: true) {
+            self.delegate?.carPlayManager(self, didPresent: navigationViewController)
+        }
 
         let mapView = carPlayMapViewController.mapView
         mapView.removeRoutes()
@@ -702,6 +705,51 @@ extension CarPlayManager: MapTemplateProviderDelegate {
     
     func mapTemplateProvider(_ provider: MapTemplateProvider, mapTemplate: CPMapTemplate, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, for activity: CarPlayActivity) -> [CPBarButton]? {
         return delegate?.carPlayManager(self, trailingNavigationBarButtonsCompatibleWith: traitCollection, in: mapTemplate, for: activity)
+    }
+}
+
+@available(iOS 13.0, *)
+extension CarPlayManager {
+    public func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnectCarInterfaceController interfaceController: CPInterfaceController, to window: CPWindow) {
+        CarPlayManager.isConnected = true
+        interfaceController.delegate = self
+        self.interfaceController = interfaceController
+
+        if let shouldDisableIdleTimer = delegate?.carplayManagerShouldDisableIdleTimer(self) {
+            UIApplication.shared.isIdleTimerDisabled = shouldDisableIdleTimer
+        } else {
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
+
+        let carPlayMapViewController = CarPlayMapViewController(styles: styles)
+        window.rootViewController = carPlayMapViewController
+        self.carWindow = window
+
+        let mapTemplate = self.mapTemplate(for: interfaceController)
+        mainMapTemplate = mapTemplate
+        interfaceController.setRootTemplate(mapTemplate, animated: false)
+
+        eventsManager.sendCarPlayConnectEvent()
+    }
+
+    public func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectCarInterfaceController interfaceController: CPInterfaceController, from window: CPWindow) {
+        CarPlayManager.isConnected = false
+        self.interfaceController = nil
+
+        window.rootViewController = nil
+        window.isHidden = true
+        window.removeFromSuperview()
+
+        mainMapTemplate = nil
+        carWindow = nil
+
+        eventsManager.sendCarPlayDisconnectEvent()
+
+        if let shouldDisableIdleTimer = delegate?.carplayManagerShouldDisableIdleTimer(self) {
+            UIApplication.shared.isIdleTimerDisabled = !shouldDisableIdleTimer
+        } else {
+            UIApplication.shared.isIdleTimerDisabled = false
+        }
     }
 }
 

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -692,7 +692,7 @@ extension CarPlayManager: CarPlayNavigationDelegate {
 
         interfaceController.setRootTemplate(mapTemplate, animated: true)
         popToRootTemplate(interfaceController: interfaceController, animated: true)
-        
+
         delegate?.carPlayManagerDidEndNavigation(self)
     }
 }

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -1,4 +1,3 @@
-#if canImport(CarPlay)
 import CarPlay
 import MapboxCoreNavigation
 import MapboxDirections
@@ -783,15 +782,3 @@ internal class MapTemplateProvider: NSObject {
         return CPMapTemplate()
     }
 }
-
-#else
-/**
- CarPlay support requires iOS 12.0 or above and the CarPlay framework.
- */
-public class CarPlayManager: NSObject {
-    /**
-     A Boolean value indicating whether the phone is connected to CarPlay.
-     */
-    public static var isConnected = false
-}
-#endif

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -249,5 +249,12 @@ public extension CarPlayManagerDelegate {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
         return false
     }
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager, didPresent navigationViewController: CarPlayNavigationViewController) {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
+    }
 }
 #endif

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -1,4 +1,3 @@
-#if canImport(CarPlay)
 import CarPlay
 import Turf
 import MapboxCoreNavigation
@@ -257,4 +256,3 @@ public extension CarPlayManagerDelegate {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self,  level: .debug)
     }
 }
-#endif

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -153,6 +153,8 @@ public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
      - returns: A Boolean value indicating whether to disable idle timer when carplay is connected and enable when disconnected.
      */
     func carplayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool
+
+    func carPlayManager(_ carPlayManager: CarPlayManager, didPresent navigationViewController: CarPlayNavigationViewController) -> ()
 }
 
 @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-#if canImport(CarPlay)
 import CarPlay
 
 /**
@@ -229,5 +228,4 @@ extension CarPlayMapViewController: StyleManagerDelegate {
         mapView.reloadStyle(self)
     }
 }
-#endif
 

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -1,7 +1,6 @@
 import Foundation
 import MapboxDirections
 import MapboxCoreNavigation
-#if canImport(CarPlay)
 import CarPlay
 
 /**
@@ -594,4 +593,3 @@ public extension CarPlayNavigationDelegate {
         //no-op, deprecated method
     }
 }
-#endif

--- a/Sources/MapboxNavigation/CarPlaySearchController+CPSearchTemplateDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlaySearchController+CPSearchTemplateDelegate.swift
@@ -1,4 +1,4 @@
-#if canImport(CarPlay) && canImport(MapboxGeocoder)
+#if canImport(MapboxGeocoder)
 import Foundation
 import CarPlay
 import MapboxGeocoder

--- a/Sources/MapboxNavigation/CarPlaySearchController.swift
+++ b/Sources/MapboxNavigation/CarPlaySearchController.swift
@@ -1,4 +1,3 @@
-#if canImport(CarPlay)
 import CarPlay
 import MapboxDirections
 
@@ -39,9 +38,3 @@ public class CarPlaySearchController: NSObject {
      */
     public weak var delegate: CarPlaySearchControllerDelegate?
 }
-#else
-/**
- CarPlay support requires iOS 12.0 or above and the CarPlay framework.
- */
-public class CarPlaySearchController: NSObject {}
-#endif

--- a/Sources/MapboxNavigation/CongestionLevel.swift
+++ b/Sources/MapboxNavigation/CongestionLevel.swift
@@ -1,6 +1,5 @@
 import Foundation
 import MapboxDirections
-#if canImport(CarPlay)
 import CarPlay
 
 extension CongestionLevel {
@@ -23,4 +22,3 @@ extension CongestionLevel {
         }
     }
 }
-#endif

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -135,6 +135,10 @@ open class DayStyle: Style {
         LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).secondaryColor = .defaultLaneArrowSecondary
         LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).primaryColorHighlighted = .defaultLaneArrowPrimaryHighlighted
         LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).secondaryColorHighlighted = .defaultLaneArrowSecondaryHighlighted
+        LaneView.appearance().primaryColor = .defaultLaneArrowPrimaryCarPlay
+        LaneView.appearance().secondaryColor = .defaultLaneArrowSecondaryCarPlay
+        LaneView.appearance().primaryColorHighlighted = .defaultLaneArrowPrimaryHighlighted
+        LaneView.appearance().secondaryColorHighlighted = .defaultLaneArrowSecondaryHighlighted
         LanesView.appearance().backgroundColor = #colorLiteral(red: 0.968627451, green: 0.968627451, blue: 0.968627451, alpha: 1)
         LineView.appearance().lineColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.1)
         ManeuverView.appearance().backgroundColor = .clear

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -80,13 +80,11 @@ open class DayStyle: Style {
         Button.appearance().textColor = .defaultPrimaryText
         CancelButton.appearance().tintColor = .defaultPrimaryText
         
-        #if canImport(CarPlay)
         CarPlayCompassView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.6022227113)
         CarPlayCompassView.appearance().cornerRadius = 4
         CarPlayCompassView.appearance().borderWidth = 1.0 / (UIScreen.mainCarPlay?.scale ?? 2.0)
         CarPlayCompassView.appearance().borderColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 0.6009573063)
-        #endif
-        
+
         DismissButton.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         DismissButton.appearance().textColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
         DismissButton.appearance().textFont = UIFont.systemFont(ofSize: 20, weight: .medium).adjustedFont

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -20,9 +20,7 @@ open class NightStyle: DayStyle {
         Button.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         CancelButton.appearance().tintColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         
-        #if canImport(CarPlay)
         CarPlayCompassView.appearance().backgroundColor = backgroundColor
-        #endif
         
         DismissButton.appearance().backgroundColor = backgroundColor
         DismissButton.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -43,7 +43,10 @@ open class NightStyle: DayStyle {
         FloatingButton.appearance().tintColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         GenericRouteShield.appearance().foregroundColor = .white
         InstructionsBannerView.appearance().backgroundColor = backgroundColor
-        LaneView.appearance().primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
+        LaneView.appearance().primaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        LaneView.appearance().secondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.3)
+        LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).primaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        LaneView.appearance(whenContainedInInstancesOf: [LanesView.self]).secondaryColor = #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1)
         LanesView.appearance().backgroundColor = backgroundColor
         ManeuverView.appearance().backgroundColor = .clear
         ManeuverView.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).primaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)

--- a/Sources/MapboxNavigation/RecentItem.swift
+++ b/Sources/MapboxNavigation/RecentItem.swift
@@ -1,4 +1,4 @@
-#if canImport(CarPlay) && canImport(MapboxGeocoder)
+#if canImport(MapboxGeocoder)
 import Foundation
 import MapboxGeocoder
 import CarPlay

--- a/Sources/MapboxNavigation/UIScreen.swift
+++ b/Sources/MapboxNavigation/UIScreen.swift
@@ -1,5 +1,4 @@
 import Foundation
-#if canImport(CarPlay)
 import CarPlay
 
 extension UIScreen {
@@ -7,4 +6,3 @@ extension UIScreen {
         return UIScreen.screens.filter { $0.traitCollection.containsTraits(in: UITraitCollection(userInterfaceIdiom: .carPlay)) }.first
     }
 }
-#endif

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -1,7 +1,5 @@
 import MapboxDirections
-#if canImport(CarPlay)
 import CarPlay
-#endif
 
 extension VisualInstruction {
     var laneComponents: [Component] {
@@ -73,7 +71,6 @@ extension VisualInstruction {
         return newImage
     }
     
-    #if canImport(CarPlay)
     /// Returns a `CPImageSet` representing the maneuver.
     @available(iOS 12.0, *)
     public func maneuverImageSet(side: DrivingSide) -> CPImageSet? {
@@ -172,5 +169,4 @@ extension VisualInstruction {
         }
         return nil
     }
-    #endif
 }

--- a/Tests/MapboxNavigationTests/CPMapTemplateTests.swift
+++ b/Tests/MapboxNavigationTests/CPMapTemplateTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import MapboxNavigation
-#if canImport(CarPlay)
 import CarPlay
 
 @available(iOS 12.0, *)
@@ -20,4 +19,3 @@ class CPMapTemplateTests: XCTestCase {
         XCTAssertNil(CLLocationDirection(panDirection: []))
     }
 }
-#endif

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -5,7 +5,6 @@ import MapboxMobileEvents
 @testable import TestHelper
 @testable import MapboxNavigation
 
-#if canImport(CarPlay)
 import CarPlay
 
 // For some reason XCTest bundles ignore @available annotations and these tests are run on iOS < 12 :(
@@ -669,4 +668,3 @@ class FakeCPInterfaceController: CPInterfaceController {
         }
     }
 }
-#endif

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -445,6 +445,10 @@ class CarPlayManagerSpec: QuickSpec {
             let directionsFake = Directions(credentials: Fixture.credentials)
             return MapboxNavigationService(route: route, routeIndex: routeIndex, routeOptions: routeOptions, directions: directionsFake, simulating: desiredSimulationMode)
         }
+
+        func carPlayManager(_ carPlayManager: CarPlayManager, didPresent navigationViewController: CarPlayNavigationViewController) {
+            //no-op
+        }
     }
 }
 
@@ -481,6 +485,10 @@ class CarPlayManagerFailureDelegateSpy: CarPlayManagerDelegate {
     }
     
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+        fatalError("This is an empty stub.")
+    }
+
+    func carPlayManager(_ carPlayManager: CarPlayManager, didPresent navigationViewController: CarPlayNavigationViewController) {
         fatalError("This is an empty stub.")
     }
 }
@@ -529,6 +537,10 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
         XCTAssertTrue(navigationInitiated)
         navigationEnded = true
         currentService = nil
+    }
+
+    func carPlayManager(_ carPlayManager: CarPlayManager, didPresent navigationViewController: CarPlayNavigationViewController) {
+        XCTAssertTrue(navigationInitiated)
     }
 }
 


### PR DESCRIPTION
### Description

In iOS 13 Apple added a Template-based mechanism for providing CarPlay support to apps. The Nav SDK needs to include support for these newer APIs while ensuring we don't break the earlier iOS 12 CarPlay delegate pattern until we drop support for iOS 12.

Fixes #2260 

### Implementation
The changes required within the Nav SDK are fairly minimal, mainly adding conformance to the CPTemplateApplicationSceneDelegate protocol. More extensive changes are needed to the Example app in order to adopt UIScene support.
