### PR TITLE
Clear ImageRepository cache when style change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * Added `OpenLROrientation` struct which describes the relationship between the road object and the referenced line. Used for `OpenLRLineLocation` struct. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
 * Added `OpenLRSideOfRoad` struct which describes the relationship between the road object and the road. Used for `OpenLRPointLocation` struct. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
 * Fixed an issue where `MultiplexedSpeechSynthesizer` could cause circular reference([#3005](https://github.com/mapbox/mapbox-navigation-ios/pull/3005))
+* Fixed the color mismatches of attributed strings in banner instructions when switching between light and dark mode. ([#2977](https://github.com/mapbox/mapbox-navigation-ios/pull/2977))
 
 ## v1.4.0
 

--- a/Sources/MapboxNavigation/InstructionLabel.swift
+++ b/Sources/MapboxNavigation/InstructionLabel.swift
@@ -33,6 +33,13 @@ open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
         }
     }
 
+    open override func update() {
+        super.update()
+        imageRepository.resetImageCache(nil)
+        let previousInstruction = instruction
+        instruction = previousInstruction
+    }
+    
     private var instructionPresenter: InstructionPresenter?
 }
 

--- a/Sources/MapboxNavigation/InstructionLabel.swift
+++ b/Sources/MapboxNavigation/InstructionLabel.swift
@@ -40,6 +40,11 @@ open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
         instruction = previousInstruction
     }
     
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        update()
+    }
+    
     private var instructionPresenter: InstructionPresenter?
 }
 


### PR DESCRIPTION
### Description
This pr is to fix #2938 by resetting `imageRepository` cache and reload `instruction` when style change.


### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
