### PR TITLE
Add Xcode 12.5 swift test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,11 @@ workflows:
           xcode: "12.4.0"
           iOS: "14.4"          
           device: "iPhone 12 Pro Max"
+      - spm-test-job:
+          name: "swift test; Xcode 12.5; iOS 14.5"
+          xcode: "12.5.0"
+          iOS: "14.5"          
+          device: "iPhone 12 Pro Max"          
       - ios-trigger-metrics:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,27 @@ jobs:
           command: xcodebuild -scheme MapboxNavigation-Package test -destination "platform=iOS Simulator,OS=<< parameters.iOS >>,name=<< parameters.device >>" | xcpretty
 
 workflows:
-  workflow:
+  extended-workflow:
+    jobs:
+      - spm-test-job:
+          name: "swift test; Xcode 12.4; iOS 14.4"
+          xcode: "12.4.0"
+          iOS: "14.4"          
+          device: "iPhone 12 Pro Max"     
+      - spm-test-job:
+          name: "swift test; Xcode 12.4; iOS 13.7"
+          xcode: "12.4.0"
+          iOS: "13.7"          
+          device: "iPhone 11 Pro Max"
+    triggers:
+       - schedule:
+           cron: "0 0 * * *" # Once per day at 00:00
+           filters:
+             branches:
+               only:
+                 - main
+                 - release-v2.0
+  main-workflow:
     jobs:
       - build-job:
           name: "Xcode_12.4_iOS_14.4"
@@ -323,16 +343,6 @@ workflows:
           iOS: "14.0"
           lint: true
       - xcode-12-examples
-      - spm-test-job:
-          name: "swift test; Xcode 12.4; iOS 13.7"
-          xcode: "12.4.0"
-          iOS: "13.7"          
-          device: "iPhone 11 Pro Max"
-      - spm-test-job:
-          name: "swift test; Xcode 12.4; iOS 14.4"
-          xcode: "12.4.0"
-          iOS: "14.4"          
-          device: "iPhone 12 Pro Max"
       - spm-test-job:
           name: "swift test; Xcode 12.5; iOS 14.5"
           xcode: "12.5.0"

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,10 @@ let package = Package(
             resources: [.copy("MBXInfo.plist")]),
         .target(
             name: "CTestHelper",
-            dependencies: ["MapboxMobileEvents"]),
+            dependencies: [
+                "MapboxMobileEvents",
+                "MapboxCoreNavigation",
+            ]),
         .target(
             name: "TestHelper",
             dependencies: [


### PR DESCRIPTION
Fixes #3048

- Move Xcode 12.4 swift test to a new "extended-workflow". 
- Create Xcode 12.5 swift test.
- Move iOS 13.7 Xcode 12.5 swift test to the "extended-workflow".
- "extended-workflow" should run an extended set of tests once a day that will
allow us to spot regressions in more cases while saving the cost on CI.