### PR TITLE
Add history methods to PassiveLocationDataSource

### DIFF
--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -147,6 +147,18 @@ open class PassiveLocationDataSource: NSObject {
         }
         NotificationCenter.default.post(name: .passiveLocationDataSourceDidUpdate, object: self, userInfo: userInfo)
     }
+    
+    public func enableLocationRecording() {
+        try! Navigator.shared.enableHistoryRecorder()
+    }
+    
+    public func disableLocationRecording() {
+        try! Navigator.shared.disableHistoryRecorder()
+    }
+    
+    public func locationHistory() throws -> Data {
+        return try Navigator.shared.history()
+    }
 }
 
 extension PassiveLocationDataSource: CLLocationManagerDelegate {


### PR DESCRIPTION
This is a quick fix that exposes history recording functionality as part of PassiveLocationDataSource for parity with RouteController. A more robust fix would entail defining a protocol that both PassiveLocationDataSource and RouteController can conform to in order to gain this functionality through default implementations, or alternatively to make Navigator itself public. The added methods are undocumented for now, in case we choose to implement a more robust fix.

/cc @mapbox/navigation-ios @bamx23