### PR TITLE
Replace JSON with Expressions in route duration annotation styling.

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1237,66 +1237,32 @@ open class NavigationMapView: UIView {
         shapeLayer.textJustify = .constant(TextJustify.left)
         shapeLayer.symbolZOrder = .constant(SymbolZOrder.auto)
         shapeLayer.textFont = .constant(self.routeDurationAnnotationFontNames)
-
-        try style.addLayer(shapeLayer)
-
-        let symbolSortKeyString =
-        """
-        ["get", "sortOrder"]
-        """
-
-        if let expressionData = symbolSortKeyString.data(using: .utf8),
-           let expJSONObject = try? JSONSerialization.jsonObject(with: expressionData, options: []) {
-            let property = "symbol-sort-key"
-            try style.setLayerProperty(for: routeDurationAnnotationsLayerIdentifier,
-                                       property: property,
-                                       value: expJSONObject)
-        }
-
-        let expressionString =
-        """
-        [
-          "match",
-          ["get", "tailPosition"],
-          [0],
-          "bottom-left",
-          [1],
-          "bottom-right",
-          "center"
-        ]
-        """
-
-        if let expressionData = expressionString.data(using: .utf8),
-           let expJSONObject = try? JSONSerialization.jsonObject(with: expressionData, options: []) {
-            try style.setLayerProperty(for: routeDurationAnnotationsLayerIdentifier,
-                                       property: "icon-anchor",
-                                       value: expJSONObject)
-            try style.setLayerProperty(for: routeDurationAnnotationsLayerIdentifier,
-                                       property: "text-anchor",
-                                       value: expJSONObject)
-        }
-
-        let offsetExpressionString =
-            """
-        [
-          "match",
-          ["get", "tailPosition"],
-          [0],
-          ["literal", [0.5, -1]],
-          ["literal", [-0.5, -1]]
-        ]
-        """
         
-        if let expressionData = offsetExpressionString.data(using: .utf8),
-           let expJSONObject = try? JSONSerialization.jsonObject(with: expressionData, options: []) {
-            try style.setLayerProperty(for: routeDurationAnnotationsLayerIdentifier,
-                                       property: "icon-offset",
-                                       value: expJSONObject)
-            
-            try style.setLayerProperty(for: routeDurationAnnotationsLayerIdentifier,
-                                       property: "text-offset",
-                                       value: expJSONObject)
+        shapeLayer.symbolSortKey = .expression(Exp(.get) {
+            "sortOrder"
+        })
+
+        let anchorExpression = Exp(.match) {
+            Exp(.get) { "tailPosition" }
+            0
+            "bottom-left"
+            1
+            "bottom-right"
+            "center"
         }
+        shapeLayer.iconAnchor = .expression(anchorExpression)
+        shapeLayer.textAnchor = .expression(anchorExpression)
+        
+        let offsetExpression = Exp(.match) {
+            Exp(.get) { "tailPosition" }
+            0
+            Exp(.literal) { [0.5, -1.0] }
+            Exp(.literal) { [-0.5, -1.0] }
+        }
+        shapeLayer.iconOffset = .expression(offsetExpression)
+        shapeLayer.textOffset = .expression(offsetExpression)
+        
+        try style.addLayer(shapeLayer)
     }
 
     /**


### PR DESCRIPTION
### Description
This pr is to fix #2996 

### Implementation
This pr is to remove the usage of `JSON` in runtime styling of route duration annotation, and replaced it with the map SDK’s type-safe `Expression` type.

### Screenshots or Gifs
With the `Expression` styling:
![ExpressionStyling](https://user-images.githubusercontent.com/48976398/126392948-f25d69d6-5fcf-409d-a89a-d37839671e1c.png)
With the `JSON` styling:
![JSon](https://user-images.githubusercontent.com/48976398/126392954-ab88ee83-4fcf-423f-90c2-7b4a2f7e459f.png)
