### PR TITLE
Add ability to show arrival UI for CarPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * `CarPlayManager.mapView` was renamed to `CarPlayManager.navigationMapView`. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Removed deprecated `CarPlayManager.overviewButton`. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Removed unused `CarPlayNavigationViewController.drivingSide` property. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
+* Added `CarPlayManagerDelegate.carPlayManager(_:shouldPresentArrivalUIFor:)` and `CarPlayNavigationViewController.navigationService(_:didArriveAt:)` to allow developers to determine whether to present Arrival UI for CarPlay. ([#3016](https://github.com/mapbox/mapbox-navigation-ios/pull/3016))
 
 ### Other changes
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -68,6 +68,10 @@ extension AppDelegate: CarPlayManagerDelegate {
         currentAppRootViewController?.dismissActiveNavigationViewController()
     }
     
+    func carPlayManager(_ carPlayManager: CarPlayManager, shouldPresentArrivalUIFor waypoint: Waypoint) -> Bool {
+        return true
+    }
+    
     func favoritesListTemplate() -> CPListTemplate {
         let mapboxSFItem = CPListItem(text: FavoritesList.POI.mapboxSF.rawValue,
                                       detailText: FavoritesList.POI.mapboxSF.subTitle)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -144,6 +144,7 @@ class ViewController: UIViewController {
         clearMap.isHidden = true
         longPressHintView.isHidden = false
         
+        // TODO: adjust camera to location after cancle
         navigationMapView?.unhighlightBuildings()
         navigationMapView?.removeRoutes()
         navigationMapView?.removeRouteDurations()
@@ -258,7 +259,7 @@ class ViewController: UIViewController {
         // Control floating buttons position in a navigation view.
         navigationViewController.floatingButtonsPosition = .topTrailing
         
-        presentAndRemoveMapview(navigationViewController)
+        presentAndRemoveMapview(navigationViewController, completion: beginCarPlayNavigation)
     }
     
     func startCustomNavigation() {
@@ -531,6 +532,11 @@ extension ViewController: RouteVoiceControllerDelegate {
 extension ViewController: NavigationViewControllerDelegate {
 
     func navigationViewController(_ navigationViewController: NavigationViewController, didArriveAt waypoint: Waypoint) -> Bool {
+        if #available(iOS 12.0, *),
+           let delegate = UIApplication.shared.delegate as? AppDelegate,
+           let carPlayNavigationViewController = delegate.carPlayManager.currentNavigator {
+            return carPlayNavigationViewController.navigationService(navigationViewController.navigationService, didArriveAt: waypoint)
+        }
         return true
     }
     

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -144,7 +144,6 @@ class ViewController: UIViewController {
         clearMap.isHidden = true
         longPressHintView.isHidden = false
         
-        // TODO: adjust camera to location after cancle
         navigationMapView?.unhighlightBuildings()
         navigationMapView?.removeRoutes()
         navigationMapView?.removeRouteDurations()

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -657,11 +657,17 @@ extension CarPlayManager: CPMapTemplateDelegate {
 
 @available(iOS 12.0, *)
 extension CarPlayManager: CarPlayNavigationDelegate {
+    public func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, shouldPresentArrivalUIFor waypoint: Waypoint) -> Bool {
+        return delegate?.carPlayManager(self, shouldPresentArrivalUIFor: waypoint) ?? true
+    }
+    
     public func carPlayNavigationViewControllerDidDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController, byCanceling canceled: Bool) {
         guard let interfaceController = interfaceController else {
             return
         }
         
+        // Dismiss the template for previous arrival UI when exit the navigation.
+        interfaceController.dismissTemplate(animated: true)
         // Unset existing main map template (fixes an issue with the buttons)
         mainMapTemplate = nil
         

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -144,6 +144,15 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) -> ()
     
     /**
+     Called when the CarPlayManager detects the user arrives at the destination waypoint for a route leg.
+     
+     - parameter carPlayManager: The CarPlay manager instance that has arrived at a waypoint.
+     - parameter waypoint: The waypoint that the user has arrived at.
+     - returns: A boolean value indicating whether to show an arrival UI.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager, shouldPresentArrivalUIFor waypoint: Waypoint) -> Bool
+    
+    /**
      Called when the carplay manager will disable the idle timer.
      
      Implementing this method will allow developers to change whether idle timer is disabled when carplay is connected and the vice-versa when disconnected.

--- a/Tests/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
@@ -14,6 +14,10 @@ fileprivate class CarPlayNavigationDelegateSpy: NSObject, CarPlayNavigationDeleg
     init(_ didArriveExpectation: XCTestExpectation) {
         self.didArriveExpectation = didArriveExpectation
     }
+    
+    func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController, shouldPresentArrivalUIFor waypoint: Waypoint) -> Bool {
+        return true
+    }
 }
 
 @available(iOS 12.0, *)

--- a/Tests/MapboxNavigationTests/Support/CarPlayUtils.swift
+++ b/Tests/MapboxNavigationTests/Support/CarPlayUtils.swift
@@ -35,6 +35,10 @@ class CarPlayManagerFailureDelegateSpy: CarPlayManagerDelegate {
     func carPlayManager(_ carPlayManager: CarPlayManager, didBeginNavigationWith service: NavigationService) {
         fatalError("This is an empty stub.")
     }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager, shouldPresentArrivalUIFor waypoint: Waypoint) -> Bool {
+        fatalError("This is an empty stub.")
+    }
 
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
         fatalError("This is an empty stub.")
@@ -83,6 +87,10 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
         XCTAssertFalse(navigationInitiated)
         navigationInitiated = true
         currentService = service
+    }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager, shouldPresentArrivalUIFor waypoint: Waypoint) -> Bool {
+        return true
     }
 
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {


### PR DESCRIPTION
### Description
This pr is to fix #2908 by adding the `CarPlayManagerDelegate.carPlayManager(_:shouldPresentArrivalUIFor:)`, to allow the developers to decide whether to present end of route view for CarPlay.

### Implementation
By adding `CarPlayManagerDelegate.carPlayManager(_:shouldPresentArrivalUIFor:)` and `CarPlayNavigationViewController.navigationService(_:didArriveAt:)`, user could determine whether to call the `CarPlayNavigationViewController` to display the arrival UI.

### Screenshots or Gifs
![carPlay_Arrival](https://user-images.githubusercontent.com/48976398/118716535-ca045580-b7d9-11eb-9972-9bb2d01032d0.png)
