### PR TITLE
Fix MapboxCoreNavigationTests failures with reset of navigator before location update each time

### DIFF
--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
@@ -63,9 +63,6 @@
                <Test
                   Identifier = "MapboxNavigationTests/testLowAlert()">
                </Test>
-               <Test
-                  Identifier = "PassiveLocationDataSourceTests/testManualLocations()">
-               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -32,6 +32,7 @@ class MapboxCoreNavigationTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         UserDefaults.resetStandardUserDefaults()
+        try? Navigator.shared.navigator.resetRideSession()
     }
     
     func testNavigationNotificationsInfoDict() {

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -55,6 +55,7 @@ class NavigationServiceTests: XCTestCase {
     }
     
     override func tearDown() {
+        super.tearDown()
         try? Navigator.shared.navigator.resetRideSession()
     }
 

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -53,6 +53,10 @@ class NavigationServiceTests: XCTestCase {
         directionsClientSpy.reset()
         delegate.reset()
     }
+    
+    override func tearDown() {
+        try? Navigator.shared.navigator.resetRideSession()
+    }
 
     func testDefaultUserInterfaceUsage() {
         XCTAssertTrue(!dependencies.navigationService.eventsManager.usesDefaultUserInterface, "MapboxCoreNavigationTests shouldn't have an implicit dependency on MapboxNavigation due to removing the Example application target as the test host.")

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
@@ -50,9 +50,9 @@ class PassiveLocationDataSourceTests: XCTestCase {
         
         func passiveLocationDataSource(_ dataSource: PassiveLocationDataSource, didUpdateLocation location: CLLocation, rawLocation: CLLocation) {
             print("Got location: \(rawLocation.coordinate.latitude), \(rawLocation.coordinate.longitude) → \(location.coordinate.latitude), \(location.coordinate.longitude)")
-            print("Value: \(road.proximity(of: location.coordinate)) should be less \(road.proximity(of: rawLocation.coordinate))")
+            print("Value: \(road.proximity(of: location.coordinate)) should be less or equal to \(road.proximity(of: rawLocation.coordinate))")
 
-            XCTAssert(road.proximity(of: location.coordinate) < road.proximity(of: rawLocation.coordinate), "Raw Location wasn't mapped to a road")
+            XCTAssert(road.proximity(of: location.coordinate) <= road.proximity(of: rawLocation.coordinate), "Raw Location wasn't mapped to a road")
         }
         
         func passiveLocationDataSource(_ dataSource: PassiveLocationDataSource, didUpdateHeading newHeading: CLHeading) {
@@ -67,6 +67,7 @@ class PassiveLocationDataSourceTests: XCTestCase {
         
         // Configure the navigator (used by PassiveLocationDataSource) with the tiles version (version is used to find the tiles in the cache folder)
         let tilesVersion = "preloadedtiles" // any string
+        Navigator.credentials = directions.credentials
         Navigator.tilesVersion = tilesVersion
 
         let bundle = Bundle(for: Fixture.self)
@@ -75,8 +76,8 @@ class PassiveLocationDataSourceTests: XCTestCase {
     }
     
     func testManualLocations() {
-        let locationManager = PassiveLocationDataSource()
-
+        let locationManager = PassiveLocationDataSource(directions: directions)
+        try? Navigator.shared.navigator.resetRideSession()
         let locationUpdateExpectation = expectation(description: "Location manager takes some time to start mapping locations to a road graph")
         locationUpdateExpectation.expectedFulfillmentCount = 1
         
@@ -86,6 +87,7 @@ class PassiveLocationDataSourceTests: XCTestCase {
         locationManager.updateLocation(CLLocation(latitude: 47.208674, longitude: 9.524650, timestamp: date.addingTimeInterval(-5)))
         locationManager.delegate = delegate
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            try? Navigator.shared.navigator.resetRideSession()
             locationManager.updateLocation(CLLocation(latitude: 47.208943, longitude: 9.524707, timestamp: date.addingTimeInterval(-4)))
             locationManager.updateLocation(CLLocation(latitude: 47.209082, longitude: 9.524319, timestamp: date.addingTimeInterval(-3)))
             locationManager.updateLocation(CLLocation(latitude: 47.209229, longitude: 9.523838, timestamp: date.addingTimeInterval(-2)))


### PR DESCRIPTION
### Description
This pr is to fix #2913 , to allow the `MapboxCoreNavigationTests` passed with reset of navigator before location update each time.

### Implementation
The tests [failure](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-ios/2950/workflows/920fa868-d1c5-4e45-b33a-a280266b252c/jobs/29227) of `MapboxCoreNavigationTests` , is caused by Navigator single entry point. Every time when the test cases need to update location, they're using the same navigator. So the `navigator.updateLocation` and `navigator.status(at: lastRawLocation.timestamp)` is causing problem in delivering the right location for each teat case running parallel. By adding the `try? Navigator.shared.navigator.resetRideSession()` every time before the location update would reset the navigator and remove the influence of other test cases.
