### PR TITLE
Reimplement label localization atop Expression

### DIFF
--- a/Example/ViewController+FreeDrive.swift
+++ b/Example/ViewController+FreeDrive.swift
@@ -70,6 +70,7 @@ extension ViewController {
         
         navigationMapView.mapView.on(.styleLoaded, handler: { [weak self] _ in
             guard let self = self else { return }
+            self.navigationMapView.localizeLabels()
             self.addStyledFeature(self.trackStyledFeature)
             self.addStyledFeature(self.rawTrackStyledFeature)
         })

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 		DABA591525E58D5600D0C1DB /* Accounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABA591425E58D5600D0C1DB /* Accounts.swift */; };
 		DAD17202214DB12B009C8161 /* CPMapTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD17201214DB12B009C8161 /* CPMapTemplateTests.swift */; };
 		DAD903AF23E3DCC80057CF1F /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD903AE23E3DCC80057CF1F /* DateTests.swift */; };
+		DADD28EF2627607D00EA6A47 /* VectorSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADD28EE2627607D00EA6A47 /* VectorSource.swift */; };
 		DADD82802161EC0300B8B47D /* UIViewAnimationOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADD827F2161EC0300B8B47D /* UIViewAnimationOptionsTests.swift */; };
 		DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */; };
 		F4BF512E24EAD7A50066A49B /* FeedbackSubtypeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BF512D24EAD7A50066A49B /* FeedbackSubtypeCollectionViewCell.swift */; };
@@ -1003,6 +1004,7 @@
 		DAD88E01202AC80100AAA536 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DAD88E02202AC81F00AAA536 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = da; path = Resources/da.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DAD903AE23E3DCC80057CF1F /* DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTests.swift; sourceTree = "<group>"; };
+		DADD28EE2627607D00EA6A47 /* VectorSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorSource.swift; sourceTree = "<group>"; };
 		DADD827F2161EC0300B8B47D /* UIViewAnimationOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewAnimationOptionsTests.swift; sourceTree = "<group>"; };
 		DAE26B1A20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Main.strings; sourceTree = "<group>"; };
 		DAE26B1C20644047001D6E1F /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Navigation.strings; sourceTree = "<group>"; };
@@ -1658,6 +1660,7 @@
 				8AE9081125FAA53300F37077 /* Collection.swift */,
 				8A8C3D97260175D20071D274 /* CLLocationDirection.swift */,
 				8A446644260A7B24008BA55E /* BoundingBox.swift */,
+				DADD28EE2627607D00EA6A47 /* VectorSource.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2468,6 +2471,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				351BEBF11E5BCC63006FE110 /* MapView.swift in Sources */,
+				DADD28EF2627607D00EA6A47 /* VectorSource.swift in Sources */,
 				DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */,
 				2B72EC5E241276D10003B370 /* RouteVoiceController.swift in Sources */,
 				2B72EC602412AA800003B370 /* SystemSpeechSynthesizer.swift in Sources */,

--- a/Sources/MapboxNavigation/Expression.swift
+++ b/Sources/MapboxNavigation/Expression.swift
@@ -1,5 +1,11 @@
 import MapboxMaps
 
+extension VectorSource {
+    static func preferredMapboxStreetsLanguage(for preferences: [String]) -> String? {
+        return nil
+    }
+}
+
 extension Expression {
     
     static func routeLineWidthExpression(_ multiplier: Double = 1.0) -> Expression {
@@ -29,5 +35,87 @@ extension Expression {
                 hightProperty
             }
         }
+    }
+    
+    func localized(into locale: Locale?) -> Expression {
+        switch elements.first {
+        case .op(.literal):
+            return self
+        case .op(.get):
+            guard elements.count == 2,
+                  case let .argument(argument) = elements[1],
+                  case let .string(propertyName) = argument else {
+                break
+            }
+            
+            if propertyName == "name" || propertyName.starts(with: "name_") {
+                var localizedPropertyName = "name"
+                if locale?.identifier != "mul" {
+                    let preferences: [String]
+                    if let identifier = locale?.identifier {
+                        preferences = [identifier]
+                    } else {
+                        preferences = Locale.preferredLanguages
+                    }
+                    if let preferredLanguage = VectorSource.preferredMapboxStreetsLanguage(for: preferences) {
+                        localizedPropertyName = "name_\(preferredLanguage)"
+                    }
+                }
+                // If the keypath is `name`, no need to fallback
+                guard localizedPropertyName != "name" else {
+                    return Exp(.get) { localizedPropertyName }
+                }
+                // If the keypath is `name_zh-Hans`, fallback to `name_zh` to `name`.
+                // CN tiles might using `name_zh-CN` for Simplified Chinese.
+                guard localizedPropertyName != "name_zh-Hans" else {
+                    return Exp(.coalesce) {
+                        localizedPropertyName
+                        "name_zh-CN"
+                        "name_zh"
+                        "name"
+                    }
+                }
+                // Mapbox Streets v8 has `name_zh-Hant`, we should fallback to Simplified Chinese if the field has no value.
+                guard localizedPropertyName != "name_zh-Hant" else {
+                    return Exp(.coalesce) {
+                        localizedPropertyName
+                        "name_zh-Hans"
+                        "name_zh-CN"
+                        "name_zh"
+                        "name"
+                    }
+                }
+                // Other keypath fallback to `name`
+                return Exp(.coalesce) {
+                    localizedPropertyName
+                    "name"
+                }
+            }
+        case .op(let op):
+            let arguments = elements.suffix(from: 1).map { (element) -> Element in
+                switch element {
+                case .argument(.option(let options)):
+                    if var options = options as? NumberFormatOptions {
+                        options.locale = locale?.identifier ?? options.locale
+                        return .argument(.option(options))
+                    } else if var options = options as? CollatorOptions {
+                        options.locale = locale?.identifier ?? options.locale
+                        return .argument(.option(options))
+                    } else {
+                        return .argument(.option(options))
+                    }
+                case .argument(.expression(let expr)):
+                    return .argument(.expression(expr.localized(into: locale)))
+                default:
+                    return element
+                }
+            }
+            var exp = Exp(op)
+            exp.elements = [.op(op)] + arguments
+            return exp
+        case .none, .argument(_):
+            return self
+        }
+        return self
     }
 }

