### PR TITLE
Tile verification fix

### DIFF
--- a/Sources/MapboxCoreNavigation/TileStore.swift
+++ b/Sources/MapboxCoreNavigation/TileStore.swift
@@ -30,7 +30,7 @@ extension TileStore {
             if expected.isValue(), let regions = expected.value as? Array<TileRegion> {
                 let lock = NSLock()
                 var count = regions.count
-                var result: Bool? = nil
+                var result: Bool? = true
 
                 for region in regions {
                     self.__tileRegionContainsDescriptors(forId: region.id,

--- a/Sources/MapboxCoreNavigation/TileStore.swift
+++ b/Sources/MapboxCoreNavigation/TileStore.swift
@@ -40,6 +40,8 @@ extension TileStore {
                                                             
                                                             if let expected = expected, expected.isValue(), let contains = expected.value as? NSNumber {
                                                                 result = result.map { $0 && contains.boolValue }
+                                                            } else if let expected = expected, expected.isError() {
+                                                                result = nil
                                                             } else {
                                                                 assertionFailure("Unexpected value or error: \(String(describing: expected)), expected: \(NSNumber.self)")
                                                                 result = nil

--- a/Sources/MapboxCoreNavigation/TileStore.swift
+++ b/Sources/MapboxCoreNavigation/TileStore.swift
@@ -30,21 +30,24 @@ extension TileStore {
             if expected.isValue(), let regions = expected.value as? Array<TileRegion> {
                 let lock = NSLock()
                 var count = regions.count
-                var results = Array(repeating: false, count: count)
+                var result: Bool? = nil
 
-                for (index, region) in regions.enumerated() {
+                for region in regions {
                     self.__tileRegionContainsDescriptors(forId: region.id,
                                                          descriptors: descriptors,
                                                          callback: { expected in
+                                                            lock.lock()
+                                                            
                                                             if let expected = expected, expected.isValue(), let contains = expected.value as? NSNumber {
-                                                                results[index] = contains.boolValue
+                                                                result = result.map { $0 && contains.boolValue }
+                                                            } else {
+                                                                assertionFailure("Unexpected value or error: \(String(describing: expected)), expected: \(NSNumber.self)")
+                                                                result = nil
                                                             }
                                                             
-                                                            lock.lock()
                                                             count -= 1
-                                                            
                                                             if count == 0 {
-                                                                completion(results.allSatisfy { $0 })
+                                                                completion(result)
                                                             }
                                                             lock.unlock()
                                                          })


### PR DESCRIPTION
### Description
Resolves #3051 
Fixing logical errors in methods, which ignored 'error' state.

### Implementation
Simplified the check a bit to force 'nil' value when encountering an error from TileStore.
Did not update a CHANGELOG because this bug is in new functionality which was not released yet.
Did not add unit tests because that would require a bit of a juggling with Commons TileStore api, and we are [trying to downstream this API directly to Common lib](https://github.com/mapbox/mapbox-navigation-android/issues/4471).