### PR TITLE
Implement a new method to change route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
 * The `EventsManagerDataSource.router`, `NavigationService.router`, `NavigationService.eventsManager`, `MapboxNavigationService.router`, `MapboxNavigationService.eventsManager` properties are no longer force unwrapped. ([#3055](https://github.com/mapbox/mapbox-navigation-ios/pull/3055))
 * Fixed an issue where traffic congestion segments along the route line blurred into each other when the map was zoomed in far enough. ([#3153](https://github.com/mapbox/mapbox-navigation-ios/pull/3153))
 * Supported feedbacks during passive navigation. Set `PassiveLocationManager` as a data source for `NavigationEventsManager` and then use this class to create and send user feedbacks. `FeedbackViewController` provides drop-in feedback screen and can be used during both passive and active navigation. ([#3122](https://github.com/mapbox/mapbox-navigation-ios/pull/3122))
+* `NavigationViewController.indexedRoute`, `NavigationService.indexedRoute` and `Router.indexedRoute` properties are readonly now. Use dedicated `Router.updateRoute(with:routeOptions:)` method to update the route. ([#3159](https://github.com/mapbox/mapbox-navigation-ios/pull/#3159))
 
 ## v1.4.1
 

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -58,12 +58,12 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     }
     
     public var indexedRoute: IndexedRoute {
-        get {
-            return routeProgress.indexedRoute
-        }
-        set {
-            routeProgress.indexedRoute = newValue
-        }
+        routeProgress.indexedRoute
+    }
+
+    public func updateRoute(with indexedRoute: IndexedRoute, routeOptions: RouteOptions?) {
+        let routeOptions = routeOptions ?? routeProgress.routeOptions
+        routeProgress = RouteProgress(route: indexedRoute.0, routeIndex: indexedRoute.1, options: routeOptions)
     }
     
     public var route: Route {
@@ -374,10 +374,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                 guard case let .route(options) = response.options, let route = response.routes?.first else {
                     return
                 }
-                strongSelf.indexedRoute = (route, 0) // unconditionally getting the first route above
-                strongSelf._routeProgress = RouteProgress(route: route, routeIndex: 0, options: options, legIndex: 0)
-                strongSelf._routeProgress.currentLegProgress.stepIndex = 0
-                strongSelf.announce(reroute: route, at: location, proactive: false)
+                strongSelf.updateRoute(with: (route, 0), routeOptions: options) // unconditionally getting the first route above
             }
         }
     }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -58,11 +58,15 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
     
     /**
      The route along which the user is expected to travel, plus its index in the `RouteResponse`, if applicable.
+
+     If you want to update the route, use `Router.updateRoute(with:routeOptions:)` method from `router`.
      */
-    var indexedRoute: IndexedRoute { get set }
-    
+    var indexedRoute: IndexedRoute { get }
+
     /**
      The route along which the user is expected to travel.
+
+     If you want to update the route, use `Router.updateRoute(with:routeOptions:)` method from `router`.
      */
     var route: Route { get }
     
@@ -313,12 +317,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     }
     
     public var indexedRoute: IndexedRoute {
-        get {
-            return router.indexedRoute
-        }
-        set {
-            router.indexedRoute = newValue
-        }
+        router.indexedRoute
     }
     
     public var route: Route {
@@ -361,6 +360,10 @@ public class MapboxNavigationService: NSObject, NavigationService {
     public func endNavigation(feedback: EndOfRouteFeedback? = nil) {
         eventsManager.sendCancelEvent(rating: feedback?.rating, comment: feedback?.comment)
         stop()
+    }
+
+    public func updateRoute(with indexedRoute: IndexedRoute, routeOptions: RouteOptions?) {
+        router.updateRoute(with: indexedRoute, routeOptions: routeOptions)
     }
 
     private func bootstrapEvents() {

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -33,13 +33,7 @@ open class RouteController: NSObject {
     }
     
     public var indexedRoute: IndexedRoute {
-        get {
-            return routeProgress.indexedRoute
-        }
-        set {
-            routeProgress = RouteProgress(route: newValue.0, routeIndex: newValue.1, options: routeProgress.routeOptions)
-            updateNavigator(with: routeProgress)
-        }
+        routeProgress.indexedRoute
     }
     
     public var route: Route {
@@ -570,6 +564,12 @@ extension RouteController: Router {
                 return
             }
         }
+    }
+
+    public func updateRoute(with indexedRoute: IndexedRoute, routeOptions: RouteOptions?) {
+        let routeOptions = routeOptions ?? routeProgress.routeOptions
+        routeProgress = RouteProgress(route: indexedRoute.0, routeIndex: indexedRoute.1, options: routeOptions)
+        updateNavigator(with: routeProgress)
     }
 }
 

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -48,9 +48,15 @@ public protocol Router: CLLocationManagerDelegate {
      Details about the user’s progress along the current route, leg, and step.
      */
     var routeProgress: RouteProgress { get }
-    
-    var indexedRoute: IndexedRoute { get set }
-    
+
+    /// The route along which the user is expected to travel, plus its index in the `RouteResponse`, if applicable.
+    ///
+    /// If you want to update the route use `Router.updateRoute(with:routeOptions:)` method.
+    var indexedRoute: IndexedRoute { get }
+
+    /// The route along which the user is expected to travel.
+    ///
+    /// You can update the route using `Router.updateRoute(with:routeOptions:)`.
     var route: Route { get }
     
     /**
@@ -90,6 +96,22 @@ public protocol Router: CLLocationManagerDelegate {
      This is a convienence method provided to advance the leg index of any given router without having to worry about the internal data structure of the router.
      */
     func advanceLegIndex()
+
+    /// Replaces currently active route with the provided `IndexedRoute`.
+    ///
+    /// You can use this method to perform manual reroutes. `delegate` will be notified about route change via
+    /// `RouterDelegate.router(router:willRerouteFrom:)` and `RouterDelegate.router(_:didRerouteAlong:at:proactive:)`
+    /// methods.
+    /// - Parameters:
+    ///   - indexedRoute: A new route along with its index in a `MapboxDirections.RouteResponse`.
+    ///   - routeOptions: Route options used to create the route. You can pass nil to reuse the `RouteOptions` from the
+    ///   currently active route. If the new `indexedRoute` is for a different set of waypoints, `routeOptions` are
+    ///   required.
+    ///
+    ///  - Important: This method can interfere with `Route.reroute(from:along:)` method. Before updating the route
+    ///  manually make sure that there is no reroute running by observing `RouterDelegate.router(_:willRerouteFrom:)`
+    ///  and `router(_:didRerouteAlong:at:proactive:)` `delegate` methods.
+    func updateRoute(with indexedRoute: IndexedRoute, routeOptions: RouteOptions?)
 }
 
 protocol InternalRouter: AnyObject {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -25,21 +25,25 @@ public typealias ContainerViewController = UIViewController & NavigationComponen
  */
 open class NavigationViewController: UIViewController, NavigationStatusPresenter, NavigationViewData {
     /**
-     A `Route` object constructed by [MapboxDirections](https://docs.mapbox.com/ios/api/directions/) along with its index in a `RouteResponse`.
+     A `Route` object constructed by [MapboxDirections](https://docs.mapbox.com/ios/api/directions/) along with its
+     index in a `RouteResponse`.
      
-     In cases where you need to update the route after navigation has started, you can set a new route here and `NavigationViewController` will update its UI accordingly.
+     In cases where you need to update the route after navigation has started, you can set a new route using
+     `Router.updateRoute(with:routeOptions:)` method in `NavigationViewController.navigationService.router` and
+     `NavigationViewController` will update its UI accordingly.
+
+     For example:
+     - If you update route with the same waypoints as the current one:
+     ```swift
+     navigationViewController.navigationService.router.updateRoute(with: indexedRoute, routeOptions: nil)
+     ```
+     - In case you update route with different set of waypoints:
+     ```swift
+     navigationViewController.navigationService.router.updateRoute(with: indexedRoute, routeOptions: newRouteOptions)
+     ```
      */
     public var indexedRoute: IndexedRoute {
-        get {
-            return navigationService.indexedRoute
-        }
-        set {
-            navigationService.indexedRoute = newValue
-            
-            for component in navigationComponents {
-                component.navigationService(navigationService, didRerouteAlong: newValue.0, at: nil, proactive: false)
-            }
-        }
+        navigationService.indexedRoute
     }
     
     var _route: Route?

--- a/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -42,8 +42,8 @@ class NavigationEventsManagerTests: TestCase {
         for location in firstTrace {
             service.router.locationManager!(locationManager, didUpdateLocations: [location])
         }
-        
-        service.indexedRoute = (secondRoute, 0)
+
+        service.router.updateRoute(with: (secondRoute, 0), routeOptions: nil)
         
         for location in secondTrace {
             service.router.locationManager!(locationManager, didUpdateLocations: [location])

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -396,7 +396,7 @@ class NavigationServiceTests: TestCase {
         let eventsManagerSpy = navigationService.eventsManager as! NavigationEventsManagerSpy
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: NavigationEventTypeRouteRetrieval))
 
-        router.indexedRoute = (alternateRoute, 0)
+        router.updateRoute(with: (alternateRoute, 0), routeOptions: nil)
 
         let simulatedLocationManager = navigationService.locationManager as! SimulatedLocationManager
 
@@ -607,7 +607,7 @@ class NavigationServiceTests: TestCase {
 
         let navigationService = dependencies.navigationService
         let routeController = navigationService.router as! RouteController
-        routeController.indexedRoute = (route, 0)
+        routeController.updateRoute(with: (route, 0), routeOptions: nil)
         let trace = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
         
         for (index, location) in trace.enumerated() {

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -63,7 +63,7 @@ class NavigationViewControllerTests: TestCase {
         super.setUp()
         customRoadName.removeAll()
         initialRoute = Fixture.route(from: jsonFileName, options: routeOptions)
-        newRoute = Fixture.route(from: jsonFileName, options: routeOptions)
+        newRoute = Fixture.route(from: "route-with-banner-instructions", options: routeOptions)
         dependencies = {
             UNUserNotificationCenter.replaceWithMock()
 
@@ -278,12 +278,14 @@ class NavigationViewControllerTests: TestCase {
             navigationViewController.navigationMapView?.pointAnnotationManager != nil
         }
         waitForExpectations(timeout: 5, handler: nil)
-        navigationViewController.indexedRoute = (initialRoute, 0)
+        navigationViewController.navigationService.router.updateRoute(with: (initialRoute, 0), routeOptions: nil)
 
         expectation(description: "Annotations loaded") {
             !navigationViewController.navigationMapView!.pointAnnotationManager!.annotations.isEmpty
         }
         waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(navigationViewController.router.routeProgress.route.routeIdentifier, initialRoute.routeIdentifier)
+
 
         let annotations = navigationViewController.navigationMapView!.pointAnnotationManager!.annotations
 
@@ -297,7 +299,7 @@ class NavigationViewControllerTests: TestCase {
                   "Destination annotation does not exist on map")
         
         // Set the second route.
-        navigationViewController.indexedRoute = (newRoute, 0)
+        navigationViewController.navigationService.router.updateRoute(with: (newRoute, 0), routeOptions: nil)
         
         let newAnnotations = navigationViewController.navigationMapView!.pointAnnotationManager!.annotations
         
@@ -310,6 +312,8 @@ class NavigationViewControllerTests: TestCase {
                     .compactMap { $0.feature.geometry.value as? Turf.Point }
                     .contains { $0.coordinates.distance(to: secondDestination) < 1 },
                   "New destination annotation does not exist on map")
+        XCTAssertEqual(navigationViewController.router.routeProgress.route.routeIdentifier,
+                       newRoute.routeIdentifier)
     }
     
     func testPuck3DLayerPosition() {

--- a/docs/guides/Using Map Matching.md
+++ b/docs/guides/Using Map Matching.md
@@ -22,14 +22,14 @@ It is up to you to listen in on reroutes and:
 
 1. Fetch a new route from your server.
 1. Make a map matching request against the Mapbox Map Matching appropriate.
-1. Update the `RouteProgress` with a the new route (covered below).
+1. Update the `Router` with a the new route (covered below).
 
-### Update the RouteProgress
+### Update the Router
 
 Once you have a fresh route after rerouting, you need to tell the UI to update according to this new route.
 
 ```
-yourNavigationViewController.route = route
+yourNavigationViewController.navigationService.router.updateRoute(with: (route, 0), routeOptions: nil)
 ```
 
 This will cause a waterfall effect, everything downstream should react to the addition of a new route.


### PR DESCRIPTION
Fixes #2948

Previous method of just updating `indexedRoute` wasn't robust enough for
cases when the new route has different waypoints than the one it is
replacing. New method allows to update route from the different set of
waypoints.