### PR TITLE
SPM: Update mapbox-events-ios to v0.10.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-events-ios.git",
         "state": {
           "branch": null,
-          "revision": "889aaa7214b5f432cf566b83dfa89359c78c26a9",
-          "version": "0.10.7"
+          "revision": "6e4aa13817d59038bf762032e938fe0f7b95b589",
+          "version": "0.10.8"
         }
       },
       {


### PR DESCRIPTION
It fixes Xcode 12.5 SPM integration and matches the version in Cartfile.resolved.