### PR TITLE
Restore availability macros to jazzy docset

### DIFF
--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -52,12 +52,6 @@ find Sources/Mapbox{Core,}Navigation/ -name '*.swift' -exec \
 find Sources/Mapbox{Core,}Navigation/ -name '*.[hm]' -exec \
     perl -pi -e 's/([<"])MapboxCoreNavigation\b/$1MapboxNavigation/' {} \;
 
-# Blow away any platform-based availability attributes, since everything is
-# compatible enough to be documented.
-# https://github.com/mapbox/mapbox-navigation-ios/issues/1682
-find Sources/Mapbox{Core,}Navigation/ -name '*.swift' -exec \
-    perl -pi -e 's/\@available\s*\(\s*iOS \d+.\d,.*?\)//' {} \;
-
 jazzy \
     --podspec MapboxNavigation-Documentation.podspec \
     --config docs/jazzy.yml \


### PR DESCRIPTION
SourceKit seems to finally generate a proper USR for symbols marked with availability macros. The v2.0.0-beta.9 and v2.0.0-beta.10 documentation was successfully generated without the need for the workaround added in #1714, without the side effects noted in https://github.com/mapbox/mapbox-navigation-ios/issues/1682#issuecomment-421984847. So I think we can simply remove the workaround at this point.

/cc @mapbox/navigation-ios