### PR TITLE
Fix the Maneuver selection in preview

### DIFF
--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -75,7 +75,7 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     func center(on step: RouteStep, route: Route, legIndex: Int, stepIndex: Int, animated: Bool = true, completion: CompletionHandler? = nil) {
         navigationMapView.navigationCamera.stop()
 
-        let edgeInsets = navigationMapView.safeArea + UIEdgeInsets(top: 10.0, left: 20.0, bottom: 10.0, right: 20.0)
+        let edgeInsets = navigationMapView.safeArea + UIEdgeInsets.centerEdgeInsets
         let cameraOptions = CameraOptions(center: step.maneuverLocation,
                                           padding: edgeInsets,
                                           zoom: navigationMapView.mapView.zoom,

--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -74,8 +74,10 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     
     func center(on step: RouteStep, route: Route, legIndex: Int, stepIndex: Int, animated: Bool = true, completion: CompletionHandler? = nil) {
         navigationMapView.navigationCamera.stop()
-        // TODO: Verify that camera is positioned correctly.
+
+        let edgeInsets = navigationMapView.safeArea + UIEdgeInsets(top: 10.0, left: 20.0, bottom: 10.0, right: 20.0)
         let cameraOptions = CameraOptions(center: step.maneuverLocation,
+                                          padding: edgeInsets,
                                           zoom: navigationMapView.mapView.zoom,
                                           bearing: step.initialHeading ?? CLLocationDirection(navigationMapView.mapView.bearing))
         

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -420,7 +420,7 @@ open class NavigationMapView: UIView {
     
     func fitCamera(to route: Route, animated: Bool = false) {
         guard let routeShape = route.shape, !routeShape.coordinates.isEmpty else { return }
-        let edgeInsets = safeArea + UIEdgeInsets(top: 10.0, left: 20.0, bottom: 10.0, right: 20.0)
+        let edgeInsets = safeArea + UIEdgeInsets.centerEdgeInsets
         if let cameraOptions = mapView?.camera.camera(fitting: .lineString(routeShape),
                                                       edgePadding: edgeInsets) {
             mapView?.camera.setCamera(to: cameraOptions, animated: animated)

--- a/Sources/MapboxNavigation/NavigationViewportDataSource.swift
+++ b/Sources/MapboxNavigation/NavigationViewportDataSource.swift
@@ -192,7 +192,7 @@ public class NavigationViewportDataSource: ViewportDataSource {
             let geometryFramingAfterManeuver = followingCameraOptions.geometryFramingAfterManeuver
             let pitchСoefficient = self.pitchСoefficient(routeProgress, currentCoordinate: location.coordinate)
             let pitch = followingCameraOptions.defaultPitch * pitchСoefficient
-            let carPlayCameraPadding = mapView.safeArea + UIEdgeInsets(top: 10.0, left: 20.0, bottom: 10.0, right: 20.0)
+            let carPlayCameraPadding = mapView.safeArea + UIEdgeInsets.centerEdgeInsets
             
             if geometryFramingAfterManeuver.enabled {
                 let stepIndex = routeProgress.currentLegProgress.stepIndex
@@ -308,7 +308,7 @@ public class NavigationViewportDataSource: ViewportDataSource {
             .map({ $0.shape?.coordinates })
         let untraveledCoordinatesOnCurrentStep = routeProgress.currentLegProgress.currentStep.shape?.coordinates.sliced(from: coordinate) ?? []
         let remainingCoordinatesOnRoute = coordinatesAfterCurrentStep.flatten() + untraveledCoordinatesOnCurrentStep
-        let carPlayCameraPadding = mapView.safeArea + UIEdgeInsets(top: 10.0, left: 20.0, bottom: 10.0, right: 20.0)
+        let carPlayCameraPadding = mapView.safeArea + UIEdgeInsets.centerEdgeInsets
         let overviewCameraOptions = options.overviewCameraOptions
         
         if overviewCameraOptions.pitchUpdatesAllowed {

--- a/Sources/MapboxNavigation/UIEdgeInsets.swift
+++ b/Sources/MapboxNavigation/UIEdgeInsets.swift
@@ -22,6 +22,10 @@ extension UIEdgeInsets {
                       width: rect.size.width - self.left - self.right,
                       height: rect.size.height - self.top - self.bottom)
     }
+    
+    static var centerEdgeInsets: UIEdgeInsets {
+        return UIEdgeInsets(top: 10.0, left: 20.0, bottom: 10.0, right: 20.0)
+    }
 }
 
 extension UIEdgeInsets: ExpressibleByFloatLiteral {


### PR DESCRIPTION
### Description
This pr is to fix #2912 , to allow the camera on the top of the selected maneuver in preview.

### Implementation
By adding the constraint of padding to the CameraOptions to set the center of `maneuverLocation` to be the center of the camera of `NavigationMapView`

### Screenshots or Gifs
![maneuver_fix](https://user-images.githubusercontent.com/48976398/117053483-df538d00-accd-11eb-9127-70d9e2050f9c.png)
