### PR TITLE
Highlight lanes based on active direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Exposed `NavigationMapView.mapTileStore`, `PassiveLocationDataSource.navigatorTileStore` and `RouteController.navigatorTileStore` for accessing corresponding `TileStore` instancies ([#2955](https://github.com/mapbox/mapbox-navigation-ios/pull/2955))
 * Removed `ElectronicHorizon` struct, now an electronic horizon notification directly contain pointer to a starting edge. `ElectronicHorizon.Edge` was renamed to `RoadGraph.Edge`. `ElectronicHorizon.NotificationUserInfoKey` was renamed to `RoadGraph.NotificationUserInfoKey`. ([#2949](https://github.com/mapbox/mapbox-navigation-ios/pull/2949))
 * Fixed an issue that the current road name label flashes when camera state changes or travels onto an unnamed road. ([#2958](https://github.com/mapbox/mapbox-navigation-ios/pull/2958))
+* Fixed an issue where lane guidance icons would sometimes highlight the wrong arrow.([#2942](https://github.com/mapbox/mapbox-navigation-ios/pull/2942))
 
 ## v1.3.0
 

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -343,6 +343,12 @@ open class LaneView: UIView {
         }
     }
     
+    var preferredDirection: LaneIndication {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
     var drivingSide: DrivingSide = .right {
         didSet {
             setNeedsDisplay()
@@ -403,6 +409,7 @@ open class LaneView: UIView {
         self.indications = indications
         maneuverDirection = direction ?? ManeuverDirection(rawValue: indications.description)
         isValid = isUsable
+        preferredDirection = direction
     }
 
     override init(frame: CGRect) {
@@ -435,7 +442,7 @@ open class LaneView: UIView {
         let resizing = LanesStyleKit.ResizingBehavior.aspectFit
         let appropriateColor = isValid ? appropriatePrimaryColor : appropriateSecondaryColor
         
-        let rankedIndications = indications.ranked(favoring: maneuverDirection)
+        let rankedIndications = indications.ranked(favoring: ManeuverDirection(preferredDirection.description))
         guard let laneConfiguration = LaneConfiguration(rankedIndications: rankedIndications, drivingSide: drivingSide) else {
             return
         }

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -401,7 +401,7 @@ open class LaneView: UIView {
         self.init(frame: LaneView.defaultFrame)
         backgroundColor = .clear
         self.indications = indications
-        maneuverDirection = direction ?? ManeuverDirection(rawValue: indications.description)
+        maneuverDirection = direction
         isValid = isUsable
     }
 

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -343,12 +343,6 @@ open class LaneView: UIView {
         }
     }
     
-    var preferredDirection: LaneIndication {
-        didSet {
-            setNeedsDisplay()
-        }
-    }
-    
     var drivingSide: DrivingSide = .right {
         didSet {
             setNeedsDisplay()
@@ -409,7 +403,6 @@ open class LaneView: UIView {
         self.indications = indications
         maneuverDirection = direction ?? ManeuverDirection(rawValue: indications.description)
         isValid = isUsable
-        preferredDirection = direction
     }
 
     override init(frame: CGRect) {
@@ -442,7 +435,8 @@ open class LaneView: UIView {
         let resizing = LanesStyleKit.ResizingBehavior.aspectFit
         let appropriateColor = isValid ? appropriatePrimaryColor : appropriateSecondaryColor
         
-        let rankedIndications = indications.ranked(favoring: ManeuverDirection(preferredDirection.description))
+//        let rankedIndications = indications.ranked(favoring: ManeuverDirection(rawValue: preferredDirection.description))
+        let rankedIndications = indications.ranked(favoring: maneuverDirection)
         guard let laneConfiguration = LaneConfiguration(rankedIndications: rankedIndications, drivingSide: drivingSide) else {
             return
         }

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -435,7 +435,6 @@ open class LaneView: UIView {
         let resizing = LanesStyleKit.ResizingBehavior.aspectFit
         let appropriateColor = isValid ? appropriatePrimaryColor : appropriateSecondaryColor
         
-//        let rankedIndications = indications.ranked(favoring: ManeuverDirection(rawValue: preferredDirection.description))
         let rankedIndications = indications.ranked(favoring: maneuverDirection)
         guard let laneConfiguration = LaneConfiguration(rankedIndications: rankedIndications, drivingSide: drivingSide) else {
             return

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -401,7 +401,7 @@ open class LaneView: UIView {
         self.init(frame: LaneView.defaultFrame)
         backgroundColor = .clear
         self.indications = indications
-        maneuverDirection = direction
+        maneuverDirection = direction ?? ManeuverDirection(rawValue: indications.description)
         isValid = isUsable
     }
 

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -85,8 +85,8 @@ open class LanesView: UIView, NavigationComponent {
 
             if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection) = component {
 //                let maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection ?? ManeuverDirection(rawValue: indications.description)
-                let maneuverDirection = ManeuverDirection(rawValue: preferredDirection.description) ?? visualInstruction?.primaryInstruction.maneuverDirection
-                
+                let preferred = preferredDirection?.description
+                let maneuverDirection = ManeuverDirection(rawValue: preferred!) ?? visualInstruction?.primaryInstruction.maneuverDirection
                 return LaneView(indications: indications, isUsable: isUsable, direction: maneuverDirection)
             } else {
                 return nil

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -82,8 +82,11 @@ open class LanesView: UIView, NavigationComponent {
         }
         
         let subviews = tertiaryInstruction.components.compactMap { (component) -> LaneView? in
-            if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: _) = component {
-                let maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection ?? ManeuverDirection(rawValue: indications.description)
+
+            if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection) = component {
+//                let maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection ?? ManeuverDirection(rawValue: indications.description)
+                let maneuverDirection = ManeuverDirection(rawValue: preferredDirection.description) ?? visualInstruction?.primaryInstruction.maneuverDirection
+                
                 return LaneView(indications: indications, isUsable: isUsable, direction: maneuverDirection)
             } else {
                 return nil

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -84,14 +84,7 @@ open class LanesView: UIView, NavigationComponent {
         let subviews = tertiaryInstruction.components.compactMap { (component) -> LaneView? in
 
             if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection) = component {
-//                let maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection ?? ManeuverDirection(rawValue: indications.description)
-                var maneuverDirection: ManeuverDirection?
-                if let preferred = preferredDirection?.descriptions.first {
-                    maneuverDirection = ManeuverDirection(rawValue: preferred)
-                } else {
-                    maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection
-                }
-                
+                let maneuverDirection = preferredDirection ?? visualInstruction?.primaryInstruction.maneuverDirection
                 return LaneView(indications: indications, isUsable: isUsable, direction: maneuverDirection)
             } else {
                 return nil

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -85,8 +85,13 @@ open class LanesView: UIView, NavigationComponent {
 
             if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection) = component {
 //                let maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection ?? ManeuverDirection(rawValue: indications.description)
-                let preferred = preferredDirection?.description
-                let maneuverDirection = ManeuverDirection(rawValue: preferred!) ?? visualInstruction?.primaryInstruction.maneuverDirection
+                var maneuverDirection: ManeuverDirection?
+                if let preferred = preferredDirection?.descriptions.first {
+                    maneuverDirection = ManeuverDirection(rawValue: preferred)
+                } else {
+                    maneuverDirection = visualInstruction?.primaryInstruction.maneuverDirection
+                }
+                
                 return LaneView(indications: indications, isUsable: isUsable, direction: maneuverDirection)
             } else {
                 return nil

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -51,7 +51,7 @@ extension VisualInstruction {
 
     func lanesImage(side: DrivingSide, direction: ManeuverDirection?, useableColor: UIColor, unuseableColor: UIColor, size: CGSize, scale: CGFloat) -> UIImage? {
         let subimages = components.compactMap { (component) -> UIImage? in
-            if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: _) = component {
+            if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection) = component {
                 return laneImage(side: side, indication: indications, maneuverDirection: direction, isUsable: isUsable, useableColor: useableColor, unuseableColor: unuseableColor, size: CGSize(width: size.height, height: size.height))
             } else {
                 return nil

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -52,7 +52,7 @@ extension VisualInstruction {
     func lanesImage(side: DrivingSide, direction: ManeuverDirection?, useableColor: UIColor, unuseableColor: UIColor, size: CGSize, scale: CGFloat) -> UIImage? {
         let subimages = components.compactMap { (component) -> UIImage? in
             if case let .lane(indications: indications, isUsable: isUsable, preferredDirection: preferredDirection) = component {
-                return laneImage(side: side, indication: indications, maneuverDirection: direction, isUsable: isUsable, useableColor: useableColor, unuseableColor: unuseableColor, size: CGSize(width: size.height, height: size.height))
+                return laneImage(side: side, indication: indications, maneuverDirection: preferredDirection ?? direction, isUsable: isUsable, useableColor: useableColor, unuseableColor: unuseableColor, size: CGSize(width: size.height, height: size.height))
             } else {
                 return nil
             }


### PR DESCRIPTION
### Description
This PR highlights lanes based on active direction using new properties from Directions API. #2801
- [x] Use active direction in ranked call
- [x] Include fallback to maneuver direction
- [x] update CHANGELOG.md

### Implementation
Use the preferred direction in the call to `LaneIndication.ranked(favoring:)` in `LaneView.draw(_:)` by passing it in when the `LaneView` is initialized by `LanesView.update(for:)`.

### Screenshots or Gifs

Before these changes, we would see issues like this one. The highlighted lanes conflict.

![Simulator Screen Shot - iPhone 8 Plus - 2021-04-20 at 10 05 29](https://user-images.githubusercontent.com/43434254/115411419-747c5f00-a1c1-11eb-8b09-ba32ffb0bf78.png)

After the changes, we see the correct maneuver instruction: 

![Simulator Screen Shot - iPhone 8 Plus - 2021-04-20 at 10 08 19](https://user-images.githubusercontent.com/43434254/115411484-83631180-a1c1-11eb-88d3-a37764c7a726.png)