--- a/Sources/MapboxNavigation/MapView.swift
+++ b/Sources/MapboxNavigation/MapView.swift
@@ -138,4 +138,47 @@ extension MapView {
         
         return []
     }
+    
+    /**
+     Returns a boolean value indicating whether the tile source is a supported version of the Mapbox Streets source.
+     */
+    func isMapboxStreets(_ identifiers: [String]) -> Bool {
+        return identifiers.contains("mapbox.mapbox-streets-v8") || identifiers.contains("mapbox.mapbox-streets-v7")
+    }
+    
+    /**
+     Returns identifiers of the tile sets that make up specific source.
+     
+     This array contains multiple entries for a composited source. This property is empty for non-Mapbox-hosted tile sets and sources with type other than `vector`.
+     */
+    func tileSetIdentifiers(_ sourceIdentifier: String, sourceType: String) -> [String] {
+        do {
+            if sourceType == "vector",
+               let properties = try __map.getStyleSourceProperties(forSourceId: sourceIdentifier).value as? Dictionary<String, Any>,
+               let url = properties["url"] as? String,
+               let configurationURL = URL(string: url),
+               configurationURL.scheme == "mapbox",
+               let tileSetIdentifiers = configurationURL.host?.components(separatedBy: ",") {
+                return tileSetIdentifiers
+            }
+        } catch {
+            NSLog("Failed to get source properties with error: \(error.localizedDescription).")
+        }
+        
+        return []
+    }
+    
+    /**
+     Returns a list of source identifiers, which contain streets tile set.
+     */
+    func streetsSources() -> [StyleObjectInfo] {
+        let streetsSources = (try? __map.getStyleSources().compactMap {
+            $0
+        }.filter {
+            let identifiers = tileSetIdentifiers($0.id, sourceType: $0.type)
+            return isMapboxStreets(identifiers)
+        }) ?? []
+        
+        return streetsSources
+    }
 }

--- a/Sources/MapboxNavigation/VectorSource.swift
+++ b/Sources/MapboxNavigation/VectorSource.swift
@@ -1,0 +1,9 @@
+import MapboxMaps
+
+extension VectorSource {
+    /// A dictionary associating known tile set identifiers with identifiers of source layers that contain road names.
+    static let roadLabelLayerIdentifiersByTileSetIdentifier = [
+        "mapbox.mapbox-streets-v8": "road",
+        "mapbox.mapbox-streets-v7": "road_label",
+    ]
+}


### PR DESCRIPTION
Restored the `NavigationMapView.localizeLabels()` implementation for automatically localizing map labels into the user’s language. The previous implementation was removed as part of upgrading to map SDK v10 in #2808, because it relied on [an NSExpression-based localization feature](https://github.com/mapbox/mapbox-gl-native-ios/blob/ddf8e35970d1a8a46171bd798bcfa8f22d2760e0/platform/darwin/src/NSExpression%2BMGLAdditions.mm#L1494-L1637) in map SDK v6._x_, which has been replaced by a new Expression type system. This PR ports map SDK v6._x_’s NSExpression-based localization feature to Expression as part of MapboxNavigation, in anticipation of a more cross-platform solution in future versions of the map SDK. Note that this implementation continues to differ from map SDK v6._x_’s default behavior, in that road labels remain unlocalized by design.

More to come:

* [x] Port NSExpression-based localization to Expression (and from Objective-C to Swift)
* [ ] Add support for localizing formatted expressions
* [x] Port MGLVectorStyleLayer-based localizable layer discovery to VectorLayer
* [ ] Port NSExpression tests to Expression

/cc @mapbox/navigation-ios @mapbox/maps-ios-reviewers