### PR TITLE
Allow the hard stop of route line gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 * Increased stability of unit tests by addressing sporadic failures. ([#3089](https://github.com/mapbox/mapbox-navigation-ios/pull/3089))([#3072](https://github.com/mapbox/mapbox-navigation-ios/pull/3072))
 * Fixed a retain cycle in `UserCourseView`. ([#3120](https://github.com/mapbox/mapbox-navigation-ios/issues/3120))
 * `EventsManagerDataSource.router`, `NavigationService.router`, `NavigationService.eventsManager`, `MapboxNavigationService.router`, `MapboxNavigationService.eventsManager` properties are not longer force unwrapped. ([#3055](https://github.com/mapbox/mapbox-navigation-ios/pull/3055))
+* Disabled the blurring line gradient of route line with hard stops. ([#3153](https://github.com/mapbox/mapbox-navigation-ios/pull/3153))
 
 ## v1.4.1
 

--- a/Sources/MapboxNavigation/Expression.swift
+++ b/Sources/MapboxNavigation/Expression.swift
@@ -10,10 +10,10 @@ extension Expression {
         }
     }
     
-    static func routeLineGradientExpression(_ gradientStops: [Double: UIColor]) -> Expression {
-        return Exp(.interpolate) {
-            Exp(.linear)
+    static func routeLineGradientExpression(_ gradientStops: [Double: UIColor], lineBaseColor: UIColor) -> Expression {
+        return Exp(.step) {
             Exp(.lineProgress)
+            lineBaseColor
             gradientStops
         }
     }

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -216,13 +216,13 @@ extension NavigationMapView {
                 try mapView.mapboxMap.style.updateLayer(withId: layerIdentifier) { (lineLayer: inout LineLayer) throws in
                     let mainRouteLayerGradient = self.routeLineGradient(congestionSegments,
                                                                         fractionTraveled: fractionTraveledUpdate)
-                    lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient))
+                    lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor))
                 }
             } else {
                 try mapView.mapboxMap.style.updateLayer(withId: layerIdentifier) { (lineLayer: inout LineLayer) throws in
                     let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveledUpdate)
                     
-                    lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient))
+                    lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient, lineBaseColor: routeCasingColor))
                 }
             }
         } catch {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -582,13 +582,13 @@ open class NavigationMapView: UIView {
                 let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
                 let gradientStops = routeLineGradient(congestionFeatures,
                                                       fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
-                lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops)))
+                lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops, lineBaseColor: trafficUnknownColor)))
             } else {
                 if showsCongestionForAlternativeRoutes {
                     let gradientStops = routeLineGradient(route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels),
                                                           fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0,
                                                           isMain: false)
-                    lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops)))
+                    lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops, lineBaseColor: trafficUnknownColor)))
                 } else {
                     lineLayer?.lineColor = .constant(.init(color: routeAlternateColor))
                 }
@@ -644,7 +644,7 @@ open class NavigationMapView: UIView {
             
             if isMainRoute {
                 let gradientStops = routeLineGradient(fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
-                lineLayer?.lineGradient = .expression(Expression.routeLineGradientExpression(gradientStops))
+                lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops, lineBaseColor: routeCasingColor)))
             } else {
                 lineLayer?.lineColor = .constant(.init(color: routeAlternateCasingColor))
             }


### PR DESCRIPTION
### Description
This pr is to allow the hard stop and abrupt change of congestion level without the blurring effect on route line layer.

### Implementation
Use `Step` instead of the `interpolate ` in expression.

### Screenshots or Gifs

![Stop_Example](https://user-images.githubusercontent.com/48976398/124803809-6b707380-df0e-11eb-92c1-94b4a4d725cd.png)

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->