### PR TITLE
CI metrics hook for V2 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,4 +297,4 @@ workflows:
       - ios-trigger-metrics:
           filters:
             branches:
-              only: main
+              only: release-v2.0


### PR DESCRIPTION
### Description
This PR changes the Metrics hook to trigger on `release-v2` branch instead of `main` since we are now interested in this release.

### Implementation
We'll need to revert this once `release-v2` branch makes it's way into `main`