### PR TITLE
Refactor StyleManager's appearance refresh logic to no longer use UIWindow loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue when feedback UI was always appearing for short routes ([#2871](https://github.com/mapbox/mapbox-navigation-ios/pull/2871))
 * Fixed automatic day/night switching ([#2881](https://github.com/mapbox/mapbox-navigation-ios/pull/2881))
+* Fixed an issue where presenting `NavigationViewController` could sometimes interefere with view presentation in other windows ([#2897](https://github.com/mapbox/mapbox-navigation-ios/pull/2897))
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Fixed an issue when feedback UI was always appearing for short routes ([#2871](https://github.com/mapbox/mapbox-navigation-ios/pull/2871))
 * Fixed automatic day/night switching ([#2881](https://github.com/mapbox/mapbox-navigation-ios/pull/2881))
-* Fixed an issue where presenting `NavigationViewController` could sometimes interefere with view presentation in other windows ([#2897](https://github.com/mapbox/mapbox-navigation-ios/pull/2897))
+* Fixed an issue where presenting `NavigationViewController` could sometimes interfere with view presentation in other windows. ([#2897](https://github.com/mapbox/mapbox-navigation-ios/pull/2897))
+* Added an optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method to determine which part of the view hierarchy is affected by a change to a different `Style`. ([#2897](https://github.com/mapbox/mapbox-navigation-ios/pull/2897))
 * Added the `NavigationViewController.styleManager`, `StyleManager.currentStyleType`, and `StyleManager.currentStyle` properties and the `StyleManager.applyStyle(type:)` method to manually change the UI style at any time. ([#2888](https://github.com/mapbox/mapbox-navigation-ios/pull/2888))
 * Fixed crash when switching between day / night modes ([#2896](https://github.com/mapbox/mapbox-navigation-ios/pull/2896))
 

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -14,8 +14,8 @@ public protocol StyleManagerDelegate: class, UnimplementedLogging {
     /**
      Asks the delegate for the view to be used when refreshing appearance. 
      
-     The default implementation of this method will attempt to cast delegate to an 
-     instance of `UIViewController` and use its `view`property.
+     The default implementation of this method will attempt to cast the delegate to type
+     `UIViewController` and use its `view` property.
      */
     func viewToRefreshOnAppearanceChange(_ styleManager: StyleManager) -> UIView?
     

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -17,7 +17,7 @@ public protocol StyleManagerDelegate: class, UnimplementedLogging {
      The default implementation of this method will attempt to cast the delegate to type
      `UIViewController` and use its `view` property.
      */
-    func viewToRefreshOnAppearanceChange(_ styleManager: StyleManager) -> UIView?
+    func styleManager(_ styleManager: StyleManager, viewForApplying currentStyle: Style?) -> UIView?
     
     /**
      Informs the delegate that a style was applied.
@@ -55,7 +55,7 @@ public extension StyleManagerDelegate {
         logUnimplemented(protocolType: StyleManagerDelegate.self, level: .debug)
     }
     
-    func viewToRefreshOnAppearanceChange(_ styleManager: StyleManager) -> UIView? {
+    func styleManager(_ styleManager: StyleManager, viewForApplying currentStyle: Style?) -> UIView? {
         // Short-circuit refresh logic if the view hasn't yet loaded since we don't want the `self.view` 
         // call to trigger `loadView`.
         if let vc = self as? UIViewController, vc.isViewLoaded { 
@@ -257,7 +257,7 @@ open class StyleManager {
     // workaround to refresh appearance by removing the view and then adding it again
     func forceRefreshAppearance() {
         if 
-            let view = delegate?.viewToRefreshOnAppearanceChange(self), 
+            let view = delegate?.styleManager(self, viewForApplying: currentStyle), 
             let superview = view.superview, 
             let index = superview.subviews.firstIndex(of: view) 
         {


### PR DESCRIPTION
### Description
This PR changes the approach used by StyleManager for refreshing appearance-based UI elements to no longer touch every subview of every UIWindow instance in the application.
 
- Fixes #2764 
- [x] Updated changelog

### Implementation
In a nutshell, the previous refresh logic was a bit too aggressive in its view hierarchy manipulation causing unexpected behavior in certain cases where multiple windows appear on screen (for example, whenever the system keyboard is presented).

For further discussion related to an instance of this issue, see the discussion in #2764 starting here: https://github.com/mapbox/mapbox-navigation-ios/issues/2764#issuecomment-806126471

In an effort to keep things DRY and since there are multiple view controllers implementing StyleManagerDelegate, there's a new method in StyleManagerDelegate `viewToRefreshOnAppearanceChange` which returns a view instance to be refreshed (read: removed and added to the view hierarchy). Since all delegates are instances of UIViewController and share the same logic, the default implementation of this method attempts to cast the delegate to an instance of UIViewController and will return it's `view` prop if successful (and the view has been loaded).

To test, I added a shake gesture hook in NavigationViewController that would toggle between day / night styles:
```swift
open override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
    if motion == .motionShake {
        let toggledStyleType: StyleType = (styleManager.currentStyleType == .day) ? .night : .day
        styleManager.applyStyle(type: toggledStyleType)
    }
}
```

See section below for videos of this in action.

As noted in https://github.com/mapbox/mapbox-navigation-ios/issues/2764#issuecomment-808423251, there are some issues with UI elements not updating during a dynamic switch, but the issues are present both before and after this refactor so I might consider this a net-neutral change in that regard and not something that should be resolved before this may be merged?

### Screenshots or Gifs
https://user-images.githubusercontent.com/630204/112897140-de16bb00-90a4-11eb-9132-27dd4dfdc58d.mov


https://user-images.githubusercontent.com/630204/112897165-e3740580-90a4-11eb-9d91-dba35a505b86.mov
