### PR TITLE
Added delegate, which is called after adding final destination PointAnnotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * `NavigationViewController.mapView` was renamed to `NavigationViewController.navigationMapView`. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * `NavigationMapView.highlightBuildings(at:in3D:)` was renamed to `NavigationMapView.highlightBuildings(at:in3D:completion:)`. ([#2827](https://github.com/mapbox/mapbox-navigation-ios/pull/2827))
 * Added the `NavigationMapView.showsCongestionForAlternativeRoutes` property to show congestion levels with different colors on alternative route lines. ([#2887](https://github.com/mapbox/mapbox-navigation-ios/pull/2887))
+* Added the `NavigationMapView.navigationMapView(_:didAdd:)` and `NavigationViewController.navigationViewController(_:didAdd:)` delegate methods, which will be called whenever final destination is added to `NavigationMapView` and `NavigationViewController` respectively. ([#2961](https://github.com/mapbox/mapbox-navigation-ios/pull/2961))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * `NavigationViewController.mapView` was renamed to `NavigationViewController.navigationMapView`. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * `NavigationMapView.highlightBuildings(at:in3D:)` was renamed to `NavigationMapView.highlightBuildings(at:in3D:completion:)`. ([#2827](https://github.com/mapbox/mapbox-navigation-ios/pull/2827))
 * Added the `NavigationMapView.showsCongestionForAlternativeRoutes` property to show congestion levels with different colors on alternative route lines. ([#2887](https://github.com/mapbox/mapbox-navigation-ios/pull/2887))
-* Added the `NavigationMapView.navigationMapView(_:didAdd:)` and `NavigationViewController.navigationViewController(_:didAdd:)` delegate methods, which will be called whenever final destination is added to `NavigationMapView` and `NavigationViewController` respectively. ([#2961](https://github.com/mapbox/mapbox-navigation-ios/pull/2961))
+* Added the `NavigationMapView.navigationMapView(_:didAdd:)` and `NavigationViewController.navigationViewController(_:didAdd:)` delegate methods, which will be called whenever final destination `PointAnnotation` is added to `NavigationMapView` or `NavigationViewController` respectively. ([#2961](https://github.com/mapbox/mapbox-navigation-ios/pull/2961))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -577,6 +577,8 @@ open class NavigationMapView: UIView {
             var destinationAnnotation = PointAnnotation(coordinate: destinationCoordinate)
             destinationAnnotation.title = "navigation_annotation"
             mapView.annotations.addAnnotation(destinationAnnotation)
+            
+            delegate?.navigationMapView(self, didAdd: destinationAnnotation)
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -99,6 +99,14 @@ public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
      - parameter waypoint: The waypoint that was selected.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, didSelect waypoint: Waypoint)
+    
+    /**
+     Tells the receiver that the final destination `PointAnnotation` was added to the `NavigationMapView`.
+     
+     - parameter navigationMapView: The `NavigationMapView` object.
+     - parameter finalDestinationAnnotation: `PointAnnotation`, which was added to the `NavigationMapView`.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, didAdd finalDestinationAnnotation: PointAnnotation)
 }
 
 public extension NavigationMapViewDelegate {
@@ -170,6 +178,13 @@ public extension NavigationMapViewDelegate {
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, didSelect waypoint: Waypoint) {
+        logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
+    }
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationMapView(_ navigationMapView: NavigationMapView, didAdd finalDestinationAnnotation: PointAnnotation) {
         logUnimplemented(protocolType: NavigationMapViewDelegate.self, level: .debug)
     }
 }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -969,3 +969,12 @@ extension NavigationViewController: CarPlayConnectionObserver {
         }
     }
 }
+
+// MARK: - NavigationMapViewDelegate methods
+
+extension NavigationViewController: NavigationMapViewDelegate {
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView, didAdd finalDestinationAnnotation: PointAnnotation) {
+        delegate?.navigationViewController(self, didAdd: finalDestinationAnnotation)
+    }
+}

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -194,6 +194,14 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      - returns: The road name to display in the label, or nil to hide the label.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, roadNameAt location: CLLocation) -> String?
+    
+    /**
+     Tells the receiver that the final destination `PointAnnotation` was added to the `NavigationViewController`.
+     
+     - parameter navigationViewController: The `NavigationViewController` object.
+     - parameter finalDestinationAnnotation: `PointAnnotation`, which was added to the `NavigationViewController`.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, didAdd finalDestinationAnnotation: PointAnnotation)
 }
 
 public extension NavigationViewControllerDelegate {
@@ -323,5 +331,12 @@ public extension NavigationViewControllerDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, roadNameAt location: CLLocation) -> String? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, didAdd finalDestinationAnnotation: PointAnnotation) {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
 }


### PR DESCRIPTION
Added delegate, which is called after adding final destination PointAnnotation.

Delegate method can be used like in Custom Waypoint Marker example in https://github.com/mapbox/mapbox-navigation-ios-examples/pull/102.