### PR TITLE
Speed limit view updates during free-driving

### DIFF
--- a/Example/ViewController+FreeDrive.swift
+++ b/Example/ViewController+FreeDrive.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Turf
+import MapboxDirections
 import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxCoreMaps
@@ -42,6 +43,9 @@ extension ViewController {
         if let rawLocation = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.rawLocationKey] as? CLLocation {
             rawTrackStyledFeature.lineString.coordinates.append(contentsOf: [rawLocation.coordinate])
         }
+        
+        speedLimitView.signStandard = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.signStandardKey] as? SignStandard
+        speedLimitView.speedLimit = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.speedLimitKey] as? Measurement<UnitSpeed>
         
         updateFreeDriveStyledFeatures()
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -65,7 +65,6 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupSpeedLimitView()
-        observeSpeedNotifications()
         view.addSubview(speedLimitView)
     }
     
@@ -76,12 +75,7 @@ class ViewController: UIViewController {
         speedLimitView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
         speedLimitView.widthAnchor.constraint(equalToConstant: 50).isActive = true
         speedLimitView.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        switch speedLimitViewPosition {
-        case .topLeading:
-            speedLimitView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10).isActive = true
-        case .topTrailing:
-            speedLimitView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10).isActive = true
-        }
+        speedLimitView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10).isActive = true
         
         self.speedLimitView = speedLimitView
     }
