### PR TITLE
Rename RoadObjectsStore to RoadObjectStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Added `RoadObjectsStore.addUserDefinedRoadObject(_:)`, `RoadObjectsStore.removeUserDefinedRoadObject(identifier:)`, and `RoadObjectsStore.removeAllUserDefinedRoadObjects()` for adding/removing user-defined road objects to the electronic horizon. ([#3004](https://github.com/mapbox/mapbox-navigation-ios/pull/3004))
 * Removed `Alert` enum, and `alert`, `distance`, `length`, `beginCoordinate`, `endCoordinate`, `beginSegmentIndex`, and `endSegmentIndex` properties from `RouteAlerts`. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
 * Added the `RouteAlerts.roadObject` property. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
+* Renamed `RoadObjectsStore` and `RoadObjectsStoreDelegate` to `RoadObjectStore` and `RoadObjectStoreDelegate` respectively. ([#3045](https://github.com/mapbox/mapbox-navigation-ios/pull/3045))
 
 ### Camera
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,9 @@
 * Added `OpenLRSideOfRoad` struct which describes the relationship between the road object and the road. Used for `OpenLRPointLocation` struct. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
 * Added `RoadObjectMatcher` class that creates user-defined road objects by matching location primitives to the road graph. Accessible through `RouteController.roadObjectMatcher` and `PassiveLocationDataSource.roadObjectMatcher`. Matched road object or matching error `RoadObjectMatcherError` is delivered via `RoadObjectMatcherDelegate`. ([#3004](https://github.com/mapbox/mapbox-navigation-ios/pull/3004))
 * Added `OpenLRStandard` enum which specifies OpenLR standard of encoded OpenLR location. Used for road object matching via `RoadObjectMatcher`. ([#3004](https://github.com/mapbox/mapbox-navigation-ios/pull/3004))
-* Added `RoadObjectsStore.addUserDefinedRoadObject(_:)`, `RoadObjectsStore.removeUserDefinedRoadObject(identifier:)`, and `RoadObjectsStore.removeAllUserDefinedRoadObjects()` for adding/removing user-defined road objects to the electronic horizon. ([#3004](https://github.com/mapbox/mapbox-navigation-ios/pull/3004))
+* Added `RoadObjectStore.addUserDefinedRoadObject(_:)`, `RoadObjectStore.removeUserDefinedRoadObject(identifier:)`, and `RoadObjectStore.removeAllUserDefinedRoadObjects()` for adding/removing user-defined road objects to the electronic horizon. ([#3004](https://github.com/mapbox/mapbox-navigation-ios/pull/3004))
 * Removed `Alert` enum, and `alert`, `distance`, `length`, `beginCoordinate`, `endCoordinate`, `beginSegmentIndex`, and `endSegmentIndex` properties from `RouteAlerts`. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
 * Added the `RouteAlerts.roadObject` property. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
-* Renamed `RoadObjectsStore` and `RoadObjectsStoreDelegate` to `RoadObjectStore` and `RoadObjectStoreDelegate` respectively. ([#3045](https://github.com/mapbox/mapbox-navigation-ios/pull/3045))
 
 ### Camera
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 		DA5F44C825F07AB700F573EC /* MapboxStreetsRoadClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44C525F07AB600F573EC /* MapboxStreetsRoadClass.swift */; };
 		DA5F44DC25F07D1500F573EC /* RoadObjectEdgeLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44DB25F07D1400F573EC /* RoadObjectEdgeLocation.swift */; };
 		DA5F44F525F07D3B00F573EC /* RoadObjectsStoreDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44F325F07D3A00F573EC /* RoadObjectsStoreDelegate.swift */; };
-		DA5F44F625F07D3B00F573EC /* RoadObjectsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44F425F07D3B00F573EC /* RoadObjectsStore.swift */; };
+		DA5F44F625F07D3B00F573EC /* RoadObjectStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44F425F07D3B00F573EC /* RoadObjectStore.swift */; };
 		DA5F450025F07DE200F573EC /* ElectronicHorizonOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44FF25F07DE200F573EC /* ElectronicHorizonOptions.swift */; };
 		DA66063023B32F99007832E5 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA66062F23B32F99007832E5 /* Array.swift */; };
 		DA754E1923AC56E5007E16B5 /* MBXAccountsLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = DA754E1723AC56E5007E16B5 /* MBXAccountsLoader.m */; };
@@ -975,7 +975,7 @@
 		DA5F44C525F07AB600F573EC /* MapboxStreetsRoadClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapboxStreetsRoadClass.swift; sourceTree = "<group>"; };
 		DA5F44DB25F07D1400F573EC /* RoadObjectEdgeLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadObjectEdgeLocation.swift; sourceTree = "<group>"; };
 		DA5F44F325F07D3A00F573EC /* RoadObjectsStoreDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadObjectsStoreDelegate.swift; sourceTree = "<group>"; };
-		DA5F44F425F07D3B00F573EC /* RoadObjectsStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadObjectsStore.swift; sourceTree = "<group>"; };
+		DA5F44F425F07D3B00F573EC /* RoadObjectStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadObjectStore.swift; sourceTree = "<group>"; };
 		DA5F44FF25F07DE200F573EC /* ElectronicHorizonOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElectronicHorizonOptions.swift; sourceTree = "<group>"; };
 		DA625E901F10557300FBE176 /* fa */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Main.strings; sourceTree = "<group>"; };
 		DA625E921F1055DE00FBE176 /* fa */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/Navigation.strings; sourceTree = "<group>"; };
@@ -1904,7 +1904,7 @@
 				2E50E0DB264E49C8009D3848 /* RoadObjectMatcherDelegate.swift */,
 				2E50E0D1264E468B009D3848 /* RoadObjectMatcherError.swift */,
 				2EFADFEE264C1F9200B618C4 /* RoadObjectPosition.swift */,
-				DA5F44F425F07D3B00F573EC /* RoadObjectsStore.swift */,
+				DA5F44F425F07D3B00F573EC /* RoadObjectStore.swift */,
 				DA5F44F325F07D3A00F573EC /* RoadObjectsStoreDelegate.swift */,
 				DA5F44A325F07A6500F573EC /* RoadObjectType.swift */,
 			);
@@ -2862,7 +2862,7 @@
 				DA5F44C825F07AB700F573EC /* MapboxStreetsRoadClass.swift in Sources */,
 				2E50E0C0264E35CA009D3848 /* RoadObjectMatcher.swift in Sources */,
 				C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */,
-				DA5F44F625F07D3B00F573EC /* RoadObjectsStore.swift in Sources */,
+				DA5F44F625F07D3B00F573EC /* RoadObjectStore.swift in Sources */,
 				DA5F44B025F07A6800F573EC /* RoadGraphEdge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -49,8 +49,8 @@ class Navigator {
     
     private(set) var roadGraph: RoadGraph
     
-    lazy var roadObjectsStore: RoadObjectsStore = {
-        return RoadObjectsStore(navigator.roadObjectStore())
+    lazy var roadObjectStore: RoadObjectStore = {
+        return RoadObjectStore(navigator.roadObjectStore())
     }()
     
     lazy var roadObjectMatcher: RoadObjectMatcher = {

--- a/Sources/MapboxCoreNavigation/EHorizon/RoadObjectStore.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/RoadObjectStore.swift
@@ -4,18 +4,18 @@ import MapboxNavigationNative
 /**
  Identifies a road object in an electronic horizon. A road object represents a notable transition point along a road, such as a toll booth or tunnel entrance. A road object is similar to a `RouteAlert` but is more closely associated with the routing graph managed by the `RoadGraph` class.
  
- Use a `RoadObjectsStore` object to get more information about a road object with a given identifier or get the locations of road objects along `RoadGraph.Edge`s.
+ Use a `RoadObjectStore` object to get more information about a road object with a given identifier or get the locations of road objects along `RoadGraph.Edge`s.
  */
 public typealias RoadObjectIdentifier = String
 
 /**
- Stores and provides access to metadata about road objects.
+ Stores and provides access to metadata about road object.
  
- You do not create a `RoadObjectsStore` object manually. Instead, use the `RouteController.roadObjectsStore` or `PassiveLocationDataSource.roadObjectsStore` to access the currently active road objects store.
+ You do not create a `RoadObjectStore` object manually. Instead, use the `RouteController.roadObjectStore` or `PassiveLocationDataSource.roadObjectStore` to access the currently active road object store.
  */
-public final class RoadObjectsStore {
-    /// The road objects store’s delegate.
-    public weak var delegate: RoadObjectsStoreDelegate? {
+public final class RoadObjectStore {
+    /// The road object store’s delegate.
+    public weak var delegate: RoadObjectStoreDelegate? {
         didSet {
             if delegate != nil {
                 native.setObserverForOptions(self)
@@ -37,7 +37,7 @@ public final class RoadObjectsStore {
 
     /**
      Returns road object with given identifier, if such object cannot be found returns null.
-     NB: since road objects can be removed/added in background we should always check return value for null,
+     NB: since road object can be removed/added in background we should always check return value for null,
      even if we know that we have object with such identifier based on previous calls.
      - parameter roadObjectIdentifier: The identifier of the road object to query.
      */
@@ -58,13 +58,13 @@ public final class RoadObjectsStore {
 
     /**
      Adds a road object to be tracked in the electronic horizon. In case if an object with such identifier already exists, updates it.
-     NB: road objects obtained from route alerts cannot be added via this API.
+     NB: road object obtained from route alerts cannot be added via this API.
 
      - parameter roadObject: Custom road object, acquired from `RoadObjectMatcher`.
      */
     public func addUserDefinedRoadObject(_ roadObject: RoadObject) {
         guard let nativeObject = roadObject.native else {
-            preconditionFailure("You can only add matched custom road objects, acquired from RoadObjectMatcher.")
+            preconditionFailure("You can only add matched custom road object, acquired from RoadObjectMatcher.")
         }
         native.addCustomRoadObject(for: nativeObject)
     }
@@ -96,7 +96,7 @@ public final class RoadObjectsStore {
     private let native: MapboxNavigationNative.RoadObjectsStore
 }
 
-extension RoadObjectsStore: RoadObjectsStoreObserver {
+extension RoadObjectStore: RoadObjectsStoreObserver {
     public func onRoadObjectAdded(forId id: String) {
         delegate?.didAddRoadObject(identifier: id)
     }

--- a/Sources/MapboxCoreNavigation/EHorizon/RoadObjectStore.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/RoadObjectStore.swift
@@ -9,7 +9,7 @@ import MapboxNavigationNative
 public typealias RoadObjectIdentifier = String
 
 /**
- Stores and provides access to metadata about road object.
+ Stores and provides access to metadata about road objects.
  
  You do not create a `RoadObjectStore` object manually. Instead, use the `RouteController.roadObjectStore` or `PassiveLocationDataSource.roadObjectStore` to access the currently active road object store.
  */
@@ -37,7 +37,7 @@ public final class RoadObjectStore {
 
     /**
      Returns road object with given identifier, if such object cannot be found returns null.
-     NB: since road object can be removed/added in background we should always check return value for null,
+     NB: since road objects can be removed/added in background we should always check return value for null,
      even if we know that we have object with such identifier based on previous calls.
      - parameter roadObjectIdentifier: The identifier of the road object to query.
      */
@@ -58,13 +58,13 @@ public final class RoadObjectStore {
 
     /**
      Adds a road object to be tracked in the electronic horizon. In case if an object with such identifier already exists, updates it.
-     NB: road object obtained from route alerts cannot be added via this API.
+     NB: a road object obtained from route alerts cannot be added via this API.
 
      - parameter roadObject: Custom road object, acquired from `RoadObjectMatcher`.
      */
     public func addUserDefinedRoadObject(_ roadObject: RoadObject) {
         guard let nativeObject = roadObject.native else {
-            preconditionFailure("You can only add matched custom road object, acquired from RoadObjectMatcher.")
+            preconditionFailure("You can only add matched a custom road object, acquired from RoadObjectMatcher.")
         }
         native.addCustomRoadObject(for: nativeObject)
     }

--- a/Sources/MapboxCoreNavigation/EHorizon/RoadObjectsStoreDelegate.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/RoadObjectsStoreDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/** `RoadObjectsStore` delegate */
-public protocol RoadObjectsStoreDelegate: AnyObject {
+/** `RoadObjectStore` delegate */
+public protocol RoadObjectStoreDelegate: AnyObject {
     /// This method is called when a road object with the given identifier has been added to the road objects store.
     func didAddRoadObject(identifier: RoadObjectIdentifier)
     

--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -86,9 +86,9 @@ open class PassiveLocationDataSource: NSObject {
         return Navigator.shared.roadGraph
     }
     
-    /// The road objects store that is updated as the passive location data source tracks the user’s location.
-    public var roadObjectsStore: RoadObjectsStore {
-        return Navigator.shared.roadObjectsStore
+    /// The road object store that is updated as the passive location data source tracks the user’s location.
+    public var roadObjectStore: RoadObjectStore {
+        return Navigator.shared.roadObjectStore
     }
 
     /// The road object matcher that allows to match user-defined road objects.

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -437,9 +437,9 @@ open class RouteController: NSObject {
         return Navigator.shared.roadGraph
     }
 
-    /// The road objects store that is updated as the route controller tracks the user’s location.
-    public var roadObjectsStore: RoadObjectsStore {
-        return Navigator.shared.roadObjectsStore
+    /// The road object store that is updated as the route controller tracks the user’s location.
+    public var roadObjectStore: RoadObjectStore {
+        return Navigator.shared.roadObjectStore
     }
 
     /// The road object matcher that allows to match user-defined road objects.


### PR DESCRIPTION
### Description
This pr is to fix #3041 to rename `RoadObjectsStore` and `RoadObjectsStoreDelegate` to `RoadObjectStore` and `RoadObjectStoreDelegate`.

### Implementation

### Screenshots or Gifs
