### PR TITLE
Onboard Routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * Removed deprecated `InstructionsBannerViewDelegate.didDragInstructionsBanner(_:)` method. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Removed `NavigationViewController.origin` property, which was not used. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * A new predictive cache proactively fetches tiles which may become necessary if the device loses its Internet connection at some point during passive or active turn-by-turn navigation. Pass a `PredictiveCacheOptions` instance into the `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:predictiveCacheOptions:)` initializer as you configure a `NavigationViewController`, or manually call `NavigationMapView.enablePredictiveCaching(options:)`. ([#2830](https://github.com/mapbox/mapbox-navigation-ios/pull/2830))
-* Added posibility for offline routing and re-routing using `Directions.calculateOffline(_:completionHandler:)` and `Directions.calculateWithCache(_:completionHandler:)`. `Router` default implementation is now configured to use the latter. ([#2848](https://github.com/mapbox/mapbox-navigation-ios/pull/2848)) 
+* Added the `Directions.calculateOffline(options:completionHandler:)` and `Directions.calculateWithCache(options:completionHandler:)` methods, which incorporate routing tiles from the predictive cache when possible to avoid relying on a network connection to calculate the route. `RouteController` now also uses the predictive cache when rerouting. ([#2848](https://github.com/mapbox/mapbox-navigation-ios/pull/2848)) 
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 * Removed deprecated `InstructionsBannerViewDelegate.didDragInstructionsBanner(_:)` method. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Removed `NavigationViewController.origin` property, which was not used. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
+* Added posibility for offline routing and re-routing using `Directions.calculateOffline(_:completionHandler:)` and `Directions.calculateWithCache(_:completionHandler:)`. `Router` default implementation is now configured to use the latter. ([#2848](https://github.com/mapbox/mapbox-navigation-ios/pull/2848)) 
 
 ## v1.3.0
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -380,7 +380,7 @@ class ViewController: UIViewController {
     }
 
     func requestRoute(with options: RouteOptions, success: @escaping RouteRequestSuccess, failure: RouteRequestFailure?) {
-        Directions.shared.calculate(options) { (session, result) in
+        Directions.shared.calculateWithCache(options) { (session, result) in
             switch result {
             case let .success(response):
                 success(response)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -380,7 +380,7 @@ class ViewController: UIViewController {
     }
 
     func requestRoute(with options: RouteOptions, success: @escaping RouteRequestSuccess, failure: RouteRequestFailure?) {
-        Directions.shared.calculateWithCache(options) { (session, result) in
+        Directions.shared.calculateWithCache(options: options) { (session, result) in
             switch result {
             case let .success(response):
                 success(response)

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2B8098432411447E00FED452 /* MultiplexedSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8098422411447E00FED452 /* MultiplexedSpeechSynthesizer.swift */; };
 		2B81EC28241A237E00145086 /* SpeechSynthesizersControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B81EC27241A237E00145086 /* SpeechSynthesizersControllerTests.swift */; };
 		2B91C9B12416357700E532A5 /* MapboxSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B91C9B02416357700E532A5 /* MapboxSpeechSynthesizer.swift */; };
+		2B955B1C25EFDDCB00BBFEC6 /* Directions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B955B1B25EFDDCB00BBFEC6 /* Directions.swift */; };
 		2BBEEDA52508DB1700C8DA4A /* RouteLegProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBEEDA42508DB1700C8DA4A /* RouteLegProgress.swift */; };
 		2BBEEDA72508E1E300C8DA4A /* RouteStepProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBEEDA62508E1E300C8DA4A /* RouteStepProgress.swift */; };
 		2BE701172535940D00F46E4E /* Tunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE701162535940D00F46E4E /* Tunnel.swift */; };
@@ -352,8 +353,8 @@
 		DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA443DDD2278C90E00ED1307 /* CPTrip.swift */; };
 		DA66063023B32F99007832E5 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA66062F23B32F99007832E5 /* Array.swift */; };
 		DA754E1923AC56E5007E16B5 /* MBXAccountsLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = DA754E1723AC56E5007E16B5 /* MBXAccountsLoader.m */; };
+		DA85D5EF25DB4AA4008A2AD4 /* LaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA85D5EE25DB4AA3008A2AD4 /* LaneViewTests.swift */; };
 		DA8805002316EAED00B54D87 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
-		DA85D5EF25DB4AA4008A2AD4 /* LaneViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA85D5EE25DB4AA3008A2AD4 /* LaneViewTests.swift */; };		DA8805002316EAED00B54D87 /* ViewController+GuidanceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */; };
 		DA8F3A7623B5D84900B56786 /* SpeedLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7523B5D84900B56786 /* SpeedLimitView.swift */; };
 		DA8F3A7823B5DB7900B56786 /* SpeedLimitStyleKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8F3A7723B5DB7900B56786 /* SpeedLimitStyleKit.swift */; };
 		DAA96D18215A961D00BEF703 /* route-doubling-back.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA96D17215A961D00BEF703 /* route-doubling-back.json */; };
