### PR TITLE
Remove some redundant force unwraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 * Fixed the moment of custom feedback event creation. ([#3049](https://github.com/mapbox/mapbox-navigation-ios/pull/3049))
 * Increased stability of unit tests by addressing sporadic failures. ([#3089](https://github.com/mapbox/mapbox-navigation-ios/pull/3089))([#3072](https://github.com/mapbox/mapbox-navigation-ios/pull/3072))
 * Fixed a retain cycle in `UserCourseView`. ([#3120](https://github.com/mapbox/mapbox-navigation-ios/issues/3120))
+* `EventsManagerDataSource.router`, `NavigationService.router`, `NavigationService.eventsManager`, `MapboxNavigationService.router`, `MapboxNavigationService.eventsManager` properties are not longer force unwrapped. ([#3055](https://github.com/mapbox/mapbox-navigation-ios/pull/3055))
 
 ## v1.4.1
 

--- a/Sources/MapboxCoreNavigation/EventDetails.swift
+++ b/Sources/MapboxCoreNavigation/EventDetails.swift
@@ -55,16 +55,13 @@ struct PerformanceEventDetails: EventDetails {
 struct NavigationEventDetails: EventDetails {
     let audioType: String = AVAudioSession.sharedInstance().audioType
     let applicationState: UIApplication.State = {
-        var state: UIApplication.State!
         if Thread.isMainThread {
-            state = UIApplication.shared.applicationState
+            return UIApplication.shared.applicationState
         } else {
-            DispatchQueue.main.sync {
-                state = UIApplication.shared.applicationState
+            return DispatchQueue.main.sync {
+                UIApplication.shared.applicationState
             }
         }
-        
-        return state
     }()
     let batteryLevel: Int = UIDevice.current.batteryLevel >= 0 ? Int(UIDevice.current.batteryLevel * 100) : -1
     let batteryPluggedIn: Bool = [.charging, .full].contains(UIDevice.current.batteryState)

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -9,7 +9,7 @@ let NavigationEventTypeRouteRetrieval = "mobile.performance_trace"
  */
 public protocol EventsManagerDataSource: AnyObject {
     var routeProgress: RouteProgress { get }
-    var router: Router! { get }
+    var router: Router { get }
     var desiredAccuracy: CLLocationAccuracy { get }
     var locationProvider: NavigationLocationManager.Type { get }
 }

--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -14,7 +14,7 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     private var navigationMapView: NavigationMapView {
         return navigationViewData.navigationView.navigationMapView
     }
-    private var router: Router! {
+    private var router: Router {
         navigationViewData.router
     }
     private var topBannerContainerView: BannerContainerView {

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -567,7 +567,7 @@ public class CarPlayNavigationViewController: UIViewController {
                                               comment: "Title on continue button in CarPlay")
         
         let continueAlert = CPAlertAction(title: continueTitle, style: .default) { (action) in
-            self.navigationService.router?.advanceLegIndex()
+            self.navigationService.router.advanceLegIndex()
             self.carInterfaceController.dismissTemplate(animated: true)
             self.updateRouteOnMap()
         }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -320,15 +320,15 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     
     // MARK: - NavigationViewData implementation
         
-    var navigationView: NavigationView! {
+    var navigationView: NavigationView {
         return (view as! NavigationView)
     }
     
-    var router: Router! {
+    var router: Router {
         navigationService.router
     }
     
-    var containerViewController: UIViewController! {
+    var containerViewController: UIViewController {
         return self
     }
     

--- a/Sources/MapboxNavigation/NavigationViewData.swift
+++ b/Sources/MapboxNavigation/NavigationViewData.swift
@@ -3,9 +3,9 @@ import MapboxCoreNavigation
 
 /// Protocol used by `NavigationViewController`'s components to get required data and manipulate it's contents.
 protocol NavigationViewData: AnyObject {
-    var navigationView: NavigationView! { get }
-    var router: Router! { get }
-    var containerViewController: UIViewController! { get }
+    var navigationView: NavigationView { get }
+    var router: Router { get }
+    var containerViewController: UIViewController { get }
 }
 
 /// Protocol for observing basic `ViewController.view` lifecycle events.

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -14,7 +14,7 @@ extension NavigationMapView {
         weak var navigationViewData: NavigationViewData!
         weak var eventsManager: NavigationEventsManager!
         
-        fileprivate var navigationView: NavigationView! {
+        fileprivate var navigationView: NavigationView {
             return navigationViewData.navigationView
         }
         
@@ -36,7 +36,7 @@ extension NavigationMapView {
             }
             set {
                 if let newPosition = newValue {
-                    navigationView?.floatingButtonsPosition = newPosition
+                    navigationView.floatingButtonsPosition = newPosition
                 }
             }
         }

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -119,7 +119,7 @@ extension NavigationMapView {
         }
         
         @objc func feedback(_ sender: Any) {
-            guard let parent = navigationViewData.containerViewController else { return }
+            let parent = navigationViewData.containerViewController
             let feedbackViewController = FeedbackViewController(eventsManager: eventsManager)
             feedbackViewController.detailedFeedbackEnabled = detailedFeedbackEnabled
             parent.present(feedbackViewController, animated: true)
@@ -181,7 +181,8 @@ extension NavigationMapView {
         }
         
         private func labelCurrentRoadFeature(at location: CLLocation) {
-            guard let router = navigationViewData.router,
+            let router = navigationViewData.router
+            guard
                   let stepShape = router.routeProgress.currentLegProgress.currentStep.shape,
                   !stepShape.coordinates.isEmpty,
                   let mapView = navigationMapView.mapView else {

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -158,7 +158,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         
         // Iterate overal locations in first step with delay of one second.
         for location in locations {
-            navigationService.router?.locationManager?(navigationService.locationManager, didUpdateLocations: [location])
+            navigationService.router.locationManager?(navigationService.locationManager, didUpdateLocations: [location])
             RunLoop.current.run(until: Date().addingTimeInterval(0.01))
         }
         
@@ -255,7 +255,7 @@ class MapboxCoreNavigationTests: XCTestCase {
         navigation.start()
         
         (locations + offRouteLocations).forEach {
-            navigation.router!.locationManager!(navigation.locationManager, didUpdateLocations: [$0])
+            navigation.router.locationManager!(navigation.locationManager, didUpdateLocations: [$0])
         }
         
         waitForExpectations(timeout: waitForInterval) { (error) in

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+fimport XCTest
 import MapboxDirections
 import Turf
 import MapboxMobileEvents
@@ -96,7 +96,7 @@ class NavigationServiceTests: XCTestCase {
         
         // Iterate over each location on the route and simulate location update
         locationsOnRoute.forEach {
-            navigation.router!.locationManager!(navigation.locationManager, didUpdateLocations: [$0])
+            navigation.router.locationManager!(navigation.locationManager, didUpdateLocations: [$0])
             
             waitForNavNativeCallbacks()
             
@@ -120,7 +120,7 @@ class NavigationServiceTests: XCTestCase {
         // Even though first location is off the route as per navigation native logic it sometimes can return tracking route state
         // even if location is visually off-route.
         locationsOffRoute.enumerated().forEach {
-            navigation.router!.locationManager!(navigation.locationManager, didUpdateLocations: [$0.element])
+            navigation.router.locationManager!(navigation.locationManager, didUpdateLocations: [$0.element])
             
             waitForNavNativeCallbacks()
             
@@ -328,7 +328,7 @@ class NavigationServiceTests: XCTestCase {
         ])
         let route = Fixture.route(from: "straight-line", options: options)
         let navigationService = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: options, directions: DirectionsSpy())
-        let router = navigationService.router!
+        let router = navigationService.router
         let firstCoordinate = router.routeProgress.nearbyShape.coordinates.first!
         let firstLocation = CLLocation(latitude: firstCoordinate.latitude, longitude: firstCoordinate.longitude)
         let coordinateNearStart = router.routeProgress.nearbyShape.coordinateFromStart(distance: 10)!
@@ -388,7 +388,7 @@ class NavigationServiceTests: XCTestCase {
     func testReroutingFromLocationUpdatesSimulatedLocationSource() {
         let navigationService = MapboxNavigationService(route: initialRoute, routeIndex: 0, routeOptions: routeOptions,  directions: directionsClientSpy, eventsManagerType: NavigationEventsManagerSpy.self, simulating: .always)
         navigationService.delegate = delegate
-        let router = navigationService.router!
+        let router = navigationService.router
 
         navigationService.eventsManager.delaysEventFlushing = false
         navigationService.start()
@@ -405,7 +405,7 @@ class NavigationServiceTests: XCTestCase {
 
     func testReroutingFromALocationSendsEvents() {
         let navigationService = dependencies.navigationService
-        let router = navigationService.router!
+        let router = navigationService.router
         let testLocation = dependencies.routeLocations.firstLocation
 
         navigationService.eventsManager.delaysEventFlushing = false
@@ -470,12 +470,12 @@ class NavigationServiceTests: XCTestCase {
         let now = Date()
         let trace = Fixture.generateTrace(for: route).shiftedToPresent()
         trace.forEach {
-            navigation.router!.locationManager!(navigation.locationManager, didUpdateLocations: [$0])
+            navigation.router.locationManager!(navigation.locationManager, didUpdateLocations: [$0])
             RunLoop.main.run(until: Date().addingTimeInterval(0.01))
         }
 
         // TODO: Verify why we need a second location update when routeState == .complete to trigger `MMEEventTypeNavigationArrive`
-        navigation.router!.locationManager!(navigation.locationManager,
+        navigation.router.locationManager!(navigation.locationManager,
                                             didUpdateLocations: [trace.last!.shifted(to: now + (trace.count + 1))])
         
         // MARK: It queues and flushes a Depart event
@@ -644,7 +644,7 @@ class NavigationServiceTests: XCTestCase {
         let directions = DirectionsSpy()
         let service = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: options, directions: directions)
         service.delegate = delegate
-        let router = service.router!
+        let router = service.router
         let locationManager = NavigationLocationManager()
 
         let didRerouteExpectation = expectation(forNotification: .routeControllerDidReroute, object: router) { (notification) -> Bool in
@@ -654,11 +654,11 @@ class NavigationServiceTests: XCTestCase {
         let rerouteExpectation = expectation(description: "Proactive reroute should trigger")
 
         for location in trace {
-            service.router!.locationManager!(locationManager, didUpdateLocations: [location])
+            service.router.locationManager!(locationManager, didUpdateLocations: [location])
             
             waitForNavNativeCallbacks()
 
-            let router = service.router! as! RouterComposition
+            let router = service.router as! RouterComposition
 
             if router.lastRerouteLocation != nil {
                 rerouteExpectation.fulfill()

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -1,4 +1,4 @@
-fimport XCTest
+import XCTest
 import MapboxDirections
 import Turf
 import MapboxMobileEvents

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -80,9 +80,7 @@ class NavigationViewControllerTests: XCTestCase {
             guard let navigationService = navigationViewController.navigationService else {
                 XCTFail("Navigation Service is nil"); return nil
             }
-            guard let router = navigationService.router else {
-                XCTFail("Router is nil"); return nil
-            }
+            let router = navigationService.router
             guard let firstCoord = router.routeProgress.nearbyShape.coordinates.first else {
                 XCTFail("First Coordinate is nil"); return nil
             }


### PR DESCRIPTION
With this change, the API for `NavigationService` is safer, although it is a breaking change. Would be good to land before RC.