### PR TITLE
Fix MapboxCoreNavigationTests and TestHelper build errors

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -3602,7 +3602,6 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Debug;
 		};
@@ -3627,7 +3626,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Release;
 		};

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -407,13 +407,6 @@
 			remoteGlobalIDString = 351BEBD61E5BCC28006FE110;
 			remoteInfo = MapboxNavigation;
 		};
-		35C8DBF2219193180053328C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C5ADFBC01DDCC7840011824B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 358D14621E5E3B7700ADE590;
-			remoteInfo = Example;
-		};
 		35C8DBFF2191DA470053328C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C5ADFBC01DDCC7840011824B /* Project object */;
@@ -2020,7 +2013,6 @@
 			dependencies = (
 				3595FE4B219191FE0035B765 /* PBXTargetDependency */,
 				C5ADFBD51DDCC7840011824B /* PBXTargetDependency */,
-				35C8DBF3219193180053328C /* PBXTargetDependency */,
 			);
 			name = MapboxCoreNavigationTests;
 			productName = MapboxNavigationTests;
@@ -2779,11 +2771,6 @@
 			isa = PBXTargetDependency;
 			target = 351BEBD61E5BCC28006FE110 /* MapboxNavigation */;
 			targetProxy = 35B711D51E5E7AD2001EDA8D /* PBXContainerItemProxy */;
-		};
-		35C8DBF3219193180053328C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 358D14621E5E3B7700ADE590 /* Example */;
-			targetProxy = 35C8DBF2219193180053328C /* PBXContainerItemProxy */;
 		};
 		35C8DC002191DA470053328C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -353,7 +353,6 @@
 		DA303CA621B7A90100F921DC /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529FCF521A5C5D900AEA9AA /* UIViewController.swift */; };
 		DA3525702010A5210048DDFC /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DA35256E2010A5200048DDFC /* Localizable.stringsdict */; };
 		DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA443DDD2278C90E00ED1307 /* CPTrip.swift */; };
-		DA5F448825F079F300F573EC /* EHorizonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F447E25F079AA00F573EC /* EHorizonTests.swift */; };
 		DA5F449A25F07A5C00F573EC /* ElectronicHorizon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F449925F07A5C00F573EC /* ElectronicHorizon.swift */; };
 		DA5F44AA25F07A6800F573EC /* RoadObjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44A325F07A6500F573EC /* RoadObjectType.swift */; };
 		DA5F44AC25F07A6800F573EC /* RoadGraphPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44A525F07A6500F573EC /* RoadGraphPosition.swift */; };
@@ -915,7 +914,6 @@
 		DA545AC41FAA86450090908E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA5AD03C1FEBA03700FC7D7B /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Main.strings; sourceTree = "<group>"; };
 		DA5AD0401FEBA23200FC7D7B /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
-		DA5F447E25F079AA00F573EC /* EHorizonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EHorizonTests.swift; sourceTree = "<group>"; };
 		DA5F449925F07A5C00F573EC /* ElectronicHorizon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElectronicHorizon.swift; sourceTree = "<group>"; };
 		DA5F44A325F07A6500F573EC /* RoadObjectType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadObjectType.swift; sourceTree = "<group>"; };
 		DA5F44A525F07A6500F573EC /* RoadGraphPosition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadGraphPosition.swift; sourceTree = "<group>"; };
@@ -1773,7 +1771,6 @@
 				3519D01D21F0842900582FF5 /* CLLocationTests.swift */,
 				352762A3225B751A0015B632 /* OptionsTests.swift */,
 				5A43FC8A24B488DC00BF7943 /* PassiveLocationDataSourceTests.swift */,
-				DA5F447E25F079AA00F573EC /* EHorizonTests.swift */,
 			);
 			name = MapboxCoreNavigationTests;
 			path = Tests/MapboxCoreNavigationTests;
