### PR TITLE
Support Driving Side flag

### DIFF
--- a/Sources/MapboxCoreNavigation/EHorizon/ElectronicHorizonEdgeMetadata.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/ElectronicHorizonEdgeMetadata.swift
@@ -51,8 +51,8 @@ extension ElectronicHorizon.Edge {
         /** The ISO 3166-2 code of the country subdivision where this edge is located. */
         public let regionCode: String?
         
-        /** True if in the current place/state uses right-hand traffic, false if left-hand. */
-        public let isRightHandTraffic: Bool
+        /** Indicates which side of a bidirectional road on which the driver must be driving. Also referred to as the rule of the road.. */
+        public let drivingSide: DrivingSide
 
         init(_ native: EdgeMetadata) {
             heading = native.heading
@@ -85,7 +85,7 @@ extension ElectronicHorizon.Edge {
             curvature = UInt(native.curvature)
             countryCode = native.countryCode
             regionCode = native.stateCode
-            isRightHandTraffic = native.isIsRightHandTraffic
+            drivingSide = native.isIsRightHandTraffic ? .right : .left
         }
     }
 }

--- a/Sources/MapboxCoreNavigation/EHorizon/ElectronicHorizonEdgeMetadata.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/ElectronicHorizonEdgeMetadata.swift
@@ -50,6 +50,9 @@ extension ElectronicHorizon.Edge {
 
         /** The ISO 3166-2 code of the country subdivision where this edge is located. */
         public let regionCode: String?
+        
+        /** True if in the current place/state uses right-hand traffic, false if left-hand. */
+        public let isRightHandTraffic: Bool
 
         init(_ native: EdgeMetadata) {
             heading = native.heading
@@ -82,6 +85,7 @@ extension ElectronicHorizon.Edge {
             curvature = UInt(native.curvature)
             countryCode = native.countryCode
             regionCode = native.stateCode
+            isRightHandTraffic = native.isIsRightHandTraffic
         }
     }
 }


### PR DESCRIPTION
### Description
Exposed NN's EdgeMetadata.isRightHandTraffic value.

### Implementation
There is a typo generated by obj-c wrapper: `isIsRightHandTraffic` which should be corrected later. A task for corresponding fix for a wrapper generation is created.
I didn't update `CHANGELOG` because this is a part of the greater EH implementation which should cover this and other updates.