### PR TITLE
Offline routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * Added methods for convenience checking Navigation tiles in a `TileStore`: `containsLatestNavigationTiles(forCacheLocation:, completion:)`, `tileRegionContainsLatestNavigationTiles(forId:, cacheLocation:, completion:)` and methods for getting Navigation tiles from `TilesetDescriptorFactory`: `getLatest(forCacheLocation:)`, `getSpecificVersion(forCacheLocation:, version:)`. ([#3015](https://github.com/mapbox/mapbox-navigation-ios/pull/3015))
 * Fixed a thread-safety issue in `UnimplementedLogging` protocol implementation. ([#3024](https://github.com/mapbox/mapbox-navigation-ios/pull/3024))
 * Fixed an issue where the current road name label sometimes displayed the name of an intersecting road instead of the current road or blinked in and out. ([#3019](https://github.com/mapbox/mapbox-navigation-ios/pull/3019))
+* Fixed an issue where offline route calculation might hang up. ([#3040](https://github.com/mapbox/mapbox-navigation-ios/pull/3040))
 
 ## v1.4.0
 

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -56,6 +56,11 @@ class Navigator {
     lazy var roadObjectMatcher: RoadObjectMatcher = {
         return RoadObjectMatcher(MapboxNavigationNative.RoadObjectMatcher(cache: cacheHandle))
     }()
+    
+    lazy var router: MapboxNavigationNative.Router = {
+        return MapboxNavigationNative.Router(cache: cacheHandle,
+                                             historyRecorder: historyRecorder)
+    }()
 
 
     private(set) var tileStore: TileStore

--- a/Sources/MapboxCoreNavigation/Directions.swift
+++ b/Sources/MapboxCoreNavigation/Directions.swift
@@ -46,9 +46,7 @@ extension Directions {
     open func calculateOffline(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) {
         let directionsUri = url(forCalculating: options)
         
-        let nativeRouter = MapboxNavigationNative.Router(cache: Navigator.shared.cacheHandle,
-                                                         historyRecorder: Navigator.shared.historyRecorder)
-        nativeRouter.getRouteForDirectionsUri(directionsUri.path) { (result) in
+        Navigator.shared.router.getRouteForDirectionsUri(directionsUri.path) { (result) in
             let json = result?.value as? String
             let data = json?.data(using: .utf8)
             let decoder = JSONDecoder()


### PR DESCRIPTION
### Description
Resolves #3037 
Fixed a bug where Router was deallocated before it actually schedules a route calculation, which results in callback not being called.

### Implementation
Moved MBNNRouter instance to be a part of Navigator wrapper. Such instance has low overhead of keeping alive, and is recommended by NN to persist it.
