### PR TITLE
Fix route selection regression and annotation selection

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -309,12 +309,9 @@ open class NavigationMapView: UIView {
     }
     
     func setupGestureRecognizers() {
-        let gestures = mapView.gestureRecognizers ?? []
-        let mapTapGesture = UITapGestureRecognizer(target: self, action: #selector(didReceiveTap(sender:)))
-        for recognizer in gestures where recognizer is UITapGestureRecognizer {
-            mapTapGesture.requireFailure(of: [recognizer])
+        for recognizer in mapView.gestureRecognizers ?? [] where recognizer is UITapGestureRecognizer {
+            recognizer.addTarget(self, action: #selector(didReceiveTap(sender:)))
         }
-        mapView.addGestureRecognizer(mapTapGesture)
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -309,8 +309,9 @@ open class NavigationMapView: UIView {
     }
     
     func setupGestureRecognizers() {
+        let gestures = mapView.gestureRecognizers ?? []
         let mapTapGesture = UITapGestureRecognizer(target: self, action: #selector(didReceiveTap(sender:)))
-        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+        for recognizer in gestures where recognizer is UITapGestureRecognizer {
             mapTapGesture.requireFailure(of: [recognizer])
         }
         mapView.addGestureRecognizer(mapTapGesture)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -309,9 +309,8 @@ open class NavigationMapView: UIView {
     }
     
     func setupGestureRecognizers() {
-        let gestures = mapView.gestureRecognizers ?? []
         let mapTapGesture = UITapGestureRecognizer(target: self, action: #selector(didReceiveTap(sender:)))
-        for recognizer in gestures where recognizer is UITapGestureRecognizer {
+        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
             mapTapGesture.requireFailure(of: [recognizer])
         }
         mapView.addGestureRecognizer(mapTapGesture)


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->
This PR is to address a regression introduced in [#2901](https://github.com/mapbox/mapbox-navigation-ios/pull/2901) as well as fix MapView annotation selection.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Added a target to the existing tap gesture recognizer to address route and waypoint selection. Maps team also investigated the gesture recognizer conflict and found that the logic that causes MapView's single tap gesture recognizer to fail is not implemented yet. Tested on both the Nav SDK side and in 1Tap.

cc/ @bamx23 
### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->