### PR TITLE
Fix crash related with the stepIndex in RouteStepProgress

### DIFF
--- a/Sources/MapboxCoreNavigation/RouteLegProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteLegProgress.swift
@@ -142,11 +142,11 @@ open class RouteLegProgress: Codable {
      */
     public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0) {
         self.leg = leg
-        self.stepIndex = stepIndex
         
         precondition(leg.steps.indices.contains(stepIndex), "It's not possible to create RouteLegProgress without any steps or when stepIndex is higher than steps count.")
         
         currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
+        self.stepIndex = stepIndex
     }
 
     typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)


### PR DESCRIPTION
### Description
This pr is to fix #2997, and also the crush reported in the #3062 

### Implementation
The `stepIndex` would trigger the `currentStepProgress`  change, and the `currentStep` with the index limit. It's safer to put it after the  `currentStepProgress` initialization and the `precondition` check.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->