### PR TITLE
Add ability to pass custom config through `UserDefaults`

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		11D1F89E269601150053A93F /* NativeHandlersFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F89D269601150053A93F /* NativeHandlersFactoryTests.swift */; };
-		11D1F8A02696048D0053A93F /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F89F2696048D0053A93F /* Dictionary.swift */; };
+		11D1F8A02696048D0053A93F /* Dictionary+DeepMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F89F2696048D0053A93F /* Dictionary+DeepMerge.swift */; };
+		11D1F8A22696EBD40053A93F /* Dictionary+Equality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F8A12696EBD40053A93F /* Dictionary+Equality.swift */; };
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
 		160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D827A2059973C00D278D6 /* DataCacheTests.swift */; };
 		162039CF216C348500875F5C /* NavigationEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162039CE216C348500875F5C /* NavigationEventsManagerTests.swift */; };
@@ -458,7 +459,8 @@
 
 /* Begin PBXFileReference section */
 		11D1F89D269601150053A93F /* NativeHandlersFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeHandlersFactoryTests.swift; sourceTree = "<group>"; };
-		11D1F89F2696048D0053A93F /* Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
+		11D1F89F2696048D0053A93F /* Dictionary+DeepMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+DeepMerge.swift"; sourceTree = "<group>"; };
+		11D1F8A12696EBD40053A93F /* Dictionary+Equality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Equality.swift"; sourceTree = "<group>"; };
 		160D8278205996DA00D278D6 /* DataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
 		160D827A2059973C00D278D6 /* DataCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCacheTests.swift; sourceTree = "<group>"; };
 		162039CE216C348500875F5C /* NavigationEventsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEventsManagerTests.swift; sourceTree = "<group>"; };
@@ -1160,6 +1162,7 @@
 			isa = PBXGroup;
 			children = (
 				3A163ADF249901C300D66A0D /* RouteStateTests.swift */,
+				11D1F8A12696EBD40053A93F /* Dictionary+Equality.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1519,7 +1522,7 @@
 				C561735A1F182113005954F6 /* RouteStep.swift */,
 				351927351F0FA072003A702D /* ScreenCapture.swift */,
 				3A8187C824BDAE9C00708F19 /* URLSession.swift */,
-				11D1F89F2696048D0053A93F /* Dictionary.swift */,
+				11D1F89F2696048D0053A93F /* Dictionary+DeepMerge.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2391,6 +2394,7 @@
 				353E68FC1EF0B7F8007B2AE5 /* NavigationLocationManager.swift in Sources */,
 				2BE7013D25359C7B00F46E4E /* RouteAlert.swift in Sources */,
 				353E68FE1EF0B985007B2AE5 /* BundleAdditions.swift in Sources */,
+				11D1F8A22696EBD40053A93F /* Dictionary+Equality.swift in Sources */,
 				354A9BCD20EA9C8100F03325 /* CoreFeedbackEvent.swift in Sources */,
 				2EFAE005264C1F9200B618C4 /* RoadObjectLocation.swift in Sources */,
 				2BE70189253734A000F46E4E /* TollCollection.swift in Sources */,
@@ -2425,7 +2429,7 @@
 				2BBED92F265E2C7D00F90032 /* NativeHandlersFactory.swift in Sources */,
 				4303A3992332CD6200B5737D /* UnimplementedLogging.swift in Sources */,
 				2E6656F9264EC912009463EE /* Result+Expected.swift in Sources */,
-				11D1F8A02696048D0053A93F /* Dictionary.swift in Sources */,
+				11D1F8A02696048D0053A93F /* Dictionary+DeepMerge.swift in Sources */,
 				3A163AE3249901D000D66A0D /* FixLocation.swift in Sources */,
 				DA5F44AA25F07A6800F573EC /* RoadObjectType.swift in Sources */,
 				2E50E0D2264E468B009D3848 /* RoadObjectMatcherError.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11D1F89E269601150053A93F /* NativeHandlersFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F89D269601150053A93F /* NativeHandlersFactoryTests.swift */; };
