### PR TITLE
Fix NavigationViewController crash in storyboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * Removed deprecated and obsoleted `EventsManager` typealias, `StatusView.delegate`, `StatusView.canChangeValue`, `RouteLegProgress.upComingStep`, `StatusViewDelegate`, `DeprecatedStatusViewDelegate` and `BottomBannerViewController.init(delegate:)`. ([#2993](https://github.com/mapbox/mapbox-navigation-ios/pull/2993))
 * Fixed a potential memory leak when using `MultiplexedSpeechSynthesizer`. ([#3005](https://github.com/mapbox/mapbox-navigation-ios/pull/3005))
 * Fixed an issue where instruction banners could appear in the wrong color after switching between `Style`s. ([#2977](https://github.com/mapbox/mapbox-navigation-ios/pull/2977))
+* Developers can create an instance of `NavigationViewController` from `UIStoryboardSegue`, which is located in `Navigation.storyboard`. To successfully create `NavigationViewController` instance developer has to pre-define `route`, `routeIndex`, `routeOptions` and `navigationOptions` properties of `NavigationViewController` in `UIViewController.prepare(for:sender:)`.
 
 ## v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 * Removed deprecated and obsoleted `EventsManager` typealias, `StatusView.delegate`, `StatusView.canChangeValue`, `RouteLegProgress.upComingStep`, `StatusViewDelegate`, `DeprecatedStatusViewDelegate` and `BottomBannerViewController.init(delegate:)`. ([#2993](https://github.com/mapbox/mapbox-navigation-ios/pull/2993))
 * Fixed a potential memory leak when using `MultiplexedSpeechSynthesizer`. ([#3005](https://github.com/mapbox/mapbox-navigation-ios/pull/3005))
 * Fixed an issue where instruction banners could appear in the wrong color after switching between `Style`s. ([#2977](https://github.com/mapbox/mapbox-navigation-ios/pull/2977))
-* Developers can create an instance of `NavigationViewController` from `UIStoryboardSegue`, which is located in `Navigation.storyboard`. To successfully create `NavigationViewController` instance developer has to pre-define `route`, `routeIndex`, `routeOptions` and `navigationOptions` properties of `NavigationViewController` in `UIViewController.prepare(for:sender:)`.
+* Developers can create an instance of `NavigationViewController` from `UIStoryboardSegue`, which is located in `Navigation.storyboard`. To successfully create `NavigationViewController` instance developer has to pre-define `route`, `routeIndex`, `routeOptions` and `navigationOptions` properties of `NavigationViewController` in `UIViewController.prepare(for:sender:)`. ([#2974](https://github.com/mapbox/mapbox-navigation-ios/pull/2974))
 
 ## v1.4.0
 

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -68,6 +68,15 @@ class CustomViewController: UIViewController {
         // By default `NavigationViewportDataSource` tracks location changes from `PassiveLocationDataSource`, to consume
         // locations in active guidance navigation `ViewportDataSourceType` should be set to `.active`.
         let navigationViewportDataSource = NavigationViewportDataSource(navigationMapView.mapView, viewportDataSourceType: .active)
+        
+        // Disable any updates to `CameraOptions.padding` in `NavigationCameraState.following` state
+        // to prevent overlapping.
+        navigationViewportDataSource.options.followingCameraOptions.paddingUpdatesAllowed = false
+        navigationViewportDataSource.followingMobileCamera.padding = UIEdgeInsets(top: 200.0,
+                                                                                  left: 10.0,
+                                                                                  bottom: 100.0,
+                                                                                  right: 10.0)
+        
         navigationMapView.navigationCamera.viewportDataSource = navigationViewportDataSource
     }
     

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -385,7 +385,9 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     func setupNavigationService() {
         guard let route = _route,
               let routeIndex = routeIndex,
-              let routeOptions = _routeOptions else { return }
+              let routeOptions = _routeOptions else {
+            fatalError("`route`, `routeIndex` and `routeOptions` must be valid to create an instance of `NavigationViewController`.")
+        }
         
         if !(routeOptions is NavigationRouteOptions) {
             print("`Route` was created using `RouteOptions` and not `NavigationRouteOptions`. Although not required, this may lead to a suboptimal navigation experience. Without `NavigationRouteOptions`, it is not guaranteed you will get congestion along the route line, better ETAs and ETA label color dependent on congestion.")

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -313,7 +313,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
     
     /**
-     Initializes a navigation view controller that presents the user interface for following a predefined route based on the given options.
+     Initializes a `NavigationViewController` that presents the user interface for following a predefined route based on the given options.
 
      The route may come directly from the completion handler of the [MapboxDirections](https://docs.mapbox.com/ios/api/directions/) framework’s `Directions.calculate(_:completionHandler:)` method, or it may be unarchived or created from a JSON object.
      
@@ -329,6 +329,35 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         super.init(nibName: nil, bundle: nil)
         
+        initialize(for: route, routeIndex: routeIndex, routeOptions: routeOptions, navigationOptions: navigationOptions)
+    }
+    
+    /**
+     Initializes a `NavigationViewController` with the given route and navigation service.
+     
+     - parameter route: The route to navigate along.
+     - parameter routeIndex: The index of the route within the original `RouteResponse` object.
+     - parameter routeOptions: the options object used to generate the route.
+     - parameter navigationService: The navigation service that manages navigation along the route.
+     */
+    convenience init(route: Route, routeIndex: Int, routeOptions: RouteOptions, navigationService service: NavigationService) {
+        let options = NavigationOptions(navigationService: service)
+        self.init(for: route, routeIndex: routeIndex, routeOptions: routeOptions, navigationOptions: options)
+    }
+    
+    /**
+     Initializes a `NavigationViewController` that presents the user interface for following a predefined route based on the given options.
+     
+     The route may come directly from the completion handler of the [MapboxDirections](https://docs.mapbox.com/ios/api/directions/) framework’s `Directions.calculate(_:completionHandler:)` method, or it may be unarchived or created from a JSON object.
+     
+     This variation of `NavigationViewController` initializer is meant to be used right after its instantiation via Storyboard and calling `NavigationViewController.init(coder:)`.
+     
+     - parameter route: The route to navigate along.
+     - parameter routeIndex: The index of the route within the original `RouteResponse` object.
+     - parameter routeOptions: The route options used to get the route.
+     - parameter navigationOptions: The navigation options to use for the navigation session.
+     */
+    public func initialize(for route: Route, routeIndex: Int, routeOptions: RouteOptions, navigationOptions: NavigationOptions? = nil) {
         if !(routeOptions is NavigationRouteOptions) {
             print("`Route` was created using `RouteOptions` and not `NavigationRouteOptions`. Although not required, this may lead to a suboptimal navigation experience. Without `NavigationRouteOptions`, it is not guaranteed you will get congestion along the route line, better ETAs and ETA label color dependent on congestion.")
         }
@@ -356,19 +385,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
                                                                  tileStoreConfiguration: navigationOptions?.tileStoreConfiguration)
             }
         }
-    }
-    
-    /**
-     Initializes a navigation view controller with the given route and navigation service.
-     
-     - parameter route: The route to navigate along.
-     - parameter routeIndex: The index of the route within the original `RouteResponse` object.
-     - parameter routeOptions: the options object used to generate the route.
-     - parameter navigationService: The navigation service that manages navigation along the route.
-     */
-    convenience init(route: Route, routeIndex: Int, routeOptions: RouteOptions, navigationService service: NavigationService) {
-        let options = NavigationOptions(navigationService: service)
-        self.init(for: route, routeIndex: routeIndex, routeOptions: routeOptions, navigationOptions: options)
     }
     
     deinit {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -42,24 +42,51 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
     }
     
+    var _route: Route?
+    
     /**
      A `Route` object constructed by [MapboxDirections](https://docs.mapbox.com/ios/api/directions/).
      */
-    public var route: Route {
-        return indexedRoute.0
+    public var route: Route? {
+        get {
+            return navigationService.indexedRoute.0
+        }
+        
+        set {
+            _route = newValue
+        }
     }
     
-    public var routeOptions: RouteOptions {
+    var _routeOptions: RouteOptions?
+    
+    /**
+     The route options used to get the route.
+     */
+    public var routeOptions: RouteOptions? {
         get {
             return navigationService.routeProgress.routeOptions
         }
+        
+        set {
+            _routeOptions = newValue
+        }
     }
+    
+    /**
+     The index of the route within the original `RouteResponse` object.
+     */
+    public var routeIndex: Int?
+    
+    /**
+     The `NavigationOptions` object, which is used for the navigation session.
+     */
+    public var navigationOptions: NavigationOptions?
     
     /**
      An instance of `Directions` need for rerouting. See [Mapbox Directions](https://docs.mapbox.com/ios/api/directions/) for further information.
      */
     public var directions: Directions {
-        return navigationService!.directions
+        return navigationService.directions
     }
     
     /**
@@ -273,7 +300,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
      */
     private(set) public var navigationService: NavigationService! {
         didSet {
-            arrivalController?.destination = route.legs.last?.destination
+            arrivalController?.destination = route?.legs.last?.destination
         }
     }
     
@@ -289,10 +316,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     var routeOverlayController: NavigationMapView.RouteOverlayController?
     var viewObservers: [NavigationComponentDelegate?] = []
     var mapTileStore: TileStoreConfiguration.Location? = .default
-    var _route: Route?
-    var _routeIndex: Int?
-    var _routeOptions: RouteOptions?
-    var navigationOptions: NavigationOptions?
     
     // MARK: - NavigationViewData implementation
         
@@ -329,12 +352,12 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
             mapTileStore = options.tileStoreConfiguration.mapLocation
         }
         
-        _route = route
-        _routeIndex = routeIndex
-        _routeOptions = routeOptions
-        self.navigationOptions = navigationOptions
-        
         super.init(nibName: nil, bundle: nil)
+        
+        self.route = route
+        self.routeIndex = routeIndex
+        self.routeOptions = routeOptions
+        self.navigationOptions = navigationOptions
     }
     
     /**
@@ -361,7 +384,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     
     func setupNavigationService() {
         guard let route = _route,
-              let routeIndex = _routeIndex,
+              let routeIndex = routeIndex,
               let routeOptions = _routeOptions else { return }
         
         if !(routeOptions is NavigationRouteOptions) {
@@ -451,7 +474,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
         subviewInits.removeAll()
         
-        arrivalController?.destination = route.legs.last?.destination
+        arrivalController?.destination = route?.legs.last?.destination
         ornamentsController?.reportButton.isHidden = !showsReportFeedback
     }
     
@@ -908,7 +931,7 @@ extension NavigationViewController: StyleManagerDelegate {
     public func location(for styleManager: StyleManager) -> CLLocation? {
         if let location = navigationService.router.location {
             return location
-        } else if let firstCoord = route.shape?.coordinates.first {
+        } else if let firstCoord = route?.shape?.coordinates.first {
             return CLLocation(latitude: firstCoord.latitude, longitude: firstCoord.longitude)
         } else {
             return nil

--- a/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -33,7 +34,7 @@
                                         <attributedString key="userComments">
                                             <fragment content="DO NOT TRANSLATE">
                                                 <attributes>
-                                                    <font key="NSFont" metaFont="controlContent" size="11"/>
+                                                    <font key="NSFont" metaFont="message" size="11"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
@@ -47,7 +48,7 @@
                                         <attributedString key="userComments">
                                             <fragment content="DO NOT TRANSLATE">
                                                 <attributes>
-                                                    <font key="NSFont" metaFont="controlContent" size="11"/>
+                                                    <font key="NSFont" metaFont="message" size="11"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
@@ -100,7 +101,7 @@
                                         <attributedString key="userComments">
                                             <fragment content="DO NOT TRANSLATE">
                                                 <attributes>
-                                                    <font key="NSFont" metaFont="controlContent" size="11"/>
+                                                    <font key="NSFont" metaFont="message" size="11"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
@@ -188,5 +189,25 @@
             </objects>
             <point key="canvasLocation" x="3832.8000000000002" y="875.26236881559225"/>
         </scene>
+        <!--Navigation View Controller-->
+        <scene sceneID="N4b-dY-Waq">
+            <objects>
+                <viewController storyboardIdentifier="NavigationViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="skD-wE-e5x" customClass="NavigationViewController" customModule="MapboxNavigation" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="2Pt-vL-Aor">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="spJ-9Q-y9C"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Nff-jZ-whT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3604" y="1415"/>
+        </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
### Description

Fixes #2973.

### Implementation

Since it's not possible to call other initializers in `NavigationViewController.init(coder:)` new public `NavigationViewController.initialize(for:routeIndex:routeOptions:navigationOptions:)` method was introduced. It's meant to be called right after `NavigationViewController` instantiation in storyboard. I've also brought back `NavigationViewController` to `Navigation.storyboard` to give the ability to create it using [this](https://docs.mapbox.com/ios/navigation/guides/storyboards/) guide.