### PR TITLE
Update refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 * Fixed an issue where offline route calculation might hang up. ([#3040](https://github.com/mapbox/mapbox-navigation-ios/pull/3040))
 * Fixed the moment of custom feedback event creation. ([#3049](https://github.com/mapbox/mapbox-navigation-ios/pull/3049))
 * Fixed a bug in `RouterDelegate.router(_:shouldDiscard:)` handling. If you implemented this method, you will need to reverse the value you return. Previously, if you returned `true`, the `Router` wouldn't discard the location. ([#3058](https://github.com/mapbox/mapbox-navigation-ios/pull/3058))
+* Changed default navigation history storage location to user's application support directory. ([#3039](https://github.com/mapbox/mapbox-navigation-ios/pull/3039))
 
 ## main
 

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -394,6 +394,8 @@ public extension Notification.Name {
      Posted when Navigator was switched to a fallback offline tiles version, but latest tiles became available again. Navigator has restarted when this notification is issued.
      
      Such action invalidates all existing matched `RoadObject`s which should be re-applied manually.
+     
+     The user info dictionary contains the key `Navigator.NotificationUserInfoKey.tilesVersionKey`
      */
     static let navigationDidSwitchToTargetVersion: Notification.Name = .init(rawValue: "NavigatorDidRestoreToOnlineVersion")
     
@@ -418,7 +420,7 @@ extension Navigator {
         
         /**
          :nodoc:
-         A key in the user info dictionary of a `Notification.Name.navigationDidSwitchToFallbackVersion` notification. The corresponding value is a string representation of selected tiles version.
+         A key in the user info dictionary of a `Notification.Name.navigationDidSwitchToFallbackVersion` or `Notification.Name.navigationDidSwitchToTargetVersion` notification. The corresponding value is a string representation of selected tiles version.
          
          For internal use only.
          */

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -12,22 +12,28 @@ class NativeHandlersFactory {
     let tileStorePath: String
     let credentials: DirectionsCredentials
     let tilesVersion: String?
-    let historyDirectoryURL: URL?
+    let historyDirectoryURL: URL
+    let targetVersion: String?
     
     init(tileStorePath: String,
          credentials: DirectionsCredentials = Directions.shared.credentials,
          tilesVersion: String? = nil,
-         historyDirectoryURL: URL? = nil) {
+         historyDirectoryURL: URL = Navigator.historyDirectoryURL,
+         targetVersion: String? = nil) {
         self.tileStorePath = tileStorePath
         self.credentials = credentials
         self.tilesVersion = tilesVersion
         self.historyDirectoryURL = historyDirectoryURL
+        self.targetVersion = targetVersion
     }
     
     // MARK: - Native Handlers
     
-    lazy var historyRecorder: HistoryRecorderHandle? = {
-        HistoryRecorderHandle.build(forHistoryDir: historyDirectoryURL?.path ?? "", config: configHandle)
+    lazy var historyRecorder: HistoryRecorderHandle = {
+        guard let historyRecorder = HistoryRecorderHandle.build(forHistoryDir: historyDirectoryURL.path, config: configHandle) else {
+            preconditionFailure("Could not setup a `HistoryRecorder` on specified directory: '\(historyDirectoryURL.path)'")
+        }
+        return historyRecorder
     }()
     
     lazy var navigator: MapboxNavigationNative.Navigator = {
@@ -62,7 +68,7 @@ class NativeHandlersFactory {
         TileEndpointConfiguration(credentials: credentials,
                                   tilesVersion: tilesVersion ?? "",
                                   minimumDaysToPersistVersion: nil,
-                                  isFallback: tilesVersion != nil)
+                                  targetVersion: targetVersion)
     }()
     
     lazy var tilesConfig: TilesConfig = {

--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -193,7 +193,7 @@ open class PassiveLocationDataSource: NSObject {
     /**
      Path to the directory where history could be stored when `PassiveLocationDataSource.writeHistory(completionHandler:)` is called.
      */
-    public static var historyDirectoryURL: URL? = nil {
+    public static var historyDirectoryURL: URL = Navigator.historyDirectoryURL {
         didSet {
             Navigator.historyDirectoryURL = historyDirectoryURL
         }
@@ -262,9 +262,9 @@ extension TileEndpointConfiguration {
            - parameter credentials: Credentials for accessing road network data.
            - parameter tilesVersion: Routing tile version.
            - parameter minimumDaysToPersistVersion: The minimum age in days that a tile version much reach before a new version can be requested from the tile endpoint.
-           - parameter isFallback: Flag allowing to look up newer tile versions.
+           - parameter targetVersion: Routing tile version, which navigator would like to eventually switch to if it becomes available
      */
-    convenience init(credentials: DirectionsCredentials, tilesVersion: String, minimumDaysToPersistVersion: Int?, isFallback: Bool) {
+    convenience init(credentials: DirectionsCredentials, tilesVersion: String, minimumDaysToPersistVersion: Int?, targetVersion: String?) {
         let host = credentials.host.absoluteString
         guard let accessToken = credentials.accessToken, !accessToken.isEmpty else {
             preconditionFailure("No access token specified in Info.plist")
@@ -276,8 +276,8 @@ extension TileEndpointConfiguration {
                   token: accessToken,
                   userAgent: URLSession.userAgent,
                   navigatorVersion: "",
-                  isFallback: isFallback,
-                  versionBeforeFallback: "",
+                  isFallback: targetVersion != nil,
+                  versionBeforeFallback: targetVersion ?? tilesVersion,
                   minDiffInDaysToConsiderServerVersion: minimumDaysToPersistVersion as NSNumber?)
     }
 }

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -435,7 +435,7 @@ open class RouteController: NSObject {
     /**
      Path to the directory where history could be stored when `RouteController.writeHistory(completionHandler:)` is called.
      */
-    public static var historyDirectoryURL: URL? = nil {
+    public static var historyDirectoryURL: URL = Navigator.historyDirectoryURL {
         didSet {
             Navigator.historyDirectoryURL = historyDirectoryURL
         }


### PR DESCRIPTION
Additional logic updates for underlying version bump #3039:
* Refined history recorder logic to always have a default path. 
* Added possibility to restore a fallback navigator to the version provided instead of always picking latest version for restoring.
* Added version info to restore from fallback notification.
