### PR TITLE
Fix automatic day/night switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4.0
 
 * Fixed an issue when feedback UI was always appearing for short routes ([#2871](https://github.com/mapbox/mapbox-navigation-ios/pull/2871))
+* Fixed automatic day/night switching ([#2881](https://github.com/mapbox/mapbox-navigation-ios/pull/2881))
 
 ## v1.3.0
 

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -131,12 +131,10 @@ open class StyleManager {
             print("Unable to get sunrise or sunset. Automatic style switching has been disabled.")
             return
         }
-        
-        timeOfDayTimer = Timer(timeInterval: interval + 1,
-                               repeats: false,
-                               block: { [weak self] _ in
+
+        timeOfDayTimer = Timer.scheduledTimer(withTimeInterval: interval + 1, repeats: false) { [weak self] _ in
             self?.timeOfDayChanged()
-        })
+        }
     }
     
     @objc func preferredContentSizeChanged(_ notification: Notification) {
@@ -159,6 +157,7 @@ open class StyleManager {
                 currentStyleType = styleType
                 currentStyle = style
                 delegate?.styleManager(self, didApply: style)
+                break
             }
         }
         

--- a/Sources/MapboxNavigation/VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/VanishingRouteLine.swift
@@ -205,7 +205,12 @@ extension NavigationMapView {
             let newFractionTraveled = self.preFractionTraveled + traveledDifference * timePassedInMilliseconds.truncatingRemainder(dividingBy: 1000) / 1000
             guard let mainRouteLayerGradient = self.routeLineGradient(routeProgress.route, fractionTraveled: newFractionTraveled) else { return }
             let mainCasingLayerStops = self.routeCasingGradient(newFractionTraveled)
-            
+
+            guard let mainRouteLayer = self.style?.layer(withIdentifier: mainRouteLayerIdentifier) as? MGLLineStyleLayer,
+                  let mainRouteCasingLayer = self.style?.layer(withIdentifier: mainRouteCasingLayerIdentifier) as? MGLLineStyleLayer else {
+                timer.invalidate()
+                return
+            }
             mainRouteLayer.lineGradient = mainRouteLayerGradient
             mainRouteCasingLayer.lineGradient = mainCasingLayerStops
         })


### PR DESCRIPTION
### Description
Fixes #2766.

### Implementation
Currently, automatic day/night switching doesn't work at all, because we don't add [timeOfDayTimer](https://github.com/mapbox/mapbox-navigation-ios/blob/99dfa3287ffdf663c3880ef6a7dd833d5d59ff24/Sources/MapboxNavigation/StyleManager.swift#L135) inside of the RunLoop, therefore it never fires. I fixed this issue by replacing plain `Timer.init` with `Timer.scheduledTimer`. The latest one, according to the [documentation](https://developer.apple.com/documentation/foundation/timer/2091889-scheduledtimer) schedules timer on the current RunLoop. After this fix, StyleManager works as expected, but the sample app crashes inside of the [VanishingRouteLine](https://github.com/mapbox/mapbox-navigation-ios/blob/main/Sources/MapboxNavigation/VanishingRouteLine.swift#L209) because it saves an outdated style internally. I fixed this by adding a guard statement inside of VanishingRouteLine.swift. I also verified that the performance wasn't affected using [os_signpost](https://developer.apple.com/documentation/os/3019241-os_signpost) and Instruments on a real iPhone with Release build.

There is also a minor change in `StyleManager.applyStyle` function, where we iterate through all styles and search for the right one. In my opinion, we can break the cycle after finding a first suitable theme, because right now we continue to iterate and do unnecessary work applying other styles as well. My fix however can break the existing behavior for our customers, but for me, this particular case looks minor enough. If you don't agree, we still can optimize this code by iterating the collection backward and breaking after the first match.

