### PR TITLE
#2923 actually call the delegate for the userAnchorPoint

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -392,20 +392,21 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             return
         }
         
-        let centerUserCourseView = { [weak self] in
-            guard let point = self?.convert(location.coordinate, toPointTo: self) else { return }
-            self?.userCourseView.center = point
-        }
-        
+        // when course tracking is on the users pin is centered and the route moves to that center,
+        // this the position where the userAnchorPoint is can this be changes by the delegate
         if tracksUserCourse {
-            centerUserCourseView()
+            
+            userCourseView.center = userAnchorPoint
             
             let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, altitude: altitude, pitch: 45, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: .linear) : nil
             setCamera(newCamera, withDuration: duration, animationTimingFunction: function, completionHandler: nil)
         } else {
             // Animate course view updates in overview mode
-            UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: centerUserCourseView)
+            UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear]) { [weak self] in
+                guard let point = self?.convert(location.coordinate, toPointTo: self) else { return }
+                self?.userCourseView.center = point
+            }
         }
         
         userCourseView.update(location: location, pitch: self.camera.pitch, direction: direction, animated: animated, tracksUserCourse: tracksUserCourse)


### PR DESCRIPTION
### Description
#2923 the users anchor point can be adjusted using the delegate. Only that delegate callback is never called. The solution for us is forking and adding the code in this PR. 

It lacks:

- actually putting the user on the route
- assumes that when you are tracking course that you want to use a fixed point for the `UserCourseView`, this might not be wanted in every case so should be setting?

### Implementation

It is assumed that in overview only you want the `UserCourseView` to follow the users location, in turn by turn navigation view the path centers under the view.

### Screenshots or Gifs

In our case we add a custom view transparant view over the 
![IMG_AB311ADAFFE9-1](https://user-images.githubusercontent.com/686038/121871428-64d25000-cd04-11eb-8f4b-5a2b204fb944.jpeg)

---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->