@@ -511,6 +512,7 @@
 		2B8098422411447E00FED452 /* MultiplexedSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplexedSpeechSynthesizer.swift; sourceTree = "<group>"; };
 		2B81EC27241A237E00145086 /* SpeechSynthesizersControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechSynthesizersControllerTests.swift; sourceTree = "<group>"; };
 		2B91C9B02416357700E532A5 /* MapboxSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxSpeechSynthesizer.swift; sourceTree = "<group>"; };
+		2B955B1B25EFDDCB00BBFEC6 /* Directions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Directions.swift; sourceTree = "<group>"; };
 		2BBEEDA42508DB1700C8DA4A /* RouteLegProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteLegProgress.swift; sourceTree = "<group>"; };
 		2BBEEDA62508E1E300C8DA4A /* RouteStepProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStepProgress.swift; sourceTree = "<group>"; };
 		2BE701162535940D00F46E4E /* Tunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tunnel.swift; sourceTree = "<group>"; };
@@ -1618,6 +1620,7 @@
 				359574A71F28CC3800838209 /* CLLocation.swift */,
 				C582FD5E203626E900A9086E /* CLLocationDirection.swift */,
 				C5D9800E1EFBCDAD006DBF2E /* Date.swift */,
+				2B955B1B25EFDDCB00BBFEC6 /* Directions.swift */,
 				3A163AE2249901D000D66A0D /* FixLocation.swift */,
 				C51DF8651F38C31C006C6A15 /* Locale.swift */,
 				35F3387B2232AEBF0071DB5C /* MinimumEditDistance.swift */,
@@ -2641,6 +2644,7 @@
 				35A5413B1EFC052700E49846 /* RouteOptions.swift in Sources */,
 				353E69041EF0C4E5007B2AE5 /* SimulatedLocationManager.swift in Sources */,
 				DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */,
