### PR TITLE
Fix partially visible maneuver problem

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -518,9 +518,9 @@ open class NavigationMapView: UIView {
             var parentLayer: String? = nil
             let identifiers = [
                 IdentifierString.arrow,
-                IdentifierString.arrowStroke,
-                IdentifierString.arrowCasingSymbol,
                 IdentifierString.arrowSymbol,
+                IdentifierString.arrowCasingSymbol,
+                IdentifierString.arrowStroke,
                 IdentifierString.waypointCircle
             ]
             

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -518,9 +518,9 @@ open class NavigationMapView: UIView {
             var parentLayer: String? = nil
             let identifiers = [
                 IdentifierString.arrow,
-                IdentifierString.arrowSymbol,
-                IdentifierString.arrowCasingSymbol,
                 IdentifierString.arrowStroke,
+                IdentifierString.arrowCasingSymbol,
+                IdentifierString.arrowSymbol,
                 IdentifierString.waypointCircle
             ]
             
@@ -651,7 +651,7 @@ open class NavigationMapView: UIView {
                 let circles = delegate?.navigationMapView(self, waypointCircleLayerWithIdentifier: IdentifierString.waypointCircle, sourceIdentifier: IdentifierString.waypointSource) ?? defaultWaypointCircleLayer()
                 let symbols = delegate?.navigationMapView(self, waypointSymbolLayerWithIdentifier: IdentifierString.waypointSymbol, sourceIdentifier: IdentifierString.waypointSource) ?? defaultWaypointSymbolLayer()
 
-                if let arrows = try? mapView.style.getLayer(with: IdentifierString.arrowCasingSymbol, type: LineLayer.self).get() {
+                if let arrows = try? mapView.style.getLayer(with: IdentifierString.arrowSymbol, type: LineLayer.self).get() {
                     mapView.style.addLayer(layer: circles, layerPosition: LayerPosition(above: arrows.id))
                 } else {
                     guard let layerIdentifier = identifier(route, identifierType: .route) else { return }
@@ -806,7 +806,7 @@ open class NavigationMapView: UIView {
             arrowSource.data = .feature(Feature(shaftPolyline))
             var arrow = LineLayer(id: IdentifierString.arrow)
             if let _ = try? mapView.style.getSource(identifier: IdentifierString.arrowSource, type: GeoJSONSource.self).get() {
-                let geoJSON = Feature.init(geometry: Geometry.lineString(shaftPolyline))
+                let geoJSON = Feature(shaftPolyline)
                 let _ = mapView.style.updateGeoJSON(for: IdentifierString.arrowSource, with: geoJSON)
             } else {
                 arrow.minZoom = Double(minimumZoomLevel)
@@ -817,18 +817,14 @@ open class NavigationMapView: UIView {
                 
                 mapView.style.addSource(source: arrowSource, identifier: IdentifierString.arrowSource)
                 arrow.source = IdentifierString.arrowSource
-                if let _ = try? mapView.style.getLayer(with: IdentifierString.waypointCircle, type: LineLayer.self).get() {
-                    mapView.style.addLayer(layer: arrow, layerPosition: LayerPosition(above: mainRouteLayerIdentifier, below: IdentifierString.waypointCircle))
-                } else {
-                    mapView.style.addLayer(layer: arrow, layerPosition: LayerPosition(above: mainRouteLayerIdentifier))
-                }
+                mapView.style.addLayer(layer: arrow, layerPosition: LayerPosition(above: mainRouteLayerIdentifier))
             }
             
             var arrowStrokeSource = GeoJSONSource()
             arrowStrokeSource.data = .feature(Feature(shaftPolyline))
             var arrowStroke = LineLayer(id: IdentifierString.arrowStroke)
             if let _ = try? mapView.style.getSource(identifier: IdentifierString.arrowStrokeSource, type: GeoJSONSource.self).get() {
-                let geoJSON = Feature.init(geometry: Geometry.lineString(shaftPolyline))
+                let geoJSON = Feature(shaftPolyline)
                 let _ = mapView.style.updateGeoJSON(for: IdentifierString.arrowStrokeSource, with: geoJSON)
             } else {
                 arrowStroke.minZoom = arrow.minZoom


### PR DESCRIPTION
### Description
This pr is to fix the partially visible maneuver problems during navigation session when multiple waypoints are selected.

### Implementation
By changing the sequence of laying addition to fix the partially visible problem caused by layer overlapping.

### Screenshots or Gifs
![maneuver_fix](https://user-images.githubusercontent.com/48976398/110394932-1c7b0600-8022-11eb-98b3-92bd8c758bb8.png)