@@ -163,15 +157,6 @@ class ViewController: UIViewController {
 
     @IBAction func startButtonPressed(_ sender: Any) {
         presentActionsAlertController()
-    }
-    
-    func observeSpeedNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateSpeedLimitView(notification:)), name:.passiveLocationDataSourceDidUpdate, object: nil)
-    }
-    
-    @objc func updateSpeedLimitView(notification: Notification) {
-        speedLimitView.speedLimit = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.speedLimitKey] as? Measurement<UnitSpeed>
-        speedLimitView.signStandard = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.signStandardKey] as? SignStandard
     }
     
     // MARK: - CarPlay navigation methods

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -19,7 +19,6 @@ class ViewController: UIViewController {
     var trackStyledFeature: StyledFeature!
     var rawTrackStyledFeature: StyledFeature!
     var speedLimitView: SpeedLimitView!
-    var speedLimitViewPosition: MapOrnamentPosition = .topTrailing
     
     typealias RouteRequestSuccess = ((RouteResponse) -> Void)
     typealias RouteRequestFailure = ((Error) -> Void)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -18,6 +18,7 @@ class ViewController: UIViewController {
     
     var trackStyledFeature: StyledFeature!
     var rawTrackStyledFeature: StyledFeature!
+    var speedLimitView: SpeedLimitView
     
     typealias RouteRequestSuccess = ((RouteResponse) -> Void)
     typealias RouteRequestFailure = ((Error) -> Void)
@@ -137,6 +138,16 @@ class ViewController: UIViewController {
 
     @IBAction func startButtonPressed(_ sender: Any) {
         presentActionsAlertController()
+    }
+    
+    func observeSpeedNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(updateSpeedLimitView(notification:)), name:.passiveLocationDataSourceDidUpdate, object: nil)
+    }
+    
+    @objc func updateSpeedLimitView(notification: Notification) {
+        speedLimitView.speedLimit = notification.userInfo?["speedLimit"] as? Measurement<UnitSpeed>
+//        FIX SIGN STANDARD
+        speedLimitView.signStandard = .mutcd
     }
     
     // MARK: - CarPlay navigation methods

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -18,7 +18,8 @@ class ViewController: UIViewController {
     
     var trackStyledFeature: StyledFeature!
     var rawTrackStyledFeature: StyledFeature!
-    var speedLimitView: SpeedLimitView
+    var speedLimitView: SpeedLimitView!
+    var speedLimitViewPosition: MapOrnamentPosition = .topTrailing
     
     typealias RouteRequestSuccess = ((RouteResponse) -> Void)
     typealias RouteRequestFailure = ((Error) -> Void)
@@ -60,6 +61,30 @@ class ViewController: UIViewController {
     weak var activeNavigationViewController: NavigationViewController?
     
     // MARK: - UIViewController lifecycle methods
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupSpeedLimitView()
+        observeSpeedNotifications()
+        view.addSubview(speedLimitView)
+    }
+    
+    func setupSpeedLimitView() {
+        let speedLimitView = SpeedLimitView()
+        speedLimitView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(speedLimitView)
+        speedLimitView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
+        speedLimitView.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        speedLimitView.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        switch speedLimitViewPosition {
+        case .topLeading:
+            speedLimitView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10).isActive = true
+        case .topTrailing:
+            speedLimitView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10).isActive = true
+        }
+        
+        self.speedLimitView = speedLimitView
+    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -145,9 +170,8 @@ class ViewController: UIViewController {
     }
     
     @objc func updateSpeedLimitView(notification: Notification) {
-        speedLimitView.speedLimit = notification.userInfo?["speedLimit"] as? Measurement<UnitSpeed>
-//        FIX SIGN STANDARD
-        speedLimitView.signStandard = .mutcd
+        speedLimitView.speedLimit = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.speedLimitKey] as? Measurement<UnitSpeed>
+        speedLimitView.signStandard = notification.userInfo?[PassiveLocationDataSource.NotificationUserInfoKey.signStandardKey] as? SignStandard
     }
     
     // MARK: - CarPlay navigation methods

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -276,9 +276,14 @@ extension PassiveLocationDataSource {
         public static let roadNameKey: NotificationUserInfoKey = .init(rawValue: "roadName")
         
         /**
-         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a TYPE representating the speed of the current road.
+         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a `Measurement<UnitSpeed>` representating the speed of the current road.
          */
         public static let speedLimitKey: NotificationUserInfoKey = .init(rawValue: "speedLimit")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a `SignStandard` representating the speed of the current road.
+         */
+        public static let signStandardKey: NotificationUserInfoKey = .init(rawValue: "signStandard")
     }
 }
 

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -276,12 +276,12 @@ extension PassiveLocationDataSource {
         public static let roadNameKey: NotificationUserInfoKey = .init(rawValue: "roadName")
         
         /**
-         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a `Measurement<UnitSpeed>` representating the speed of the current road.
+         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a `Measurement<UnitSpeed>` representing the maximum speed limit of the current road.
          */
         public static let speedLimitKey: NotificationUserInfoKey = .init(rawValue: "speedLimit")
         
         /**
-         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a `SignStandard` representating the speed of the current road.
+         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a `SignStandard` representing the sign standard used for speed limit signs along the current road.
          */
         public static let signStandardKey: NotificationUserInfoKey = .init(rawValue: "signStandard")
     }

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -274,6 +274,11 @@ extension PassiveLocationDataSource {
          - seealso: `WayNameView`
          */
         public static let roadNameKey: NotificationUserInfoKey = .init(rawValue: "roadName")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.passiveLocationDataSourceDidUpdate` notification. The corresponding value is a TYPE representating the speed of the current road.
+         */
+        public static let speedLimitKey: NotificationUserInfoKey = .init(rawValue: "speedLimit")
     }
 }
 

--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -90,6 +90,7 @@ open class PassiveLocationDataSource: NSObject {
             NotificationUserInfoKey.rawLocationKey: lastRawLocation,
             NotificationUserInfoKey.matchesKey: matches,
             NotificationUserInfoKey.roadNameKey: status.roadName,
+            NotificationUserInfoKey.speedLimitKey: status.speedLimit
         ])
     }
 }


### PR DESCRIPTION
### Description
This PR adds a speed limit view that updates during free-driving #2797.
- [x]  Post/observe `passiveLocationDataSourceDidUpdate` notifications for `NavigationStatus.speedLimit` and `NavigationStatus.signStandard`
- [x] Add `SpeedLimitView` UI to respond to notifications to update the speed limit and sign standard accordingly
- [x] Update CHANGELOG.md
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->

### Implementation
Posted notifications in PassiveLocationDataSource.swift for the `speedLimit` and `signStandard`. Added methods to set up the view, observe notifications from `passiveLocationDataSource`, and update the `SpeedLimitView` accordingly.
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
![Simulator Screen Shot - iPhone 8 - 2021-03-02 at 17 53 38](https://user-images.githubusercontent.com/43434254/109727291-13052000-7b82-11eb-9602-7f227fdd0c26.png)
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->