### PR TITLE
When the NavigationMapView updateCourseTracking is called and tracksUserCourse is active the camera does not use  edgePadding and updates puck before camera is in position

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -25,7 +25,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
     }
     
     /// By default this is 150 from the bottom. This will allow the puck for the user location to be above the bottom banner while navigation is active
-    public var cameraUserTrackingCourseEdgePadding: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 150, right: 0)
+    public var cameraUserTrackingCourseEdgePadding: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     
     /**
      The minimum preferred frames per second at which to render map animations.
@@ -401,7 +401,6 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         }
         
         if tracksUserCourse {
-            centerUserCourseView()
             
             let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, altitude: altitude, pitch: 45, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: .linear) : nil
@@ -410,7 +409,7 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
                 withDuration: duration,
                 animationTimingFunction: function,
                 edgePadding: cameraUserTrackingCourseEdgePadding,
-                completionHandler: nil
+                completionHandler: centerUserCourseView
             )
 
         } else {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -24,6 +24,9 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
         static let pluggedInFramesPerSecond = MGLMapViewPreferredFramesPerSecond.lowPower
     }
     
+    /// By default this is 150 from the bottom. This will allow the puck for the user location to be above the bottom banner while navigation is active
+    public var cameraUserTrackingCourseEdgePadding: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 150, right: 0)
+    
     /**
      The minimum preferred frames per second at which to render map animations.
      
@@ -402,7 +405,14 @@ open class NavigationMapView: MGLMapView, UIGestureRecognizerDelegate {
             
             let newCamera = camera ?? MGLMapCamera(lookingAtCenter: location.coordinate, altitude: altitude, pitch: 45, heading: location.course)
             let function: CAMediaTimingFunction? = animated ? CAMediaTimingFunction(name: .linear) : nil
-            setCamera(newCamera, withDuration: duration, animationTimingFunction: function, completionHandler: nil)
+            setCamera(
+                newCamera,
+                withDuration: duration,
+                animationTimingFunction: function,
+                edgePadding: cameraUserTrackingCourseEdgePadding,
+                completionHandler: nil
+            )
+
         } else {
             // Animate course view updates in overview mode
             UIView.animate(withDuration: duration, delay: 0, options: [.curveLinear], animations: centerUserCourseView)


### PR DESCRIPTION
### Description
See issue #3086 and possibly related #2587 

### Implementation
Added extra parameter to set the edge padding when user course tracking is active. ### Screenshots or Gifs

![IMG_CB7344740558-1](https://user-images.githubusercontent.com/686038/122202555-74d16780-ce9d-11eb-970a-1a6407541cc2.jpeg)
