### PR TITLE
Fixes the race in ImageDownload

### DIFF
--- a/Sources/MapboxNavigation/ImageDownload.swift
+++ b/Sources/MapboxNavigation/ImageDownload.swift
@@ -92,28 +92,28 @@ final class ImageDownloadOperation: Operation, ImageDownload {
     }
 
     override func cancel() {
-        super.cancel()
         withLock {
+            super.cancel()
             if let dataTask = dataTask {
                 dataTask.cancel()
                 incomingData = nil
                 self.dataTask = nil
             }
+            state = .finished
         }
-        state = .finished
     }
 
     override func start() {
-        guard !isCancelled else {
-            state = .finished;
-            return
-        }
-
-        state = .executing
-        let dataTask = session.dataTask(with: self.request)
-        dataTask.resume()
-
         withLock {
+            guard !isCancelled && state != .finished else {
+                state = .finished;
+                return
+            }
+
+            state = .executing
+            let dataTask = session.dataTask(with: self.request)
+            dataTask.resume()
+
             self.dataTask = dataTask
         }
     }


### PR DESCRIPTION
Fixes sporadic failures in tests. 

When cancel is called, `start` method can be executed on a different thread. There is a room when cancel hasn't updated the state yet and `start` method verified it could start.
With the fix, we make sure that start can't be executed while cancel is by guarding methods in a lock.