### PR TITLE
Fixing Navigation end event loss of cancelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * Added methods for convenience checking Navigation tiles in a `TileStore`: `containsLatestNavigationTiles(forCacheLocation:, completion:)`, `tileRegionContainsLatestNavigationTiles(forId:, cacheLocation:, completion:)` and methods for getting Navigation tiles from `TilesetDescriptorFactory`: `getLatest(forCacheLocation:)`, `getSpecificVersion(forCacheLocation:, version:)`. ([#3015](https://github.com/mapbox/mapbox-navigation-ios/pull/3015))
 * Fixed a thread-safety issue in `UnimplementedLogging` protocol implementation. ([#3024](https://github.com/mapbox/mapbox-navigation-ios/pull/3024))
 * Fixed an issue where the current road name label sometimes displayed the name of an intersecting road instead of the current road or blinked in and out. ([#3019](https://github.com/mapbox/mapbox-navigation-ios/pull/3019))
+* Fixed an issue where 'Navigation cancel' event might be not logged. ([#3050](https://github.com/mapbox/mapbox-navigation-ios/pull/3050))
 * Fixed an issue where offline route calculation might hang up. ([#3040](https://github.com/mapbox/mapbox-navigation-ios/pull/3040))
 
 ## v1.4.0

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -22,7 +22,23 @@ open class NavigationEventsManager {
     
     var outstandingFeedbackEvents = [CoreFeedbackEvent]()
     
-    weak var dataSource: EventsManagerDataSource?
+    func withBackupDataSource(_ forcedDataSource: EventsManagerDataSource, action: () -> Swift.Void) {
+        backupDataSource = forcedDataSource
+        action()
+        backupDataSource = nil
+    }
+    
+    private var backupDataSource: EventsManagerDataSource?
+    private weak var _dataSource: EventsManagerDataSource?
+    var dataSource: EventsManagerDataSource?
+    {
+        get {
+            return _dataSource ?? backupDataSource
+        }
+        set {
+            _dataSource = newValue
+        }
+    }
     
     /**
      Indicates whether the application depends on MapboxNavigation in addition to MapboxCoreNavigation.

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -22,7 +22,7 @@ open class NavigationEventsManager {
     
     var outstandingFeedbackEvents = [CoreFeedbackEvent]()
     
-    func withBackupDataSource(_ forcedDataSource: EventsManagerDataSource, action: () -> Swift.Void) {
+    func withBackupDataSource(_ forcedDataSource: EventsManagerDataSource, action: () -> Void) {
         backupDataSource = forcedDataSource
         action()
         backupDataSource = nil

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -266,7 +266,9 @@ public class MapboxNavigationService: NSObject, NavigationService {
     
     deinit {
         suspendNotifications()
-        endNavigation()
+        eventsManager.withBackupDataSource(self) {
+            endNavigation()
+        }
         nativeLocationSource.delegate = nil
         simulatedLocationSource?.delegate = nil
     }


### PR DESCRIPTION
vk-694-cancel-event-loss: added forcing EventsManager datasource to o……verride nilling weak reference during deallocation.

### Description
Resolves an issue, where `Navigation end` event was not logged if trips was cancelled.

### Implementation
Issue is caused by nilling weak reference to a `NavigationService` during it's deinit stage. To avoid that I've added forcing a strong reference during event logging.