### PR TITLE
Update the mapSDK puck in NavigationMapView with location course for bearing

### DIFF
--- a/Example/ViewController+FreeDrive.swift
+++ b/Example/ViewController+FreeDrive.swift
@@ -43,7 +43,6 @@ extension ViewController {
         
         if let location = notification.userInfo?[PassiveLocationManager.NotificationUserInfoKey.locationKey] as? CLLocation {
             trackStyledFeature.lineString.coordinates.append(contentsOf: [location.coordinate])
-            navigationMapView.moveUserLocation(to: location)
         }
         
         if let rawLocation = notification.userInfo?[PassiveLocationManager.NotificationUserInfoKey.rawLocationKey] as? CLLocation {

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -228,6 +228,10 @@ public class CarPlayManager: NSObject {
         let route = navigationService.route
         let routeOptions = navigationService.routeProgress.routeOptions
         
+        // Stop the background `PassiveLocationProvider` sending location and heading update `mapView` before turn-by-turn navigation session starts.
+        navigationMapView?.mapView.location.locationProvider.stopUpdatingLocation()
+        navigationMapView?.mapView.location.locationProvider.stopUpdatingHeading()
+        
         var trip = CPTrip(routes: [route], routeOptions: routeOptions, waypoints: routeOptions.waypoints)
         trip = delegate?.carPlayManager(self, willPreview: trip) ?? trip
         

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -151,6 +151,7 @@ extension NavigationMapView {
      */
     func updateTraveledRouteLine(_ coordinate: CLLocationCoordinate2D?) {
         guard let granularDistances = routeLineGranularDistances,let index = routeRemainingDistancesIndex, let location = coordinate else { return }
+        guard index < granularDistances.distanceArray.endIndex else { return }
         let traveledIndex = granularDistances.distanceArray[index]
         let upcomingPoint = traveledIndex.point
         
@@ -205,27 +206,8 @@ extension NavigationMapView {
         
         let congestionSegments = routeProgress.route.congestionFeatures(legIndex: currentLegIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
         
-        switch userLocationStyle {
-        
-        case .courseView:
-            let startDate = Date()
-            vanishingRouteLineUpdateTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true, block: { timer in
-                let timePassedInMilliseconds = Date().timeIntervalSince(startDate) * 1000
-                // In case if the time was already in the last interval - invalidate the timer and wait for the next routeProgress update.
-                if timePassedInMilliseconds >= 980 {
-                    timer.invalidate()
-                    return
-                }
-                
-                let newFractionTraveled = self.preFractionTraveled + traveledDifference * timePassedInMilliseconds.truncatingRemainder(dividingBy: 1000) / 1000
-                self.updateRouteLine(congestionSegments:congestionSegments, layerIdentifier: mainRouteLayerIdentifier, fractionTraveledUpdate: newFractionTraveled)
-                self.updateRouteLine(layerIdentifier: mainRouteCasingLayerIdentifier, fractionTraveledUpdate: newFractionTraveled)
-            })
-            
-        default:
-            self.updateRouteLine(congestionSegments:congestionSegments, layerIdentifier: mainRouteLayerIdentifier, fractionTraveledUpdate: fractionTraveled)
-            self.updateRouteLine(layerIdentifier: mainRouteCasingLayerIdentifier, fractionTraveledUpdate: fractionTraveled)
-        }
+        updateRouteLine(congestionSegments:congestionSegments, layerIdentifier: mainRouteLayerIdentifier, fractionTraveledUpdate: fractionTraveled)
+        updateRouteLine(layerIdentifier: mainRouteCasingLayerIdentifier, fractionTraveledUpdate: fractionTraveled)
     }
     
     func updateRouteLine(congestionSegments: [Turf.Feature]? = nil, layerIdentifier: String, fractionTraveledUpdate: Double) {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -474,7 +474,10 @@ open class NavigationMapView: UIView {
                                   animated: animated,
                                   navigationCameraState: navigationCamera.state)
             
-        default: break
+        default:
+            if simulatesLocation, let locationProvider = mapView.location.locationProvider {
+                mapView.location.locationProvider(locationProvider, didUpdateLocations: [location])
+            }
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -477,6 +477,7 @@ open class NavigationMapView: UIView {
         default:
             if simulatesLocation, let locationProvider = mapView.location.locationProvider {
                 mapView.location.locationProvider(locationProvider, didUpdateLocations: [location])
+                mapView.location.locationProvider.stopUpdatingLocation()
             }
         }
     }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -172,21 +172,12 @@ open class NavigationMapView: UIView {
         }
     }
     
-    var simulatesLocation: Bool = true {
-        didSet {
-            if simulatesLocation {
-                mapView.location.options.puckBearingSource = .course
-                
-            } else {
-                mapView.location.options.puckBearingSource = .heading
-            }
-        }
-    }
+    var simulatesLocation: Bool = true
     
     /**
      Specifies how the map displays the user’s current location, including the appearance and underlying implementation.
      
-     By default, this property is set to `UserLocationStyle.courseView`.
+     By default, this property is set to `UserLocationStyle.courseView`, the bearing source is location course.
      */
     public var userLocationStyle: UserLocationStyle = .courseView(UserPuckCourseView(frame: CGRect(origin: .zero, size: 75.0))) {
         didSet {
@@ -271,7 +262,7 @@ open class NavigationMapView: UIView {
                 self.mapView.location.options.puckType = .puck3D(configuration)
             }
         }
-        mapView.location.options.puckBearingSource = simulatesLocation ? .course : .heading
+        mapView.location.options.puckBearingSource = .course
     }
     
     deinit {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -344,6 +344,12 @@ open class NavigationMapView: UIView {
             case .courseView: self.moveUserLocation(to: location)
             default: break
             }
+            
+            if self.simulatesLocation {
+                if let locationProvider = self.mapView.location.locationProvider {
+                    self.mapView.location.locationProvider(locationProvider, didUpdateLocations: [location])
+                }
+            }
         }
         
         mapView.mapboxMap.onNext(.styleLoaded) { [weak self] _ in
@@ -474,11 +480,7 @@ open class NavigationMapView: UIView {
                                   animated: animated,
                                   navigationCameraState: navigationCamera.state)
             
-        default:
-            if simulatesLocation, let locationProvider = mapView.location.locationProvider {
-                mapView.location.locationProvider(locationProvider, didUpdateLocations: [location])
-                mapView.location.locationProvider.stopUpdatingLocation()
-            }
+        default: break
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -340,10 +340,7 @@ open class NavigationMapView: UIView {
         mapView.mapboxMap.onEvery(.renderFrameFinished) { [weak self] _ in
             guard let self = self,
                   let location = self.mostRecentUserCourseViewLocation else { return }
-            switch self.userLocationStyle {
-            case .courseView: self.moveUserLocation(to: location)
-            default: break
-            }
+            self.moveUserLocation(to: location)
             
             if self.simulatesLocation {
                 if let locationProvider = self.mapView.location.locationProvider {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -837,6 +837,8 @@ extension NavigationViewController: NavigationServiceDelegate {
         for component in navigationComponents {
             component.navigationService(service, didBeginSimulating: progress, becauseOf: reason)
         }
+        let simulatedLocationProvider = NavigationLocationProvider(locationManager: SimulatedLocationManager(routeProgress: progress))
+        navigationMapView?.mapView.location.overrideLocationProvider(with: simulatedLocationProvider)
     }
     
     public func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
@@ -850,6 +852,7 @@ extension NavigationViewController: NavigationServiceDelegate {
         for component in navigationComponents {
             component.navigationService(service, didEndSimulating: progress, becauseOf: reason)
         }
+        navigationMapView?.mapView.location.overrideLocationProvider(with: AppleLocationProvider())
     }
     
     private func checkTunnelState(at location: CLLocation, along progress: RouteProgress) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -836,6 +836,8 @@ extension NavigationViewController: NavigationServiceDelegate {
         for component in navigationComponents {
             component.navigationService(service, didBeginSimulating: progress, becauseOf: reason)
         }
+        let simulatedLocationProvider = NavigationLocationProvider(locationManager: SimulatedLocationManager(routeProgress: progress))
+        navigationMapView?.mapView.location.overrideLocationProvider(with: simulatedLocationProvider)
     }
     
     public func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
@@ -849,6 +851,7 @@ extension NavigationViewController: NavigationServiceDelegate {
         for component in navigationComponents {
             component.navigationService(service, didEndSimulating: progress, becauseOf: reason)
         }
+        navigationMapView?.mapView.location.overrideLocationProvider(with: AppleLocationProvider())
     }
     
     private func checkTunnelState(at location: CLLocation, along progress: RouteProgress) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -195,6 +195,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
         set {
             navigationMapView?.routeLineTracksTraversal = newValue
+            routeOverlayController?.routeLineTracksTraversal = newValue
         }
     }
 

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -842,7 +842,7 @@ extension NavigationViewController: NavigationServiceDelegate {
         for component in navigationComponents {
             component.navigationService(service, willEndSimulating: progress, becauseOf: reason)
         }
-        navigationMapView?.simulatesLocation = true
+        navigationMapView?.simulatesLocation = false
     }
     
     public func navigationService(_ service: NavigationService, didEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -837,8 +837,6 @@ extension NavigationViewController: NavigationServiceDelegate {
         for component in navigationComponents {
             component.navigationService(service, didBeginSimulating: progress, becauseOf: reason)
         }
-        let simulatedLocationProvider = NavigationLocationProvider(locationManager: SimulatedLocationManager(routeProgress: progress))
-        navigationMapView?.mapView.location.overrideLocationProvider(with: simulatedLocationProvider)
     }
     
     public func navigationService(_ service: NavigationService, willEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
@@ -852,7 +850,6 @@ extension NavigationViewController: NavigationServiceDelegate {
         for component in navigationComponents {
             component.navigationService(service, didEndSimulating: progress, becauseOf: reason)
         }
-        navigationMapView?.mapView.location.overrideLocationProvider(with: AppleLocationProvider())
     }
     
     private func checkTunnelState(at location: CLLocation, along progress: RouteProgress) {

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -1,11 +1,12 @@
 import MapboxDirections
 import MapboxCoreNavigation
+import MapboxMaps
 import CoreLocation
 import UIKit
 
 extension NavigationMapView {
     /// A component meant to assist displaying route line and related items like arrows, waypoints, annotations and other.
-    class RouteOverlayController: NavigationComponent, NavigationComponentDelegate {
+    class RouteOverlayController: NavigationComponent, NavigationComponentDelegate, LocationConsumer {
         
         // MARK: - Properties
         
@@ -20,12 +21,17 @@ extension NavigationMapView {
             navigationViewData.router
         }
         
-        fileprivate var routeLineTracksTraversal: Bool {
+        fileprivate var routeProgress: RouteProgress?
+        
+        var routeLineTracksTraversal: Bool {
             get {
                 navigationMapView.routeLineTracksTraversal
             }
             set {
                 navigationMapView.routeLineTracksTraversal = newValue
+                if newValue {
+                    navigationMapView.mapView.location.addLocationConsumer(newConsumer: self)
+                }
             }
         }
         
@@ -59,6 +65,12 @@ extension NavigationMapView {
             }
         }
         
+        internal func locationUpdate(newLocation: Location) {
+            guard routeLineTracksTraversal, let progress = routeProgress else { return }
+            navigationMapView.updateTraveledRouteLine(newLocation.coordinate)
+            navigationMapView.updateRoute(progress)
+        }
+        
         private func updateMapOverlays(for routeProgress: RouteProgress) {
             if routeProgress.currentLegProgress.followOnStep != nil {
                 navigationMapView.addArrow(route: routeProgress.route,
@@ -75,8 +87,7 @@ extension NavigationMapView {
             navigationMapView.show([routeProgress.route], legIndex: routeProgress.legIndex)
             if routeLineTracksTraversal {
                 navigationMapView.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
-                navigationMapView.updateTraveledRouteLine(router.location?.coordinate)
-                navigationMapView.updateRoute(routeProgress)
+                self.routeProgress = routeProgress
             }
         }
         
@@ -121,8 +132,7 @@ extension NavigationMapView {
             
             if routeLineTracksTraversal {
                 navigationMapView.updateUpcomingRoutePointIndex(routeProgress: progress)
-                navigationMapView.updateTraveledRouteLine(location.coordinate)
-                navigationMapView.updateRoute(progress)
+                routeProgress = progress
             }
         }
         


### PR DESCRIPTION
### Description
This pr is to fix #3105, to remove the manually puck heading update code in `navigationMapView.moveUserLocation(to:animated:)`  introduced in #2968 
- [x] fix #3105 , default the mapSDK puck use location course for puck bearing
- [x] fix #3069 , update the vanishing route line update with location consumer, synced with the location update from `mapView`

### Implementation
Use the `simulatesLocation` to switch between the `course` and `heading` as the puck bearing source, instead of manually stop and update the puck layer.

Create a `SimulatedLocationManger` based `NavigationLocationProvider` to provide location update during simulated session.

Add the `RouteOverlayController` as the location consumer for the `mapView`, to receive the location update.

Use the `renderFrameFinished` to check the location change under simulation, and push location update to allow the vanishing route line synced with puck.

Stop the location update from the CarPlay before navigation session starts, to avoid the background navigator trigger.

### Screenshots or Gifs
![puckUpdate](https://user-images.githubusercontent.com/48976398/124044432-4043cc80-d9c2-11eb-844c-2d49362c2ec5.gif)


