### PR TITLE
Fix style image flipping in current road name label

### DIFF
--- a/Sources/MapboxNavigation/WayNameView.swift
+++ b/Sources/MapboxNavigation/WayNameView.swift
@@ -123,12 +123,12 @@ open class WayNameView: UIView {
     }
     
     private func roadShieldAttributedText(for text: String, textColor: UIColor, style: MapboxMaps.Style?, imageName: String) -> NSAttributedString? {
-        guard let image = style?.image(withId: imageName)?.cgImage else { return nil }
+        guard let image = style?.image(withId: imageName) else { return nil }
         let attachment = ShieldAttachment()
-        attachment.image = UIImage(cgImage: image).withCenteredText(text,
-                                                                    color: textColor,
-                                                                    font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize),
-                                                                    scale: UIScreen.main.scale)
+        attachment.image = image.withCenteredText(text,
+                                                  color: textColor,
+                                                  font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize),
+                                                  scale: UIScreen.main.scale)
         return NSAttributedString(attachment: attachment)
     }
 }


### PR DESCRIPTION
Fixed vertical flipping of the route shield in the current road name label. As of mapbox/mapbox-maps-ios#321, the UIImage returned by `Style.image(withId:)` has `downMirrored` orientation and a specific scale by virtue of using [this conversion utility](https://github.com/mapbox/mapbox-maps-ios/blob/1a0505c37410f9629771480f34e37356d9f6ff54/Sources/MapboxMaps/Foundation/Extensions/UIImage.swift#L32). Extracting the CGImage and stuffing it in a new UIImage erases that metadata, resulting in flipping and potentially incorrect scaling. Removing that unnecessary indirection fixes the flipping:

<img src="https://user-images.githubusercontent.com/1231218/123713017-53229980-d828-11eb-8d01-fa2b65637c21.png" width="300" alt="right side up">

<img src="https://user-images.githubusercontent.com/1231218/123713188-b4e30380-d828-11eb-8aa5-fa9671b6665c.png" width="300" alt="this side up">

Fixes #3124.

/cc @mapbox/navigation-ios