### PR TITLE
Update Transifex configuration after SPM refactor

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -5,19 +5,19 @@ minimum_perc = 80
 type = STRINGS
 
 [mapbox-navigation-ios.LocalizableStrings]
-file_filter = MapboxNavigation/Resources/<lang>.lproj/Localizable.strings
-source_file = MapboxNavigation/Resources/Base.lproj/Localizable.strings
+file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Localizable.strings
+source_file = Sources/MapboxNavigation/Resources/Base.lproj/Localizable.strings
 source_lang = en
 
 [mapbox-navigation-ios.localizablestringsdict]
-file_filter = MapboxNavigation/Resources/<lang>.lproj/Localizable.stringsdict
-source_file = MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
+file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Localizable.stringsdict
+source_file = Sources/MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
 source_lang = en
 type = STRINGSDICT
 
 [mapbox-navigation-ios.LocalizableCoreStrings]
-file_filter = MapboxCoreNavigation/Resources/<lang>.lproj/Localizable.strings
-source_file = MapboxCoreNavigation/Resources/Base.lproj/Localizable.strings
+file_filter = Sources/MapboxCoreNavigation/Resources/<lang>.lproj/Localizable.strings
+source_file = Sources/MapboxCoreNavigation/Resources/Base.lproj/Localizable.strings
 source_lang = en
 
 [mapbox-navigation-ios.ExampleMainStrings]
@@ -26,6 +26,6 @@ source_file = Example/en.lproj/Main.strings
 source_lang = en
 
 [mapbox-navigation-ios.navigationstrings]
-file_filter = MapboxNavigation/Resources/<lang>.lproj/Navigation.strings
-source_file = MapboxNavigation/Resources/Base.lproj/Navigation.strings
+file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Navigation.strings
+source_file = Sources/MapboxNavigation/Resources/Base.lproj/Navigation.strings
 source_lang = en

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -885,7 +885,7 @@
 		AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+GuidanceCards.swift"; path = "Example/ViewController+GuidanceCards.swift"; sourceTree = "<group>"; };
 		AEF2C8F12072B603007B061F /* routeWithTunnels_9thStreetDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = routeWithTunnels_9thStreetDC.json; sourceTree = "<group>"; };
-        B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
+		B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
 		B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-for-vanishing-route-line.json"; sourceTree = "<group>"; };
 		B4F7631B2578751300177B33 /* VanishingRouteLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VanishingRouteLine.swift; sourceTree = "<group>"; };
 		C3D225502587F411007DBCDF /* StatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusViewTests.swift; sourceTree = "<group>"; };
@@ -948,6 +948,7 @@
 		DA0557242155040700A1F2AA /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
 		DA0A4B7724D0BC7000D6B4F8 /* MapboxCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapboxCommon.framework; path = Carthage/Build/iOS/MapboxCommon.framework; sourceTree = "<group>"; };
 		DA0A4B8024D1C9B200D6B4F8 /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		DA0DBA2125FC4CC200E86BDF /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ca; path = Resources/ca.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA1811FE20128B0900C91918 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Navigation.strings; sourceTree = "<group>"; };
 		DA18120120128B7B00C91918 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA18120320128E9400C91918 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -3115,6 +3116,7 @@
 				354691B222C0D97000626C4F /* yo */,
 				8B808F982487D2BE00EEE453 /* el */,
 				DA6C925924C60A43003A0AD6 /* tr */,
+				DA0DBA2125FC4CC200E86BDF /* ca */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";

--- a/Sources/MapboxNavigation/Resources/ca.lproj/Localizable.stringsdict
+++ b/Sources/MapboxNavigation/Resources/ca.lproj/Localizable.stringsdict
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>RATING_ACCESSIBILITY_SET</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>Estableix una puntuació de %ld-estels</string>
+			<key>other</key>
+			<string>Estableix una puntuació de %ld-estels</string>
+		</dict>
+	</dict>
+	<key>RATING_STARS_FORMAT</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@stars@</string>
+		<key>stars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%ld estels assignats.</string>
+			<key>other</key>
+			<string>%ld estels assignats.</string>
+		</dict>
+	</dict>
+	<key>NAVIGATION_REPORT_ISSUES</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@items@</string>
+		<key>items</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>Enviar 1 element</string>
+			<key>other</key>
+			<string>Enviar %ld elements</string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Updated the Transifex configuration to reflect file moves in #2808 to support Swift Package Manager. Also synchronized the localizations with Transifex, pulling in some Catalan translations.

/cc @mapbox/navigation-ios