### PR TITLE
Enable MapboxNavigationTests with SPM

### DIFF
--- a/MapboxNavigation.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "FBSnapshotTestCase",
+        "repositoryURL": "https://github.com/alanzeino/ios-snapshot-test-case.git",
+        "state": {
+          "branch": "master",
+          "revision": "c3189948974569421d867af5bedd8addf44330b0",
+          "version": null
+        }
+      },
+      {
         "package": "MapboxCommon",
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "FBSnapshotTestCase",
+        "repositoryURL": "https://github.com/alanzeino/ios-snapshot-test-case.git",
+        "state": {
+          "branch": "master",
+          "revision": "c3189948974569421d867af5bedd8addf44330b0",
+          "version": null
+        }
+      },
+      {
         "package": "MapboxCommon",
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0-alpha.1"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", from: "2.0.0"),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
+        .package(name: "FBSnapshotTestCase", url: "https://github.com/alanzeino/ios-snapshot-test-case.git", .branch("master")),
     ],
     targets: [
         .target(
@@ -73,5 +74,24 @@ let package = Package(
             name: "MapboxCoreNavigationTests",
             dependencies: ["TestHelper"],
             exclude: ["Info.plist"]),
+        .testTarget(
+            name: "MapboxNavigationTests",
+            dependencies: [
+                "MapboxNavigation",
+                "FBSnapshotTestCase",
+            ],
+            exclude: [
+                "Info.plist",
+                "CPBarButton+MBTestable.h",
+                "CPBarButton+MBTestable.m",
+                "CPMapTemplate+MBTestable.h",
+                "CPMapTemplate+MBTestable.mm",
+                "MapboxNavigationTests-Bridging.h",
+            ],
+            resources: [
+                .process("Fixtures"),
+                .process("ReferenceImages"),
+                .process("ReferenceImages_64"),
+            ]),
     ]
 )

--- a/Tests/MapboxNavigationTests/BottomBannerSnapshotTests.swift
+++ b/Tests/MapboxNavigationTests/BottomBannerSnapshotTests.swift
@@ -1,8 +1,10 @@
 import XCTest
 import Foundation
+#if !SWIFT_PACKAGE
 import SnappyShrimp
-import MapboxDirections
 @testable import TestHelper
+#endif
+import MapboxDirections
 @testable import MapboxNavigation
 @testable import MapboxCoreNavigation
 

--- a/Tests/MapboxNavigationTests/CarPlayCompassViewSnapshotTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayCompassViewSnapshotTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+#if !SWIFT_PACKAGE
 import SnappyShrimp
+#endif
 import MapboxMaps
 @testable import MapboxNavigation
 


### PR DESCRIPTION
Added a MapboxNavigationTests target under SPM.

Working towards #2791.

/cc @mapbox/navigation-ios