### PR TITLE
Fix Index out of bounds crash in RouteLegProgress.currentStep

### DIFF
--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -318,11 +318,14 @@ open class RouteController: NSObject {
         let newStepIndex = Int(status.stepIndex)
         let newIntersectionIndex = Int(status.intersectionIndex)
         
+        let oldLegIndex = progress.legIndex
         if newLegIndex != progress.legIndex {
             progress.legIndex = newLegIndex
         }
+        
+        if newStepIndex != progress.currentLegProgress.stepIndex {
+            precondition(progress.currentLegProgress.leg.steps.indices.contains(newStepIndex), "The stepIndex: \(newStepIndex) is higher than steps count: \(progress.currentLegProgress.leg.steps.count) of the leg :\(newLegIndex) or not included. The old leg index: \(oldLegIndex) will not be updated in this case.")
 
-        if (newStepIndex != progress.currentLegProgress.stepIndex) && (newStepIndex < progress.currentLeg.steps.endIndex) {
             progress.currentLegProgress.stepIndex = newStepIndex
         }
         

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -321,8 +321,8 @@ open class RouteController: NSObject {
         if newLegIndex != progress.legIndex {
             progress.legIndex = newLegIndex
         }
-        
-        if newStepIndex != progress.currentLegProgress.stepIndex {
+
+        if (newStepIndex != progress.currentLegProgress.stepIndex) && (newStepIndex < progress.currentLeg.steps.endIndex) {
             progress.currentLegProgress.stepIndex = newStepIndex
         }
         

--- a/Sources/MapboxCoreNavigation/RouteLegProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteLegProgress.swift
@@ -16,7 +16,7 @@ open class RouteLegProgress: Codable {
      */
     public var stepIndex: Int {
         didSet {
-            assert(stepIndex >= 0 && stepIndex < leg.steps.endIndex)
+            precondition(leg.steps.indices.contains(stepIndex), "It's not possible to set the stepIndex: \(stepIndex) when it's higher than steps count \(leg.steps.count) or not included.")
             currentStepProgress = RouteStepProgress(step: currentStep)
         }
     }
@@ -141,10 +141,10 @@ open class RouteLegProgress: Codable {
      - parameter stepIndex: Current step the user is on.
      */
     public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0) {
+        precondition(leg.steps.indices.contains(stepIndex), "It's not possible to set the stepIndex: \(stepIndex) when it's higher than steps count \(leg.steps.count) or not included.")
+        
         self.leg = leg
         self.stepIndex = stepIndex
-        
-        precondition(leg.steps.indices.contains(stepIndex), "It's not possible to create RouteLegProgress without any steps or when stepIndex is higher than steps count.")
         
         currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
     }


### PR DESCRIPTION
### Description
This pr is to add the range check of the `routeProgress.currentLeg.steps` before assign value to `routeProgress.currentLegProgress.stepIndex`, to avoid the out of bounds crush in the `RouteLegProgress.currentStep`
