### PR TITLE
Add integration test for Swift Package Manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,26 @@ jobs:
       - *build-Example
       - *save-cache
 
+  spm-integration-test:
+    parameters:
+      iOS:
+        type: string
+        default: "14.4"
+      xcode:
+        type: string
+        default: "12.4.0"
+    macos:
+      xcode: << parameters.xcode >>
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *prepare-mapbox-file
+      - *prepare-netrc-file
+      - run: sed -i '' -e "s/6cc9728a615ed9b08632a6c2d09f7fca57a5c542/`git rev-parse --verify HEAD`/" Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj # Replace SPM package reference with current revision
+      - run: cd Tests/SPMTest && xcodebuild -scheme SPMTest -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=iPhone 8 Plus' -derivedDataPath derivedData/ clean build | xcpretty
+      - run: cd Tests/SPMTest && xcodebuild -scheme SPMTest -sdk iphoneos<< parameters.iOS >> -destination generic/platform=iOS -derivedDataPath derivedData/ clean archive CODE_SIGNING_ALLOWED="NO" | xcpretty
+
   ios-trigger-metrics:
     parameters:
       xcode:
@@ -294,6 +314,7 @@ workflows:
           iOS: "14.0"
           lint: true
       - xcode-12-examples
+      - spm-integration-test
       - ios-trigger-metrics:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,9 +272,7 @@ jobs:
       - *prepare-mapbox-file
       - *prepare-netrc-file
       - *add-github-to-known-hosts
-      - run: sed -i '' -e "s/6cc9728a615ed9b08632a6c2d09f7fca57a5c542/`git rev-parse --verify HEAD`/" Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj # Replace SPM package reference with current revision
-      - run: cd Tests/SPMTest && xcodebuild -scheme SPMTest -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=iPhone 8 Plus' -derivedDataPath derivedData/ clean build | xcpretty
-      - run: cd Tests/SPMTest && xcodebuild -scheme SPMTest -sdk iphoneos<< parameters.iOS >> -destination generic/platform=iOS -derivedDataPath derivedData/ clean archive CODE_SIGNING_ALLOWED="NO" | xcpretty
+      - run: scripts/build_spm_integration_test.sh << parameters.iOS >>
 
   ios-trigger-metrics:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
       - checkout
       - *prepare-mapbox-file
       - *prepare-netrc-file
+      - *add-github-to-known-hosts
       - run: sed -i '' -e "s/6cc9728a615ed9b08632a6c2d09f7fca57a5c542/`git rev-parse --verify HEAD`/" Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj # Replace SPM package reference with current revision
       - run: cd Tests/SPMTest && xcodebuild -scheme SPMTest -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=iPhone 8 Plus' -derivedDataPath derivedData/ clean build | xcpretty
       - run: cd Tests/SPMTest && xcodebuild -scheme SPMTest -sdk iphoneos<< parameters.iOS >> -destination generic/platform=iOS -derivedDataPath derivedData/ clean archive CODE_SIGNING_ALLOWED="NO" | xcpretty

