### PR TITLE
Fix issues with calling NavigationViewControllerDelegate methods.

### DIFF
--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -992,6 +992,26 @@ extension NavigationViewController: CarPlayConnectionObserver {
 
 extension NavigationViewController: NavigationMapViewDelegate {
     
+    public func navigationMapView(_ navigationMapView: NavigationMapView, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer? {
+        delegate?.navigationViewController(self, routeLineLayerWithIdentifier: identifier, sourceIdentifier: sourceIdentifier)
+    }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer? {
+        delegate?.navigationViewController(self, routeCasingLineLayerWithIdentifier: identifier, sourceIdentifier: sourceIdentifier)
+    }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView, waypointCircleLayerWithIdentifier identifier: String, sourceIdentifier: String) -> CircleLayer? {
+        delegate?.navigationViewController(self, waypointCircleLayerWithIdentifier: identifier, sourceIdentifier: sourceIdentifier)
+    }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView, waypointSymbolLayerWithIdentifier identifier: String, sourceIdentifier: String) -> SymbolLayer? {
+        delegate?.navigationViewController(self, waypointSymbolLayerWithIdentifier: identifier, sourceIdentifier: sourceIdentifier)
+    }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView, shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection? {
+        delegate?.navigationViewController(self, shapeFor: waypoints, legIndex: legIndex)
+    }
+    
     public func navigationMapView(_ navigationMapView: NavigationMapView, didAdd finalDestinationAnnotation: PointAnnotation) {
         delegate?.navigationViewController(self, didAdd: finalDestinationAnnotation)
     }

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -166,14 +166,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection?
     
     /**
-     Called when the user taps to select a route on the navigation view controller’s map view.
-     
-     - parameter navigationViewController: The navigation view controller presenting the route that the user selected.
-     - parameter route: The route on the map that the user selected.
-     */
-    func navigationViewController(_ navigationViewController: NavigationViewController, didSelect route: Route)
-    
-    /**
      Allows the delegate to decide whether to ignore a location update.
      
      This method is called on every location update. By default, the navigation view controller ignores certain location updates that appear to be unreliable, as determined by the `CLLocation.isQualified` property.

--- a/Sources/MapboxNavigation/NavigationViewData.swift
+++ b/Sources/MapboxNavigation/NavigationViewData.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 import MapboxCoreNavigation
 

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -242,10 +242,6 @@ extension NavigationMapView {
                     for queriedFeature in queriedFeatures {
                         var lineStrings: [LineString] = []
                         
-                        //                    if let line = feature.geometry.value as? LineString {
-                        //                        lineStrings.append(line)
-                        //                    } else if let multiLine = feature.geometry.value as? MultiLineString {
-                        //                        for coordinates in multiLine.coordinates {
                         if queriedFeature.feature.geometry.geometryType == MBXGeometryType_Line,
                            let coordinates = queriedFeature.feature.geometry.extractLocationsArray() as? [CLLocationCoordinate2D] {
                             lineStrings.append(LineString(coordinates))

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 import MapboxDirections
 import MapboxCoreNavigation

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -1,4 +1,3 @@
-
 import MapboxDirections
 import MapboxCoreNavigation
 import CoreLocation


### PR DESCRIPTION
After dropping `RouteMapViewController` certain `NavigationViewControllerDelegate` delegate methods were not called anymore.

Fixes #2962.