+		11D1F8A02696048D0053A93F /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F89F2696048D0053A93F /* Dictionary.swift */; };
 		160D8279205996DA00D278D6 /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D8278205996DA00D278D6 /* DataCache.swift */; };
 		160D827B2059973C00D278D6 /* DataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160D827A2059973C00D278D6 /* DataCacheTests.swift */; };
 		162039CF216C348500875F5C /* NavigationEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162039CE216C348500875F5C /* NavigationEventsManagerTests.swift */; };
@@ -455,6 +457,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		11D1F89D269601150053A93F /* NativeHandlersFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeHandlersFactoryTests.swift; sourceTree = "<group>"; };
+		11D1F89F2696048D0053A93F /* Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		160D8278205996DA00D278D6 /* DataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
 		160D827A2059973C00D278D6 /* DataCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCacheTests.swift; sourceTree = "<group>"; };
 		162039CE216C348500875F5C /* NavigationEventsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEventsManagerTests.swift; sourceTree = "<group>"; };
@@ -1515,6 +1519,7 @@
 				C561735A1F182113005954F6 /* RouteStep.swift */,
 				351927351F0FA072003A702D /* ScreenCapture.swift */,
 				3A8187C824BDAE9C00708F19 /* URLSession.swift */,
+				11D1F89F2696048D0053A93F /* Dictionary.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1602,6 +1607,7 @@
 				3A163AE1249901D000D66A0D /* Extensions */,
 				DAD903AE23E3DCC80057CF1F /* DateTests.swift */,
 				359A8AEC1FA78D3000BDB486 /* DistanceFormatterTests.swift */,
+				11D1F89D269601150053A93F /* NativeHandlersFactoryTests.swift */,
 				C5ADFBD91DDCC7840011824B /* Info.plist */,
 				359574A91F28CCBB00838209 /* LocationTests.swift */,
 				C5BF7370206AB0DE00CDBB6D /* MapboxCoreNavigationTests-Bridging-Header.h */,
@@ -2419,6 +2425,7 @@
 				2BBED92F265E2C7D00F90032 /* NativeHandlersFactory.swift in Sources */,
 				4303A3992332CD6200B5737D /* UnimplementedLogging.swift in Sources */,
 				2E6656F9264EC912009463EE /* Result+Expected.swift in Sources */,
+				11D1F8A02696048D0053A93F /* Dictionary.swift in Sources */,
 				3A163AE3249901D000D66A0D /* FixLocation.swift in Sources */,
 				DA5F44AA25F07A6800F573EC /* RoadObjectType.swift in Sources */,
 				2E50E0D2264E468B009D3848 /* RoadObjectMatcherError.swift in Sources */,
@@ -2476,6 +2483,7 @@
 				35EF782A212C324E001B4BB5 /* TunnelAuthorityTests.swift in Sources */,
 				3A163AE0249901C300D66A0D /* RouteStateTests.swift in Sources */,
 				C5ABB50E20408D2C00AFA92C /* NavigationServiceTests.swift in Sources */,
