### PR TITLE
Fix UnimplementedLogging.logUnimplemented method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 * Fixed a potential memory leak when using `MultiplexedSpeechSynthesizer`. ([#3005](https://github.com/mapbox/mapbox-navigation-ios/pull/3005))
 * Fixed an issue where instruction banners could appear in the wrong color after switching between `Style`s. ([#2977](https://github.com/mapbox/mapbox-navigation-ios/pull/2977))
 * Developers can create an instance of `NavigationViewController` from `UIStoryboardSegue`, which is located in `Navigation.storyboard`. To successfully create `NavigationViewController` instance developer has to pre-define `route`, `routeIndex`, `routeOptions` and `navigationOptions` properties of `NavigationViewController` in `UIViewController.prepare(for:sender:)`. ([#2974](https://github.com/mapbox/mapbox-navigation-ios/pull/2974))
+* Fixed a thread-safety issue in `UnimplementedLogging` protocol implementation. ([#3024](https://github.com/mapbox/mapbox-navigation-ios/pull/3024))
 
 ## v1.4.0
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		DAF27252264E02D800C0AC37 /* RoadObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF27251264E02D800C0AC37 /* RoadObject.swift */; };
 		DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */; };
 		E27A2204265674E400AA935F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E27A2202265674E400AA935F /* Localizable.strings */; };
+		E2842798265B907C003F86E4 /* UnimplementedLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2842797265B907C003F86E4 /* UnimplementedLoggingTests.swift */; };
 		F46FF187260277F7007CC0E0 /* DateComponentsFormatter+NavigationAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46FF186260277F7007CC0E0 /* DateComponentsFormatter+NavigationAdditions.swift */; };
 		F4BF512E24EAD7A50066A49B /* FeedbackSubtypeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BF512D24EAD7A50066A49B /* FeedbackSubtypeCollectionViewCell.swift */; };
 		F4C5A26F24EF1D16004ED0DD /* FeedbackSubtypeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C5A26E24EF1D16004ED0DD /* FeedbackSubtypeViewController.swift */; };
@@ -1045,6 +1046,7 @@
 		E27A21F22654FB6800AA935F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E27A21FD265672D500AA935F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E27A2203265674E400AA935F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E2842797265B907C003F86E4 /* UnimplementedLoggingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnimplementedLoggingTests.swift; sourceTree = "<group>"; };
 		F46FF186260277F7007CC0E0 /* DateComponentsFormatter+NavigationAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateComponentsFormatter+NavigationAdditions.swift"; sourceTree = "<group>"; };
 		F4BF512D24EAD7A50066A49B /* FeedbackSubtypeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSubtypeCollectionViewCell.swift; sourceTree = "<group>"; };
 		F4C5A26E24EF1D16004ED0DD /* FeedbackSubtypeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSubtypeViewController.swift; sourceTree = "<group>"; };
@@ -1856,6 +1858,7 @@
 				3519D01D21F0842900582FF5 /* CLLocationTests.swift */,
 				352762A3225B751A0015B632 /* OptionsTests.swift */,
 				5A43FC8A24B488DC00BF7943 /* PassiveLocationDataSourceTests.swift */,
+				E2842797265B907C003F86E4 /* UnimplementedLoggingTests.swift */,
 			);
 			name = MapboxCoreNavigationTests;
 			path = Tests/MapboxCoreNavigationTests;
@@ -2859,6 +2862,7 @@
 				3519D01E21F0842900582FF5 /* CLLocationTests.swift in Sources */,
 				162039CF216C348500875F5C /* NavigationEventsManagerTests.swift in Sources */,
 				C5ADFBD81DDCC7840011824B /* MapboxCoreNavigationTests.swift in Sources */,
+				E2842798265B907C003F86E4 /* UnimplementedLoggingTests.swift in Sources */,
 				DAD903AF23E3DCC80057CF1F /* DateTests.swift in Sources */,
 				C551B0E620D42222009A986F /* NavigationLocationManagerTests.swift in Sources */,
 				359A8AED1FA78D3000BDB486 /* DistanceFormatterTests.swift in Sources */,

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -597,7 +597,7 @@ class NavigationServiceTests: XCTestCase {
     }
 
     func testUnimplementedLogging() {
-        unimplementedTestLogs = []
+        _unimplementedLoggingState.clear()
 
         let options =  NavigationRouteOptions(coordinates: [
                    CLLocationCoordinate2D(latitude: 38.853108, longitude: -77.043331),
@@ -618,16 +618,8 @@ class NavigationServiceTests: XCTestCase {
             service.locationManager(locationManager, didUpdateLocations: [location])
         }
 
-        guard let logs = unimplementedTestLogs else {
-            XCTFail("Unable to fetch logs")
-            return
-        }
-
-        let ourLogs = logs.filter { $0.0 == "EmptyNavigationServiceDelegate" }
-
-        XCTAssertEqual(ourLogs.count, 7, "Expected logs to be populated and expected number of messages sent")
-        unimplementedTestLogs = nil
-    }
+        XCTAssertEqual(_unimplementedLoggingState.countWarned(forTypeDescription: "EmptyNavigationServiceDelegate"), 7, "Expected logs to be populated and expected number of messages sent")
+    }    
 }
 
 class EmptyNavigationServiceDelegate: NavigationServiceDelegate {}

