### PR TITLE
Fix destination annotation incorrectly placed below route line

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -521,7 +521,8 @@ open class NavigationMapView: UIView {
                 IdentifierString.arrowSymbol,
                 IdentifierString.arrowCasingSymbol,
                 IdentifierString.arrowStroke,
-                IdentifierString.waypointCircle
+                IdentifierString.waypointCircle,
+                IdentifierString.buildingExtrusionLayer
             ]
             
             guard let layers = try? mapView.__map.getStyleLayers().reversed() else { return nil }


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->
This PR is to address the destination annotation that was placed incorrectly below the route line (and all labels on the map), specifically when using building highlighting.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Changed the for loop in `NavigationMapView.addMainRouteLayer()` to exclude the `buildingExtrusionLayer` when searching for a parent layer.

### Screenshots or Gifs
Before:
![Simulator Screen Shot - iPhone 8 - 2021-03-17 at 14 20 58](https://user-images.githubusercontent.com/43434254/111518360-6358b200-872c-11eb-8398-21da26b77abb.png)

Now:
![Simulator Screen Shot - iPhone 8 - 2021-03-17 at 14 17 31](https://user-images.githubusercontent.com/43434254/111518394-69e72980-872c-11eb-934c-53d4f13a50f9.png)

<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->