+				11D1F89E269601150053A93F /* NativeHandlersFactoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/MapboxCoreNavigation/Dictionary+DeepMerge.swift
+++ b/Sources/MapboxCoreNavigation/Dictionary+DeepMerge.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 extension Dictionary where Value == Any {
-    mutating func deepMerge(with dictionary: Dictionary) {
+    mutating func deepMerge(with dictionary: Dictionary, uniquingKeysWith combine: @escaping (Value, Value) -> Value) {
         merge(dictionary) { (current, new) in
             guard var currentDict = current as? Dictionary, let newDict = new as? Dictionary else {
-                return current
+                return combine(current, new)
             }
-            currentDict.deepMerge(with: newDict)
+            currentDict.deepMerge(with: newDict, uniquingKeysWith: combine)
             return currentDict
         }
     }

--- a/Sources/MapboxCoreNavigation/Dictionary.swift
+++ b/Sources/MapboxCoreNavigation/Dictionary.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension Dictionary where Value == Any {
+    mutating func deepMerge(with dictionary: Dictionary) {
+        merge(dictionary) { (current, new) in
+            guard var currentDict = current as? Dictionary, let newDict = new as? Dictionary else {
+                return current
+            }
+            currentDict.deepMerge(with: newDict)
+            return currentDict
+        }
+    }
+}

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -2,7 +2,8 @@ import MapboxNavigationNative
 import MapboxDirections
 import Foundation
 
-private let customConfigKey = "com.mapbox.navigation.custom-config"
+public let customConfigKey = "com.mapbox.navigation.custom-config"
+public let customConfigFeaturesKey = "features"
 
 /// Internal class, designed for handling initialisation of various NavigationNative entities.
 ///
@@ -87,18 +88,21 @@ class NativeHandlersFactory {
     
     lazy var configHandle: ConfigHandle = {
         let historyAutorecordingConfig = [
-            "features": [
+            customConfigFeaturesKey: [
                 "historyAutorecording": true
             ]
         ]
         
         var customConfig = UserDefaults.standard.dictionary(forKey: customConfigKey) ?? [:]
-        customConfig.deepMerge(with: historyAutorecordingConfig)
+        customConfig.deepMerge(with: historyAutorecordingConfig, uniquingKeysWith: { first, _ in first })
         
-        var customConfigJSON = ""
+        let customConfigJSON: String
         if let jsonDataConfig = try? JSONSerialization.data(withJSONObject: customConfig, options: []),
            let encodedConfig = String(data: jsonDataConfig, encoding: .utf8) {
             customConfigJSON = encodedConfig
+        } else {
+            assertionFailure("Custom config can not be serialized")
+            customConfigJSON = ""
         }
         
         let navigatorConfig = NavigatorConfig(voiceInstructionThreshold: nil,

--- a/Tests/MapboxCoreNavigationTests/Extensions/Dictionary+Equality.swift
+++ b/Tests/MapboxCoreNavigationTests/Extensions/Dictionary+Equality.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+func ==(lhs: [String: Any], rhs: [String: Any] ) -> Bool {
+    return NSDictionary(dictionary: lhs).isEqual(to: rhs)
+}

--- a/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 import MapboxNavigationNative
+import MapboxDirections
+import TestHelper
 @testable import MapboxCoreNavigation
 
 private let customConfigKey = "com.mapbox.navigation.custom-config"
@@ -23,6 +25,7 @@ class NativeHandlersFactoryTests: XCTestCase {
     override func setUp() {
         UserDefaults.standard.set(nil, forKey: customConfigKey)
         handlersFactory = NativeHandlersFactory(tileStorePath: "tile store path",
+                                                credentials: Fixture.credentials,
                                                 configFactoryType: ConfigFactorySpy.self)
     }
     

--- a/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import MapboxNavigationNative
+@testable import MapboxCoreNavigation
+
+private let customConfigKey = "com.mapbox.navigation.custom-config"
+
+class ConfigFactorySpy: ConfigFactory {
+    
+    static var passedCustomConfig: String?
+    
+    override class func build(for profile: SettingsProfile,
+                              config: NavigatorConfig,
+                              customConfig: String) -> ConfigHandle {
+        passedCustomConfig = customConfig
+        return super.build(for: profile, config: config, customConfig: customConfig)
+    }
+}
+
+class NativeHandlersFactoryTests: XCTestCase {
+    
+    var handlersFactory: NativeHandlersFactory!
+    
+    override func setUp() {
+        UserDefaults.standard.set(nil, forKey: customConfigKey)
+        handlersFactory = NativeHandlersFactory(tileStorePath: "tile store path",
+                                                configFactoryType: ConfigFactorySpy.self)
+    }
+    
+    func testDefaultCustomConfig() {
+        let expectedCustomConfig = customConfig(from: [
+            "features": [
+                "historyAutorecording": true
+            ]
+        ])
+        _ = handlersFactory.configHandle
+        XCTAssertEqual(ConfigFactorySpy.passedCustomConfig, expectedCustomConfig)
+    }
+    
+    func testCustomConfigFromUserDefatuls() {
+        UserDefaults.standard.set([
+            "features": [
+                "custom_feature_key": "custom_feature_value"
+            ]
+        ], forKey: customConfigKey)
+        let expectedCustomConfig = customConfig(from: [
+            "features": [
+                "historyAutorecording": true,
+                "custom_feature_key": "custom_feature_value"
+            ]
+        ])
+        _ = handlersFactory.configHandle
+        XCTAssertEqual(ConfigFactorySpy.passedCustomConfig, expectedCustomConfig)
+    }
+    
+    func testUserDefaultsOverwritesDefaultCustomConfig() {
+        UserDefaults.standard.set([
+            "features": [
+                "historyAutorecording": false
+            ]
+        ], forKey: customConfigKey)
+        let expectedCustomConfig = customConfig(from: [
+            "features": [
+                "historyAutorecording": false
+            ]
+        ])
+        _ = handlersFactory.configHandle
+        XCTAssertEqual(ConfigFactorySpy.passedCustomConfig, expectedCustomConfig)
+    }
+    
+    // MARK: Helpers
+    
+    private func customConfig(from dictionary: [String: Any]) -> String {
+        let data = (try? JSONSerialization.data(withJSONObject: dictionary, options: [])) ?? Data()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
@@ -27,13 +27,14 @@ class NativeHandlersFactoryTests: XCTestCase {
     }
     
     func testDefaultCustomConfig() {
-        let expectedCustomConfig = customConfig(from: [
+        let expectedCustomConfig: [String: Any] = [
             "features": [
                 "historyAutorecording": true
             ]
-        ])
+        ]
         _ = handlersFactory.configHandle
-        XCTAssertEqual(ConfigFactorySpy.passedCustomConfig, expectedCustomConfig)
+        let config = customConfig(from: ConfigFactorySpy.passedCustomConfig)
+        XCTAssertTrue(config == expectedCustomConfig)
     }
     
     func testCustomConfigFromUserDefatuls() {
@@ -42,14 +43,15 @@ class NativeHandlersFactoryTests: XCTestCase {
                 "custom_feature_key": "custom_feature_value"
             ]
         ], forKey: customConfigKey)
-        let expectedCustomConfig = customConfig(from: [
+        let expectedCustomConfig = [
             "features": [
                 "historyAutorecording": true,
                 "custom_feature_key": "custom_feature_value"
             ]
-        ])
+        ]
         _ = handlersFactory.configHandle
-        XCTAssertEqual(ConfigFactorySpy.passedCustomConfig, expectedCustomConfig)
+        let config = customConfig(from: ConfigFactorySpy.passedCustomConfig)
+        XCTAssertTrue(config == expectedCustomConfig)
     }
     
     func testUserDefaultsOverwritesDefaultCustomConfig() {
@@ -58,19 +60,21 @@ class NativeHandlersFactoryTests: XCTestCase {
                 "historyAutorecording": false
             ]
         ], forKey: customConfigKey)
-        let expectedCustomConfig = customConfig(from: [
+        let expectedCustomConfig = [
             "features": [
                 "historyAutorecording": false
             ]
-        ])
+        ]
         _ = handlersFactory.configHandle
-        XCTAssertEqual(ConfigFactorySpy.passedCustomConfig, expectedCustomConfig)
+        let config = customConfig(from: ConfigFactorySpy.passedCustomConfig)
+        XCTAssertTrue(config == expectedCustomConfig)
     }
     
     // MARK: Helpers
     
-    private func customConfig(from dictionary: [String: Any]) -> String {
-        let data = (try? JSONSerialization.data(withJSONObject: dictionary, options: [])) ?? Data()
-        return String(data: data, encoding: .utf8) ?? ""
+    private func customConfig(from string: String?) -> [String: Any] {
+        let stringData = string?.data(using: .utf8) ?? Data()
+        let config = try? JSONSerialization.jsonObject(with: stringData, options: []) as? [String: Any]
+        return config ?? [:]
     }
 }


### PR DESCRIPTION
### Description
Add ability to pass custom navigation config through UserDefaults. The default config will be deep-merged with the application-provided config and the second one will take preference in case of merge conflicts.

Also added new test approach, any feedback will be appreciated.