--- a/Tests/MapboxCoreNavigationTests/UnimplementedLoggingTests.swift
+++ b/Tests/MapboxCoreNavigationTests/UnimplementedLoggingTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+@testable import MapboxCoreNavigation
+
+final class UnimplementedLoggingTests: XCTestCase {
+    class UnimplementedClass: UnimplementedLogging {
+        func func1() {
+            logUnimplemented(protocolType: self, level: .default)
+        }
+        func func2() {
+            logUnimplemented(protocolType: self, level: .default)
+        }
+        func func3() {
+            logUnimplemented(protocolType: self, level: .default)
+        }
+    }
+
+    func testUnimplementedLoggingMultithreaded() {
+        let iterations = 100
+        let iterationsFinished = expectation(description: "Iterations finished")
+        iterationsFinished.expectedFulfillmentCount = iterations
+        let unimplementedClass = UnimplementedClass()
+        DispatchQueue.concurrentPerform(iterations: iterations) { iterationIdx in
+            unimplementedClass.func1()
+            unimplementedClass.func2()
+            unimplementedClass.func3()
+            iterationsFinished.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+        XCTAssertEqual(_unimplementedLoggingState.countWarned(forTypeDescription: "UnimplementedClass"), 3)
+    }
+
+    func testUnimplementedLoggingPerformance() {
+        measure {
+            let iterations = 50
+            for _ in 0..<iterations {
+                let unimplementedClass = UnimplementedClass()
+                unimplementedClass.func1()
+                unimplementedClass.func2()
+                unimplementedClass.func3()
+            }
+        }
+    }
+}


### PR DESCRIPTION
The method is part of the public SDK API, and there are no guarantees
that it will be called in a thread-safe manner. The fact current
implementation isn't thread-safe was proofed by running a test with
Thread Sanitizer (TSan) enabled (see the log at the end).

- UnimplementedLogging.logUnimplemented reimplemented so that it is safe
to use from multiple threads.
- Adds a test to verify that the new implementation is safe.
- Adds a test to catch performance regressions in implementation.

Below is a log from TSan when run for old implementation:
```
WARNING: ThreadSanitizer: Swift access race (pid=14419)
  Modifying access of Swift variable at 0x00010a65a7a0 by thread T2:
    #0 UnimplementedLogging.logUnimplemented(protocolType:level:function:) <null>:12416464 (MapboxCoreNavigationTests:arm64+0x3a7464)
    #1 func1() in UnimplementedClass #1 in UnimplementedLoggingTests.testUnimplementedLoggingMultithreaded() UnimplementedLoggingTests.swift:9 (MapboxCoreNavigationTests:arm64+0xb26f4)
    #2 closure #1 in UnimplementedLoggingTests.testUnimplementedLoggingMultithreaded() UnimplementedLoggingTests.swift:24 (MapboxCoreNavigationTests:arm64+0xb1e9c)
    #3 partial apply for closure #1 in UnimplementedLoggingTests.testUnimplementedLoggingMultithreaded() <compiler-generated> (MapboxCoreNavigationTests:arm64+0xb1f34)
    #4 partial apply for thunk for @callee_guaranteed (@unowned Int) -> () <null>:12416464 (libswiftDispatch.dylib:arm64+0x5030)
    #5 _dispatch_client_callout2 <null>:12416464 (libdispatch.dylib:arm64+0x3d80)

  Previous read of size 8 at 0x00010a65a7a0 by thread T4:
    #0 UnimplementedLogging.logUnimplemented(protocolType:level:function:) <null>:12416464 (MapboxCoreNavigationTests:arm64+0x3a6f9c)
    #1 func1() in UnimplementedClass #1 in UnimplementedLoggingTests.testUnimplementedLoggingMultithreaded() UnimplementedLoggingTests.swift:9 (MapboxCoreNavigationTests:arm64+0xb26f4)
    #2 closure #1 in UnimplementedLoggingTests.testUnimplementedLoggingMultithreaded() UnimplementedLoggingTests.swift:24 (MapboxCoreNavigationTests:arm64+0xb1e9c)
    #3 partial apply for closure #1 in UnimplementedLoggingTests.testUnimplementedLoggingMultithreaded() <compiler-generated> (MapboxCoreNavigationTests:arm64+0xb1f34)
    #4 partial apply for thunk for @callee_guaranteed (@unowned Int) -> () <null>:12416464 (libswiftDispatch.dylib:arm64+0x5030)
    #5 _dispatch_client_callout2 <null>:12416464 (libdispatch.dylib:arm64+0x3d80)

  Location is global 'warned' at 0x00010a65a7a0 (MapboxCoreNavigationTests+0x000000e3a7a0)

  Thread T2 (tid=3981887, running) is a GCD worker thread

  Thread T4 (tid=3981890, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race (MapboxCoreNavigationTests:arm64+0x3a7464) in UnimplementedLogging.logUnimplemented(protocolType:level:function:)+0x770
```

- [x] Do I need to update the changelog for such fix? 