### PR TITLE
TileStore navigation tiles API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 * Fixed a potential memory leak when using `MultiplexedSpeechSynthesizer`. ([#3005](https://github.com/mapbox/mapbox-navigation-ios/pull/3005))
 * Fixed an issue where instruction banners could appear in the wrong color after switching between `Style`s. ([#2977](https://github.com/mapbox/mapbox-navigation-ios/pull/2977))
 * Developers can create an instance of `NavigationViewController` from `UIStoryboardSegue`, which is located in `Navigation.storyboard`. To successfully create `NavigationViewController` instance developer has to pre-define `route`, `routeIndex`, `routeOptions` and `navigationOptions` properties of `NavigationViewController` in `UIViewController.prepare(for:sender:)`. ([#2974](https://github.com/mapbox/mapbox-navigation-ios/pull/2974))
+* Added methods for convenience checking Navigation tiles in a `TileStore`: `containsLatestNavigationTiles(forCacheLocation:, completion:)`, `tileRegionContainsLatestNavigationTiles(forId:, cacheLocation:, completion:)` and methods for getting Navigation tiles from `TilesetDescriptorFactory`: `getLatest(forCacheLocation:)`, `getSpecificVersion(forCacheLocation:, version:)`. ([#3015](https://github.com/mapbox/mapbox-navigation-ios/pull/3015))
 
 ## v1.4.0
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		2B3ED38C2609FA7900861A84 /* ArrivalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3ED38B2609FA7900861A84 /* ArrivalController.swift */; };
 		2B3ED3962609FB2300861A84 /* CameraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3ED3952609FB2300861A84 /* CameraController.swift */; };
 		2B3ED3B4260A162900861A84 /* NavigationViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3ED3B3260A162900861A84 /* NavigationViewData.swift */; };
+		2B42586D2657BF9100B487C3 /* TilesetDescriptorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42586B2657BF9000B487C3 /* TilesetDescriptorFactory.swift */; };
+		2B42586E2657BF9100B487C3 /* TileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42586C2657BF9100B487C3 /* TileStore.swift */; };
+		2B4258702657BFEE00B487C3 /* NativeHandlersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B42586F2657BFEE00B487C3 /* NativeHandlersFactory.swift */; };
 		2B5407EB24470B0A006C820B /* AVAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5407EA24470B0A006C820B /* AVAudioSession.swift */; };
 		2B72EC5E241276D10003B370 /* RouteVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B72EC5D241276D10003B370 /* RouteVoiceController.swift */; };
 		2B72EC602412AA800003B370 /* SystemSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B72EC5F2412AA800003B370 /* SystemSpeechSynthesizer.swift */; };
@@ -540,6 +543,9 @@
 		2B3ED38B2609FA7900861A84 /* ArrivalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrivalController.swift; sourceTree = "<group>"; };
 		2B3ED3952609FB2300861A84 /* CameraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraController.swift; sourceTree = "<group>"; };
 		2B3ED3B3260A162900861A84 /* NavigationViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewData.swift; sourceTree = "<group>"; };
+		2B42586B2657BF9000B487C3 /* TilesetDescriptorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TilesetDescriptorFactory.swift; sourceTree = "<group>"; };
+		2B42586C2657BF9100B487C3 /* TileStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TileStore.swift; sourceTree = "<group>"; };
+		2B42586F2657BFEE00B487C3 /* NativeHandlersFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeHandlersFactory.swift; sourceTree = "<group>"; };
 		2B5407EA24470B0A006C820B /* AVAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAudioSession.swift; sourceTree = "<group>"; };
 		2B72EC5D241276D10003B370 /* RouteVoiceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteVoiceController.swift; sourceTree = "<group>"; };
 		2B72EC5F2412AA800003B370 /* SystemSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSpeechSynthesizer.swift; sourceTree = "<group>"; };
@@ -1811,10 +1817,13 @@
 				35375EC01F31FA86004CE727 /* NavigationSettings.swift */,
 				351174F31EF1C0530065E248 /* ReplayLocationManager.swift */,
 				C5ADFBF91DDCC9580011824B /* LegacyRouteController.swift */,
+				2B42586F2657BFEE00B487C3 /* NativeHandlersFactory.swift */,
 				8D2AA744211CDD4000EB7F72 /* NavigationService.swift */,
 				8D4CF9C521349FFB009C3FEE /* NavigationServiceDelegate.swift */,
 				4303A3982332CD6200B5737D /* UnimplementedLogging.swift */,
 				8D1A5CD1212DDFCD0059BA4A /* DispatchTimer.swift */,