--- a/Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -357,7 +357,7 @@
 			repositoryURL = "../..";
 			requirement = {
 				kind = revision;
-				revision = 6cc9728a615ed9b08632a6c2d09f7fca57a5c542;
+				revision = 0460c440b8b80dfe64356364787f41ea2ccf9ee8;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -1,0 +1,379 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		119B08442625D913007E909F /* MapboxNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = 119B08432625D913007E909F /* MapboxNavigation */; };
+		119B08462625D913007E909F /* MapboxCoreNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = 119B08452625D913007E909F /* MapboxCoreNavigation */; };
+		11E727432625BEA600C1890B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E727422625BEA600C1890B /* AppDelegate.swift */; };
+		11E727452625BEA600C1890B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E727442625BEA600C1890B /* SceneDelegate.swift */; };
+		11E727472625BEA600C1890B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E727462625BEA600C1890B /* ViewController.swift */; };
+		11E7274A2625BEA600C1890B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 11E727482625BEA600C1890B /* Main.storyboard */; };
+		11E7274C2625BEA800C1890B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 11E7274B2625BEA800C1890B /* Assets.xcassets */; };
+		11E7274F2625BEA800C1890B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 11E7274D2625BEA800C1890B /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		11E7273F2625BEA600C1890B /* SPMTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SPMTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		11E727422625BEA600C1890B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		11E727442625BEA600C1890B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		11E727462625BEA600C1890B /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		11E727492625BEA600C1890B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		11E7274B2625BEA800C1890B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		11E7274E2625BEA800C1890B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		11E727502625BEA800C1890B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		11E7273C2625BEA600C1890B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				119B08462625D913007E909F /* MapboxCoreNavigation in Frameworks */,
+				119B08442625D913007E909F /* MapboxNavigation in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		11E727362625BEA500C1890B = {
+			isa = PBXGroup;
+			children = (
+				11E727412625BEA600C1890B /* SPMTest */,
+				11E727402625BEA600C1890B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		11E727402625BEA600C1890B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				11E7273F2625BEA600C1890B /* SPMTest.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		11E727412625BEA600C1890B /* SPMTest */ = {
+			isa = PBXGroup;
+			children = (
+				11E727422625BEA600C1890B /* AppDelegate.swift */,
+				11E727442625BEA600C1890B /* SceneDelegate.swift */,
+				11E727462625BEA600C1890B /* ViewController.swift */,
+				11E727482625BEA600C1890B /* Main.storyboard */,
+				11E7274B2625BEA800C1890B /* Assets.xcassets */,
+				11E7274D2625BEA800C1890B /* LaunchScreen.storyboard */,
+				11E727502625BEA800C1890B /* Info.plist */,
+			);
+			path = SPMTest;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		11E7273E2625BEA600C1890B /* SPMTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 11E727532625BEA800C1890B /* Build configuration list for PBXNativeTarget "SPMTest" */;
+			buildPhases = (
+				11E7273B2625BEA600C1890B /* Sources */,
+				11E7273C2625BEA600C1890B /* Frameworks */,
+				11E7273D2625BEA600C1890B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SPMTest;
+			packageProductDependencies = (
+				119B08432625D913007E909F /* MapboxNavigation */,
+				119B08452625D913007E909F /* MapboxCoreNavigation */,
+			);
+			productName = SPMTest;
+			productReference = 11E7273F2625BEA600C1890B /* SPMTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		11E727372625BEA500C1890B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					11E7273E2625BEA600C1890B = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = 11E7273A2625BEA500C1890B /* Build configuration list for PBXProject "SPMTest" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 11E727362625BEA500C1890B;
+			packageReferences = (
+				119B08422625D913007E909F /* XCRemoteSwiftPackageReference "mapbox-navigation-ios" */,
+			);
+			productRefGroup = 11E727402625BEA600C1890B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				11E7273E2625BEA600C1890B /* SPMTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		11E7273D2625BEA600C1890B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11E7274F2625BEA800C1890B /* LaunchScreen.storyboard in Resources */,
+				11E7274C2625BEA800C1890B /* Assets.xcassets in Resources */,
+				11E7274A2625BEA600C1890B /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		11E7273B2625BEA600C1890B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11E727472625BEA600C1890B /* ViewController.swift in Sources */,
+				11E727432625BEA600C1890B /* AppDelegate.swift in Sources */,
+				11E727452625BEA600C1890B /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		11E727482625BEA600C1890B /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				11E727492625BEA600C1890B /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		11E7274D2625BEA800C1890B /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				11E7274E2625BEA800C1890B /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		11E727512625BEA800C1890B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		11E727522625BEA800C1890B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		11E727542625BEA800C1890B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SPMTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.navigation.SPMTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		11E727552625BEA800C1890B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SPMTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.navigation.SPMTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		11E7273A2625BEA500C1890B /* Build configuration list for PBXProject "SPMTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				11E727512625BEA800C1890B /* Debug */,
+				11E727522625BEA800C1890B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		11E727532625BEA800C1890B /* Build configuration list for PBXNativeTarget "SPMTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				11E727542625BEA800C1890B /* Debug */,
+				11E727552625BEA800C1890B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		119B08422625D913007E909F /* XCRemoteSwiftPackageReference "mapbox-navigation-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "../..";
+			requirement = {
+				kind = revision;
+				revision = 6cc9728a615ed9b08632a6c2d09f7fca57a5c542;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		119B08432625D913007E909F /* MapboxNavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 119B08422625D913007E909F /* XCRemoteSwiftPackageReference "mapbox-navigation-ios" */;
+			productName = MapboxNavigation;
+		};
+		119B08452625D913007E909F /* MapboxCoreNavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 119B08422625D913007E909F /* XCRemoteSwiftPackageReference "mapbox-navigation-ios" */;
+			productName = MapboxCoreNavigation;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 11E727372625BEA500C1890B /* Project object */;
+}

