### PR TITLE
Fix retain cycle in UserPuckCourseView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 * Fixed an issue where offline route calculation might hang up. ([#3040](https://github.com/mapbox/mapbox-navigation-ios/pull/3040))
 * Fixed the moment of custom feedback event creation. ([#3049](https://github.com/mapbox/mapbox-navigation-ios/pull/3049))
 * Increased stability of unit tests by addressing sporadic failures. ([#3089](https://github.com/mapbox/mapbox-navigation-ios/pull/3089))([#3072](https://github.com/mapbox/mapbox-navigation-ios/pull/3072))
+* Fixed a retain cycle in `UserCourseView`. ([#3120](https://github.com/mapbox/mapbox-navigation-ios/issues/3120))
 
 ## v1.4.1
 

--- a/Sources/MapboxNavigation/UserCourseView.swift
+++ b/Sources/MapboxNavigation/UserCourseView.swift
@@ -129,14 +129,14 @@ open class UserPuckCourseView: UIView, CourseUpdatable {
     
     private func initTimer() {
         staleTimer = Timer(timeInterval: staleRefreshInterval,
-                           target: self,
-                           selector: #selector(refreshPuckStaleState),
-                           userInfo: nil,
-                           repeats: true)
+                           repeats: true,
+                           block: { [weak self] _ in
+            self?.refreshPuckStaleState()
+        })
         RunLoop.current.add(staleTimer, forMode: .common)
     }
-    
-    @objc func refreshPuckStaleState() {
+
+    private func refreshPuckStaleState() {
         if let lastUpdate = lastLocationUpdate {
             let ratio = CGFloat(Date().timeIntervalSince(lastUpdate) / staleInterval)
             puckView.staleRatio = max(0.0, min(1.0, ratio))

--- a/Sources/TestHelper/LeakTest.swift
+++ b/Sources/TestHelper/LeakTest.swift
@@ -11,7 +11,7 @@ public struct LeakTest {
         self.constructor = constructor
     }
     
-    internal func isLeaking() -> Bool {
+    public func isLeaking() -> Bool {
         weak var leaked : AnyObject? = nil
         
         autoreleasepool {

--- a/Tests/MapboxNavigationTests/LeaksTests.swift
+++ b/Tests/MapboxNavigationTests/LeaksTests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import XCTest
+@testable import MapboxNavigation
+import TestHelper
+
+final class LeaksTests: XCTestCase {
+    func testUserCourseViewLeak() {
+        let leakTester = LeakTest {
+            UserPuckCourseView(frame: .zero)
+        }
+        XCTAssertFalse(leakTester.isLeaking())
+    }
+}


### PR DESCRIPTION
### Description

Fixed #3120

### Implementation

Use block based API. Also added a test to catch regressions in the future. 