### PR TITLE
Allow the Navigator set access token other than in Info.plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Removed `NavigationViewController.origin` property, which was not used. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * A new predictive cache proactively fetches tiles which may become necessary if the device loses its Internet connection at some point during passive or active turn-by-turn navigation. Pass a `PredictiveCacheOptions` instance into the `NavigationOptions(styles:navigationService:voiceController:topBanner:bottomBanner:predictiveCacheOptions:)` initializer as you configure a `NavigationViewController`, or manually call `NavigationMapView.enablePredictiveCaching(options:)`. ([#2830](https://github.com/mapbox/mapbox-navigation-ios/pull/2830))
 * Added the `Directions.calculateOffline(options:completionHandler:)` and `Directions.calculateWithCache(options:completionHandler:)` methods, which incorporate routing tiles from the predictive cache when possible to avoid relying on a network connection to calculate the route. `RouteController` now also uses the predictive cache when rerouting. ([#2848](https://github.com/mapbox/mapbox-navigation-ios/pull/2848)) 
+* Added the `Navigator.credentials` to accept `DirectionsCredentials` from `PassiveLocationDataSource`, `RouteController` and `PredictiveCacheManager`. Added the `PredictiveCacheOptions.credentials` to allow developers dynamically switching between access tokens. ([#2876](https://github.com/mapbox/mapbox-navigation-ios/pull/2876))
 
 ## v1.3.0
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -3307,6 +3307,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3343,6 +3344,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.TestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Sources/MapboxCoreNavigation/BundleAdditions.swift
+++ b/Sources/MapboxCoreNavigation/BundleAdditions.swift
@@ -23,12 +23,6 @@ extension Bundle {
         }
     }
     
-    var locationAlwaysUsageDescription: String? {
-        get {
-            return object(forInfoDictionaryKey: "NSLocationAlwaysUsageDescription") as? String
-        }
-    }
-    
     /**
      The Mapbox Core Navigation framework bundle.
      */

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -46,6 +46,13 @@ class Navigator {
     }()
     
     /**
+     The Authorization & Authentication credentials that are used for this service. If not specified - will be automatically intialized from the token and host from your app's `info.plist`.
+     
+     - precondition: `credentials` should be set before getting the shared navigator for the first time.
+     */
+    static var credentials: DirectionsCredentials? = nil
+    
+    /**
      Provides a new or an existing `MapboxCoreNavigation.Navigator` instance. Upon first initialization will trigger creation of `MapboxNavigationNative.Navigator` and `HistoryRecorderHandle` instances,
      satisfying provided configuration (`tilesVersion` and `tilesURL`).
      */
@@ -68,7 +75,7 @@ class Navigator {
         let settingsProfile = SettingsProfile(application: ProfileApplication.kMobile,
                                               platform: ProfilePlatform.KIOS)
         
-        let endpointConfig = TileEndpointConfiguration(credentials: Directions.shared.credentials,
+        let endpointConfig = TileEndpointConfiguration(credentials:Navigator.credentials ?? Directions.shared.credentials,
                                                        tilesVersion: Self.tilesVersion,
                                                        minimumDaysToPersistVersion: nil)
         

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -405,8 +405,10 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         guard let _ = Bundle.main.bundleIdentifier else {
             return
         }
-        if Bundle.main.locationAlwaysUsageDescription == nil && Bundle.main.locationWhenInUseUsageDescription == nil && Bundle.main.locationAlwaysAndWhenInUseUsageDescription == nil {
-            preconditionFailure("This application’s Info.plist file must include a NSLocationWhenInUseUsageDescription. See https://developer.apple.com/documentation/corelocation for more information.")
+        if Bundle.main.locationWhenInUseUsageDescription == nil && Bundle.main.locationAlwaysAndWhenInUseUsageDescription == nil {
+            if UserDefaults.standard.object(forKey: "NSLocationWhenInUseUsageDescription") == nil && UserDefaults.standard.object(forKey: "NSLocationAlwaysAndWhenInUseUsageDescription") == nil {
+                        preconditionFailure("This application’s Info.plist file must include a NSLocationWhenInUseUsageDescription. See https://developer.apple.com/documentation/corelocation for more information.")
+            }
         }
     }
 

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -575,7 +575,9 @@ private func checkForLocationUsageDescription() {
     guard let _ = Bundle.main.bundleIdentifier else {
         return
     }
-    if Bundle.main.locationAlwaysUsageDescription == nil && Bundle.main.locationWhenInUseUsageDescription == nil && Bundle.main.locationAlwaysAndWhenInUseUsageDescription == nil {
-        preconditionFailure("This application’s Info.plist file must include a NSLocationWhenInUseUsageDescription. See https://developer.apple.com/documentation/corelocation for more information.")
+    if Bundle.main.locationWhenInUseUsageDescription == nil && Bundle.main.locationAlwaysAndWhenInUseUsageDescription == nil {
+        if UserDefaults.standard.object(forKey: "NSLocationWhenInUseUsageDescription") == nil && UserDefaults.standard.object(forKey: "NSLocationAlwaysAndWhenInUseUsageDescription") == nil {
+                    preconditionFailure("This application’s Info.plist file must include a NSLocationWhenInUseUsageDescription. See https://developer.apple.com/documentation/corelocation for more information.")
+        }
     }
 }

--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -20,6 +20,7 @@ open class PassiveLocationDataSource: NSObject {
      */
     public required init(directions: Directions = Directions.shared, systemLocationManager: NavigationLocationManager? = nil) {
         self.directions = directions
+        Navigator.credentials = directions.credentials
 
         self.systemLocationManager = systemLocationManager ?? NavigationLocationManager()
         

--- a/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
+++ b/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
@@ -18,6 +18,7 @@ public class PredictiveCacheManager {
      - parameter mapOptions: Information about `MapView` tiles such as the location and tilesets to cache. If this argument is set to `nil`, predictive caching is disabled for map tiles.
      */
     public init(predictiveCacheOptions: PredictiveCacheOptions, mapOptions: MapOptions?) {
+        Navigator.credentials = predictiveCacheOptions.credentials
         self.controllers.append(initNavigatorController(options: predictiveCacheOptions))
         if let mapOptions = mapOptions {
             self.controllers.append(contentsOf: initMapControllers(options: predictiveCacheOptions, mapOptions: mapOptions))

--- a/Sources/MapboxCoreNavigation/PredictiveCacheOptions.swift
+++ b/Sources/MapboxCoreNavigation/PredictiveCacheOptions.swift
@@ -1,5 +1,5 @@
 import MapboxNavigationNative
-
+import MapboxDirections
 /**
  Specifies the content that a predictive cache fetches and how it fetches the content.
  
@@ -34,6 +34,11 @@ public struct PredictiveCacheOptions {
      Defaults to 2 concurrent requests.
      */
     public var maximumConcurrentRequests: UInt32 = 2
+    
+     /**
+     The Authorization & Authentication credentials that are used for this service. If not specified - will be automatically intialized from the token and host from your app's `info.plist`.
+     */
+    public var credentials: DirectionsCredentials = .init()
     
     public init() {
         // No-op

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -152,6 +152,7 @@ open class RouteController: NSObject {
     
     required public init(along route: Route, routeIndex: Int, options: RouteOptions, directions: Directions = Directions.shared, dataSource source: RouterDataSource) {
         self.directions = directions
+        Navigator.credentials = directions.credentials
         self._routeProgress = RouteProgress(route: route, routeIndex: routeIndex, options: options)
         self.dataSource = source
         self.refreshesRoute = options.profileIdentifier == .automobileAvoidingTraffic && options.refreshingEnabled

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -23,6 +23,17 @@ let waitForInterval: TimeInterval = 5
 class MapboxCoreNavigationTests: XCTestCase {
     var navigation: MapboxNavigationService!
     
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationWhenInUseUsageDescription")
+        UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        UserDefaults.resetStandardUserDefaults()
+    }
+    
     func testNavigationNotificationsInfoDict() {
         navigation = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: routeOptions, directions: directions, simulating: .never)
         let now = Date()

--- a/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -34,7 +34,7 @@ class NavigationEventsManagerTests: XCTestCase {
         let locationManager = NavigationLocationManager()
         let service = MapboxNavigationService(route: firstRoute, routeIndex: 0,
                                               routeOptions: firstRouteOptions,
-                                              directions: nil,
+                                              directions: directions,
                                               locationSource: locationManager,
                                               eventsManagerType: NavigationEventsManagerSpy.self,
                                               simulating: .always)
@@ -78,7 +78,7 @@ class NavigationEventsManagerTests: XCTestCase {
         ])
         let eventTimeout = 0.3
         let route = Fixture.route(from: "DCA-Arboretum", options: routeOptions)
-        let dataSource = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: routeOptions)
+        let dataSource = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: routeOptions, directions: directions, simulating: .onPoorGPS)
         let sessionState = SessionState(currentRoute: route, originalRoute: route)
         
         // Attempt to create NavigationEventDetails object from global queue, no errors from Main Thread Checker

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -55,7 +55,7 @@ class NavigationServiceTests: XCTestCase {
     }
 
     func testDefaultUserInterfaceUsage() {
-        XCTAssertTrue(dependencies.navigationService.eventsManager.usesDefaultUserInterface, "MapboxCoreNavigationTests should have an implicit dependency on MapboxNavigation due to running inside the Example application target.")
+        XCTAssertTrue(!dependencies.navigationService.eventsManager.usesDefaultUserInterface, "MapboxCoreNavigationTests shouldn't have an implicit dependency on MapboxNavigation due to removing the Example application target as the test host.")
     }
 
     func testUserIsOnRoute() {

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -36,15 +36,12 @@ class RouteControllerTests: XCTestCase {
         let options = NavigationMatchOptions(coordinates: coordinates)
         let route = Fixture.routesFromMatches(at: "sthlm-double-back", options: options)![0]
         
-        let bundle = Bundle(for: RouteControllerTests.self)
-        let filePath = bundle.path(forResource: "sthlm-double-back-replay", ofType: "json")
-        
-        let locations = Array<CLLocation>.locations(from: filePath!)
+        let locations = Array<CLLocation>.locations(from: "sthlm-double-back-replay")
         let locationManager = ReplayLocationManager(locations: locations)
         replayManager = locationManager
         locationManager.startDate = Date()
         let equivalentRouteOptions = NavigationRouteOptions(navigationMatchOptions: options)
-        let routeController = RouteController(along: route, routeIndex: 0, options: equivalentRouteOptions, dataSource: self)
+        let routeController = RouteController(along: route, routeIndex: 0, options: equivalentRouteOptions, directions: DirectionsSpy(), dataSource: self)
         locationManager.delegate = routeController
         
         var testCoordinates = [CLLocationCoordinate2D]()
@@ -54,7 +51,8 @@ class RouteControllerTests: XCTestCase {
             testCoordinates.append(routeController.location!.coordinate)
         }
         
-        XCTAssert(coordinates == testCoordinates)
+        let expectedCoordinates = locations.map{$0.coordinate}
+        XCTAssert(expectedCoordinates == testCoordinates)
     }
 }
 

--- a/Tests/MapboxCoreNavigationTests/SimulatedLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/SimulatedLocationManagerTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import MapboxDirections
+import Turf
 @testable import MapboxCoreNavigation
 #if !SWIFT_PACKAGE
 import TestHelper
@@ -39,11 +40,20 @@ class SimulatedLocationManagerTests: XCTestCase {
             locationManager.tick()
         }
         
+        var testCoordinates:[CLLocationCoordinate2D] = locationManagerSpy.locations.map { $0.coordinate }
+        let expectedDistance = LineString(coordinates).distance()
+        let testDistance = LineString(testCoordinates).distance()
+        XCTAssert(abs(expectedDistance! - testDistance!) < 70)
+        
+        while locationManager.currentDistance < route.distance + 30 {
+            locationManager.tick()
+        }
+
         locationManager.delegate = nil
-        
-        let testCoordinates:[CLLocationCoordinate2D] = locationManagerSpy.locations.map { $0.coordinate }
-        
-        XCTAssert(testCoordinates == coordinates)
+
+        testCoordinates = locationManagerSpy.locations.map { $0.coordinate }
+        let endPointDifferences = (testCoordinates.first?.distance(to: coordinates.first!))! + (testCoordinates.last?.distance(to: coordinates.last!))!
+        XCTAssert(endPointDifferences < 5)
     }
 }
 

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -61,6 +61,12 @@ class NavigationViewControllerTests: XCTestCase {
         customRoadName.removeAll()
     }
     
+    func testDefaultUserInterfaceUsage() {
+        let navigationViewController = dependencies.navigationViewController
+        let service = dependencies.navigationService
+        XCTAssertTrue(service.eventsManager.usesDefaultUserInterface, "MapboxNavigationTests should run inside the Example application target.")
+    }
+    
     // Brief: navigationViewController(_:roadNameAt:) delegate method is implemented,
     //        with a road name provided and wayNameView label is visible.
     func testNavigationViewControllerDelegateRoadNameAtLocationImplemented() {

--- a/Tests/TestHelper/CoreLocation.swift
+++ b/Tests/TestHelper/CoreLocation.swift
@@ -169,9 +169,7 @@ extension Array where Element == CLLocation {
     }
     
     public static func locations(from filePath: String) -> [CLLocation] {
-        let url = URL(fileURLWithPath: filePath)
-        
-        let data = try! Data(contentsOf: url)
+        let data = Fixture.JSONFromFileNamed(name: filePath)
         let locations = try! JSONDecoder().decode([Location].self, from: data)
         
         return locations.map { CLLocation($0) }

--- a/Tests/TestHelper/Fixture.swift
+++ b/Tests/TestHelper/Fixture.swift
@@ -52,14 +52,7 @@ public class Fixture: NSObject {
     }
     
     public class func locations(from name: String) -> [CLLocation] {
-        guard let path = Bundle(for: Fixture.self).path(forResource: name, ofType: "json") else {
-            assert(false, "Fixture \(name) not found.")
-            return []
-        }
-        guard let data = NSData(contentsOfFile: path) as Data? else {
-            assert(false, "No data found at \(path).")
-            return []
-        }
+        let data = JSONFromFileNamed(name: name)
         
         let locations = try! JSONDecoder().decode([Location].self, from: data)
         
@@ -115,6 +108,7 @@ public class Fixture: NSObject {
     
     // Returns `Route` objects from a match response
     public class func routesFromMatches(at filePath: String, options: MatchOptions) -> [Route]? {
+        options.shapeFormat = .polyline
         let response = mapMatchingResponse(from: filePath, options: options)
         let routeResponse = try! RouteResponse(matching: response, options: options, credentials: Fixture.credentials)
         guard let routes = routeResponse.routes else {


### PR DESCRIPTION
### Description
This pr is to fix the integration error and other errors in the MapboxcoreNavigationTest.
- [x] remove deprecated property list key and check.
- [x] add workaround for bundle info check under Carthage
- [x] fix the directions in MapboxNavigationService.
- [x] fix #2851 , allow the `Navigator` accepts DirectionsCredentials from `PassiveLocationDataSource`, `RouteController` and `PredictiveCacheManager`.
- [x] allow all the MapboxCoreNavigationTests run/build (except some exempt from SPM).
- [x] update the changelog.

### Implementation
Creating a property called `credentials` in `Navigator` to be set before getting the shared navigator. It could take value value from `PassiveLocationDataSource` and `RouteController`.
By adding a `credentials` property to `PredictiveCacheOptions`, it also allows the `PredictiveCacheManager` passing the DirectionsCredentials to `Navigator`.