### PR TITLE
Fix more lane icon edge cases and tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -108,7 +108,6 @@ let package = Package(
                 "NavigationViewControllerTests.swift", // Crash on `UNUserNotificationCenter.current()`. This API doesn't work in SPM.
                 "CarPlayManagerTests.swift", // There are issues with setting accessToken
                 "LeaksSpec.swift", // Crash on `UNUserNotificationCenter.current()`. This API doesn't work in SPM.
-                "LaneViewTests.swift", // Needs proofread for new correct behaviour
                 "__Snapshots__", // Ignore snapshots folder
             ],
             resources: [

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -28,6 +28,10 @@ extension LaneIndication {
             primaryIndication = .slightLeft
         } else if indications.contains(.slightRight) && maneuverDirection ?? .slightRight == .slightRight {
             primaryIndication = .slightRight
+        } else if indications.isSubset(of: [.left, .straightAhead]) && maneuverDirection ?? .slightLeft == .slightLeft {
+            primaryIndication = .left
+        } else if indications.isSubset(of: [.right, .straightAhead]) && maneuverDirection ?? .slightRight == .slightRight {
+            primaryIndication = .right
         } else if indications.contains(.left) && maneuverDirection ?? .left == .left {
             primaryIndication = .left
         } else if indications.contains(.right) && maneuverDirection ?? .right == .right {
@@ -36,6 +40,14 @@ extension LaneIndication {
             primaryIndication = .sharpLeft
         } else if indications.contains(.sharpRight) && maneuverDirection ?? .sharpRight == .sharpRight {
             primaryIndication = .sharpRight
+        } else if indications.contains(.left) && !indications.contains(.sharpLeft) && !indications.contains(.uTurn) && maneuverDirection ?? .sharpLeft == .sharpLeft {
+            primaryIndication = .left
+        } else if indications.contains(.right) && !indications.contains(.sharpRight) && !indications.contains(.uTurn) && maneuverDirection ?? .sharpRight == .sharpRight {
+            primaryIndication = .right
+        } else if !indications.isDisjoint(with: .lefts) && !indications.isDisjoint(with: .rights) && maneuverDirection?.isLeft ?? false {
+            primaryIndication = .left
+        } else if !indications.isDisjoint(with: .lefts) && !indications.isDisjoint(with: .rights) && maneuverDirection?.isRight ?? false {
+            primaryIndication = .right
         } else if indications.contains(.uTurn) && maneuverDirection ?? .uTurn == .uTurn {
             primaryIndication = .uTurn
         } else {
@@ -71,10 +83,10 @@ extension LaneIndication {
             secondaryIndication = .straightAhead
         } else if !primaryIndication.isDisjoint(with: .rights) && indications.contains(.slightLeft) {
             // No assets for slight or sharp opposite turns.
-            secondaryIndication = .slightLeft
+            secondaryIndication = .left
         } else if !primaryIndication.isDisjoint(with: .lefts) && indications.contains(.slightRight) {
             // No assets for slight or sharp opposite turns.
-            secondaryIndication = .slightRight
+            secondaryIndication = .right
         } else if indications.contains(.left) {
             secondaryIndication = .left
             // No assets for slight or sharp opposite turns.
@@ -89,10 +101,10 @@ extension LaneIndication {
             }
         } else if !primaryIndication.isDisjoint(with: .rights) && indications.contains(.sharpLeft) {
             // No assets for slight or sharp opposite turns.
-            secondaryIndication = .sharpLeft
+            secondaryIndication = .left
         } else if !primaryIndication.isDisjoint(with: .lefts) && indications.contains(.sharpRight) {
             // No assets for slight or sharp opposite turns.
-            secondaryIndication = .sharpRight
+            secondaryIndication = .right
         } else if indications.contains(.uTurn) {
             secondaryIndication = .uTurn
             // No asset for sharp turn or U-turn.
@@ -105,6 +117,10 @@ extension LaneIndication {
             secondaryIndication = .left
         } else if !primaryIndication.isDisjoint(with: .lefts) && !indications.isDisjoint(with: .rights) {
             secondaryIndication = .right
+        } else if primaryIndication == .straightAhead && indications == .slightLeft {
+            secondaryIndication = .slightLeft
+        } else if primaryIndication == .straightAhead && indications == .slightRight {
+            secondaryIndication = .slightRight
         } else {
             secondaryIndication = nil
         }

--- a/Tests/MapboxNavigationTests/LaneViewTests.swift
+++ b/Tests/MapboxNavigationTests/LaneViewTests.swift
@@ -21,22 +21,22 @@ class LaneViewTests: XCTestCase {
                        .init(primary: .uTurn, secondary: nil, tertiary: nil))
         
         XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: nil),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpLeft, secondary: nil, tertiary: nil))
         XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: .sharpLeft),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpLeft, secondary: nil, tertiary: nil))
         XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: .left),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpLeft, secondary: nil, tertiary: nil))
         XCTAssertEqual(LaneIndication.sharpLeft.ranked(favoring: .right),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpLeft, secondary: nil, tertiary: nil))
         
         XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: nil),
