### PR TITLE
Fix issues in ImageDownload and ImageDownloader

### DIFF
--- a/Sources/MapboxNavigation/ImageDownload.swift
+++ b/Sources/MapboxNavigation/ImageDownload.swift
@@ -12,44 +12,73 @@ protocol ImageDownload: URLSessionDataDelegate {
     var isFinished: Bool { get }
 }
 
-class ImageDownloadOperation: Operation, ImageDownload {
+final class ImageDownloadOperation: Operation, ImageDownload {
+    @objc(ImageDownloadOperationState)
+    private enum State: Int {
+        case ready
+        case executing
+        case finished
+    }
+
+    private let stateLock: NSLock = .init()
+    private var _state: State = .ready
+
+    @objc
+    private dynamic var state: State {
+        get {
+            stateLock.lock(); defer {
+                stateLock.unlock()
+            }
+            return _state
+        }
+        set {
+            willChangeValue(forKey: #keyPath(state))
+            stateLock.lock()
+            _state = newValue
+            stateLock.unlock()
+            didChangeValue(forKey: #keyPath(state))
+        }
+    }
+
+    final override var isReady: Bool {
+        return state == .ready && super.isReady
+    }
+
+    final override var isExecuting: Bool {
+        return state == .executing
+    }
+
+    final override var isFinished: Bool {
+        return state == .finished
+    }
+
     override var isConcurrent: Bool {
         return true
     }
 
-    override var isFinished: Bool {
-        return _finished
+    // MARK: - NSObject
+
+    @objc
+    private dynamic class func keyPathsForValuesAffectingIsReady() -> Set<String> {
+        return [#keyPath(state)]
     }
 
-    override var isExecuting: Bool {
-        return _executing
+    @objc
+    private dynamic class func keyPathsForValuesAffectingIsExecuting() -> Set<String> {
+        return [#keyPath(state)]
     }
 
-    private var _finished = false {
-        willSet {
-            willChangeValue(forKey: "isFinished")
-        }
-        didSet {
-            didChangeValue(forKey: "isFinished")
-        }
+    @objc private dynamic class func keyPathsForValuesAffectingIsFinished() -> Set<String> {
+        return [#keyPath(state)]
     }
 
-    private var _executing = false {
-        willSet {
-            willChangeValue(forKey: "isExecuting")
-        }
-        didSet {
-            didChangeValue(forKey: "isExecuting")
-        }
-    }
-
-    private var request: URLRequest
-    private var session: URLSession
+    private let request: URLRequest
+    private let session: URLSession
 
     private var dataTask: URLSessionDataTask?
     private var incomingData: Data?
-    private var completionBlocks: Array<ImageDownloadCompletionBlock> = []
-    private let barrierQueue = DispatchQueue(label: Bundle.mapboxNavigation.bundleIdentifier! + ".ImageDownloadCompletionBarrierQueue", attributes: .concurrent)
+    private var completionBlocks: [ImageDownloadCompletionBlock] = .init()
+    private let lock: NSLock = .init()
 
     required init(request: URLRequest, in session: URLSession) {
         self.request = request
@@ -57,103 +86,112 @@ class ImageDownloadOperation: Operation, ImageDownload {
     }
 
     func addCompletion(_ completion: @escaping ImageDownloadCompletionBlock) {
-        barrierQueue.async(flags: .barrier) {
-            self.completionBlocks.append(completion)
+        withLock {
+            completionBlocks.append(completion)
         }
     }
 
     override func cancel() {
-        objc_sync_enter(self)
-        defer {
-            objc_sync_exit(self)
-        }
         super.cancel()
-
-        if let dataTask = dataTask {
-            dataTask.cancel()
-            incomingData = nil
-            self.dataTask = nil
+        withLock {
+            if let dataTask = dataTask {
+                dataTask.cancel()
+                incomingData = nil
+                self.dataTask = nil
+            }
         }
-
-        if isExecuting {
-            _executing = false
-        }
-
-        if !isFinished {
-            _finished = true
-        }
-
-        barrierQueue.async {
-            self.completionBlocks.removeAll()
-        }
+        state = .finished
     }
 
     override func start() {
-        objc_sync_enter(self)
-        defer {
-            objc_sync_exit(self)
-        }
-
-        if isCancelled == true {
-            _finished = true
+        guard !isCancelled else {
+            state = .finished;
             return
         }
 
-        dataTask = session.dataTask(with: self.request)
-        if let dataTask = dataTask {
-            _executing = true
-            dataTask.resume()
-        } else {
-            //fail and bail; connection failed or bad URL (client-side error)
+        state = .executing
+        let dataTask = session.dataTask(with: self.request)
+        dataTask.resume()
+
+        withLock {
+            self.dataTask = dataTask
         }
     }
 
     // MARK: URLSessionDataDelegate
 
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         guard let response: HTTPURLResponse = response as? HTTPURLResponse else {
             completionHandler(.cancel)
             return
         }
         if response.statusCode < 400 {
-            self.incomingData = Data()
+            withLock {
+                incomingData = Data()
+            }
             completionHandler(.allow)
         } else {
-            fireAllCompletions(nil, data: nil, error: DownloadError.serverError)
             completionHandler(.cancel)
         }
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        if var localData: Data = self.incomingData {
-            let bytes = [UInt8](data)
-            localData.append(bytes, count: bytes.count)
-            self.incomingData = localData
+        withLock {
+            incomingData?.append(data)
         }
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        guard error == nil else {
-            fireAllCompletions(nil, data: nil, error: DownloadError.clientError)
-            return
+        let (incomingData, completions) = withLock { () -> (Data?, [ImageDownloadCompletionBlock]) in
+            let returnData = (self.incomingData, self.completionBlocks)
+            self.completionBlocks.removeAll()
+            return returnData
         }
 
-        if let data = incomingData, let image = UIImage(data: data, scale: UIScreen.main.scale) {
-            fireAllCompletions(image, data: data, error: nil)
-        } else {
-            fireAllCompletions(nil, data: incomingData, error: DownloadError.noImageData)
+        let completionData: (UIImage?, Data?, Error?)
+
+        if error != nil {
+            if let urlResponse = task.response as? HTTPURLResponse,
+               urlResponse.statusCode >= 400 {
+                completionData = (nil, nil, DownloadError.serverError)
+
+            }
+            else {
+                completionData = (nil, nil, DownloadError.clientError)
+            }
         }
-        _finished = true
-        _executing = false
-        dataTask = nil
-        barrierQueue.async {
-            self.completionBlocks.removeAll()
+        else {
+            if let data = incomingData {
+                if let image = UIImage(data: data, scale: UIScreen.main.scale) {
+                    completionData = (image, data,  nil)
+                }
+                else {
+                    completionData = (nil, data,  nil)
+                }
+            }
+            else {
+                completionData = (nil, nil,  nil)
+            }
         }
+
+        // The motivation is to call completions outside the lock to reduce the likehood of a deadlock.
+        for completion in completions {
+            completion(completionData.0, completionData.1, completionData.2)
+        }
+
+        withLock {
+            dataTask = nil
+        }
+        state = .finished
     }
 
-    private func fireAllCompletions(_ image: UIImage?, data: Data?, error: Error?) {
-        barrierQueue.sync {
-            completionBlocks.forEach { $0(image, data, error) }
+    private func withLock<ReturnValue>(_ perform: () throws -> ReturnValue) rethrows -> ReturnValue {
+        lock.lock(); defer {
+            lock.unlock()
         }
+        return try perform()
     }
 }

--- a/Sources/MapboxNavigation/ImageDownloader.swift
+++ b/Sources/MapboxNavigation/ImageDownloader.swift
@@ -11,36 +11,35 @@ protocol ReentrantImageDownloader {
 }
 
 class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegate {
-    private var sessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.default
+    private let sessionConfiguration: URLSessionConfiguration
 
-    lazy private var urlSession: URLSession = {
-        return URLSession.init(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
+    private lazy var urlSession: URLSession = {
+        return URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
     }()
 
-    private var downloadQueue: OperationQueue
-    private var accessQueue: DispatchQueue
+    private let downloadQueue: OperationQueue
+    private let accessQueue: DispatchQueue
 
-    private var operationType: ImageDownload.Type = ImageDownloadOperation.self
+    private var operationType: ImageDownload.Type
     private var operations: [URL: ImageDownload] = [:]
 
-    private var headers: [String: String] = ["Accept": "image/*;q=0.8"]
+    private let headers: [String: String] = ["Accept": "image/*;q=0.8"]
 
-    override init() {
+    init(sessionConfiguration: URLSessionConfiguration = .default,
+         operationType: ImageDownload.Type = ImageDownloadOperation.self) {
+        self.sessionConfiguration = sessionConfiguration
+        self.operationType = operationType
+
         self.downloadQueue = OperationQueue()
         self.downloadQueue.name = Bundle.mapboxNavigation.bundleIdentifier! + ".ImageDownloader"
-        self.accessQueue = DispatchQueue(label: Bundle.mapboxNavigation.bundleIdentifier! + ".ImageDownloaderInternal", attributes: .concurrent)
-    }
+        self.accessQueue = DispatchQueue(label: Bundle.mapboxNavigation.bundleIdentifier! + ".ImageDownloaderInternal")
+        super.init()
 
-    convenience init(sessionConfiguration: URLSessionConfiguration? = nil, operationType: ImageDownload.Type? = nil) {
-        self.init()
-
-        if let config = sessionConfiguration {
-            self.sessionConfiguration = config
-        }
-        
-        if let op = operationType {
-            self.operationType = op
-        }
+        // NOTE: `lazy var` isn't thread safe while `init` methods are.
+        //       `lazy var` for `urlSession` is used to specify `self` as a delegate which only available after
+        //       all properties are initialized ans `super.init` is called if appropriate.
+        //       So we trigger `init` here so that `urlSession` is initialized in a thread safe manner.
+        _ = urlSession
     }
 
     deinit {
@@ -48,10 +47,10 @@ class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegat
     }
 
     func downloadImage(with url: URL, completion: ImageDownloadCompletionBlock?) {
-        accessQueue.sync(flags: .barrier) {
+        accessQueue.sync {
             let request: URLRequest = self.urlRequest(with: url)
             var operation: ImageDownload
-            if let activeOperation = self.activeOperation(with: url) {
+            if let activeOperation = self.unsafeActiveOperation(with: url) {
                 operation = activeOperation
             } else {
                 operation = self.operationType.init(request: request, in: self.urlSession)
@@ -67,13 +66,14 @@ class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegat
     }
 
     func activeOperation(with url: URL) -> ImageDownload? {
-        var activeOperation: ImageDownload?
+        return accessQueue.sync { unsafeActiveOperation(with: url) }
+    }
 
-        if let operation = operations[url], !operation.isFinished {
-            activeOperation = operation
+    private func unsafeActiveOperation(with url: URL) -> ImageDownload? {
+        guard let operation = operations[url], !operation.isFinished else {
+            return nil
         }
-
-        return activeOperation
+        return operation
     }
     
     private func urlRequest(with url: URL) -> URLRequest {
@@ -85,36 +85,46 @@ class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegat
     }
 
     func setOperationType(_ operationType: ImageDownload.Type?) {
-        if let operationType = operationType {
-            self.operationType = operationType
-        } else {
-            self.operationType = ImageDownloadOperation.self
+        accessQueue.sync {
+            if let operationType = operationType {
+                self.operationType = operationType
+            } else {
+                self.operationType = ImageDownloadOperation.self
+            }
         }
     }
 
     // MARK: URLSessionDataDelegate
 
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        guard let response: HTTPURLResponse = response as? HTTPURLResponse, let url = response.url, let operation: ImageDownload = activeOperation(with: url) else {
-            completionHandler(.cancel)
-            return
-        }
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        guard let response: HTTPURLResponse = response as? HTTPURLResponse,
+              let url = response.url,
+              let operation: ImageDownload = activeOperation(with: url) else {
+                  completionHandler(.cancel)
+                  return
+              }
+
         operation.urlSession?(session, dataTask: dataTask, didReceive: response, completionHandler: completionHandler)
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        guard let url = dataTask.originalRequest?.url, let operation: ImageDownload = activeOperation(with: url) else {
-            return
+        guard let url = dataTask.originalRequest?.url,
+              let operation: ImageDownload = activeOperation(with: url) else {
+                  return
         }
         operation.urlSession?(session, dataTask: dataTask, didReceive: data)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        guard let url = task.originalRequest?.url, let operation: ImageDownload = activeOperation(with: url) else {
-            return
-        }
+        guard let url = task.originalRequest?.url,
+              let operation: ImageDownload = activeOperation(with: url) else {
+                  return
+              }
         operation.urlSession?(session, task: task, didCompleteWithError: error)
-        accessQueue.async {
+        accessQueue.sync {
             self.operations[url] = nil
         }
     }

--- a/Sources/MapboxNavigation/ImageDownloader.swift
+++ b/Sources/MapboxNavigation/ImageDownloader.swift
@@ -13,10 +13,7 @@ protocol ReentrantImageDownloader {
 class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegate {
     private let sessionConfiguration: URLSessionConfiguration
 
-    private lazy var urlSession: URLSession = {
-        return URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
-    }()
-
+    private var urlSession: URLSession!
     private let downloadQueue: OperationQueue
     private let accessQueue: DispatchQueue
 
@@ -35,11 +32,8 @@ class ImageDownloader: NSObject, ReentrantImageDownloader, URLSessionDataDelegat
         self.accessQueue = DispatchQueue(label: Bundle.mapboxNavigation.bundleIdentifier! + ".ImageDownloaderInternal")
         super.init()
 
-        // NOTE: `lazy var` isn't thread safe while `init` methods are.
-        //       `lazy var` for `urlSession` is used to specify `self` as a delegate which only available after
-        //       all properties are initialized ans `super.init` is called if appropriate.
-        //       So we trigger `init` here so that `urlSession` is initialized in a thread safe manner.
-        _ = urlSession
+        // TODO: Write `URLSessionDelegate` proxy to break retain cycle between `Self` and `URLSession.delegate`.
+        urlSession = URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
     }
 
     deinit {

--- a/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MapboxNavigation
+import TestHelper
 
 class ImageDownloaderTests: XCTestCase {
     lazy var sessionConfig: URLSessionConfiguration = {
@@ -8,7 +9,7 @@ class ImageDownloaderTests: XCTestCase {
         return config
     }()
 
-    var downloader: ReentrantImageDownloader?
+    var downloader: ReentrantImageDownloader!
 
     let imageURL = URL(string: "https://github.com/mapbox/mapbox-navigation-ios/blob/main/docs/img/navigation.png")!
 
@@ -31,10 +32,6 @@ class ImageDownloaderTests: XCTestCase {
     }
 
     func testDownloadingAnImage() {
-        guard let downloader = downloader else {
-            XCTFail()
-            return
-        }
         var imageReturned: UIImage?
         var dataReturned: Data?
         var errorReturned: Error?
@@ -60,10 +57,6 @@ class ImageDownloaderTests: XCTestCase {
     }
 
     func testDownloadingImageWhileAlreadyInProgressAddsCallbacksWithoutAddingAnotherRequest() {
-        guard let downloader = downloader else {
-            XCTFail()
-            return
-        }
         var firstCallbackCalled = false
         var secondCallbackCalled = false
         var operation: ImageDownload
@@ -99,10 +92,6 @@ class ImageDownloaderTests: XCTestCase {
     }
 
     func testDownloadingImageAgainAfterFirstDownloadCompletes() {
-        guard let downloader = downloader else {
-            XCTFail()
-            return
-        }
         var callbackCalled = false
         var spinCount = 0
 
@@ -134,5 +123,135 @@ class ImageDownloaderTests: XCTestCase {
 
         print("Succeeded after evaluating second condition \(spinCount) times.")
         XCTAssertTrue(callbackCalled)
+    }
+
+    func testDownloadImageWithIncorrectUrl() {
+        var imageReturned: UIImage?
+        var dataReturned: Data?
+        var errorReturned: Error?
+        let imageDownloaded = expectation(description: "Image Downloaded")
+
+        let incorrectUrl = URL(fileURLWithPath: "/incorrect_url")
+        downloader.downloadImage(with: incorrectUrl) { (image, data, error) in
+            imageReturned = image
+            dataReturned = data
+            errorReturned = error
+            imageDownloaded.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+
+        XCTAssertNil(imageReturned)
+        XCTAssertNil(dataReturned)
+        XCTAssertNotNil(errorReturned)
+    }
+
+    func testDownloadWith400StatusCode() {
+        var imageReturned: UIImage?
+        var dataReturned: Data?
+        var errorReturned: Error?
+        let imageDownloaded = expectation(description: "Image Downloaded")
+
+        let faultyUrl = URL(string: "https://www.mapbox.com/incorrect")!
+        downloader.downloadImage(with: faultyUrl) { (image, data, error) in
+            imageReturned = image
+            dataReturned = data
+            errorReturned = error
+            imageDownloaded.fulfill()
+        }
+        let operation = (downloader.activeOperation(with: faultyUrl) as! ImageDownloadOperation)
+
+        waitForExpectations(timeout: 10, handler: nil)
+        XCTAssertTrue(operation.isFinished)
+        XCTAssertFalse(operation.isExecuting)
+        XCTAssertNil(imageReturned)
+        XCTAssertNil(dataReturned)
+        XCTAssertNotNil(errorReturned)
+        guard let downloadError = errorReturned as? DownloadError else {
+            XCTFail("Incorrect error returned"); return
+        }
+        XCTAssertEqual(downloadError, DownloadError.serverError)
+    }
+
+    func testDownloadWithImmidiateCancel() {
+        let incorrectUrl = URL(fileURLWithPath: "/incorrect_url")
+        downloader.downloadImage(with: incorrectUrl, completion: nil)
+        let operation = (downloader.activeOperation(with: incorrectUrl) as! ImageDownloadOperation)
+        operation.cancel()
+        
+        XCTAssertFalse(operation.isReady)
+        XCTAssertFalse(operation.isExecuting)
+        XCTAssertTrue(operation.isCancelled)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    func testDownloadWithImmidiateCancelFromAnotherThread() {
+        let incorrectUrl = URL(fileURLWithPath: "/incorrect_url")
+        downloader.downloadImage(with: incorrectUrl, completion: nil)
+        let operation = (downloader.activeOperation(with: incorrectUrl) as! ImageDownloadOperation)
+        DispatchQueue.global().sync {
+            operation.cancel()
+        }
+
+        XCTAssertFalse(operation.isReady)
+        XCTAssertFalse(operation.isExecuting)
+        XCTAssertTrue(operation.isCancelled)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    func testThreadSafetyStressTests() {
+        let numberOfTests: Int = 100
+        let imageData = ShieldImage.i280.image.pngData()!
+
+        let imageUrls: [URL] = (0..<numberOfTests).map { idx in
+            URL(string: "https://mapbox.com/image/\(idx)")!
+        }
+
+        imageUrls.forEach {
+            ImageLoadingURLProtocolSpy.registerData(imageData, forURL: $0)
+        }
+
+        let concurrentOvercommitQueue = DispatchQueue(label: "queue", attributes: .concurrent)
+
+        let lock: NSLock = .init()
+        var downloadedImages: [URL: UIImage?] = .init()
+        func addDownloadedImage(_ image: UIImage?, for url: URL) {
+            lock.lock(); defer {
+                lock.unlock()
+            }
+            downloadedImages[url] = image
+        }
+
+        let allImagesDownloaded = expectation(description: "All Images Downloaded")
+        allImagesDownloaded.expectedFulfillmentCount = imageUrls.count
+
+        for imageUrl in imageUrls {
+            concurrentOvercommitQueue.async {
+                self.downloader.downloadImage(with: imageUrl) { image, data, error in
+                    addDownloadedImage(image, for: imageUrl)
+                    allImagesDownloaded.fulfill()
+                }
+            }
+        }
+
+        for imageUrl in imageUrls {
+            concurrentOvercommitQueue.async {
+                /// `activeOperation(with:)` should be thread safe
+                _ = self.downloader.activeOperation(with: imageUrl)
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+
+        XCTAssertEqual(downloadedImages.values.compactMap({$0}).count, imageUrls.count)
+    }
+
+    @available(iOS 13.0, *)
+    func testPerformance() {
+        measure(metrics: [
+            XCTCPUMetric(),
+            XCTMemoryMetric(),
+        ]) {
+            testThreadSafetyStressTests()
+        }
     }
 }

--- a/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -151,7 +151,8 @@ class ImageDownloaderTests: XCTestCase {
         var errorReturned: Error?
         let imageDownloaded = expectation(description: "Image Downloaded")
 
-        let faultyUrl = URL(string: "https://www.mapbox.com/incorrect")!
+        let faultyUrl = URL(string: "https://www.mapbox.com")!
+        ImageLoadingURLProtocolSpy.registerHttpStatusCodeError(404, for: faultyUrl)
         downloader.downloadImage(with: faultyUrl) { (image, data, error) in
             imageReturned = image
             dataReturned = data

--- a/Tests/MapboxNavigationTests/Support/ImageLoadingURLProtocolSpy.swift
+++ b/Tests/MapboxNavigationTests/Support/ImageLoadingURLProtocolSpy.swift
@@ -4,7 +4,7 @@ import XCTest
 /**
  * This class stubs out the URL loading for any request url registered in `registerData(_, forURL:)` and records requests for a given URL for inspection. Note that unstubbed URLs will continue to load as normal.
  */
-class ImageLoadingURLProtocolSpy: URLProtocol {
+final class ImageLoadingURLProtocolSpy: URLProtocol {
     enum Error: Swift.Error {
         case httpStatus(Int)
         case other(Swift.Error)
@@ -18,24 +18,24 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
 
     private var loadingStopped: Bool = false
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override static func canInit(with request: URLRequest) -> Bool {
         return withLock {
             responseData.keys.contains(request.url!)
         }
     }
 
-    override class func canInit(with task: URLSessionTask) -> Bool {
+    override static func canInit(with task: URLSessionTask) -> Bool {
         return withLock {
             let keys = responseData.keys
             return keys.contains(task.currentRequest!.url!) || keys.contains(task.originalRequest!.url!)
         }
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }
 
-    override class func requestIsCacheEquivalent(_ a: URLRequest, to b: URLRequest) -> Bool {
+    override static func requestIsCacheEquivalent(_ a: URLRequest, to b: URLRequest) -> Bool {
         return a.url == b.url
     }
 
@@ -88,7 +88,7 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
                         client.urlProtocol(self, didFailWithError: otherError)
                     case .httpStatus(let statusCode):
                         // send an NSHTTPURLResponse to the client
-                        let response = HTTPURLResponse.init(url: url, statusCode: 404, httpVersion: "1.1", headerFields: nil)
+                        let response = HTTPURLResponse.init(url: url, statusCode: statusCode, httpVersion: "1.1", headerFields: nil)
                         client.urlProtocol(self, didReceive: response!, cacheStoragePolicy: .notAllowed)
                     }
                 }
@@ -109,7 +109,7 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
     /**
      * Registers data for a given URL
      */
-    class func registerData(_ data: Data, forURL url: URL) {
+    static func registerData(_ data: Data, forURL url: URL) {
         withLock {
             responseData[url] = .success(data)
         }
@@ -132,7 +132,7 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
     /**
      * Reset stubbed data, active and past requests
      */
-    class func reset() {
+    static func reset() {
         withLock {
             responseData = [:]
             activeRequests = [:]
@@ -143,7 +143,7 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
     /**
      * Indicates whether a request for the given URL is in progress
      */
-    class func hasActiveRequestForURL(_ url: URL) -> Bool {
+    static func hasActiveRequestForURL(_ url: URL) -> Bool {
         return withLock {
             activeRequests.keys.contains(url)
         }
@@ -152,7 +152,7 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
     /**
      * Returns the most recently completed request for the given URL
      */
-    class func pastRequestForURL(_ url: URL) -> URLRequest? {
+    static func pastRequestForURL(_ url: URL) -> URLRequest? {
         return withLock {
             pastRequests[url]
         }
@@ -161,14 +161,14 @@ class ImageLoadingURLProtocolSpy: URLProtocol {
     /**
      * Pauses image loading once a request receives a response. Useful for testing re-entrant resource requests.
      */
-    class func delayImageLoading() {
+    static func delayImageLoading() {
         ImageLoadingURLProtocolSpy.imageLoadingSemaphore.wait()
     }
 
     /**
      * Resumes image loading which was previously delayed due to `delayImageLoading()` having been called.
      */
-    class func resumeImageLoading() {
+    static func resumeImageLoading() {
         ImageLoadingURLProtocolSpy.imageLoadingSemaphore.signal()
     }
 


### PR DESCRIPTION
Fixes #3067

- Fix a lot of thread-safety issues.
- Fix incorrect handling of errors:
   - Completions are called two times for HTTP status code >= 400.
   - `ImageDownload` operation wasn't properly transition into finished
      state.
- `ImageDownload` operation didn't have proper `isReady` state.
- Increase test coverage for these types.

### Implementation
#### `ImageDownloader`
- `ImageDownloader` is fixed by properly using Dispatch Queue: perform protected state read/write inside the queue.
-  concurrent `accessQueue` replaced by a serial one, because most accesses to the queue modifies the protected state that require a barrier to be placed. That makes the `accessQueue` merely a serial queue. 
#### `ImageDownload`
`ImageDownload` is a subclass of NSOperation. 
- The implementation is improved with a simpler to use `State` variable. No more multiple flags juggling. 
- A queue replaced with a lock. 
- Replace `objc_sync_enter` with a lock. 