+				2B42586B2657BF9000B487C3 /* TilesetDescriptorFactory.swift */,
+				2B42586C2657BF9100B487C3 /* TileStore.swift */,
 				2B8712682639631C001082A9 /* TileStoreConfiguration.swift */,
 				8D75F990212B5C7F00F99CF3 /* TunnelAuthority.swift */,
 				2B7ACA9A25E3F84600B0ACFD /* PredictiveCacheOptions.swift */,
@@ -2780,6 +2789,7 @@
 				35C98733212E037900808B82 /* RouteState.swift in Sources */,
 				C582FD5F203626E900A9086E /* CLLocationDirection.swift in Sources */,
 				DA5F44DC25F07D1500F573EC /* RoadObjectEdgeLocation.swift in Sources */,
+				2B42586D2657BF9100B487C3 /* TilesetDescriptorFactory.swift in Sources */,
 				3582A25220EFA9680029C5DE /* RouterDelegate.swift in Sources */,
 				353E68FC1EF0B7F8007B2AE5 /* NavigationLocationManager.swift in Sources */,
 				2BE7013D25359C7B00F46E4E /* RouteAlert.swift in Sources */,
@@ -2839,11 +2849,13 @@
 				8D4CF9C621349FFB009C3FEE /* NavigationServiceDelegate.swift in Sources */,
 				C5CFE4881EF2FD4C006F48E8 /* MMEEventsManager.swift in Sources */,
 				C578DA081EFD0FFF0052079F /* ProcessInfo.swift in Sources */,
+				2B42586E2657BF9100B487C3 /* TileStore.swift in Sources */,
 				64847A041F04629D003F3A69 /* Feedback.swift in Sources */,
 				2BE7016925371E3400F46E4E /* Incident.swift in Sources */,
 				C58D6BAD1DDCF2AE00387F53 /* CoreConstants.swift in Sources */,
 				2B7ACA9B25E3F84700B0ACFD /* PredictiveCacheManager.swift in Sources */,
 				35C77F621FE8219900338416 /* NavigationSettings.swift in Sources */,
+				2B4258702657BFEE00B487C3 /* NativeHandlersFactory.swift in Sources */,
 				DA5F44C825F07AB700F573EC /* MapboxStreetsRoadClass.swift in Sources */,
 				2E50E0C0264E35CA009D3848 /* RoadObjectMatcher.swift in Sources */,
 				C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -41,23 +41,24 @@ class Navigator {
         }
     }
     
-    let historyRecorder: HistoryRecorderHandle
+    private(set) var historyRecorder: HistoryRecorderHandle
     
-    let navigator: MapboxNavigationNative.Navigator
+    private(set) var navigator: MapboxNavigationNative.Navigator
     
-    let cacheHandle: CacheHandle
+    private(set) var cacheHandle: CacheHandle
     
-    let roadGraph: RoadGraph
+    private(set) var roadGraph: RoadGraph
     
     lazy var roadObjectsStore: RoadObjectsStore = {
         return RoadObjectsStore(navigator.roadObjectStore())
     }()
-
-    let tileStore: TileStore
-
+    
     lazy var roadObjectMatcher: RoadObjectMatcher = {
         return RoadObjectMatcher(MapboxNavigationNative.RoadObjectMatcher(cache: cacheHandle))
     }()
