### PR TITLE
Improve performance of Array.boundingBoxPoints by 5x

### DIFF
--- a/Sources/MapboxNavigation/Array.swift
+++ b/Sources/MapboxNavigation/Array.swift
@@ -125,23 +125,35 @@ extension Array where Iterator.Element == CLLocationCoordinate2D {
 }
 
 extension Array where Iterator.Element == CGPoint {
-    
     var boundingBoxPoints: [CGPoint] {
-        let yCoordinates = self.map({ $0.y })
-        let xCoordinates = self.map({ $0.x })
-        if let yMax = yCoordinates.max(),
-           let xMin = xCoordinates.min(),
-           let yMin = yCoordinates.min(),
-           let xMax = xCoordinates.max() {
-            let topLeftPoint = CGPoint(x: xMin, y: yMin)
-            let topRightPoint = CGPoint(x: xMax, y: yMin)
-            let bottomRightPoint = CGPoint(x: xMax, y: yMax)
-            let bottomLeftPoint = CGPoint(x: xMin, y: yMax)
-            
-            return [topLeftPoint, topRightPoint, bottomRightPoint, bottomLeftPoint]
+        guard !isEmpty else { return [] }
+
+        var xMin: CGFloat = CGFloat.greatestFiniteMagnitude
+        var yMin: CGFloat = CGFloat.greatestFiniteMagnitude
+        var xMax: CGFloat = CGFloat.leastNormalMagnitude
+        var yMax: CGFloat = CGFloat.leastNormalMagnitude
+
+        for point in self {
+            if point.x < xMin {
+                xMin = point.x
+            }
+            if point.x > xMax {
+                xMax = point.x
+            }
+            if point.y < yMin {
+                yMin = point.y
+            }
+            if point.y > yMax {
+                yMax = point.y
+            }
         }
-        
-        return []
+
+        let topLeftPoint = CGPoint(x: xMin, y: yMin)
+        let topRightPoint = CGPoint(x: xMax, y: yMin)
+        let bottomRightPoint = CGPoint(x: xMax, y: yMax)
+        let bottomLeftPoint = CGPoint(x: xMin, y: yMax)
+
+        return [topLeftPoint, topRightPoint, bottomRightPoint, bottomLeftPoint]
     }
 }
 

--- a/Tests/MapboxNavigationTests/ArrayTests.swift
+++ b/Tests/MapboxNavigationTests/ArrayTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import XCTest
+@testable import MapboxNavigation
+
+final class ArrayTests: XCTestCase {
+    static let largePointsArray: [CGPoint] = {
+        var points: [CGPoint] = []
+        for _ in 0..<100000 {
+            points.append(
+                .init(
+                    x: CGFloat.random(in: 0..<1000),
+                    y: CGFloat.random(in: 0..<1000)
+                )
+            )
+        }
+        return points
+    }()
+
+    func testBoundingBoxPointsPerformance() {
+        let points = Self.largePointsArray
+
+        measure {
+            _ = points.boundingBoxPoints
+        }
+    }
+}
+


### PR DESCRIPTION
Instead of iterating by all points many times, we can solve the problem
in one iteration.

<img width="947" alt="Screenshot 2021-06-29 at 10 14 14" src="https://user-images.githubusercontent.com/413986/123755854-017c1c80-d8c5-11eb-957a-17131da3d71c.png">