@@ -2394,7 +2391,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/TestHelper/tiles",
+				"$(SRCROOT)/Tests/TestHelper/tiles",
 			);
 			name = "Copy Tiles";
 			outputFileListPaths = (
@@ -2404,7 +2401,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\ncp -r $SRCROOT/TestHelper/tiles $TARGET_BUILD_DIR\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\ncp -r $SRCROOT/Tests/TestHelper/tiles $TARGET_BUILD_DIR\n";
 		};
 		DA408F661FB3CA3C004D9661 /* Apply Mapbox Access Token */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2750,7 +2747,6 @@
 				DAD903AF23E3DCC80057CF1F /* DateTests.swift in Sources */,
 				C551B0E620D42222009A986F /* NavigationLocationManagerTests.swift in Sources */,
 				359A8AED1FA78D3000BDB486 /* DistanceFormatterTests.swift in Sources */,
-				DA5F448825F079F300F573EC /* EHorizonTests.swift in Sources */,
 				C52AC1261DF0E48600396B9F /* RouteProgressTests.swift in Sources */,
 				5A43FC8B24B488DC00BF7943 /* PassiveLocationDataSourceTests.swift in Sources */,
 				359574AA1F28CCBB00838209 /* LocationTests.swift in Sources */,

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
@@ -69,13 +69,9 @@ class PassiveLocationDataSourceTests: XCTestCase {
         let filePathURL: URL = URL(fileURLWithPath: bundle.bundlePath.appending("/tiles/liechtenstein"))
 
         // Create PassiveLocationDataSource and configure it with the tiles version (version is used to find the tiles in the cache folder)
+        Navigator.tilesVersion = tilesVersion
+        Navigator.tilesURL = filePathURL
         let locationManager = PassiveLocationDataSource()
-        do {
-            try locationManager.configureNavigator(withTilesVersion: tilesVersion)
-            try locationManager.configureNavigator(withURL: filePathURL, tilesVersion: tilesVersion)
-        } catch {
-            XCTAssertTrue(false)
-        }
 
         let locationUpdateExpectation = expectation(description: "Location manager takes some time to start mapping locations to a road graph")
         locationUpdateExpectation.expectedFulfillmentCount = 1

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
@@ -62,15 +62,19 @@ class PassiveLocationDataSourceTests: XCTestCase {
         }
     }
     
-    func testManualLocations() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        // Configure the navigator (used by PassiveLocationDataSource) with the tiles version (version is used to find the tiles in the cache folder)
         let tilesVersion = "preloadedtiles" // any string
+        Navigator.tilesVersion = tilesVersion
 
         let bundle = Bundle(for: Fixture.self)
         let filePathURL: URL = URL(fileURLWithPath: bundle.bundlePath.appending("/tiles/liechtenstein"))
-
-        // Create PassiveLocationDataSource and configure it with the tiles version (version is used to find the tiles in the cache folder)
-        Navigator.tilesVersion = tilesVersion
         Navigator.tilesURL = filePathURL
+    }
+    
+    func testManualLocations() {
         let locationManager = PassiveLocationDataSource()
 
         let locationUpdateExpectation = expectation(description: "Location manager takes some time to start mapping locations to a road graph")

--- a/Tests/TestHelper/CoreLocation.swift
+++ b/Tests/TestHelper/CoreLocation.swift
@@ -6,6 +6,20 @@ enum DecodingError: Error {
     case missingData
 }
 
+extension CLLocationCoordinate2D: Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(longitude)
+        try container.encode(latitude)
+    }
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let longitude = try container.decode(CLLocationDegrees.self)
+        let latitude = try container.decode(CLLocationDegrees.self)
+        self.init(latitude: latitude, longitude: longitude)
+    }
+}
+
 /// A Codable Location with support for the following format:
 /**
  "latitude/lat": Double,


### PR DESCRIPTION
Updated test code to reflect file moves related to expanded SPM support in #2808 and the shared navigator refactor in #2823. Removed a broken file reference left over from when #2834 included a unit test of electronic horizon functionality.

Fixes #2866.

/cc @mapbox/navigation-ios