### PR TITLE
Fix "class" as protocol deprecation warnings

### DIFF
--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -5,7 +5,7 @@ import Polyline
 import MapboxMobileEvents
 import Turf
 
-protocol RouteControllerDataSource: class {
+protocol RouteControllerDataSource: AnyObject {
     var location: CLLocation? { get }
     var locationProvider: NavigationLocationManager.Type { get }
 }

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -7,7 +7,7 @@ let NavigationEventTypeRouteRetrieval = "mobile.performance_trace"
 /**
  The `EventsManagerDataSource` protocol declares values required for recording route following events.
  */
-public protocol EventsManagerDataSource: class {
+public protocol EventsManagerDataSource: AnyObject {
     var routeProgress: RouteProgress { get }
     var router: Router! { get }
     var desiredAccuracy: CLLocationAccuracy { get }

--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -114,7 +114,7 @@ open class NavigationMatchOptions: MatchOptions, OptimizedForNavigation {
     }
 }
 
-protocol OptimizedForNavigation: class {
+protocol OptimizedForNavigation: AnyObject {
     var includesSteps: Bool { get set }
     var routeShapeResolution: RouteShapeResolution { get set }
     var shapeFormat: RouteShapeFormat { get set }

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -15,7 +15,7 @@ import os.log
  - seealso: NavigationViewControllerDelegate
  - seealso: RouterDelegate
  */
-public protocol NavigationServiceDelegate: class, UnimplementedLogging {
+public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Returns whether the navigation service should be allowed to calculate a new route.
      

--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -167,7 +167,7 @@ extension PassiveLocationDataSource: CLLocationManagerDelegate {
 /**
  A delegate of a `PassiveLocationDataSource` object implements methods that the location data source calls as the user’s location changes.
  */
-public protocol PassiveLocationDataSourceDelegate: class {
+public protocol PassiveLocationDataSourceDelegate: AnyObject {
     /// - seealso: `CLLocationManagerDelegate.locationManagerDidChangeAuthorization(_:)`
     @available(iOS 14.0, *)
     func passiveLocationDataSourceDidChangeAuthorization(_ dataSource: PassiveLocationDataSource)

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -5,7 +5,7 @@ import MapboxDirections
 /**
  A router data source, also known as a location manager, supplies location data to a `Router` instance. For example, a `MapboxNavigationService` supplies location data to a `RouteController` or `LegacyRouteController`.
  */
-public protocol RouterDataSource: class {
+public protocol RouterDataSource: AnyObject {
     /**
      The location provider for the `Router.` This class is designated as the object that will provide location updates when requested.
      */
@@ -22,7 +22,7 @@ public typealias IndexedRoute = (Route, Int)
  
  There are two concrete implementations of the `Router` protocol. `RouteController`, the default implementation, is capable of client-side routing and depends on the Mapbox Navigation Native framework. `LegacyRouteController` is an alternative implementation that does not have this dependency but must be used in conjunction with the Mapbox Directions API over a network connection.
  */
-public protocol Router: class, CLLocationManagerDelegate {
+public protocol Router: CLLocationManagerDelegate {
     /**
      The route controller’s associated location manager.
      */
@@ -95,7 +95,7 @@ public protocol Router: class, CLLocationManagerDelegate {
     func locationHistory() -> String?
 }
 
-protocol InternalRouter: class {
+protocol InternalRouter: AnyObject {
     var lastProactiveRerouteDate: Date? { get set }
     
     var lastRouteRefresh: Date? { get set }

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -10,7 +10,7 @@ import MapboxDirections
  - seealso: MapboxNavigationService
  - seealso: NavigationServiceDelegate
  */
-public protocol RouterDelegate: class, UnimplementedLogging {
+public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Returns whether the router should be allowed to calculate a new route.
      

--- a/Sources/MapboxNavigation/BottomBannerViewController.swift
+++ b/Sources/MapboxNavigation/BottomBannerViewController.swift
@@ -5,7 +5,7 @@ import MapboxDirections
 /**
  `BottomBannerViewControllerDelegate` provides a method for reacting to the user tapping on the "cancel" button in the `BottomBannerViewController`.
  */
-public protocol BottomBannerViewControllerDelegate: class {
+public protocol BottomBannerViewControllerDelegate: AnyObject {
     /**
      A method that is invoked when the user taps on the cancel button.
      - parameter sender: The button that originated the tap event.

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -753,7 +753,7 @@ extension CarPlayManager {
 }
 
 @available(iOS 12.0, *)
-internal protocol MapTemplateProviderDelegate: class {
+internal protocol MapTemplateProviderDelegate: AnyObject {
     func mapTemplateProvider(_ provider: MapTemplateProvider, mapTemplate: CPMapTemplate, leadingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, for activity: CarPlayActivity) -> [CPBarButton]?
     
     func mapTemplateProvider(_ provider: MapTemplateProvider, mapTemplate: CPMapTemplate, trailingNavigationBarButtonsCompatibleWith traitCollection: UITraitCollection, for activity: CarPlayActivity) -> [CPBarButton]?

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -11,7 +11,7 @@ import MapboxDirections
  If no delegate is set, a default built-in MapboxNavigationService will be created and used when a trip begins.
  */
 @available(iOS 12.0, *)
-public protocol CarPlayManagerDelegate: class, UnimplementedLogging {
+public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
     /**
      Offers the delegate an opportunity to provide a customized list of leading bar buttons at the root of the template stack for the given activity.
      

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -565,7 +565,7 @@ extension CarPlayNavigationViewController: StyleManagerDelegate {
  The `CarPlayNavigationDelegate` protocol provides methods for reacting to significant events during turn-by-turn navigation with `CarPlayNavigationViewController`.
  */
 @available(iOS 12.0, *)
-public protocol CarPlayNavigationDelegate: class, UnimplementedLogging {
+public protocol CarPlayNavigationDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the CarPlay navigation view controller is dismissed, such as when the user ends a trip.
      

--- a/Sources/MapboxNavigation/CarPlaySearchController.swift
+++ b/Sources/MapboxNavigation/CarPlaySearchController.swift
@@ -2,7 +2,7 @@ import CarPlay
 import MapboxDirections
 
 @available(iOS 12.0, *)
-public protocol CarPlaySearchControllerDelegate: class {
+public protocol CarPlaySearchControllerDelegate: AnyObject {
     func previewRoutes(to waypoint: Waypoint, completionHandler: @escaping () -> Void)
     func resetPanButtons(_ mapTemplate: CPMapTemplate)
     func pushTemplate(_ template: CPTemplate, animated: Bool)

--- a/Sources/MapboxNavigation/FeedbackViewController.swift
+++ b/Sources/MapboxNavigation/FeedbackViewController.swift
@@ -18,7 +18,7 @@ extension FeedbackViewController: UIViewControllerTransitioningDelegate {
 /**
  The `FeedbackViewControllerDelegate` protocol provides methods for responding to feedback events.
  */
-public protocol FeedbackViewControllerDelegate: class, UnimplementedLogging {
+public protocol FeedbackViewControllerDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the user opens the feedback form.
      */

--- a/Sources/MapboxNavigation/InstructionLabel.swift
+++ b/Sources/MapboxNavigation/InstructionLabel.swift
@@ -39,7 +39,7 @@ open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
 /**
  The `VisualInstructionDelegate` protocol defines a method that allows an object to customize presented visual instructions.
  */
-public protocol VisualInstructionDelegate: class, UnimplementedLogging {
+public protocol VisualInstructionDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when an InstructionLabel will present a visual instruction.
      

--- a/Sources/MapboxNavigation/InstructionPresenter.swift
+++ b/Sources/MapboxNavigation/InstructionPresenter.swift
@@ -1,7 +1,7 @@
 import UIKit
 import MapboxDirections
 
-protocol InstructionPresenterDataSource: class {
+protocol InstructionPresenterDataSource: AnyObject {
     var availableBounds: (() -> CGRect)! { get }
     var font: UIFont! { get }
     var textColor: UIColor! { get }

--- a/Sources/MapboxNavigation/InstructionsBannerView.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerView.swift
@@ -5,7 +5,7 @@ import MapboxDirections
 /**
  `InstructionsBannerViewDelegate` provides methods for reacting to user interactions in `InstructionsBannerView`.
  */
-public protocol InstructionsBannerViewDelegate: class, UnimplementedLogging {
+public protocol InstructionsBannerViewDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the user taps the `InstructionsBannerView`.
      */

--- a/Sources/MapboxNavigation/NavigationComponent.swift
+++ b/Sources/MapboxNavigation/NavigationComponent.swift
@@ -10,7 +10,7 @@ public protocol NavigationComponent: NavigationServiceDelegate {}
 /**
  The NavigationInteractionDelegate protocol is used to define interaction events that the top banner may need to know about.
  */
-public protocol NavigationMapInteractionObserver: class {
+public protocol NavigationMapInteractionObserver: AnyObject {
     /**
      Called when the NavigationMapView centers on a location.
      */
@@ -20,7 +20,7 @@ public protocol NavigationMapInteractionObserver: class {
 /**
  The CarPlayConnectionObserver protocol provides notification of a carplay unit connecting two the NavigationViewController.
  */
-public protocol CarPlayConnectionObserver: class {
+public protocol CarPlayConnectionObserver: AnyObject {
     /**
      Called when the NavigationViewController detects that a CarPlay device has been connected.
      */
@@ -35,7 +35,7 @@ public protocol CarPlayConnectionObserver: class {
 /**
  This protocol defines a UI Component that is capable of presenting a status message.
  */
-public protocol NavigationStatusPresenter: class {
+public protocol NavigationStatusPresenter: AnyObject {
     /**
      Shows a Status for a specified amount of time.
      */

--- a/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -5,7 +5,7 @@ import MapboxCoreNavigation
 /**
  The `NavigationMapViewDelegate` provides methods for configuring the NavigationMapView, as well as responding to events triggered by the NavigationMapView.
  */
-public protocol NavigationMapViewDelegate: class, UnimplementedLogging {
+public protocol NavigationMapViewDelegate: AnyObject, UnimplementedLogging {
 
     /**
      Asks the receiver to return an MGLStyleLayer for the main route line, given an identifier and source.
@@ -221,7 +221,7 @@ public extension NavigationMapViewDelegate {
 /**
  The `NavigationMapViewCourseTrackingDelegate` provides methods for responding to the `NavigationMapView` starting or stopping course tracking.
  */
-public protocol NavigationMapViewCourseTrackingDelegate: class, UnimplementedLogging {
+public protocol NavigationMapViewCourseTrackingDelegate: AnyObject, UnimplementedLogging {
     /**
      Tells the receiver that the map is now tracking the user course.
      - seealso: NavigationMapView.tracksUserCourse

--- a/Sources/MapboxNavigation/RouteVoiceController.swift
+++ b/Sources/MapboxNavigation/RouteVoiceController.swift
@@ -190,7 +190,7 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
 /**
  The `RouteVoiceControllerDelegate` protocol defines methods that allow an object to respond to significant events related to route vocalization
  */
-public protocol RouteVoiceControllerDelegate: class, UnimplementedLogging {
+public protocol RouteVoiceControllerDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the route voice controller reports an error
      

--- a/Sources/MapboxNavigation/SpeechSynthesizing.swift
+++ b/Sources/MapboxNavigation/SpeechSynthesizing.swift
@@ -5,7 +5,7 @@ import MapboxCoreNavigation
 /**
  Protocol for implementing speech synthesizer to be used in `RouteVoiceController`.
  */
-public protocol SpeechSynthesizing: class {
+public protocol SpeechSynthesizing: AnyObject {
     
     /// A delegate that will be notified about significant events related to spoken instructions.
     var delegate: SpeechSynthesizingDelegate? { get set }
@@ -44,7 +44,7 @@ public protocol SpeechSynthesizing: class {
 /**
  The `SpeechSynthesizingDelegate` protocol defines methods that allow an object to respond to significant events related to spoken instructions.
  */
-public protocol SpeechSynthesizingDelegate: class, UnimplementedLogging {
+public protocol SpeechSynthesizingDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the speech synthesizer encountered an error during processing, but may still be able to speak the instruction.
      - parameter speechSynthesizer: The voice controller that experienced the failure.

--- a/Sources/MapboxNavigation/StatusView.swift
+++ b/Sources/MapboxNavigation/StatusView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// :nodoc:
-public protocol DeprecatedStatusViewDelegate: class {}
+public protocol DeprecatedStatusViewDelegate: AnyObject {}
 
 /**
  A protocol for listening in on changes made to a `StatusView`.

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -9,7 +9,7 @@ open class StepsBackgroundView: UIView { }
 /**
  `StepsViewControllerDelegate` provides methods for user interactions in a `StepsViewController`.
  */
-public protocol StepsViewControllerDelegate: class {
+public protocol StepsViewControllerDelegate: AnyObject {
     /**
      Called when the user selects a step in a `StepsViewController`.
      */

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -5,7 +5,7 @@ import MapboxCoreNavigation
 /**
  The `StyleManagerDelegate` protocol defines a set of methods used for controlling the style.
  */
-public protocol StyleManagerDelegate: class, UnimplementedLogging {
+public protocol StyleManagerDelegate: AnyObject, UnimplementedLogging {
     /**
      Asks the delegate for a location to use when calculating sunset and sunrise
      */

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -2,7 +2,7 @@ import Foundation
 import MapboxCoreNavigation
 import MapboxDirections
 
-public protocol TopBannerViewControllerDelegate: class, UnimplementedLogging {
+public protocol TopBannerViewControllerDelegate: AnyObject, UnimplementedLogging {
     func topBanner(_ banner: TopBannerViewController, didSwipeInDirection direction: UISwipeGestureRecognizer.Direction)
     
     func topBanner(_ banner: TopBannerViewController, didSelect legIndex: Int, stepIndex: Int, cell: StepTableViewCell)


### PR DESCRIPTION
It is Swift 5.4 warning:
`Using "class" keyword for protocol inheritance is deprecated;
use "AnyObject" instead`

This is the same as https://github.com/mapbox/mapbox-navigation-ios/pull/3008 but for `main` branch.