### PR TITLE
Use  EHorizon to improve road label during turn-by-turn navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 * Developers can create an instance of `NavigationViewController` from `UIStoryboardSegue`, which is located in `Navigation.storyboard`. To successfully create `NavigationViewController` instance developer has to pre-define `route`, `routeIndex`, `routeOptions` and `navigationOptions` properties of `NavigationViewController` in `UIViewController.prepare(for:sender:)`. ([#2974](https://github.com/mapbox/mapbox-navigation-ios/pull/2974))
 * Added methods for convenience checking Navigation tiles in a `TileStore`: `containsLatestNavigationTiles(forCacheLocation:, completion:)`, `tileRegionContainsLatestNavigationTiles(forId:, cacheLocation:, completion:)` and methods for getting Navigation tiles from `TilesetDescriptorFactory`: `getLatest(forCacheLocation:)`, `getSpecificVersion(forCacheLocation:, version:)`. ([#3015](https://github.com/mapbox/mapbox-navigation-ios/pull/3015))
 * Fixed a thread-safety issue in `UnimplementedLogging` protocol implementation. ([#3024](https://github.com/mapbox/mapbox-navigation-ios/pull/3024))
+* Fixed an issue where the current road name label sometimes displayed the name of an intersecting road instead of the current road or blinked in and out. ([#3019](https://github.com/mapbox/mapbox-navigation-ios/pull/3019))
 
 ## v1.4.0
 

--- a/Sources/MapboxCoreNavigation/MinimumEditDistance.swift
+++ b/Sources/MapboxCoreNavigation/MinimumEditDistance.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension String {
     // Adapted from https://github.com/raywenderlich/swift-algorithm-club/blob/master/Minimum%20Edit%20Distance/MinimumEditDistance.playground/Contents.swift
-    func minimumEditDistance(to word: String) -> Int {
+    public func minimumEditDistance(to word: String) -> Int {
         let fromWordCount = count
         let toWordCount = word.count
         

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -100,12 +100,8 @@ extension NavigationMapView {
                 case .name(let name):
                     return name
                 case .code(let code):
-                    return "(\(code))"
+                    return code
                 }
-            }
-            
-            if electronicHorizonRoadNames.isEmpty {
-                electronicHorizonRoadNames = ["\(metadata.mapboxStreetsRoadClass.rawValue)"]
             }
         }
         
@@ -295,7 +291,7 @@ extension NavigationMapView {
                         if let roadName = queriedFeature.feature.properties["name"] as? String,
                            !roadName.isEmpty,
                            !self.electronicHorizonRoadNames.isEmpty {
-                            let stringEditDistance = self.electronicHorizonRoadNames.first!.minimumEditDistance(to: roadName)
+                            let stringEditDistance = self.electronicHorizonRoadNames.map{ $0.minimumEditDistance(to: roadName) }.reduce(0, +)
                             if stringEditDistance < minimumEditDistance {
                                 minimumEditDistance = stringEditDistance
                                 similarFeature = queriedFeature.feature


### PR DESCRIPTION
### Description
This pr is to fix #1440 , by improving the road label after feature query results from the EHorizon notification.

### Implementation
 Receiving the e-horizon road names through `Notification`. During the turn-by-turn navigation, when there're multiple feature query results, comparing the road name of the feature with the e-horizon road names. And then choosing the most similar feature to label the road if it's not the nearest one.

### Screenshots or Gifs