+				2B955B1C25EFDDCB00BBFEC6 /* Directions.swift in Sources */,
 				5A39B9282498F9890026DFD1 /* PassiveLocationDataSource.swift in Sources */,
 				C5C94C1D1DDCD2370097296A /* RouteProgress.swift in Sources */,
 				2BE701352535948100F46E4E /* RestStop.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -37,6 +37,8 @@ class Navigator {
     
     var navigator: MapboxNavigationNative.Navigator!
     
+    var cacheHandle: CacheHandle!
+    
     /**
      Provides a new or an existing `MapboxCoreNavigation.Navigator` instance. Upon first initialization will trigger creation of `MapboxNavigationNative.Navigator` and `HistoryRecorderHandle` instances,
      satisfying provided configuration (`tilesVersion` and `tilesURL`).
@@ -75,14 +77,14 @@ class Navigator {
         instance.historyRecorder = try! HistoryRecorderHandle.build(forConfig: configFactory)
         
         let runloopExecutor = try! RunLoopExecutorFactory.build()
-        let cacheHandle = try! CacheFactory.build(for: tilesConfig,
-                                                  config: configFactory,
-                                                  runLoop: runloopExecutor,
-                                                  historyRecorder: instance.historyRecorder)
+        instance.cacheHandle = try! CacheFactory.build(for: tilesConfig,
+                                                       config: configFactory,
+                                                       runLoop: runloopExecutor,
+                                                       historyRecorder: instance.historyRecorder)
         
         instance.navigator = try! MapboxNavigationNative.Navigator(config: configFactory,
                                                                    runLoopExecutor: runloopExecutor,
-                                                                   cache: cacheHandle,
+                                                                   cache: instance.cacheHandle,
                                                                    historyRecorder: instance.historyRecorder)
         
         return instance

--- a/Sources/MapboxCoreNavigation/Directions.swift
+++ b/Sources/MapboxCoreNavigation/Directions.swift
@@ -1,0 +1,76 @@
+
+import Foundation
+import Network
+import MapboxDirections
+import MapboxNavigationNative
+
+extension Directions {
+    
+    /**
+     Begins asynchronously calculating routes using the given options and delivers the results to a closure.
+     
+     This method retrieves the routes asynchronously from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/navigation/#directions) over a network connection. If a  server error occurs, details about the error are passed into the given completion handler in lieu of the routes. If network error is encountered, onboard routing engine will attempt to provide directions using existing cached tiles.
+     
+     Routes may be displayed atop a [Mapbox map](https://www.mapbox.com/maps/).
+     
+     - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
+     - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
+     - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel this task.
+     */
+    @discardableResult open func calculateWithCache(_ options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) -> URLSessionDataTask? {
+        return calculate(options) { (session, result) in
+            switch result {
+            case .success(_):
+                completionHandler(session, result)
+            case .failure(let error):
+                if case DirectionsError.network(_) = error {
+                    // we're offline
+                    self.calculateOffline(options) {
+                        completionHandler(session, $0)
+                    }
+                } else {
+                    completionHandler(session, result)
+                }
+            }
+            
+        }
+    }
+    
+    /**
+     Begins asynchronously calculating routes using the given options and delivers the results to a closure.
+     
+     This method retrieves the routes asynchronously from onboard routing engine using existing cached tiles.
+     
+     Routes may be displayed atop a [Mapbox map](https://www.mapbox.com/maps/).
+     
+     - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
+     - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
+     */
+    open func calculateOffline(_ options: RouteOptions, completionHandler: @escaping (Result<RouteResponse, DirectionsError>) -> ()) {
+        let directionsUri = url(forCalculating: options)
+        
+        let nativeRouter = try! MapboxNavigationNative.Router(cache: Navigator.shared.cacheHandle,
+                                                              historyRecorder: Navigator.shared.historyRecorder)
+        try? nativeRouter.getRouteForDirectionsUri(directionsUri.path) { (result) in
+            let json = result?.value as? String
+            let data = json?.data(using: .utf8)
+            let decoder = JSONDecoder()
+            decoder.userInfo = [.options: options,
+                                .credentials: self.credentials]
+            
+            if let jsonData = data,
+               let response = try? decoder.decode(RouteResponse.self, from: jsonData) {
+                DispatchQueue.main.async {
+                    completionHandler(.success(response))
+                }
+            } else {
+                DispatchQueue.main.async {
+                    completionHandler(.failure(.unknown(response: nil,
+                                                        underlying: result?.error as? Error,
+                                                        code: nil,
+                                                        message: nil)))
+                }
+            }
+        }
+    }
+}

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -226,7 +226,7 @@ extension InternalRouter where Self: Router {
         
         lastRerouteLocation = location
         
-        routeTask = directions.calculate(options) {(session, result) in
+        routeTask = directions.calculateWithCache(options) {(session, result) in
             
             guard case let .success(response) = result else {
                 return completion(session, result)

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -226,7 +226,7 @@ extension InternalRouter where Self: Router {
         
         lastRerouteLocation = location
         
-        routeTask = directions.calculateWithCache(options) {(session, result) in
+        routeTask = directions.calculateWithCache(options: options) {(session, result) in
             
             guard case let .success(response) = result else {
                 return completion(session, result)

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -391,7 +391,7 @@ extension CarPlayManager {
     }
     
     internal func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) {
-        directions.calculate(options, completionHandler: completionHandler)
+        directions.calculateWithCache(options, completionHandler: completionHandler)
     }
     
     internal func didCalculate(_ result: Result<RouteResponse, DirectionsError>,in session: Directions.Session, for routeOptions: RouteOptions, completionHandler: CompletionHandler) {

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -391,7 +391,7 @@ extension CarPlayManager {
     }
     
     internal func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) {
-        directions.calculateWithCache(options, completionHandler: completionHandler)
+        directions.calculateWithCache(options: options, completionHandler: completionHandler)
     }
     
     internal func didCalculate(_ result: Result<RouteResponse, DirectionsError>,in session: Directions.Session, for routeOptions: RouteOptions, completionHandler: CompletionHandler) {


### PR DESCRIPTION
added Directions extension to utilize Navigatio……nNative.Router for offline routing. Extended CoreNavigationNavigator to also share cacheHandle

### Description
This PR adds usage of Navigation Native `Router` which is used for providing offline (onboard) directions utilising existing cached tile data.

### Implementation
Added an extension for `Directions` with 2 convenience methods: one to attempt usual online routing with automatic fallback to onboard engine, and another one for purely offline calculation.
Currently `Router` does not support Map Matching requests, so implementation covers only `directions`. In the future it may be easily extended.