### PR TITLE
Fix crash when accessing `compassView`.

### DIFF
--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -488,14 +488,15 @@ extension CarPlayManager: CPMapTemplateDelegate {
         navigationViewController.startNavigationSession(for: trip)
         navigationViewController.carPlayNavigationDelegate = self
         currentNavigator = navigationViewController
-
-        carPlayMapViewController.present(navigationViewController, animated: true)
-
+        
+        carPlayMapViewController.present(navigationViewController, animated: true) { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.carPlayManager(self, didBeginNavigationWith: service)
+        }
+        
         let navigationMapView = carPlayMapViewController.navigationMapView
         navigationMapView.removeRoutes()
         navigationMapView.removeWaypoints()
-
-        delegate?.carPlayManager(self, didBeginNavigationWith: service)
     }
 
     func mapTemplate(forNavigating trip: CPTrip) -> CPMapTemplate {


### PR DESCRIPTION
### Description

Fixed crash when accessing `compassView` on `CarPlay` when presenting `CarPlayNavigationViewController`, by calling delegate method only after finishing presentation.
Since crash happens mostly because of race-condition, it's pretty hard to reproduce it. I had to add such delay to see it:

```swift
DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0) {
    carPlayMapViewController.present(navigationViewController, animated: true)
}

self.delegate?.carPlayManager(self, didBeginNavigationWith: service)
```
