### PR TITLE
Fix MapboxCoreNavigation bundle when building with SPM

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -820,6 +820,7 @@
 		B456A8EB2620D26A00FD86D8 /* LeakTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeakTest.swift; sourceTree = "<group>"; };
 		B456A9052620D73700FD86D8 /* CLHeadingPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CLHeadingPrivate.h; path = include/CLHeadingPrivate.h; sourceTree = "<group>"; };
 		B47C1AAA261FCDF30078546C /* CTestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTestHelper.h; sourceTree = "<group>"; };
+		B47C1AAB261FCDF30078546C /* MMEEventsManager+Spy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MMEEventsManager+Spy.m"; sourceTree = "<group>"; };
 		B47C1ACF261FD0A30078546C /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		B47C1AD0261FD0A30078546C /* NavigationEventsManagerTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEventsManagerTestDoubles.swift; sourceTree = "<group>"; };
 		B47C1AD2261FD0A30078546C /* DummyURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyURLSessionDataTask.swift; sourceTree = "<group>"; };

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -813,6 +813,7 @@
 		AEC3AC992106703100A26F34 /* HighwayShield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighwayShield.swift; sourceTree = "<group>"; };
 		AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewControllerTests.swift; sourceTree = "<group>"; };
 		AED6285522CBE4CE00058A51 /* ViewController+GuidanceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+GuidanceCards.swift"; path = "Example/ViewController+GuidanceCards.swift"; sourceTree = "<group>"; };
+		B417913A2624F9EA001E0348 /* MBXInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MBXInfo.plist; sourceTree = "<group>"; };
 		B419BFF125F00A9C0086639B /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		B430D2F925534FDC0088CC23 /* UserHaloCourseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHaloCourseView.swift; sourceTree = "<group>"; };
 		B456A8B72620C9C000FD86D8 /* MMEEventsManager+Spy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "MMEEventsManager+Spy.m"; path = "include/MMEEventsManager+Spy.m"; sourceTree = "<group>"; };
@@ -1784,6 +1785,7 @@
 				351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */,
 				8DCE104F210FC5880048B0FB /* EndOfRouteFeedback.swift */,
 				64847A031F04629D003F3A69 /* Feedback.swift */,
+				B417913A2624F9EA001E0348 /* MBXInfo.plist */,
 				C5ADFBCD1DDCC7840011824B /* Info.plist */,
 				C5ADFBCC1DDCC7840011824B /* MapboxCoreNavigation.h */,
 				353E68FB1EF0B7F8007B2AE5 /* NavigationLocationManager.swift */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -863,6 +863,7 @@
 		B47C1B03261FD0A30078546C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B47C1B04261FD0A30078546C /* turn_left.data */ = {isa = PBXFileReference; lastKnownFileType = file; path = turn_left.data; sourceTree = "<group>"; };
 		B48CEFAB25796F5A00696BB3 /* route-for-vanishing-route-line.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-for-vanishing-route-line.json"; sourceTree = "<group>"; };
+		B4D4291826260D5900EE92A8 /* MBXInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MBXInfo.plist; sourceTree = "<group>"; };
 		C51511D020EAC89D00372A91 /* CPMapTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPMapTemplate.swift; sourceTree = "<group>"; };
 		C51DF8651F38C31C006C6A15 /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		C51FC31620F689F800400CE7 /* CustomStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomStyles.swift; path = Example/CustomStyles.swift; sourceTree = "<group>"; };
@@ -1235,6 +1236,7 @@
 			children = (
 				351BEC211E5BD506006FE110 /* Resources */,
 				351BEBDA1E5BCC28006FE110 /* Info.plist */,
+				B4D4291826260D5900EE92A8 /* MBXInfo.plist */,
 				2EBF20AD25D6F89000DB7BF2 /* Utils.swift */,
 			);
 			name = "Supporting files";

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,8 @@ let package = Package(
                 "MapboxSpeech",
                 "Solar",
             ],
-            exclude: ["Info.plist"]),
+            exclude: ["Info.plist"],
+            resources: [.copy("MBXInfo.plist")]),
         .target(
             name: "CTestHelper",
             dependencies: ["MapboxMobileEvents"]),

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,8 @@ let package = Package(
                 "MapboxMobileEvents",
                 "MapboxNavigationNative",
             ],
