### PR TITLE
Fix text missing in Guidance Card navigation

### DIFF
--- a/Sources/MapboxNavigation/InstructionLabel.swift
+++ b/Sources/MapboxNavigation/InstructionLabel.swift
@@ -28,16 +28,16 @@ open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
             let presenter = InstructionPresenter(instruction, dataSource: self, imageRepository: imageRepository, downloadCompletion: update)
             
             let attributed = presenter.attributedText()
-            text = instructionDelegate?.label(self, willPresent: instruction, as: attributed)?.string ?? attributed.string
+            attributedText = instructionDelegate?.label(self, willPresent: instruction, as: attributed) ?? attributed
             instructionPresenter = presenter
         }
     }
 
     open override func update() {
-        super.update()
         imageRepository.resetImageCache(nil)
         let previousInstruction = instruction
         instruction = previousInstruction
+        super.update()
     }
     
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Sources/MapboxNavigation/InstructionLabel.swift
+++ b/Sources/MapboxNavigation/InstructionLabel.swift
@@ -28,7 +28,7 @@ open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
             let presenter = InstructionPresenter(instruction, dataSource: self, imageRepository: imageRepository, downloadCompletion: update)
             
             let attributed = presenter.attributedText()
-            attributedText = instructionDelegate?.label(self, willPresent: instruction, as: attributed) ?? attributed
+            text = instructionDelegate?.label(self, willPresent: instruction, as: attributed)?.string ?? attributed.string
             instructionPresenter = presenter
         }
     }


### PR DESCRIPTION
### Description
This pr is to fix #3027 

### Implementation
The `textColor` and `font` of the instruction label should be updated after the instruction reset.

### Screenshots or Gifs
