### PR TITLE
Restart history recording before finishing writing history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 * Fixed an issue where `RouteController` or `PassiveLocationManager` sometimes snapped the user’s location assuming a path that violated a turn restriction. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Improved performance and decreased memory usage when downloading routing tiles. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Renamed `PassiveLocationManager.startUpdatingLocation(completionHandler:)` to `PassiveLocationProvider.startUpdatingLocation()`. This method now runs synchronously like `CLLocationManager.startUpdatingLocation()`. ([#2823](https://github.com/mapbox/mapbox-navigation-ios/pull/2823))
-* Added the `RouteController.historyDirectoryURL` property and `RouteController.writeHistory(completionHandler:)` method for recording details about a trip for debugging purposes. ([#2930](https://github.com/mapbox/mapbox-navigation-ios/pull/2930))
+* Added the  `RouteController.startRecordingHistory()`, `RouteController.stopRecordingHistory(completionHandler:)`,  `PassiveLocationManager.startRecordingHistory()`, and `PassiveLocationManager.stopRecordingHistory(completionHandler:)` methods for recording details about a trip for debugging purposes. ([#2930](https://github.com/mapbox/mapbox-navigation-ios/pull/2930))
 
 ### Electronic horizon
 

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -111,7 +111,6 @@ class Navigator {
         navigator.setElectronicHorizonObserverFor(self)
         navigator.addObserver(for: self)
         navigator.setFallbackVersionsObserverFor(self)
-        historyRecorder?.startRecording()
     }
     
     private func unsubscribeNavigator() {
@@ -132,19 +131,33 @@ class Navigator {
     private(set) var historyRecorder: HistoryRecorderHandle?
     
     /**
-     Store history to the directory stored in `Navigator.historyDirectoryURL` and asynchronously run a callback
-     when writing finishes.
+     Starts recording history for debugging purposes.
      
-     - parameter completionHandler: A block object to be executed when history dumping ends.
+     - postcondition: Use the `stopRecordingHistory(writingFileWith:)` method to stop recording history and write the recorded history to a file.
      */
-    func writeHistory(completionHandler: @escaping (URL?) -> Void) {
-        historyRecorder?.stopRecording { [weak self] (path) in
+    func startRecordingHistory() {
+        historyRecorder?.startRecording()
+    }
+    
+    /**
+     Stops recording history, asynchronously writing any recorded history to a file.
+     
+     Upon completion, the completion handler is called with the URL to a file in the directory specified by `Navigator.historyDirectoryURL`.
+     
+     This method immediately stops recording history, though the file may take longer to prepare.
+     
+     - precondition: Use the `startRecordingHistory()` method to begin recording history. If the `startRecordingHistory()` method has not been called, this method has no effect.
+     - postcondition: To write history incrementally without an interruption in history recording, use the `startRecordingHistory()` method immediately after this method. If you use the `startRecordingHistory()` method inside the completion handler of this method, history recording will be paused while the file is being prepared.
+     
+     - parameter completionHandler: A closure to be executed when the history file is ready.
+     */
+    func stopRecordingHistory(writingFileWith completionHandler: @escaping (URL?) -> Void) {
+        historyRecorder?.stopRecording { (path) in
             if let path = path {
                 completionHandler(URL(fileURLWithPath: path))
             } else {
                 completionHandler(nil)
             }
-            self?.historyRecorder?.startRecording()
         }
     }
     

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -21,47 +21,15 @@ class Navigator {
      */
     static var tilesURL: URL? = nil
     
-    /**
-     Path to the directory where history file could be stored when `Navigator.writeHistory(completionHandler:)` is called.
-     
-     Setting `nil` disables history recording. Defaults to `nil`.
-     */
-    static var historyDirectoryURL: URL? = nil
-    
-    /**
-     Store history to the directory stored in `Navigator.historyDirectoryURL` and asynchronously run a callback
-     when writing finishes.
-     
-     - parameter completionHandler: A block object to be executed when history dumping ends.
-     */
-    func writeHistory(completionHandler: @escaping (URL?) -> Void) {
-        historyRecorder?.stopRecording { [weak self] (path) in
-            if let path = path {
-                completionHandler(URL(fileURLWithPath: path))
-            } else {
-                completionHandler(nil)
-            }
-            self?.historyRecorder?.startRecording()
-        }
-    }
-    
-    private(set) var historyRecorder: HistoryRecorderHandle?
-    
     private(set) var navigator: MapboxNavigationNative.Navigator
     
     private(set) var cacheHandle: CacheHandle
-    
-    private(set) var roadGraph: RoadGraph
     
     lazy var routerInterface: MapboxNavigationNative.RouterInterface = {
         return MapboxNavigationNative.RouterFactory.build(for: .hybrid,
                                                           cache: cacheHandle,
                                                           historyRecorder: historyRecorder)
     }()
-
-    private(set) var roadObjectStore: RoadObjectStore
-
-    private(set) var roadObjectMatcher: RoadObjectMatcher
 
     private(set) var tileStore: TileStore
     
@@ -151,6 +119,42 @@ class Navigator {
         navigator.removeObserver(for: self)
         navigator.setFallbackVersionsObserverFor(nil)
     }
+    
+    // MARK: History
+    
+    /**
+     Path to the directory where history file could be stored when `Navigator.writeHistory(completionHandler:)` is called.
+     
+     Setting `nil` disables history recording. Defaults to `nil`.
+     */
+    static var historyDirectoryURL: URL? = nil
+    
+    private(set) var historyRecorder: HistoryRecorderHandle?
+    
+    /**
+     Store history to the directory stored in `Navigator.historyDirectoryURL` and asynchronously run a callback
+     when writing finishes.
+     
+     - parameter completionHandler: A block object to be executed when history dumping ends.
+     */
+    func writeHistory(completionHandler: @escaping (URL?) -> Void) {
+        historyRecorder?.stopRecording { [weak self] (path) in
+            if let path = path {
+                completionHandler(URL(fileURLWithPath: path))
+            } else {
+                completionHandler(nil)
+            }
+            self?.historyRecorder?.startRecording()
+        }
+    }
+    
+    // MARK: Electronic horizon
+    
+    private(set) var roadGraph: RoadGraph
+
+    private(set) var roadObjectStore: RoadObjectStore
+
+    private(set) var roadObjectMatcher: RoadObjectMatcher
      
     private func setupElectronicHorizonOptions() {
         let nativeOptions = electronicHorizonOptions.map(MapboxNavigationNative.ElectronicHorizonOptions.init)

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -204,20 +204,33 @@ open class PassiveLocationManager: NSObject {
     }
     
     /**
+     Starts recording history for debugging purposes.
+     
+     - postcondition: Use the `stopRecordingHistory(writingFileWith:)` method to stop recording history and write the recorded history to a file.
+     */
+    public static func startRecordingHistory() {
+        Navigator.shared.startRecordingHistory()
+    }
+    
+    /**
      A closure to be called when history writing ends.
      
      - parameter historyFileURL: A path to file, where history was written to.
      */
-    public typealias WriteHistoryCompletionHandler = (_ historyFileURL: URL?) -> Void
+    public typealias HistoryFileWritingCompletionHandler = (_ historyFileURL: URL?) -> Void
     
     /**
-     Store history to the directory stored in `PassiveLocationManager.historyDirectoryURL` and asynchronously run a callback
-     when writing finishes.
+     Stops recording history, asynchronously writing any recorded history to a file.
      
-     - parameter completion: A block object to be executed when history writing ends.
+     Upon completion, the completion handler is called with the URL to a file in the directory specified by `PassiveLocationManager.historyDirectoryURL`. The file contains details about the passive location manager’s activity that may be useful to include when reporting an issue to Mapbox.
+     
+     - precondition: Use the `startRecordingHistory()` method to begin recording history. If the `startRecordingHistory()` method has not been called, this method has no effect.
+     - postcondition: To write history incrementally without an interruption in history recording, use the `startRecordingHistory()` method immediately after this method. If you use the `startRecordingHistory()` method inside the completion handler of this method, history recording will be paused while the file is being prepared.
+     
+     - parameter completionHandler: A closure to be executed when the history file is ready.
      */
-    public static func writeHistory(completionHandler: @escaping WriteHistoryCompletionHandler) {
-        Navigator.shared.writeHistory(completionHandler: completionHandler)
+    public static func stopRecordingHistory(writingFileWith completionHandler: @escaping HistoryFileWritingCompletionHandler) {
+        Navigator.shared.stopRecordingHistory(writingFileWith: completionHandler)
     }
 }
 

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -72,35 +72,6 @@ open class PassiveLocationManager: NSObject {
     public func startUpdatingLocation() {
         systemLocationManager.startUpdatingLocation()
     }
-
-    /**
-     A custom configuration for electronic horizon observations.
-     
-     Set this property to `nil` to use the default configuration.
-     */
-    public var electronicHorizonOptions: ElectronicHorizonOptions? {
-        get {
-            Navigator.shared.electronicHorizonOptions
-        }
-        set {
-            Navigator.shared.electronicHorizonOptions = newValue
-        }
-    }
-    
-    /// The road graph that is updated as the passive location manager tracks the user’s location.
-    public var roadGraph: RoadGraph {
-        return Navigator.shared.roadGraph
-    }
-    
-    /// The road object store that is updated as the passive location manager tracks the user’s location.
-    public var roadObjectStore: RoadObjectStore {
-        return Navigator.shared.roadObjectStore
-    }
-
-    /// The road object matcher that allows to match user-defined road objects.
-    public var roadObjectMatcher: RoadObjectMatcher {
-        return Navigator.shared.roadObjectMatcher
-    }
     
     var lastRawLocation: CLLocation?
     
@@ -189,6 +160,39 @@ open class PassiveLocationManager: NSObject {
     private func unsubscribeNotifications() {
         NotificationCenter.default.removeObserver(self)
     }
+    
+    // MARK: Accessing Relevant Routing Data
+    
+    /**
+     A custom configuration for electronic horizon observations.
+     
+     Set this property to `nil` to use the default configuration.
+     */
+    public var electronicHorizonOptions: ElectronicHorizonOptions? {
+        get {
+            Navigator.shared.electronicHorizonOptions
+        }
+        set {
+            Navigator.shared.electronicHorizonOptions = newValue
+        }
+    }
+    
+    /// The road graph that is updated as the passive location manager tracks the user’s location.
+    public var roadGraph: RoadGraph {
+        return Navigator.shared.roadGraph
+    }
+    
+    /// The road object store that is updated as the passive location manager tracks the user’s location.
+    public var roadObjectStore: RoadObjectStore {
+        return Navigator.shared.roadObjectStore
+    }
+
+    /// The road object matcher that allows to match user-defined road objects.
+    public var roadObjectMatcher: RoadObjectMatcher {
+        return Navigator.shared.roadObjectMatcher
+    }
+    
+    // MARK: Recording History to Diagnose Problems
     
     /**
      Path to the directory where history could be stored when `PassiveLocationManager.writeHistory(completionHandler:)` is called.

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -215,7 +215,7 @@ open class PassiveLocationManager: NSObject {
     /**
      A closure to be called when history writing ends.
      
-     - parameter historyFileURL: A path to file, where history was written to.
+     - parameter historyFileURL: A URL to the file that contains history data. This argument is `nil` if no history data has been written because history recording has not yet begun. Use the `startRecordingHistory()` method to begin recording before attempting to write a history file.
      */
     public typealias HistoryFileWritingCompletionHandler = (_ historyFileURL: URL?) -> Void
     

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -432,31 +432,7 @@ open class RouteController: NSObject {
         updateRouteLeg(to: routeProgress.legIndex + 1)
     }
     
-    /**
-     Path to the directory where history could be stored when `RouteController.writeHistory(completionHandler:)` is called.
-     */
-    public static var historyDirectoryURL: URL? = nil {
-        didSet {
-            Navigator.historyDirectoryURL = historyDirectoryURL
-        }
-    }
-    
-    /**
-     A closure to be called when history writing ends.
-     
-     - parameter historyFileURL: A path to file, where history was written to.
-     */
-    public typealias WriteHistoryCompletionHandler = (_ historyFileURL: URL?) -> Void
-    
-    /**
-     Store history to the directory stored in `RouteController.historyDirectoryURL` and asynchronously run a callback
-     when writing finishes.
-     
-     - parameter completionHandler: A block object to be executed when history writing ends.
-     */
-    public static func writeHistory(completionHandler: @escaping WriteHistoryCompletionHandler) {
-        Navigator.shared.writeHistory(completionHandler: completionHandler)
-    }
+    // MARK: Accessing Relevant Routing Data
     
     /**
      A custom configuration for electronic horizon observations.
@@ -485,6 +461,34 @@ open class RouteController: NSObject {
     /// The road object matcher that allows to match user-defined road objects.
     public var roadObjectMatcher: RoadObjectMatcher {
         return Navigator.shared.roadObjectMatcher
+    }
+    
+    // MARK: Recording History to Diagnose Problems
+    
+    /**
+     Path to the directory where history could be stored when `RouteController.writeHistory(completionHandler:)` is called.
+     */
+    public static var historyDirectoryURL: URL? = nil {
+        didSet {
+            Navigator.historyDirectoryURL = historyDirectoryURL
+        }
+    }
+    
+    /**
+     A closure to be called when history writing ends.
+     
+     - parameter historyFileURL: A path to file, where history was written to.
+     */
+    public typealias WriteHistoryCompletionHandler = (_ historyFileURL: URL?) -> Void
+    
+    /**
+     Store history to the directory stored in `RouteController.historyDirectoryURL` and asynchronously run a callback
+     when writing finishes.
+     
+     - parameter completionHandler: A block object to be executed when history writing ends.
+     */
+    public static func writeHistory(completionHandler: @escaping WriteHistoryCompletionHandler) {
+        Navigator.shared.writeHistory(completionHandler: completionHandler)
     }
 }
 

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -486,7 +486,7 @@ open class RouteController: NSObject {
     /**
      A closure to be called when history writing ends.
      
-     - parameter historyFileURL: A path to file, where history was written to.
+     - parameter historyFileURL: A URL to the file that contains history data. This argument is `nil` if no history data has been written because history recording has not yet begun. Use the `startRecordingHistory()` method to begin recording before attempting to write a history file.
      */
     public typealias HistoryFileWritingCompletionHandler = (_ historyFileURL: URL?) -> Void
     

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -475,20 +475,33 @@ open class RouteController: NSObject {
     }
     
     /**
+     Starts recording history for debugging purposes.
+     
+     - postcondition: Use the `stopRecordingHistory(writingFileWith:)` method to stop recording history and write the recorded history to a file.
+     */
+    public static func startRecordingHistory() {
+        Navigator.shared.startRecordingHistory()
+    }
+    
+    /**
      A closure to be called when history writing ends.
      
      - parameter historyFileURL: A path to file, where history was written to.
      */
-    public typealias WriteHistoryCompletionHandler = (_ historyFileURL: URL?) -> Void
+    public typealias HistoryFileWritingCompletionHandler = (_ historyFileURL: URL?) -> Void
     
     /**
-     Store history to the directory stored in `RouteController.historyDirectoryURL` and asynchronously run a callback
-     when writing finishes.
+     Stops recording history, asynchronously writing any recorded history to a file.
      
-     - parameter completionHandler: A block object to be executed when history writing ends.
+     Upon completion, the completion handler is called with the URL to a file in the directory specified by `RouteController.historyDirectoryURL`. The file contains details about the route controller’s activity that may be useful to include when reporting an issue to Mapbox.
+     
+     - precondition: Use the `startRecordingHistory()` method to begin recording history. If the `startRecordingHistory()` method has not been called, this method has no effect.
+     - postcondition: To write history incrementally without an interruption in history recording, use the `startRecordingHistory()` method immediately after this method. If you use the `startRecordingHistory()` method inside the completion handler of this method, history recording will be paused while the file is being prepared.
+     
+     - parameter completionHandler: A closure to be executed when the history file is ready.
      */
-    public static func writeHistory(completionHandler: @escaping WriteHistoryCompletionHandler) {
-        Navigator.shared.writeHistory(completionHandler: completionHandler)
+    public static func stopRecordingHistory(writingFileWith completionHandler: @escaping HistoryFileWritingCompletionHandler) {
+        Navigator.shared.stopRecordingHistory(writingFileWith: completionHandler)
     }
 }
 

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
@@ -104,10 +104,11 @@ class PassiveLocationManagerTests: XCTestCase {
     func testNoHistoryRecording() {
         PassiveLocationManager.historyDirectoryURL = nil
         Navigator._recreateNavigator()
+        PassiveLocationManager.startRecordingHistory()
                 
         let noHistoryExpectation = XCTestExpectation(description: "History should not be written on 'nil' path")
         noHistoryExpectation.isInverted = true
-        PassiveLocationManager.writeHistory { _ in
+        PassiveLocationManager.stopRecordingHistory { _ in
             noHistoryExpectation.fulfill()
         }
         wait(for: [noHistoryExpectation], timeout: 3)
@@ -118,9 +119,10 @@ class PassiveLocationManagerTests: XCTestCase {
         
         PassiveLocationManager.historyDirectoryURL = supportDir
         Navigator._recreateNavigator()
+        PassiveLocationManager.startRecordingHistory()
                 
         let historyExpectation = XCTestExpectation(description: "History should be written to '\(supportDir)'")
-        PassiveLocationManager.writeHistory { url in
+        PassiveLocationManager.stopRecordingHistory { url in
             XCTAssertNotNil(url)
             historyExpectation.fulfill()
         }


### PR DESCRIPTION
Introduced explicit methods to start and stop history recording. For performance reasons, the navigation SDK no longer automatically records history upon starting a route or free-driving session as it did in previous v2.0.0 betas. This change also makes it possible for an application to avoid the gap in history recording that was introduced in #3156.

For the next beta’s release notes:

* Renamed the `RouteController.writeHistory(completionHandler:)` method to `RouteController.stopRecordingHistory(completionHandler:)` and the `PassiveLocationManager.writeHistory(completionHandler:)` method to `PassiveLocationManager.stopRecordingHistory(completionHandler:)`. ([#3157](https://github.com/mapbox/mapbox-navigation-ios/pull/3157))
* Added the `RouteController.startRecordingHistory()` and `PassiveLocationManager.startRecordingHistory()` methods. You are now responsible for calling this method before stopping and writing history. ([#3157](https://github.com/mapbox/mapbox-navigation-ios/pull/3157))

Original change: ~~Restored the previous history autorecording behavior by closing a gap while writing history during which no history was being recorded. This is a followup to #3156.~~

/cc @mapbox/navigation-ios @DmitryAk