### PR TITLE
Add a will refresh event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4.0
 
 * Fixed an issue when feedback UI was always appearing for short routes ([#2871](https://github.com/mapbox/mapbox-navigation-ios/pull/2871))
+* Add a new `Notification.Name.routeControllerWillRefreshRoute` notification, `NavigationServiceDelegate.navigationService(_:willRefresh:)` method, and `NavigationViewControllerDelegate.navigationViewController(_:willRefresh:)` method ([#2871](https://github.com/mapbox/mapbox-navigation-ios/pull/2885))
 
 ## v1.3.0
 

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -131,6 +131,13 @@ public extension Notification.Name {
      - seealso: `passiveLocationDataSourceDidUpdate`
      */
     static let routeControllerProgressDidChange: Notification.Name = .init(rawValue: "RouteControllerProgressDidChange")
+
+    /**
+     Posted when `RouteController` will request updated information about the current route.
+
+     The user info dictionary contains the key `RouteController.NotificationUserInfoKey.routeProgressKey`.
+     */
+    static let routeControllerWillRefreshRoute: Notification.Name = .init(rawValue: "RouteControllerWillRefreshRoute")
     
     /**
      Posted when `RouteController` receives updated information about the current route.

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -460,6 +460,10 @@ extension MapboxNavigationService: RouterDelegate {
     public func router(_ router: Router, didFailToRerouteWith error: Error) {
         delegate?.navigationService(self, didFailToRerouteWith: error)
     }
+
+    public func router(_ router: Router, willRefresh routeProgress: RouteProgress) {
+        delegate?.navigationService(self, willRefresh: routeProgress)
+    }
     
     public func router(_ router: Router, didRefresh routeProgress: RouteProgress) {
         delegate?.navigationService(self, didRefresh: routeProgress)

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -67,6 +67,16 @@ public protocol NavigationServiceDelegate: class, UnimplementedLogging {
      - parameter error: An error raised during the process of obtaining a new route.
      */
     func navigationService(_ service: NavigationService, didFailToRerouteWith error: Error)
+
+    /**
+     Called immediately before the navigation service refreshes the current route.
+
+     This method is called simultaneously with the `Notification.Name.routeControllerWillRefreshRoute` notification being posted, and before `navigationService(_:didRefresh:)` is called.
+
+     - parameter service: The navigation service that will refresh the current route.
+     - parameter routeProgress: The current RouteProgress model that will be refreshed.
+     */
+    func navigationService(_ service: NavigationService, willRefresh routeProgress: RouteProgress)
     
     /**
      Called immediately after the navigation service refreshes the route.
@@ -239,6 +249,13 @@ public extension NavigationServiceDelegate {
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
     func navigationService(_ service: NavigationService, didFailToRerouteWith error: Error) {
+        logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
+    }
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationService(_ service: NavigationService, willRefresh routeProgress: RouteProgress) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -151,6 +151,11 @@ extension InternalRouter where Self: Router {
             return
         }
         isRefreshing = true
+
+        var userInfo = [RouteController.NotificationUserInfoKey: Any]()
+        userInfo[.routeProgressKey] = self.routeProgress
+        NotificationCenter.default.post(name: .routeControllerWillRefreshRoute, object: self, userInfo: userInfo)
+        self.delegate?.router(self, willRefresh: self.routeProgress)
         
         directions.refreshRoute(responseIdentifier: routeIdentifier, routeIndex: indexedRoute.1, fromLegAtIndex: legIndex) { [weak self] (session, result) in
             defer {

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -165,6 +165,10 @@ public extension RouterDelegate {
     func router(_ router: Router, didFailToRerouteWith error: Error) {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
     }
+
+    func router(_ router: Router, didRefresh routeProgress: RouteProgress) {
+        logUnimplemented(protocolType: RouterDelegate.self, level: .info)
+    }
     
     func router(_ router: Router, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
         logUnimplemented(protocolType: RouterDelegate.self, level: .info)

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -64,6 +64,16 @@ public protocol RouterDelegate: class, UnimplementedLogging {
     func router(_ router: Router, didFailToRerouteWith error: Error)
 
     /**
+     Called immediately before the router refreshes the current route.
+
+     This method is called before `router(_:didRefresh:)` is called.
+
+     - parameter router: The router that will refresh the current route.
+     - parameter routeProgress: The route progress object that the router will refresh.
+     */
+    func router(_ router: Router, willRefresh routeProgress: RouteProgress)
+
+    /**
      Called immediately after the router refreshes the route.
      
      - parameter router: The router that has refreshed the route.
@@ -163,6 +173,10 @@ public extension RouterDelegate {
     }
     
     func router(_ router: Router, didFailToRerouteWith error: Error) {
+        logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
+    }
+
+    func router(_ router: Router, willRefresh routeProgress: RouteProgress) {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
     }
 

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -605,6 +605,14 @@ extension NavigationViewController: NavigationServiceDelegate {
 
         delegate?.navigationViewController(self, didFailToRerouteWith: error)
     }
+
+    public func navigationService(_ service: NavigationService, willRefresh routeProgress: RouteProgress) {
+        for component in navigationComponents {
+            component.navigationService(service, willRefresh: routeProgress)
+        }
+
+        delegate?.navigationViewController(self, willRefresh: routeProgress)
+    }
     
     public func navigationService(_ service: NavigationService, didRefresh routeProgress: RouteProgress) {
         for component in navigationComponents {

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -90,6 +90,16 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate{
      - parameter error: An error raised during the process of obtaining a new route.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didFailToRerouteWith error: Error)
+
+    /**
+     Called immediately before the navigation view controller refreshes the current route.
+
+     This method is called simultaneously with the `Notification.Name.routeControllerWillRefreshRoute` notification being posted, and before `navigationViewController(_:didRefresh:)` is called.
+
+     - parameter navigationViewController: The navigation view controller that will refresh the current route.
+     - parameter routeProgress: The current route progress that will be refreshed.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, willRefresh routeProgress: RouteProgress)
     
     /**
      Called immediately after the navigation view controller refreshes the route.
@@ -256,6 +266,13 @@ public extension NavigationViewControllerDelegate {
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didFailToRerouteWith error: Error) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+    }
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, willRefresh routeProgress: RouteProgress) {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self, level: .debug)
     }
     
     /**

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -621,7 +621,7 @@ class NavigationServiceTests: XCTestCase {
 
         let ourLogs = logs.filter { $0.0 == "EmptyNavigationServiceDelegate" }
 
-        XCTAssertEqual(ourLogs.count, 7, "Expected logs to be populated and expected number of messages sent")
+        XCTAssertEqual(ourLogs.count, 8, "Expected logs to be populated and expected number of messages sent")
         unimplementedTestLogs = nil
     }
 }


### PR DESCRIPTION
### Description

Hello,

My team needed to be notified before a route refresh occurs in our project so I added a willRefresh event to the navigation service & router protocol.

As this may be useful to more people here is a PR. I'll let you judge if this can be added to the project or not.

I've also included a missing default implementation for the "didRefresh" event to the router delegate.

### Implementation

I've followed the general pattern used in the SDK:
- the "willRefresh" event is triggered before the actual request is initiated (follows "willReroute" behavior)
- a notification is posted at the same time the delegate is called
- code documentation follows general wording used throughout the project