+
+
+    private(set) var tileStore: TileStore
     
     /**
      The Authorization & Authentication credentials that are used for this service. If not specified - will be automatically intialized from the token and host from your app's `info.plist`.
@@ -76,61 +77,29 @@ class Navigator {
      Restrict direct initializer access.
      */
     private init() {
-        let settingsProfile = SettingsProfile(application: .mobile, platform: .IOS)
+        let factory = NativeHandlersFactory(tileStorePath: Self.tilesURL?.path ?? "",
+                                            credentials: Self.credentials ?? Directions.shared.credentials,
+                                            tilesVersion: Self.tilesVersion,
+                                            historyDirectoryURL: Self.historyDirectoryURL)
+        tileStore = factory.tileStore
+        historyRecorder = factory.historyRecorder
+        cacheHandle = factory.cacheHandle
+        roadGraph = factory.roadGraph
+        navigator = factory.navigator
         
-        let navigatorConfig = NavigatorConfig(voiceInstructionThreshold: nil,
-                                              electronicHorizonOptions: nil,
-                                              polling: nil,
-                                              incidentsOptions: nil,
-                                              noSignalSimulationEnabled: nil)
-        
-        let historyAutorecordingConfig = [
-            "features": [
-                "historyAutorecording": true
-            ]
-        ]
-        
-        var customConfig = ""
-        if let jsonDataConfig = try? JSONSerialization.data(withJSONObject: historyAutorecordingConfig, options: []),
-           let encodedConfig = String(data: jsonDataConfig, encoding: .utf8) {
-            customConfig = encodedConfig
-        }
-        
-        let configFactory = ConfigFactory.build(for: settingsProfile, config: navigatorConfig, customConfig: customConfig)
-        
-        historyRecorder = HistoryRecorderHandle.build(forHistoryFile: Navigator.historyDirectoryURL?.path ?? "", config: configFactory)
-        
-        let endpointConfig = TileEndpointConfiguration(credentials:Navigator.credentials ?? Directions.shared.credentials,
-                                                       tilesVersion: Self.tilesVersion,
-                                                       minimumDaysToPersistVersion: nil)
-
-        let tileStorePath = Self.tilesURL?.path ?? ""
-        tileStore = TileStore.__getInstanceForPath(tileStorePath)
-        let tilesConfig = TilesConfig(tilesPath: tileStorePath,
-                                      tileStore: tileStore,
-                                      inMemoryTileCache: nil,
-                                      onDiskTileCache: nil,
-                                      mapMatchingSpatialCache: nil,
-                                      threadsCount: nil,
-                                      endpointConfig: endpointConfig)
-        
-        let runloopExecutor = RunLoopExecutorFactory.build()
-        cacheHandle = CacheFactory.build(for: tilesConfig,
-                                         config: configFactory,
-                                         runLoop: runloopExecutor,
-                                         historyRecorder: historyRecorder)
-        
-        roadGraph = RoadGraph(MapboxNavigationNative.GraphAccessor(cache: cacheHandle))
-        
-        navigator = MapboxNavigationNative.Navigator(config: configFactory,
-                                                     runLoopExecutor: runloopExecutor,
-                                                     cache: cacheHandle,
-                                                     historyRecorder: historyRecorder)
+        subscribeNavigator()
+    }
+    
+    private func subscribeNavigator() {
         navigator.setElectronicHorizonObserverFor(self)
     }
     
