### PR TITLE
Disabling History recording by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,6 @@
 * Fixed an issue where offline route calculation might hang up. ([#3040](https://github.com/mapbox/mapbox-navigation-ios/pull/3040))
 * Fixed the moment of custom feedback event creation. ([#3049](https://github.com/mapbox/mapbox-navigation-ios/pull/3049))
 * Fixed a bug in `RouterDelegate.router(_:shouldDiscard:)` handling. If you implemented this method, you will need to reverse the value you return. Previously, if you returned `true`, the `Router` wouldn't discard the location. ([#3058](https://github.com/mapbox/mapbox-navigation-ios/pull/3058))
-* Changed default navigation history storage location to user's application support directory. ([#3039](https://github.com/mapbox/mapbox-navigation-ios/pull/3039))
 
 ## v1.4.0
 

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -21,13 +21,11 @@ class Navigator {
     static var tilesURL: URL? = nil
     
     /**
-     Path to the directory where history file could be stored when `Navigator.writeHistory(completionHandler:)` is called. Defaults to user support directory.
+     Path to the directory where history file could be stored when `Navigator.writeHistory(completionHandler:)` is called.
+     
+     Setting `nil` disables history recording. Defaults to `nil`.
      */
-    static var historyDirectoryURL: URL = {
-        let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        
-        return supportDir.appendingPathComponent("com.mapbox.navigation.history")
-    }()
+    static var historyDirectoryURL: URL? = nil
     
     /**
      Store history to the directory stored in `Navigator.historyDirectoryURL` and asynchronously run a callback
@@ -36,7 +34,7 @@ class Navigator {
      - parameter completionHandler: A block object to be executed when history dumping ends.
      */
     func writeHistory(completionHandler: @escaping (URL?) -> Void) {
-        historyRecorder.dumpHistory { (path) in
+        historyRecorder?.dumpHistory { (path) in
             if let path = path {
                 completionHandler(URL(fileURLWithPath: path))
             } else {
@@ -45,7 +43,7 @@ class Navigator {
         }
     }
     
-    private(set) var historyRecorder: HistoryRecorderHandle
+    private(set) var historyRecorder: HistoryRecorderHandle?
     
     private(set) var navigator: MapboxNavigationNative.Navigator
     

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -12,13 +12,13 @@ class NativeHandlersFactory {
     let tileStorePath: String
     let credentials: DirectionsCredentials
     let tilesVersion: String?
-    let historyDirectoryURL: URL
+    let historyDirectoryURL: URL?
     let targetVersion: String?
     
     init(tileStorePath: String,
          credentials: DirectionsCredentials = Directions.shared.credentials,
          tilesVersion: String? = nil,
-         historyDirectoryURL: URL = Navigator.historyDirectoryURL,
+         historyDirectoryURL: URL? = nil,
          targetVersion: String? = nil) {
         self.tileStorePath = tileStorePath
         self.credentials = credentials
@@ -29,11 +29,8 @@ class NativeHandlersFactory {
     
     // MARK: - Native Handlers
     
-    lazy var historyRecorder: HistoryRecorderHandle = {
-        guard let historyRecorder = HistoryRecorderHandle.build(forHistoryDir: historyDirectoryURL.path, config: configHandle) else {
-            preconditionFailure("Could not setup a `HistoryRecorder` on specified directory: '\(historyDirectoryURL.path)'")
-        }
-        return historyRecorder
+    lazy var historyRecorder: HistoryRecorderHandle? = {
+        HistoryRecorderHandle.build(forHistoryDir: historyDirectoryURL?.path ?? "", config: configHandle)
     }()
     
     lazy var navigator: MapboxNavigationNative.Navigator = {

--- a/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationDataSource.swift
@@ -193,7 +193,7 @@ open class PassiveLocationDataSource: NSObject {
     /**
      Path to the directory where history could be stored when `PassiveLocationDataSource.writeHistory(completionHandler:)` is called.
      */
-    public static var historyDirectoryURL: URL = Navigator.historyDirectoryURL {
+    public static var historyDirectoryURL: URL? = nil {
         didSet {
             Navigator.historyDirectoryURL = historyDirectoryURL
         }

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -435,7 +435,7 @@ open class RouteController: NSObject {
     /**
      Path to the directory where history could be stored when `RouteController.writeHistory(completionHandler:)` is called.
      */
-    public static var historyDirectoryURL: URL = Navigator.historyDirectoryURL {
+    public static var historyDirectoryURL: URL? = nil {
         didSet {
             Navigator.historyDirectoryURL = historyDirectoryURL
         }

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
@@ -71,6 +71,11 @@ class PassiveLocationDataSourceTests: XCTestCase {
         Navigator.tilesURL = filePathURL
     }
     
+    override func tearDown() {
+        PassiveLocationDataSource.historyDirectoryURL = nil
+        Navigator._recreateNavigator()
+    }
+    
     func testManualLocations() {
         let locationManager = PassiveLocationDataSource(directions: directions)
         Navigator.shared.navigator.resetRideSession()
@@ -97,9 +102,7 @@ class PassiveLocationDataSourceTests: XCTestCase {
     
     func testNoHistoryRecording() {
         PassiveLocationDataSource.historyDirectoryURL = nil
-        
-        Navigator.shared.restartNavigator()
-        
+                
         let noHistoryExpectation = XCTestExpectation(description: "History should not be written on 'nil' path")
         noHistoryExpectation.isInverted = true
         PassiveLocationDataSource.writeHistory { _ in
@@ -112,9 +115,7 @@ class PassiveLocationDataSourceTests: XCTestCase {
         let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("test")
         
         PassiveLocationDataSource.historyDirectoryURL = supportDir
-        
-        Navigator.shared.restartNavigator()
-        
+                
         let historyExpectation = XCTestExpectation(description: "History should be written to '\(supportDir)'")
         PassiveLocationDataSource.writeHistory { _ in
             historyExpectation.fulfill()

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationDataSourceTests.swift
@@ -73,6 +73,7 @@ class PassiveLocationDataSourceTests: XCTestCase {
     
     override func tearDown() {
         PassiveLocationDataSource.historyDirectoryURL = nil
+        Navigator.tilesURL = nil
         Navigator._recreateNavigator()
     }
     
@@ -102,6 +103,7 @@ class PassiveLocationDataSourceTests: XCTestCase {
     
     func testNoHistoryRecording() {
         PassiveLocationDataSource.historyDirectoryURL = nil
+        Navigator._recreateNavigator()
                 
         let noHistoryExpectation = XCTestExpectation(description: "History should not be written on 'nil' path")
         noHistoryExpectation.isInverted = true
@@ -115,9 +117,11 @@ class PassiveLocationDataSourceTests: XCTestCase {
         let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("test")
         
         PassiveLocationDataSource.historyDirectoryURL = supportDir
+        Navigator._recreateNavigator()
                 
         let historyExpectation = XCTestExpectation(description: "History should be written to '\(supportDir)'")
-        PassiveLocationDataSource.writeHistory { _ in
+        PassiveLocationDataSource.writeHistory { url in
+            XCTAssertNotNil(url)
             historyExpectation.fulfill()
         }
         wait(for: [historyExpectation], timeout: 3)

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -4,6 +4,7 @@ import MapboxDirections
 import CoreLocation
 @testable import MapboxCoreNavigation
 import TestHelper
+import MapboxNavigationNative
 
 class RouteControllerTests: XCTestCase {
     var replayManager: ReplayLocationManager?
@@ -45,6 +46,14 @@ class RouteControllerTests: XCTestCase {
         locationManager.delegate = routeController
         
         var testCoordinates = [CLLocationCoordinate2D]()
+
+        // Dirty fix
+        // Setting dummy first location to kick start NN.Navigator
+        routeController.navigator.updateLocation(for: FixLocation(CLLocation(coordinate: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0),
+                                                                             altitude: 0,
+                                                                             horizontalAccuracy: 0,
+                                                                             verticalAccuracy: 0,
+                                                                             timestamp: Date())))
         
         while testCoordinates.count < locationManager.locations.count {
             locationManager.tick()


### PR DESCRIPTION
### Description
[Previous PR](https://github.com/mapbox/mapbox-navigation-ios/pull/3074) accidentally enabled history recording by default. We should not do this.

### Implementation
Basically a reverse commit.