### PR TITLE
Allow the maneuver arrow disappear on customized low zoom level

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -702,7 +702,7 @@ open class NavigationMapView: UIView {
         
         if shaftPolyline.coordinates.count > 1 {
             let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
-            let minimumZoomLevel: Double = 8.0
+            let minimumZoomLevel: Double = 14.5
             let shaftStrokeCoordinates = shaftPolyline.coordinates
             let shaftDirection = shaftStrokeCoordinates[shaftStrokeCoordinates.count - 2].direction(to: shaftStrokeCoordinates.last!)
             


### PR DESCRIPTION
### Description
This pr is to fix #2867 , to allow the maneuver arrow disappearing on low zoom level, same as in 1.x.

### Implementation
By adjusting the `minimumZoomLevel` to `14.5`, the maneuver could disappear when the zoom level is smaller than 14.5

### Screenshots or Gifs
When the zoom level is smaller than a certain number, the maneuver arrow will hide, same as in 1.x
![arrowHide](https://user-images.githubusercontent.com/48976398/117361367-cdf5b680-ae6e-11eb-9c50-a2530c3d5d16.png)

