### PR TITLE
Don't trigger viewDidLoad in NavigationViewController.init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v1.4.0
+
+* Fixed an issue when feedback UI was always appearing for short routes ([#2871](https://github.com/mapbox/mapbox-navigation-ios/pull/2871))
+
 ## v1.3.0
 
 * MapboxCoreNavigation can now be installed using Swift Package Manager. ([#2771](https://github.com/mapbox/mapbox-navigation-ios/pull/2771))

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -329,17 +329,10 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         mapViewController.destination = route.legs.last?.destination
         mapViewController.view.translatesAutoresizingMaskIntoConstraints = false
         
-        embed(mapViewController, in: view) { (parent, map) -> [NSLayoutConstraint] in
-            return map.view.constraintsForPinning(to: parent.view)
-        }
-        
         //Manually update the map style since the RMVC missed the "map style change" notification when the style manager was set up.
         if let currentStyle = styleManager.currentStyle {
             updateMapStyle(currentStyle, animated: false)
         }
-        
-        mapViewController.view.pinInSuperview()
-        mapViewController.reportButton.isHidden = !showsReportFeedback
         
         if !(routeOptions is NavigationRouteOptions) {
             print("`Route` was created using `RouteOptions` and not `NavigationRouteOptions`. Although not required, this may lead to a suboptimal navigation experience. Without `NavigationRouteOptions`, it is not guaranteed you will get congestion along the route line, better ETAs and ETA label color dependent on congestion.")
@@ -365,6 +358,15 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     
     override open func viewDidLoad() {
         super.viewDidLoad()
+        
+        if let mapViewController = mapViewController {
+            embed(mapViewController, in: view) { (parent, map) -> [NSLayoutConstraint] in
+                return map.view.constraintsForPinning(to: parent.view)
+            }
+            mapViewController.view.pinInSuperview()
+            mapViewController.reportButton.isHidden = !showsReportFeedback
+        }
+        
         // Initialize voice controller if it hasn't been overridden.
         // This is optional and lazy so it can be mutated by the developer after init.
         _ = voiceController


### PR DESCRIPTION
### Description
Fixes #2786.

### Implementation
The main problem I see right now is that the initializer of NavigationViewController uses the `view` property and therefore triggers `viewDidLoad`. This in turn triggers `self.navigationService.start()`. It leads to the situation where a user already created NavigationViewController but hasn't presented it just yet but we've started the navigation session. 
Expected behavior for `viewDidLoad` is to be executed when the actual presentation of the NavigationViewController happens.
In fact, current behavior leads to the bug #2786. If the route is very small we can arrive at the final point during the initialization of NavigationViewController. The call stack will look like this:
`init -> viewDidLoad -> navigationService.start() -> .... -> navigationService(_:,didArrive:)`
[At this point,](https://github.com/mapbox/mapbox-navigation-ios/blob/main/Sources/MapboxNavigation/NavigationViewController.swift#L691) we should notify NavigationViewController.delegate about arrival, but `delegate` will be always nil because we are still inside of initialization and the user has no opportunity to set the delegate yet.
The second bug happens on the next line. We check `showsEndOfRouteFeedback` property and always show a feedback screen since the default value of this property is `true`, this happens even if the user explicitly sets this property to `false`.

The solution that I propose in this PR is to postpone all work with view property until actual viewDidLoad happens.

This is my first PR here, so any comments are welcome.
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->