### PR TITLE
bring the arrival frame back to same as 1.x

### DIFF
--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -66,6 +66,8 @@ class ArrivalController: NavigationComponentDelegate {
                                                  left: 20,
                                                  bottom: height + 20,
                                                  right: 20)
+            cameraOptions.center = destination?.coordinate
+            cameraOptions.pitch = 0
             navigationMapView.mapView.camera.setCamera(to: cameraOptions,
                                                        animated: duration > 0.0 ? true : false,
                                                        duration: duration) { (animatingPosition) in

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -738,20 +738,12 @@ extension NavigationViewController: NavigationServiceDelegate {
         
         arrivalController?.showEndOfRouteIfNeeded(self,
                                                   advancesToNextLeg: advancesToNextLeg,
-                                                  completion: { [ weak self] _ in
-                                                    self?.frameDestinationArrival(for: service.router.location)
-                                                  },
+                                                  completion: nil,
                                                   onDismiss: { [weak self] in
                                                     self?.navigationService.endNavigation(feedback: $0)
                                                     self?.handleCancelAction()
                                                   })
         return advancesToNextLeg
-    }
-    
-    func frameDestinationArrival(for location: CLLocation?) {
-        if waypointStyle == .annotation { return }
-        guard let location = location else { return }
-        navigationMapView?.updateUserCourseView(location, animated: false)
     }
 
     public func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -738,12 +738,20 @@ extension NavigationViewController: NavigationServiceDelegate {
         
         arrivalController?.showEndOfRouteIfNeeded(self,
                                                   advancesToNextLeg: advancesToNextLeg,
-                                                  completion: nil,
+                                                  completion: { [ weak self] _ in
+                                                    self?.frameDestinationArrival(for: service.router.location)
+                                                  },
                                                   onDismiss: { [weak self] in
                                                     self?.navigationService.endNavigation(feedback: $0)
                                                     self?.handleCancelAction()
                                                   })
         return advancesToNextLeg
+    }
+    
+    func frameDestinationArrival(for location: CLLocation?) {
+        if waypointStyle == .annotation { return }
+        guard let location = location else { return }
+        navigationMapView?.updateUserCourseView(location, animated: false)
     }
 
     public func navigationService(_ service: NavigationService, willBeginSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {


### PR DESCRIPTION
### Description
This pr is to fix the #2929 . After the arrival at the destination, the destination should be at the center of the mapView in an overview mode, which is the essential to display the building highlighting feature. And the user location puck should be at the destination.

### Implementation
By adding the center and pitch constraint to the camera, to let the destination at the center of the `mapView` and also update the `userCourseView` to be at the destination point.

### Screenshots or Gifs
![arrival_fix](https://user-images.githubusercontent.com/48976398/117063177-50e50880-acd9-11eb-96dd-dc44be3fb78d.png)
