### PR TITLE
Fix ImageCache image cost estimation logic

### DIFF
--- a/Sources/MapboxNavigation/ImageCache.swift
+++ b/Sources/MapboxNavigation/ImageCache.swift
@@ -63,14 +63,8 @@ internal class ImageCache: BimodalImageCache {
         fileCache.clearDisk(completion: completion)
     }
 
-    private func cost(forImage image: UIImage) -> Int {
-        let xDimensionCost = image.size.width * image.scale
-        let yDimensionCost = image.size.height * image.scale
-        return Int(xDimensionCost * yDimensionCost)
-    }
-
     private func storeImageInMemoryCache(_ image: UIImage, forKey key: String) {
-        memoryCache.setObject(image, forKey: key as NSString, cost: cost(forImage: image))
+        memoryCache.setObject(image, forKey: key as NSString, cost: image.memoryCost)
     }
 
     private func imageFromMemoryCache(forKey key: String) -> UIImage? {

--- a/Sources/MapboxNavigation/UIImage.swift
+++ b/Sources/MapboxNavigation/UIImage.swift
@@ -68,4 +68,27 @@ extension UIImage {
 
         return finalImage
     }
+
+    /// Returns how much bytes the image takes in the memory.
+    /// - important: Works reliably only for CGImage backed images.
+    var memoryCost: Int {
+        let costPerFrame: Int
+        let framesCount: Int
+
+        if let images = images {
+            framesCount = images.count > 0 ? images.count : 1
+        }
+        else {
+            framesCount = 1
+        }
+
+        if let cgImage = cgImage {
+            costPerFrame = cgImage.bytesPerRow * cgImage.height
+        }
+        else { // fallback to manual estimation
+            costPerFrame = (Int(scale * size.width)) * (Int(scale * size.height)) * 4 // 4 for 4 RGBA colour components.
+        }
+
+        return costPerFrame * framesCount
+    }
 }


### PR DESCRIPTION
How much an image takes in memory can be different for different images:
- An image created with CGContext will have a different memory size
than the same image but loaded from a jpg file.
Example: https://stackoverflow.com/a/25706554/425838.
- Size depends on the image's colour space (how many bytes needed to
encode one pixel of the image).

The fix uses the data returned by CGImage, which is the most reliable
source of information available to estimate the size of an image in
memory.