### PR TITLE
Adjust the layer position to make puck layer at topmost

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -884,6 +884,15 @@ open class NavigationMapView: UIView {
             let shaftLength = max(min(30 * mapView.metersPerPointAtLatitude(latitude: maneuverCoordinate.latitude), 30), 10)
             let shaftPolyline = route.polylineAroundManeuver(legIndex: legIndex, stepIndex: stepIndex, distance: shaftLength)
             
+            var puckLayerIdentifier: String?
+            switch userLocationStyle {
+            case .puck2D(configuration: _):
+                puckLayerIdentifier = NavigationMapView.LayerIdentifier.puck2DLayer
+            case .puck3D(configuration: _):
+                puckLayerIdentifier = NavigationMapView.LayerIdentifier.puck3DLayer
+            default: break
+            }
+            
             if shaftPolyline.coordinates.count > 1 {
                 let allLayerIds = mapView.mapboxMap.style.allLayerIdentifiers.map{ $0.id }
                 let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
@@ -907,8 +916,8 @@ open class NavigationMapView: UIView {
                     try mapView.mapboxMap.style.addSource(arrowSource, id: NavigationMapView.SourceIdentifier.arrowSource)
                     arrowLayer.source = NavigationMapView.SourceIdentifier.arrowSource
                     
-                    if allLayerIds.contains(NavigationMapView.LayerIdentifier.puck3DLayer) {
-                        try mapView.mapboxMap.style.addLayer(arrowLayer, layerPosition: .below(NavigationMapView.LayerIdentifier.puck3DLayer))
+                    if let puckLayer = puckLayerIdentifier, allLayerIds.contains(puckLayer) {
+                        try mapView.mapboxMap.style.addLayer(arrowLayer, layerPosition: .below(puckLayer))
                     } else if mapView.mapboxMap.style.sourceExists(withId: NavigationMapView.LayerIdentifier.waypointCircleLayer) {
                         try mapView.mapboxMap.style.addLayer(arrowLayer, layerPosition: .below(NavigationMapView.LayerIdentifier.waypointCircleLayer))
                     } else {
@@ -979,9 +988,8 @@ open class NavigationMapView: UIView {
                     arrowSymbolLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     arrowSymbolCasingLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     
-                    if allLayerIds.contains(NavigationMapView.LayerIdentifier.puck3DLayer) {
-                        try mapView.mapboxMap.style.addLayer(arrowSymbolLayer,
-                                                             layerPosition: .below(NavigationMapView.LayerIdentifier.puck3DLayer))
+                    if let puckLayer = puckLayerIdentifier, allLayerIds.contains(puckLayer) {
+                        try mapView.mapboxMap.style.addLayer(arrowSymbolLayer, layerPosition: .below(puckLayer))
                     } else {
                         try mapView.mapboxMap.style.addLayer(arrowSymbolLayer)
                     }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -885,6 +885,7 @@ open class NavigationMapView: UIView {
             let shaftPolyline = route.polylineAroundManeuver(legIndex: legIndex, stepIndex: stepIndex, distance: shaftLength)
             
             if shaftPolyline.coordinates.count > 1 {
+                let allLayerIds = mapView.mapboxMap.style.allLayerIdentifiers.map{ $0.id }
                 let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
                 let minimumZoomLevel: Double = 14.5
                 let shaftStrokeCoordinates = shaftPolyline.coordinates
@@ -906,7 +907,9 @@ open class NavigationMapView: UIView {
                     try mapView.mapboxMap.style.addSource(arrowSource, id: NavigationMapView.SourceIdentifier.arrowSource)
                     arrowLayer.source = NavigationMapView.SourceIdentifier.arrowSource
                     
-                    if mapView.mapboxMap.style.sourceExists(withId: NavigationMapView.LayerIdentifier.waypointCircleLayer) {
+                    if allLayerIds.contains(NavigationMapView.LayerIdentifier.puck3DLayer) {
+                        try mapView.mapboxMap.style.addLayer(arrowLayer, layerPosition: .below(NavigationMapView.LayerIdentifier.puck3DLayer))
+                    } else if mapView.mapboxMap.style.sourceExists(withId: NavigationMapView.LayerIdentifier.waypointCircleLayer) {
                         try mapView.mapboxMap.style.addLayer(arrowLayer, layerPosition: .below(NavigationMapView.LayerIdentifier.waypointCircleLayer))
                     } else {
                         try mapView.mapboxMap.style.addLayer(arrowLayer)
@@ -972,7 +975,12 @@ open class NavigationMapView: UIView {
                     arrowSymbolLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     arrowSymbolCasingLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     
-                    try mapView.mapboxMap.style.addLayer(arrowSymbolLayer)
+                    if allLayerIds.contains(NavigationMapView.LayerIdentifier.puck3DLayer) {
+                        try mapView.mapboxMap.style.addLayer(arrowSymbolLayer,
+                                                             layerPosition: .below(NavigationMapView.LayerIdentifier.puck3DLayer))
+                    } else {
+                        try mapView.mapboxMap.style.addLayer(arrowSymbolLayer)
+                    }
                     try mapView.mapboxMap.style.addLayer(arrowSymbolCasingLayer,
                                                          layerPosition: .below(NavigationMapView.LayerIdentifier.arrowSymbolLayer))
                 }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -941,11 +941,9 @@ open class NavigationMapView: UIView {
                     
                     try mapView.mapboxMap.style.addSource(arrowStrokeSource, id: NavigationMapView.SourceIdentifier.arrowStrokeSource)
                     arrowStrokeLayer.source = NavigationMapView.SourceIdentifier.arrowStrokeSource
-                    if allLayerIds.contains(mainRouteLayerIdentifier) {
-                        try mapView.mapboxMap.style.addLayer(arrowStrokeLayer, layerPosition: .above(mainRouteLayerIdentifier))
-                    } else {
-                        try mapView.mapboxMap.style.addLayer(arrowStrokeLayer, layerPosition: .below(NavigationMapView.LayerIdentifier.arrowLayer))
-                    }
+                    
+                    let arrowStrokeLayerPsoition = allLayerIds.contains(mainRouteLayerIdentifier) ? LayerPosition.above(mainRouteLayerIdentifier) : LayerPosition.below(NavigationMapView.LayerIdentifier.arrowLayer)
+                    try mapView.mapboxMap.style.addLayer(arrowStrokeLayer, layerPosition: arrowStrokeLayerPsoition)
                 }
                 
                 let point = Point(shaftStrokeCoordinates.last!)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -932,7 +932,11 @@ open class NavigationMapView: UIView {
                     
                     try mapView.mapboxMap.style.addSource(arrowStrokeSource, id: NavigationMapView.SourceIdentifier.arrowStrokeSource)
                     arrowStrokeLayer.source = NavigationMapView.SourceIdentifier.arrowStrokeSource
-                    try mapView.mapboxMap.style.addLayer(arrowStrokeLayer, layerPosition: .above(mainRouteLayerIdentifier))
+                    if allLayerIds.contains(mainRouteLayerIdentifier) {
+                        try mapView.mapboxMap.style.addLayer(arrowStrokeLayer, layerPosition: .above(mainRouteLayerIdentifier))
+                    } else {
+                        try mapView.mapboxMap.style.addLayer(arrowStrokeLayer, layerPosition: .below(NavigationMapView.LayerIdentifier.arrowLayer))
+                    }
                 }
                 
                 let point = Point(shaftStrokeCoordinates.last!)

--- a/Sources/MapboxNavigation/NavigationMapViewIdentifiers.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewIdentifiers.swift
@@ -16,6 +16,7 @@ extension NavigationMapView {
         static let buildingExtrusionLayer = "\(identifier)_buildingExtrusionLayer"
         static let routeDurationAnnotationsLayer: String = "\(identifier)_routeDurationAnnotationsLayer"
         static let puck2DLayer: String = "puck"
+        static let puck3DLayer: String = "puck-model-layer"
     }
     
     struct SourceIdentifier {

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -235,7 +235,7 @@ class NavigationViewControllerTests: XCTestCase {
         XCTAssert(newAnnotations.contains { $0.coordinate.distance(to: secondDestination) < 1 }, "New destination annotation does not exist on map")
     }
     
-    func testpuck3DLayerPosition() {
+    func testPuck3DLayerPosition() {
         let service = MapboxNavigationService(route: initialRoute, routeIndex: 0, routeOptions: routeOptions,  directions: DirectionsSpy(), simulating: .never)
         let options = NavigationOptions(styles: [TestableDayStyle()], navigationService: service)
         let navigationViewController = NavigationViewController(for: initialRoute, routeIndex: 0, routeOptions: routeOptions, navigationOptions: options)


### PR DESCRIPTION
### Description
This pr is to fix #3098 , because the 3D puck from map side doesn't support the default topmost layer position similar as 2D puck. This pr is to check the 3D puck layer and make it above the maneuvers when we call `func navigationMapView.addArrow`.

### Implementation
Because the 3D puck from map side doesn't support the default topmost layer position similar as 2D puck. This pr is to check the 3D puck layer and make it above the maneuvers when we call `func navigationMapView.addArrow`

### Screenshots or Gifs