-            exclude: ["Info.plist"]),
+            exclude: ["Info.plist"],
+            resources: [.copy("MBXInfo.plist")]),
         .target(name: "CMapboxCoreNavigation"),
         .target(
             name: "MapboxNavigation",

--- a/Sources/MapboxCoreNavigation/BundleAdditions.swift
+++ b/Sources/MapboxCoreNavigation/BundleAdditions.swift
@@ -54,6 +54,49 @@ extension Bundle {
     }
     
     /**
+     Returns a dictionary of `MBXInfo.plist` in Mapbox Core Navigation.
+     */
+    static var mapboxCoreNavigationMBX: Dictionary<String, Any>? {
+        guard let fileURL = Bundle.mapboxCoreNavigation.url(forResource: "MBXInfo", withExtension: "plist"),
+              let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any> else { return nil }
+        return infoDictionary
+    }
+    
+    /**
+     Returns a dictionary of `MBXInfo.plist` in Mapbox Navigation framework bundle, if installed.
+     */
+    static var mapboxNavigationMBX: Dictionary<String, Any>? {
+        guard let fileURL = Bundle.mapboxNavigationIfInstalled?.url(forResource: "MBXInfo", withExtension: "plist"),
+              let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any> else { return nil }
+        return infoDictionary
+    }
+    
+    /**
+     Returns the value associated with the specific key in the Mapbox Navigation bundle's  information property list, if installed.
+     */
+    public class func object(forMapboxNavigationInfoDictionaryKey key: String) -> String? {
+        if let stringForKey = Bundle.mapboxNavigationIfInstalled?.object(forInfoDictionaryKey: key) {
+            return stringForKey as? String
+        } else if let infoDictionary = Bundle.mapboxNavigationMBX {
+            return infoDictionary[key] as? String
+        } else {
+            return nil
+        }
+    }
+    /**
+     Returns the value associated with the specific key in the Mapbox Core Navigation bundle's  information property list.
+     */
+    public class func object(forMapboxCoreNavigationInfoDictionaryKey key: String) -> String? {
+        if let stringForKey = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: key) {
+            return stringForKey as? String
+        } else if let infoDictionary = Bundle.mapboxCoreNavigationMBX {
+            return infoDictionary[key] as? String
+        } else {
+            return nil
+        }
+    }
+    
+    /**
      A file URL representing a directory in which the application can place downloaded tile files.
      */
     public var suggestedTileURL: URL? {

--- a/Sources/MapboxCoreNavigation/BundleAdditions.swift
+++ b/Sources/MapboxCoreNavigation/BundleAdditions.swift
@@ -40,11 +40,20 @@ extension Bundle {
      The Mapbox Navigation framework bundle, if installed.
      */
     class var mapboxNavigationIfInstalled: Bundle? {
-        // Assumption: MapboxNavigation.framework includes NavigationViewController and exposes it to the Objective-C runtime as MapboxNavigation.NavigationViewController.
-        guard let NavigationViewController = NSClassFromString("MapboxNavigation.NavigationViewController") else {
+        get {
+            #if SWIFT_PACKAGE
+            for bundleIdentifier in Bundle.allBundles.compactMap({ $0.bundleIdentifier }) {
+                if bundleIdentifier.contains("MapboxNavigation-MapboxNavigation") {
+                    return Bundle(identifier: bundleIdentifier)
+                }
+            }
             return nil
+            #else
+            // Assumption: MapboxNavigation.framework includes NavigationViewController and exposes it to the Objective-C runtime as MapboxNavigation.NavigationViewController.
+            guard let NavigationViewController = NSClassFromString("MapboxNavigation.NavigationViewController") else { return nil }
+            return Bundle(for: NavigationViewController)
+            #endif
         }
-        return Bundle(for: NavigationViewController)
     }
     
     public func ensureSuggestedTileURLExists() -> Bool {

--- a/Sources/MapboxCoreNavigation/BundleAdditions.swift
+++ b/Sources/MapboxCoreNavigation/BundleAdditions.swift
@@ -27,7 +27,13 @@ extension Bundle {
      The Mapbox Core Navigation framework bundle.
      */
     public class var mapboxCoreNavigation: Bundle {
-        return Bundle(for: RouteController.self)
+        get {
+            #if SWIFT_PACKAGE
+            return .module
+            #else
+            return Bundle(for: RouteController.self)
+            #endif
+        }
     }
     
     /**

--- a/Sources/MapboxCoreNavigation/BundleAdditions.swift
+++ b/Sources/MapboxCoreNavigation/BundleAdditions.swift
@@ -56,20 +56,20 @@ extension Bundle {
     /**
      Returns a dictionary of `MBXInfo.plist` in Mapbox Core Navigation.
      */
-    static var mapboxCoreNavigationMBX: Dictionary<String, Any>? {
+    static let mapboxCoreNavigationInfoDictionary: [String: Any]? = {
         guard let fileURL = Bundle.mapboxCoreNavigation.url(forResource: "MBXInfo", withExtension: "plist"),
-              let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any> else { return nil }
+              let infoDictionary = NSDictionary(contentsOf: fileURL) as? [String: Any] else { return nil }
         return infoDictionary
-    }
+    }()
     
     /**
      Returns a dictionary of `MBXInfo.plist` in Mapbox Navigation framework bundle, if installed.
      */
-    static var mapboxNavigationMBX: Dictionary<String, Any>? {
+    static let mapboxNavigationInfoDictionary: [String: Any]? = {
         guard let fileURL = Bundle.mapboxNavigationIfInstalled?.url(forResource: "MBXInfo", withExtension: "plist"),
-              let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any> else { return nil }
+              let infoDictionary = NSDictionary(contentsOf: fileURL) as? [String: Any] else { return nil }
         return infoDictionary
-    }
+    }()
     
     /**
      Returns the value associated with the specific key in the Mapbox Navigation bundle's  information property list, if installed.
@@ -77,7 +77,7 @@ extension Bundle {
     public class func object(forMapboxNavigationInfoDictionaryKey key: String) -> String? {
         if let stringForKey = Bundle.mapboxNavigationIfInstalled?.object(forInfoDictionaryKey: key) {
             return stringForKey as? String
-        } else if let infoDictionary = Bundle.mapboxNavigationMBX {
+        } else if let infoDictionary = Bundle.mapboxNavigationInfoDictionary {
             return infoDictionary[key] as? String
         } else {
             return nil
@@ -89,7 +89,7 @@ extension Bundle {
     public class func object(forMapboxCoreNavigationInfoDictionaryKey key: String) -> String? {
         if let stringForKey = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: key) {
             return stringForKey as? String
-        } else if let infoDictionary = Bundle.mapboxCoreNavigationMBX {
+        } else if let infoDictionary = Bundle.mapboxCoreNavigationInfoDictionary {
             return infoDictionary[key] as? String
         } else {
             return nil

--- a/Sources/MapboxCoreNavigation/EventDetails.swift
+++ b/Sources/MapboxCoreNavigation/EventDetails.swift
@@ -96,15 +96,10 @@ struct NavigationEventDetails: EventDetails {
     let startTimestamp: Date?
     let sdkIdentifier: String
     var sdkVersion: String {
-        if let stringForShortVersion = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: "CFBundleShortVersionString") {
-            return String(describing: stringForShortVersion)
-        } else if let fileURL = Bundle.mapboxCoreNavigation.url(forResource: "MBXInfo", withExtension: "plist"),
-                  let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any>,
-                  let stringFromMBX = infoDictionary["CFBundleShortVersionString"] as? String {
-            return stringFromMBX
-        } else {
+        guard let stringForShortVersion = Bundle.object(forMapboxCoreNavigationInfoDictionaryKey: "CFBundleShortVersionString") else {
             preconditionFailure("CFBundleShortVersionString must be set in the Info.plist.")
         }
+        return stringForShortVersion
     }
     let userAbsoluteDistanceToDestination: CLLocationDistance?
     let volumeLevel: Int = Int(AVAudioSession.sharedInstance().outputVolume * 100)

--- a/Sources/MapboxCoreNavigation/EventDetails.swift
+++ b/Sources/MapboxCoreNavigation/EventDetails.swift
@@ -98,8 +98,12 @@ struct NavigationEventDetails: EventDetails {
     var sdkVersion: String {
         if let stringForShortVersion = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: "CFBundleShortVersionString") {
             return String(describing: stringForShortVersion)
+        } else if let fileURL = Bundle.mapboxCoreNavigation.url(forResource: "MBXInfo", withExtension: "plist"),
+                  let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any>,
+                  let stringFromMBX = infoDictionary["CFBundleShortVersionString"] as? String {
+            return stringFromMBX
         } else {
-            return String(describing: UserDefaults.standard.object(forKey: "CFBundleShortVersionString"))
+            preconditionFailure("CFBundleShortVersionString must be set in the Info.plist.")
         }
     }
     let userAbsoluteDistanceToDestination: CLLocationDistance?

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -385,7 +385,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     private func checkForUpdates() {
         #if TARGET_IPHONE_SIMULATOR
         guard (NSClassFromString("XCTestCase") == nil) else { return } // Short-circuit when running unit tests
-        guard let version = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: "CFBundleShortVersionString") else { return }
+        guard let version = Bundle.object(forMapboxCoreNavigationInfoDictionaryKey: "CFBundleShortVersionString") else { return }
             let latestVersion = String(describing: version)
             _ = URLSession.shared.dataTask(with: URL(string: "https://docs.mapbox.com/ios/navigation/latest_version.txt")!, completionHandler: { (data, response, error) in
                 if let _ = error { return }

--- a/Sources/MapboxCoreNavigation/MBXInfo.plist
+++ b/Sources/MapboxCoreNavigation/MBXInfo.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>MapboxCoreNavigation</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>

--- a/Sources/MapboxCoreNavigation/MBXInfo.plist
+++ b/Sources/MapboxCoreNavigation/MBXInfo.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>48</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -83,12 +83,18 @@ open class NavigationEventsManager {
     func start() {
         let userAgent = usesDefaultUserInterface ? "mapbox-navigation-ui-ios" : "mapbox-navigation-ios"
 
-        if let stringForShortVersion = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: "CFBundleShortVersionString") {
-            mobileEventsManager.initialize(withAccessToken: accessToken, userAgentBase: userAgent, hostSDKVersion: String(describing:stringForShortVersion))
+        var stringForShortVersion: String?
+        if let stringFromInfo = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
+            stringForShortVersion = stringFromInfo
+        } else if let fileURL = Bundle.mapboxCoreNavigation.url(forResource: "MBXInfo", withExtension: "plist"),
+                  let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any>,
+                  let stringFromMBX = infoDictionary["CFBundleShortVersionString"] as? String {
+            stringForShortVersion = stringFromMBX
         } else {
-            mobileEventsManager.initialize(withAccessToken: accessToken, userAgentBase: userAgent, hostSDKVersion: String(describing: UserDefaults.standard.object(forKey: "CFBundleShortVersionString")!))
+            preconditionFailure("CFBundleShortVersionString must be set in the Info.plist.")
         }
-
+        
+        mobileEventsManager.initialize(withAccessToken: accessToken, userAgentBase: userAgent, hostSDKVersion: String(describing:stringForShortVersion))
         mobileEventsManager.sendTurnstileEvent()
     }
     

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -83,17 +83,9 @@ open class NavigationEventsManager {
     func start() {
         let userAgent = usesDefaultUserInterface ? "mapbox-navigation-ui-ios" : "mapbox-navigation-ios"
 
-        var stringForShortVersion: String?
-        if let stringFromInfo = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
-            stringForShortVersion = stringFromInfo
-        } else if let fileURL = Bundle.mapboxCoreNavigation.url(forResource: "MBXInfo", withExtension: "plist"),
-                  let infoDictionary = NSDictionary(contentsOf: fileURL) as? Dictionary<String, Any>,
-                  let stringFromMBX = infoDictionary["CFBundleShortVersionString"] as? String {
-            stringForShortVersion = stringFromMBX
-        } else {
+        guard let stringForShortVersion = Bundle.object(forMapboxCoreNavigationInfoDictionaryKey: "CFBundleShortVersionString") else {
             preconditionFailure("CFBundleShortVersionString must be set in the Info.plist.")
         }
-        
         mobileEventsManager.initialize(withAccessToken: accessToken, userAgentBase: userAgent, hostSDKVersion: String(describing:stringForShortVersion))
         mobileEventsManager.sendTurnstileEvent()
     }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -555,7 +555,7 @@ private extension Double {
 private func checkForUpdates() {
     #if TARGET_IPHONE_SIMULATOR
     guard (NSClassFromString("XCTestCase") == nil) else { return } // Short-circuit when running unit tests
-    guard let version = Bundle.mapboxCoreNavigation.object(forInfoDictionaryKey: "CFBundleShortVersionString") else { return }
+    guard let version = Bundle.object(forMapboxCoreNavigationInfoDictionaryKey: "CFBundleShortVersionString") else { return }
     let latestVersion = String(describing: version)
     _ = URLSession.shared.dataTask(with: URL(string: "https://docs.mapbox.com/ios/navigation/latest_version.txt")!, completionHandler: { (data, response, error) in
         if let _ = error { return }

--- a/Sources/MapboxCoreNavigation/URLSession.swift
+++ b/Sources/MapboxCoreNavigation/URLSession.swift
@@ -16,10 +16,18 @@ extension URLSession {
             .init(for: Directions.self),
         ]
         let bundleComponents = bundles.compactMap { (bundle) -> String? in
-            guard let name = bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundle?.bundleIdentifier,
-                let version = bundle?.object(forInfoDictionaryKey:"CFBundleShortVersionString") as? String else {
-                return nil
+            guard let name = bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundle?.bundleIdentifier else { return nil }
+            var stringForShortVersion: String? {
+                switch name {
+                case "MapboxNavigation":
+                    return Bundle.object(forMapboxNavigationInfoDictionaryKey: "CFBundleShortVersionString")
+                case "MapboxCoreNavigation":
+                    return Bundle.object(forMapboxCoreNavigationInfoDictionaryKey: "CFBundleShortVersionString")
+                default:
+                    return bundle?.object(forInfoDictionaryKey:"CFBundleShortVersionString") as? String
+                }
             }
+            guard let version = stringForShortVersion else { return nil }
             return "\(name)/\(version)"
         }
 

--- a/Sources/MapboxNavigation/MBXInfo.plist
+++ b/Sources/MapboxNavigation/MBXInfo.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>MapboxNavigation</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>

--- a/Sources/MapboxNavigation/MBXInfo.plist
+++ b/Sources/MapboxNavigation/MBXInfo.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>48</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -26,7 +26,6 @@ class MapboxCoreNavigationTests: XCTestCase {
         super.setUp()
         UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationWhenInUseUsageDescription")
         UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
-        UserDefaults.standard.set("2.0.0", forKey: "CFBundleShortVersionString")
     }
     
     override func tearDown() {

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -36,6 +36,10 @@ cd Tests/CocoaPodsTest/PodInstall/
 pod update
 cd -
 
+cd Sources/MapboxCoreNavigation/
+cp Info.plist MBXInfo.plist
+cd -
+
 step "Updating changelog to version ${SHORT_VERSION}…"
 
 sed -i '' -E "s/## *main/## ${SHORT_VERSION}/g" CHANGELOG.md

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -38,6 +38,12 @@ cd -
 
 cd Sources/MapboxCoreNavigation/
 cp Info.plist MBXInfo.plist
+plutil -replace CFBundleName -string 'MapboxCoreNavigation' MBXInfo.plist
+cd -
+
+cd Sources/MapboxNavigation/
+cp Info.plist MBXInfo.plist
+plutil -replace CFBundleName -string 'MapboxNavigation' MBXInfo.plist
 cd -
 
 step "Updating changelog to version ${SHORT_VERSION}…"


### PR DESCRIPTION
### Description
This pr is to fix #2922 .

### Implementation
When running the app generated by SPM, the `Info.plist` is also default to the one generated by SPM, which is missing some certain keys, such as the `CFBundleShortVersionString` . This pr is to create a resource file `MBXInfo.plist` same as `Info.plist`, and copy it to the MapboxCoreNavigation. When the bundle couldn't find certain keys contained in `Info.plist` , it would check the `MBXInfo.plist`.

Update the `update-script.sh` to copy the `Info.plist` to `MBXInfo.plist`.

### Screenshots or Gifs
