### PR TITLE
Fix the new user location layer in CarPlay

### DIFF
--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -146,7 +146,7 @@ public class CarPlayMapViewController: UIViewController {
             navigationMapView.localizeLabels()
         }
         
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         navigationMapView.mapView.ornaments.options.logo._visibility = .hidden
         navigationMapView.mapView.ornaments.options.attributionButton._visibility = .hidden

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -147,9 +147,6 @@ public class CarPlayNavigationViewController: UIViewController {
         navigationMapView.mapView.ornaments.options.logo._visibility = .hidden
         navigationMapView.mapView.ornaments.options.attributionButton._visibility = .hidden
         
-        navigationMapView.mapView.location.options.puckType = .none
-        
-        navigationMapView.userCourseView.isHidden = false
         navigationMapView.navigationCamera.follow()
         
         view.addSubview(navigationMapView)


### PR DESCRIPTION
### Description
This pr is to fix #3071 

### Implementation
Updated the expression to use the `navigationMapView.userLocationStyle` in CarPlay.

### Screenshots or Gifs
NavigationMapView Preview:
![preview](https://user-images.githubusercontent.com/48976398/121716903-75c95a00-ca95-11eb-90bf-cac94a0266ad.png)

During turn-by-turn navigation:
![activeGuidance](https://user-images.githubusercontent.com/48976398/121716916-78c44a80-ca95-11eb-8464-72f2b705e0a1.png)