--- a/Tests/SPMTest/SPMTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/SPMTest/SPMTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tests/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,7 +51,7 @@
         "repositoryURL": "/Users/alexander/Developer/Mapbox/mapbox-navigation-ios",
         "state": {
           "branch": null,
-          "revision": "93922e0397a63ae297c839fa96ac9e13d5bd8def",
+          "revision": "0460c440b8b80dfe64356364787f41ea2ccf9ee8",
           "version": null
         }
       },

--- a/Tests/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,124 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "MapboxCommon",
+        "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "50a87705438ee5b2c890a1fcacb54dfd867d738f",
+          "version": "10.0.2"
+        }
+      },
+      {
+        "package": "MapboxCoreMaps",
+        "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "4c3d0fbb1cb2fc25351cb105a05be487bcc8ffe6",
+          "version": "10.0.0-beta.17"
+        }
+      },
+      {
+        "package": "MapboxDirections",
+        "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "399d28ca1c7306a0188d4368bf4b86af2ab9e8e4",
+          "version": "2.0.0-beta.2"
+        }
+      },
+      {
+        "package": "MapboxMobileEvents",
+        "repositoryURL": "https://github.com/mapbox/mapbox-events-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "6e4aa13817d59038bf762032e938fe0f7b95b589",
+          "version": "0.10.8"
+        }
+      },
+      {
+        "package": "MapboxMaps",
+        "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "bb9bffb2ac6bef5acd5cd7051a6f9b7cd8c0a014",
+          "version": "10.0.0-beta.16"
+        }
+      },
+      {
+        "package": "MapboxNavigation",
+        "repositoryURL": "/Users/alexander/Developer/Mapbox/mapbox-navigation-ios",
+        "state": {
+          "branch": null,
+          "revision": "93922e0397a63ae297c839fa96ac9e13d5bd8def",
+          "version": null
+        }
+      },
+      {
+        "package": "MapboxNavigationNative",
+        "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "11dcfc7cc48ab06af17fd0efd4211bc221196d07",
+          "version": "47.0.0"
+        }
+      },
+      {
+        "package": "MapboxSpeech",
+        "repositoryURL": "https://github.com/mapbox/mapbox-speech-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "4501b0cbf709ae9fdabb82a2942cd3d54295b411",
+          "version": "2.0.0-alpha.1"
+        }
+      },
+      {
+        "package": "MapboxGeocoder",
+        "repositoryURL": "https://github.com/mapbox/MapboxGeocoder.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "91fb908bb57c0fcddc0062b5d64ea2002e0ea789",
+          "version": "0.14.0"
+        }
+      },
+      {
+        "package": "Polyline",
+        "repositoryURL": "https://github.com/raphaelmor/Polyline.git",
+        "state": {
+          "branch": null,
+          "revision": "36f7b1222aaf8fa741d0d179c12e186998d97f42",
+          "version": "5.0.2"
+        }
+      },
+      {
+        "package": "Solar",
+        "repositoryURL": "https://github.com/ceeK/Solar.git",
+        "state": {
+          "branch": null,
+          "revision": "eacab01aa732612d97c723ceb77c748aaba54c82",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "package": "SwiftCLI",
+        "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
+        "state": {
+          "branch": null,
+          "revision": "2816678bcc37f4833d32abeddbdf5e757fa891d8",
+          "version": "6.0.2"
+        }
+      },
+      {
+        "package": "Turf",
+        "repositoryURL": "https://github.com/mapbox/turf-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "23e72d4174eacd76cc6414f063b427d2dac81cfb",
+          "version": "2.0.0-alpha.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Tests/SPMTest/SPMTest/AppDelegate.swift
+++ b/Tests/SPMTest/SPMTest/AppDelegate.swift
@@ -1,10 +1,3 @@
-//
-//  AppDelegate.swift
-//  SPMTest
-//
-//  Created by Alexander Azarov on 13.04.21.
-//
-
 import UIKit
 
 @main

--- a/Tests/SPMTest/SPMTest/AppDelegate.swift
+++ b/Tests/SPMTest/SPMTest/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  SPMTest
+//
+//  Created by Alexander Azarov on 13.04.21.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Tests/SPMTest/SPMTest/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Tests/SPMTest/SPMTest/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SPMTest/SPMTest/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tests/SPMTest/SPMTest/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SPMTest/SPMTest/Assets.xcassets/Contents.json
+++ b/Tests/SPMTest/SPMTest/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SPMTest/SPMTest/Base.lproj/LaunchScreen.storyboard
+++ b/Tests/SPMTest/SPMTest/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/SPMTest/SPMTest/Base.lproj/Main.storyboard
+++ b/Tests/SPMTest/SPMTest/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/SPMTest/SPMTest/Info.plist
+++ b/Tests/SPMTest/SPMTest/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/SPMTest/SPMTest/SceneDelegate.swift
+++ b/Tests/SPMTest/SPMTest/SceneDelegate.swift
@@ -1,10 +1,3 @@
-//
-//  SceneDelegate.swift
-//  SPMTest
-//
-//  Created by Alexander Azarov on 13.04.21.
-//
-
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/Tests/SPMTest/SPMTest/SceneDelegate.swift
+++ b/Tests/SPMTest/SPMTest/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  SPMTest
+//
+//  Created by Alexander Azarov on 13.04.21.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Tests/SPMTest/SPMTest/ViewController.swift
+++ b/Tests/SPMTest/SPMTest/ViewController.swift
@@ -1,12 +1,12 @@
 import UIKit
-import MapboxCoreNavigation
+import MapboxNavigation
 
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let distanceFormatter = DistanceFormatter()
-        print(distanceFormatter.attributedString(from: .init(value: 10, unit: .meters)))
+        let stepsViewController = StepsViewController()
+        print(stepsViewController)
     }
 }