-    deinit {
+    private func unsubscribeNavigator() {
         navigator.setElectronicHorizonObserverFor(nil)
+    }
+    
+    deinit {
+        unsubscribeNavigator()
     }
     
     var electronicHorizonOptions: ElectronicHorizonOptions? {

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -1,0 +1,105 @@
+import MapboxNavigationNative
+import MapboxDirections
+
+
+/// Internal class, designed for handling initialisation of various NavigationNative entities.
+///
+/// Such entities might be used not only as a part of Navigator init sequece, so it is meant not to rely on it's settings.
+class NativeHandlersFactory {
+    
+    // MARK: - Settings
+    
+    let tileStorePath: String
+    let credentials: DirectionsCredentials
+    let tilesVersion: String?
+    let historyDirectoryURL: URL?
+    
+    init(tileStorePath: String,
+         credentials: DirectionsCredentials = Directions.shared.credentials,
+         tilesVersion: String? = nil,
+         historyDirectoryURL: URL? = nil) {
+        self.tileStorePath = tileStorePath
+        self.credentials = credentials
+        self.tilesVersion = tilesVersion
+        self.historyDirectoryURL = historyDirectoryURL
+    }
+    
+    // MARK: - Native Handlers
+    
+    lazy var historyRecorder: HistoryRecorderHandle = {
+        HistoryRecorderHandle.build(forHistoryFile: historyDirectoryURL?.path ?? "", config: configHandle)
+    }()
+    
+    lazy var navigator: MapboxNavigationNative.Navigator = {
+        MapboxNavigationNative.Navigator(config: configHandle,
+                                         runLoopExecutor: runloopExecutor,
+                                         cache: cacheHandle,
+                                         historyRecorder: historyRecorder)
+    }()
+    
+    lazy var cacheHandle: CacheHandle = {
+        CacheFactory.build(for: tilesConfig,
+                           config: configHandle,
+                           runLoop: runloopExecutor,
+                           historyRecorder: historyRecorder)
+    }()
+    
+    lazy var roadGraph: RoadGraph = {
+        RoadGraph(MapboxNavigationNative.GraphAccessor(cache: cacheHandle))
+    }()
+    
+    lazy var tileStore: TileStore = {
+        TileStore.__getInstanceForPath(tileStorePath)
+    }()
+    
+    // MARK: - Support objects
+    
+    lazy var settingsProfile: SettingsProfile = {
+        SettingsProfile(application: .mobile,
+                        platform: .IOS)
+    }()
+    
+    lazy var endpointConfig: TileEndpointConfiguration = {
+        TileEndpointConfiguration(credentials: credentials,
+                                  tilesVersion: tilesVersion ?? "",
+                                  minimumDaysToPersistVersion: nil)
+    }()
+    
+    lazy var tilesConfig: TilesConfig = {
+        TilesConfig(tilesPath: tileStorePath,
+                    tileStore: TileStore.__getInstanceForPath(tileStorePath),
+                    inMemoryTileCache: nil,
+                    onDiskTileCache: nil,
+                    mapMatchingSpatialCache: nil,
+                    threadsCount: nil,
+                    endpointConfig: endpointConfig)
+    }()
+    
+    lazy var configHandle: ConfigHandle = {
+        let historyAutorecordingConfig = [
+            "features": [
+                "historyAutorecording": true
+            ]
+        ]
+        
+        var customConfig = ""
+        if let jsonDataConfig = try? JSONSerialization.data(withJSONObject: historyAutorecordingConfig, options: []),
+           let encodedConfig = String(data: jsonDataConfig, encoding: .utf8) {
+            customConfig = encodedConfig
+        }
+        
+        let navigatorConfig = NavigatorConfig(voiceInstructionThreshold: nil,
+                                              electronicHorizonOptions: nil,
+                                              polling: nil,
+                                              incidentsOptions: nil,
+                                              noSignalSimulationEnabled: nil)
+        
+        return  ConfigFactory.build(for: settingsProfile,
+                                    config: navigatorConfig,
+                                    customConfig: customConfig)
+    }()
+    
+    lazy var runloopExecutor: RunLoopExecutorHandle = {
+        RunLoopExecutorFactory.build()
+    }()
+}

--- a/Sources/MapboxCoreNavigation/TileStore.swift
+++ b/Sources/MapboxCoreNavigation/TileStore.swift
@@ -1,0 +1,95 @@
+import MapboxNavigationNative
+
+
+extension TileStore {
+    public typealias ContainsCompletion = (Bool?) -> Void
+    
+    /**
+     Checks if all `OfflineRegion`s in current `TileStore` contain latest version of Navigation tiles.
+     
+     This method iterates all existing `OfflineRegion`s. If any of the regions have older version of nav tiles or do not have them at all - it will report `false`.
+     
+     - parameter cacheLocation: A `Location` where cache data is stored.
+     - parameter completion: A completion callback, reporting the result. `nil` is returned if error occured during the process.
+     
+     - Note:
+     The user-provided callbacks will be executed on a TileStore-controlled
+     worker thread; it is the responsibility of the user to dispatch to a
+     user-controlled thread.
+     */
+    public func containsLatestNavigationTiles(forCacheLocation cacheLocation: TileStoreConfiguration.Location = .default, completion: @escaping ContainsCompletion) {
+        let descriptors = [TilesetDescriptorFactory.getLatest(forCacheLocation: cacheLocation)]
+        
+        __getAllTileRegions { expected in
+            guard let expected = expected else {
+                assertionFailure("Invalid MBXExpected.")
+                completion(nil)
+                return
+            }
+            
+            if expected.isValue(), let regions = expected.value as? Array<TileRegion> {
+                let lock = NSLock()
+                var count = regions.count
+                var results = Array(repeating: false, count: count)
+
+                for (index, region) in regions.enumerated() {
+                    self.__tileRegionContainsDescriptors(forId: region.id,
+                                                         descriptors: descriptors,
+                                                         callback: { expected in
+                                                            if let expected = expected, expected.isValue(), let contains = expected.value as? NSNumber {
+                                                                results[index] = contains.boolValue
+                                                            }
+                                                            
+                                                            lock.lock()
+                                                            count -= 1
+                                                            
+                                                            if count == 0 {
+                                                                completion(results.allSatisfy { $0 })
+                                                            }
+                                                            lock.unlock()
+                                                         })
+                }
+            } else if expected.isError() {
+                completion(nil)
+            } else {
+                assertionFailure("Unexpected value or error: \(expected), expected: \(Array<TileRegion>.self)")
+                completion(nil)
+            }
+        }
+    }
+    
+    /**
+     Checks if a tile region with the given id contains latest version of Navigation tiles.
+     
+     - parameter regionId: The tile region identifier.
+     - parameter cacheLocation: A `Location` where cache data is stored.
+     - parameter completion: The result callback. If error occured - `nil` will be returned.
+     
+     - Note:
+     The user-provided callbacks will be executed on a TileStore-controlled
+     worker thread; it is the responsibility of the user to dispatch to a
+     user-controlled thread.
+     */
+    public func tileRegionContainsLatestNavigationTiles(forId regionId: String, cacheLocation: TileStoreConfiguration.Location = .default, completion: @escaping ContainsCompletion) {
+        let descriptors = [TilesetDescriptorFactory.getLatest(forCacheLocation: cacheLocation)]
+        
+        __tileRegionContainsDescriptors(forId: regionId,
+                                        descriptors: descriptors,
+                                        callback: { expected in
+                                            guard let expected = expected else {
+                                                assertionFailure("Invalid MBXExpected.")
+                                                completion(nil)
+                                                return
+                                            }
+                                            
+                                            if expected.isValue(), let value = expected.value as? NSNumber {
+                                                completion(value.boolValue)
+                                            } else if expected.isError() {
+                                                completion(nil)
+                                            } else {
+                                                assertionFailure("Unexpected value or error: \(expected), expected: \(NSNumber.self)")
+                                                completion(nil)
+                                            }
+                                        })
+    }
+}

--- a/Sources/MapboxCoreNavigation/TilesetDescriptorFactory.swift
+++ b/Sources/MapboxCoreNavigation/TilesetDescriptorFactory.swift
@@ -1,0 +1,27 @@
+import Foundation
+import MapboxNavigationNative
+import MapboxDirections
+
+extension TilesetDescriptorFactory {
+    /**
+     Gets TilesetDescriptor which corresponds to current Navigator dataset and the specified `version`.
+     - parameter cacheLocation: A `Location` where cache data is stored.
+     - parameter version: TilesetDescriptor version.
+     */
+    open class func getSpecificVersion(forCacheLocation cacheLocation: TileStoreConfiguration.Location = .default, version: String) -> TilesetDescriptor {
+        let cacheHandle = NativeHandlersFactory(tileStorePath: cacheLocation.tileStoreURL?.path ?? "").cacheHandle
+        return getSpecificVersion(forCache: cacheHandle, version: version)
+    }
+
+    /**
+     Gets TilesetDescriptor which corresponds to the latest availble version of routing tiles.
+     
+     Intended for using when creating off-line tile packs.
+     
+     - parameter location: A `Location` where cache data is stored.
+     */
+    open class func getLatest(forCacheLocation cacheLocation: TileStoreConfiguration.Location = .default) -> TilesetDescriptor {
+        let cacheHandle = NativeHandlersFactory(tileStorePath: cacheLocation.tileStoreURL?.path ?? "").cacheHandle
+        return getLatestForCache(cacheHandle)
+    }
+}

--- a/Sources/MapboxCoreNavigation/TilesetDescriptorFactory.swift
+++ b/Sources/MapboxCoreNavigation/TilesetDescriptorFactory.swift
@@ -8,7 +8,7 @@ extension TilesetDescriptorFactory {
      - parameter cacheLocation: A `Location` where cache data is stored.
      - parameter version: TilesetDescriptor version.
      */
-    open class func getSpecificVersion(forCacheLocation cacheLocation: TileStoreConfiguration.Location = .default, version: String) -> TilesetDescriptor {
+    public class func getSpecificVersion(forCacheLocation cacheLocation: TileStoreConfiguration.Location = .default, version: String) -> TilesetDescriptor {
         let cacheHandle = NativeHandlersFactory(tileStorePath: cacheLocation.tileStoreURL?.path ?? "").cacheHandle
         return getSpecificVersion(forCache: cacheHandle, version: version)
     }
@@ -20,7 +20,7 @@ extension TilesetDescriptorFactory {
      
      - parameter location: A `Location` where cache data is stored.
      */
-    open class func getLatest(forCacheLocation cacheLocation: TileStoreConfiguration.Location = .default) -> TilesetDescriptor {
+    public class func getLatest(forCacheLocation cacheLocation: TileStoreConfiguration.Location = .default) -> TilesetDescriptor {
         let cacheHandle = NativeHandlersFactory(tileStorePath: cacheLocation.tileStoreURL?.path ?? "").cacheHandle
         return getLatestForCache(cacheHandle)
     }


### PR DESCRIPTION
Resolves #2987 

### Description

The PR adds convenience methods to verify validity of Navigation tiles in Offline Region or entire TileStore, and an accessor method for corresponding TilesetDescriptor which is required for downloading navigation tiles.

### Implementation

TilesetDescriptor methods are a bit awkward as they require a `CacheHandle` which is configured during Navigator instance startup. Getting a descriptor should be independent of Navigation, but share configuration values. That's why there is a chunk of duplicated logic. I was thinking about moving `CacheHandle` initialisation logic into `CoreNavigationNavigator` but could not come up with a solution which looked pretty. The problem is that `CacheHandle` construction is coupled with other entities initialisation and it messes up the Navigator init sequence.