-                       .init(primary: .right, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpRight, secondary: nil, tertiary: nil))
         XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: .sharpRight),
-                       .init(primary: .right, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpRight, secondary: nil, tertiary: nil))
         XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: .right),
-                       .init(primary: .right, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpRight, secondary: nil, tertiary: nil))
         XCTAssertEqual(LaneIndication.sharpRight.ranked(favoring: .left),
-                       .init(primary: .right, secondary: nil, tertiary: nil))
+                       .init(primary: .sharpRight, secondary: nil, tertiary: nil))
         
         XCTAssertEqual(LaneIndication.left.ranked(favoring: nil),
                        .init(primary: .left, secondary: nil, tertiary: nil))
@@ -94,15 +94,15 @@ class LaneViewTests: XCTestCase {
                        .init(primary: .left, secondary: .straightAhead, tertiary: nil))
         
         XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: nil),
-                       .init(primary: .straightAhead, secondary: .left, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightLeft, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .right),
-                       .init(primary: .straightAhead, secondary: .left, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightLeft, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .left),
-                       .init(primary: .straightAhead, secondary: .left, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightLeft, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .sharpLeft),
-                       .init(primary: .straightAhead, secondary: .left, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightLeft, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightLeft] as LaneIndication).ranked(favoring: .slightLeft),
-                       .init(primary: .left, secondary: .straightAhead, tertiary: nil))
+                       .init(primary: .slightLeft, secondary: .straightAhead, tertiary: nil))
         
         XCTAssertEqual(([.straightAhead, .right] as LaneIndication).ranked(favoring: nil),
                        .init(primary: .straightAhead, secondary: .right, tertiary: nil))
@@ -116,47 +116,47 @@ class LaneViewTests: XCTestCase {
                        .init(primary: .right, secondary: .straightAhead, tertiary: nil))
         
         XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: nil),
-                       .init(primary: .straightAhead, secondary: .right, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightRight, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .left),
-                       .init(primary: .straightAhead, secondary: .right, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightRight, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .right),
-                       .init(primary: .straightAhead, secondary: .right, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightRight, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .sharpRight),
-                       .init(primary: .straightAhead, secondary: .right, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .slightRight, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .slightRight] as LaneIndication).ranked(favoring: .slightRight),
-                       .init(primary: .right, secondary: .straightAhead, tertiary: nil))
+                       .init(primary: .slightRight, secondary: .straightAhead, tertiary: nil))
         
         XCTAssertEqual(([.left, .uTurn] as LaneIndication).ranked(favoring: nil),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .left, secondary: .uTurn, tertiary: nil))
         XCTAssertEqual(([.left, .uTurn] as LaneIndication).ranked(favoring: .left),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .left, secondary: .uTurn, tertiary: nil))
         XCTAssertEqual(([.left, .uTurn] as LaneIndication).ranked(favoring: .uTurn),
-                       .init(primary: .uTurn, secondary: nil, tertiary: nil))
+                       .init(primary: .uTurn, secondary: .left, tertiary: nil))
         
         XCTAssertEqual(([.straightAhead, .uTurn] as LaneIndication).ranked(favoring: nil),
-                       .init(primary: .straightAhead, secondary: nil, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .uTurn, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .uTurn] as LaneIndication).ranked(favoring: .straightAhead),
-                       .init(primary: .straightAhead, secondary: nil, tertiary: nil))
+                       .init(primary: .straightAhead, secondary: .uTurn, tertiary: nil))
         XCTAssertEqual(([.straightAhead, .uTurn] as LaneIndication).ranked(favoring: .uTurn),
-                       .init(primary: .uTurn, secondary: nil, tertiary: nil))
+                       .init(primary: .uTurn, secondary: .straightAhead, tertiary: nil))
         
         XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: nil),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .left, secondary: .right, tertiary: nil))
         XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: .left),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .left, secondary: .right, tertiary: nil))
         XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: .right),
