### PR TITLE
Fix crash when switching between day / night modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue when feedback UI was always appearing for short routes ([#2871](https://github.com/mapbox/mapbox-navigation-ios/pull/2871))
 * Fixed automatic day/night switching ([#2881](https://github.com/mapbox/mapbox-navigation-ios/pull/2881))
+* Fixed crash when switching between day / night modes ([#2896](https://github.com/mapbox/mapbox-navigation-ios/pull/2896))
 
 ## v1.3.0
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -281,6 +281,12 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         
     }
     
+    open override func reloadStyle(_ sender: Any?) {
+        vanishingRouteLineUpdateTimer?.invalidate()
+        vanishingRouteLineUpdateTimer = nil
+        super.reloadStyle(sender)
+    }
+    
     open override func layoutMarginsDidChange() {
         super.layoutMarginsDidChange()
         enableFrameByFrameCourseViewTracking(for: 3)


### PR DESCRIPTION
### Description
This PR fixes a crash that sometimes may occur due to a race condition when switching between day / night modes.

- [x] Update changelog

### Implementation
When switching between day / night mode via `StyleManager.applyStyle(type:)`, sometimes a crash may occur within the Mapbox iOS SDK with the following trace:
```
2021-03-29 10:24:19.829496-0500 Example[13984:7659400] *** Terminating app due to uncaught exception 'MGLInvalidStyleLayerException', reason: 'Either this layer got invalidated after the style change or -[MGLStyle removeLayer:] has been called with this instance but another style layer instance was added with the same identifier. It is an error to send any message to this layer since it cannot be recovered after removal due to the identifier collision. Use unique identifiers for all layer instances including layers of different types.'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000010e551af6 __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x000000010e3e1e78 objc_exception_throw + 48
	2   CoreFoundation                      0x000000010e5519d4 -[NSException initWithCoder:] + 0
	3   Mapbox                              0x000000010daaee08 -[MGLLineStyleLayer setLineGradient:] + 88
	4   MapboxNavigation                    0x000000010bc4c45a $s16MapboxNavigation0B7MapViewC11updateRouteyy0a4CoreB00F8ProgressCFySo7NSTimerCcfU_ + 826
	5   MapboxNavigation                    0x000000010bc4f579 $sSo7NSTimerCIegg_ABIeyBy_TR + 73
	6   Foundation                          0x000000010df7fecb __NSFireTimer + 67
	7   CoreFoundation                      0x000000010e4c0c57 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
	8   CoreFoundation                      0x000000010e4c072a __CFRunLoopDoTimer + 926
	9   CoreFoundation                      0x000000010e4bfcdd __CFRunLoopDoTimers + 265
	10  CoreFoundation                      0x000000010e4ba35e __CFRunLoopRun + 1949
	11  CoreFoundation                      0x000000010e4b96d6 CFRunLoopRunSpecific + 567
	12  GraphicsServices                    0x000000011b938db3 GSEventRunModal + 139
	13  UIKitCore                           0x000000011cd8fcf7 -[UIApplication _run] + 912
	14  UIKitCore                           0x000000011cd94ba8 UIApplicationMain + 101
	15  Example                             0x000000010b89638b main + 75
	16  libdyld.dylib                       0x000000011486b3e9 start + 1
```

From the trace I was able to determine the cause was a call in `NavigationMapView.updateRoute(_:)` (which is found in `VanishingRouteLine.swift`). The timer block setting `MGLLineStyleLayer.lineGradient` within `vanishingRouteLineUpdateTimer`'s execution block appears to sometimes reference the layer _after_ it has been removed from the hierarchy due to a style change (which removes the view from the view hierarchy). This is what triggers the exception to be thrown.

The fix is to ensure the timer is invalided on a reload of style in NavigationMapView.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->