--- a/Tests/SPMTest/SPMTest/ViewController.swift
+++ b/Tests/SPMTest/SPMTest/ViewController.swift
@@ -1,0 +1,12 @@
+import UIKit
+import MapboxCoreNavigation
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let distanceFormatter = DistanceFormatter()
+        print(distanceFormatter.attributedString(from: .init(value: 10, unit: .meters)))
+    }
+}

--- a/scripts/build_spm_integration_test.sh
+++ b/scripts/build_spm_integration_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Updates SPM integration test to use Package.swift from the current commit, builds and archives the app.
+# Input argument – iOS version (default value is 14.4)
+
+set -euo pipefail
+
+IOS_VERSION=${1:-14.4}
+
+cd Tests/SPMTest
+sed -i '' -e "s/6cc9728a615ed9b08632a6c2d09f7fca57a5c542/`git rev-parse --verify HEAD`/" SPMTest.xcodeproj/project.pbxproj
+xcodebuild -scheme SPMTest -destination "platform=iOS Simulator,OS=$IOS_VERSION,name=iPhone 8 Plus" clean build | xcpretty
+xcodebuild -scheme SPMTest -sdk iphoneos$IOS_VERSION -destination generic/platform=iOS clean archive CODE_SIGNING_ALLOWED="NO" | xcpretty


### PR DESCRIPTION
### Description
Fixes #2903.

### Implementation
We already build the Example scheme on CI, where our SDKs are included via SPM, however, we added the `mapbox-navigation-ios` package to the Xcode project: 
![image](https://user-images.githubusercontent.com/1976216/114573828-64c0c000-9c81-11eb-967e-4b0e57459f1d.png)



This isn't the way our package will be integrated into the consumer apps. For example, we don't have MapboxNavigation and MapboxCoreNavigation in our [Package.resolved](https://github.com/mapbox/mapbox-navigation-ios/blob/release-v2.0/MapboxNavigation.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved) file.

On the other hand, my sample app contains an external reference to the `MapboxNavigation` package, which is the expected way to integrate our SDK:
![image](https://user-images.githubusercontent.com/1976216/114574255-c41ed000-9c81-11eb-9fcd-d7f8ac1f4479.png)

By integrating the package this way we now have it in [Package.resolved](https://github.com/mapbox/mapbox-navigation-ios/blob/3cf0ef9b36c4ce8e2dc27b4c078098d260c0bc4b/Tests/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved#L50) file.
Also now we have `XCRemoteSwiftPackageReference` section in [.pbxproj file](https://github.com/mapbox/mapbox-navigation-ios/blob/3cf0ef9b36c4ce8e2dc27b4c078098d260c0bc4b/Tests/SPMTest/SPMTest.xcodeproj/project.pbxproj#L354-L363), which we don't have in current development project.
All these will help us to test SPM integration fairer and avoid issues like #2824.

I also added new CircleCI step that builds and archives this sample app.