-                       .init(primary: .right, secondary: nil, tertiary: nil))
+                       .init(primary: .right, secondary: .left, tertiary: nil))
         XCTAssertEqual(([.left, .right] as LaneIndication).ranked(favoring: .slightRight),
-                       .init(primary: .right, secondary: nil, tertiary: nil))
+                       .init(primary: .right, secondary: .left, tertiary: nil))
         
         XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: nil),
-                       .init(primary: .slightRight, secondary: nil, tertiary: nil))
+                       .init(primary: .right, secondary: .left, tertiary: nil))
         XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: .left),
-                       .init(primary: .left, secondary: nil, tertiary: nil))
+                       .init(primary: .left, secondary: .right, tertiary: nil))
         XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: .slightRight),
-                       .init(primary: .slightRight, secondary: nil, tertiary: nil))
+                       .init(primary: .right, secondary: .left, tertiary: nil))
         XCTAssertEqual(([.left, .slightRight] as LaneIndication).ranked(favoring: .right),
-                       .init(primary: .slightRight, secondary: nil, tertiary: nil))
+                       .init(primary: .right, secondary: .left, tertiary: nil))
     }
     
     func testLaneConfiguration() {
@@ -164,23 +164,27 @@ class LaneViewTests: XCTestCase {
                        .uTurn(side: .left))
         XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .uTurn, secondary: nil, tertiary: nil), drivingSide: .left),
                        .uTurn(side: .right))
-        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .uTurn, secondary: .left, tertiary: nil), drivingSide: .right))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .uTurn, secondary: .left, tertiary: nil), drivingSide: .right),
+                       .turnOrUTurn(side: .left, turn: false, uTurn: true))
         
         XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .straightAhead, secondary: nil, tertiary: nil), drivingSide: .right),
                        .straight)
-        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .straightAhead, secondary: .slightLeft, tertiary: nil), drivingSide: .right))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .straightAhead, secondary: .slightLeft, tertiary: nil), drivingSide: .right),
+                       .straightOrSlightTurn(side: .left, straight: true, slightTurn: false))
         
         XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .slightLeft, secondary: nil, tertiary: nil), drivingSide: .right),
                        .slightTurn(side: .left))
         XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .slightRight, secondary: nil, tertiary: nil), drivingSide: .right),
                        .slightTurn(side: .right))
-        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .slightLeft, secondary: .straightAhead, tertiary: nil), drivingSide: .right))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .slightLeft, secondary: .straightAhead, tertiary: nil), drivingSide: .right),
+                       .straightOrSlightTurn(side: .left, straight: false, slightTurn: true))
         
         XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .left, secondary: nil, tertiary: nil), drivingSide: .right),
                        .turn(side: .left))
         XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .right, secondary: nil, tertiary: nil), drivingSide: .right),
                        .turn(side: .right))
-        XCTAssertNil(LaneConfiguration(rankedIndications: .init(primary: .left, secondary: .right, tertiary: nil), drivingSide: .right))
+        XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .left, secondary: .right, tertiary: nil), drivingSide: .right),
+                       .turnOrOppositeTurn(side: .left))
         
         XCTAssertEqual(LaneConfiguration(rankedIndications: .init(primary: .left, secondary: .straightAhead, tertiary: nil), drivingSide: .right),
                        .straightOrTurn(side: .left, straight: false, turn: true))


### PR DESCRIPTION
This PR fixes several edge cases in lane indication ranking that I missed in #2882 due to disabled unit tests. It also fixes numerous errors in the tests themselves. In some cases, the library or tests weren’t wrong, but the additional assets in #2882 make a better result possible. LaneViewTests has been reenabled, now that it passes.

Fixes #3107.

/cc @mapbox/navigation-ios @avi-c