### PR TITLE
NavigationMapView injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * Added the `NavigationMapView.userLocationStyle` property to customize how the user’s current location is displayed on the map. Set this property to `UserLocationStyle.puck2D(configuration:)` or `UserLocationStyle.puck3D(configuration:)` to use the [location indicator layer](https://docs.mapbox.com/ios/maps/api/10.0.0-beta.21/Enums/LayerType.html#/s:10MapboxMaps9LayerTypeO17locationIndicatoryA2CmF) powered by the Mapbox Maps SDK instead of the default view-backed implementation specified by the `NavigationMapView.userCourseView` property. ([#2968](https://github.com/mapbox/mapbox-navigation-ios/pull/2968))
 * If you need to customize the appearance of the user location indicator, you can subclass `UserPuckCourseView` and `UserHaloCourseView` as a starting point. ([#2968](https://github.com/mapbox/mapbox-navigation-ios/pull/2968))
 * Fixed an issue where route line disappears when changing `MapView` style. ([#3136](https://github.com/mapbox/mapbox-navigation-ios/pull/3136))
-* Added `NavigationOptions.navigationMapView` property to allow customization or reusing options for `NavigationViewController.navigationMapView` ([#3186](https://github.com/mapbox/mapbox-navigation-ios/pull/3186)).
+* Added `NavigationOptions.navigationMapView` property to allow customization or reusing possibilities for `NavigationViewController.navigationMapView` ([#3186](https://github.com/mapbox/mapbox-navigation-ios/pull/3186)).
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Added the `NavigationMapView.userLocationStyle` property to customize how the user’s current location is displayed on the map. Set this property to `UserLocationStyle.puck2D(configuration:)` or `UserLocationStyle.puck3D(configuration:)` to use the [location indicator layer](https://docs.mapbox.com/ios/maps/api/10.0.0-beta.21/Enums/LayerType.html#/s:10MapboxMaps9LayerTypeO17locationIndicatoryA2CmF) powered by the Mapbox Maps SDK instead of the default view-backed implementation specified by the `NavigationMapView.userCourseView` property. ([#2968](https://github.com/mapbox/mapbox-navigation-ios/pull/2968))
 * If you need to customize the appearance of the user location indicator, you can subclass `UserPuckCourseView` and `UserHaloCourseView` as a starting point. ([#2968](https://github.com/mapbox/mapbox-navigation-ios/pull/2968))
 * Fixed an issue where route line disappears when changing `MapView` style. ([#3136](https://github.com/mapbox/mapbox-navigation-ios/pull/3136))
+* Added `NavigationOptions.navigationMapView` property to allow customization or reusing options for `NavigationViewController.navigationMapView` ([#3186](https://github.com/mapbox/mapbox-navigation-ios/pull/3186)).
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/NavigationOptions.swift
+++ b/Sources/MapboxNavigation/NavigationOptions.swift
@@ -55,7 +55,7 @@ open class NavigationOptions: NavigationCustomizable {
     /**
      Custom `NavigationMapView` instance to be embedded in navigation UI.
      
-     If set to `nil` - new `NavigationMapView` instance will be created. When setting a custom instance, `NavigationView` will update it's delegate and camera's `viewportDatasource` to function correctly. You may want to use this property for customization or optimization purposes.
+     If set to `nil`, a default `NavigationMapView` instance will be created. When a custom instance is set, `NavigationView` will update its delegate and camera's `viewportDatasource` to function correctly. You may want to use this property for customization or optimization purposes.
      */
     open var navigationMapView: NavigationMapView?
     

--- a/Sources/MapboxNavigation/NavigationOptions.swift
+++ b/Sources/MapboxNavigation/NavigationOptions.swift
@@ -52,6 +52,12 @@ open class NavigationOptions: NavigationCustomizable {
      */
     open var tileStoreConfiguration: TileStoreConfiguration = .default
     
+    /**
+     Custom `NavigationMapView` instance to be embedded in navigation UI.
+     
+     If set to `nil` - new `NavigationMapView` instance will be created. When setting a custom instance, `NavigationView` will update it's delegate and camera's `viewportDatasource` to function correctly. You may want to use this property for customization or optimization purposes.
+     */
+    open var navigationMapView: NavigationMapView?
     
     // This makes the compiler happy.
     required public init() {
@@ -68,8 +74,9 @@ open class NavigationOptions: NavigationCustomizable {
      - parameter bottomBanner: The container view controller that presents the bottom banner.
      - parameter predictiveCacheOptions: Configuration for predictive caching. These options control how the `PredictiveCacheManager` will try to proactively fetch data related to the route. A `nil` value disables the feature.
      - parameter tileStoreConfiguration: Configuration of `TileStore` location, where Map and Navigation tiles are stored.
+     - parameter navigationMapView: Custom `NavigationMapView` instance to supersede the default one.
      */
-    public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil, predictiveCacheOptions: PredictiveCacheOptions? = nil, tileStoreConfiguration: TileStoreConfiguration = .default) {
+    public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil, predictiveCacheOptions: PredictiveCacheOptions? = nil, tileStoreConfiguration: TileStoreConfiguration = .default, navigationMapView: NavigationMapView? = nil) {
         self.init()
         self.styles = styles
         self.navigationService = navigationService
@@ -78,6 +85,7 @@ open class NavigationOptions: NavigationCustomizable {
         self.bottomBanner = bottomBanner
         self.predictiveCacheOptions = predictiveCacheOptions
         self.tileStoreConfiguration = tileStoreConfiguration
+        self.navigationMapView = navigationMapView
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -58,8 +58,10 @@ open class NavigationView: UIView {
     lazy var endOfRouteHeightConstraint: NSLayoutConstraint? = self.endOfRouteView?.heightAnchor.constraint(equalToConstant: Constants.endOfRouteHeight)
     
     var tileStoreLocation: TileStoreConfiguration.Location? = .default
+    private var _navigationMapView: NavigationMapView? = nil
     lazy var navigationMapView: NavigationMapView = {
-        let navigationMapView = NavigationMapView(frame: self.bounds, tileStoreLocation: tileStoreLocation)
+        _navigationMapView?.frame = self.bounds
+        let navigationMapView = _navigationMapView ?? NavigationMapView(frame: self.bounds, tileStoreLocation: tileStoreLocation)
         navigationMapView.isHidden = false
         navigationMapView.translatesAutoresizingMaskIntoConstraints = false
         
@@ -129,8 +131,8 @@ open class NavigationView: UIView {
     
     // MARK: - Initialization methods
     
-    convenience init(delegate: NavigationViewDelegate, frame: CGRect = .zero, tileStoreLocation: TileStoreConfiguration.Location? = .default) {
-        self.init(frame: frame, tileStoreLocation: tileStoreLocation)
+    convenience init(delegate: NavigationViewDelegate, frame: CGRect = .zero, tileStoreLocation: TileStoreConfiguration.Location? = .default, navigationMapView: NavigationMapView? = nil) {
+        self.init(frame: frame, tileStoreLocation: tileStoreLocation, navigationMapView: navigationMapView)
         self.delegate = delegate
         updateDelegates() // this needs to be called because didSet's do not fire in init contexts.
     }
@@ -142,8 +144,9 @@ open class NavigationView: UIView {
     }
     
     // TODO: Refine public APIs, which are exposed by `NavigationView`.
-    public init(frame: CGRect, tileStoreLocation: TileStoreConfiguration.Location? = .default) {
+    public init(frame: CGRect, tileStoreLocation: TileStoreConfiguration.Location? = .default, navigationMapView: NavigationMapView? = nil) {
         self.tileStoreLocation = tileStoreLocation
+        self._navigationMapView = navigationMapView
         super.init(frame: frame)
         commonInit()
     }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -531,7 +531,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     
     open override func loadView() {
         let frame = parent?.view.bounds ?? UIScreen.main.bounds
-        view = NavigationView(delegate: self, frame: frame, tileStoreLocation: mapTileStore)
+        view = NavigationView(delegate: self, frame: frame, tileStoreLocation: mapTileStore, navigationMapView: self.navigationOptions?.navigationMapView)
     }
     
     /**

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -387,6 +387,27 @@ class NavigationViewControllerTests: XCTestCase {
         XCTAssert(subject.children.contains(top), "Top banner not found in child VC heirarchy")
         XCTAssert(subject.children.contains(bottom), "Bottom banner not found in child VC heirarchy")
     }
+    
+    func testNavigationMapViewInjection() {
+        class CustomNavigationMapView: NavigationMapView { }
+        
+        let injected = CustomNavigationMapView()
+        
+        let routeOptions = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 38.853108, longitude: -77.043331),
+            CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
+        ])
+
+        let route = Fixture.route(from: "DCA-Arboretum", options: routeOptions)
+        let navService = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: routeOptions, directions: .mocked)
+        let navOptions = NavigationOptions(navigationService: navService, navigationMapView: injected)
+
+        let subject = NavigationViewController(for: route, routeIndex: 0, routeOptions: routeOptions, navigationOptions: navOptions)
+        _ = subject.view // trigger view load
+        
+        XCTAssert(subject.navigationMapView == injected, "NavigtionMapView not injected properly.")
+        XCTAssert(subject.view.subviews.contains(injected), "NavigtionMapView not injected in view hierarchy.")
+    }
 }
 
 extension NavigationViewControllerTests: NavigationViewControllerDelegate, StyleManagerDelegate {


### PR DESCRIPTION
### Description
Resolves #3165 

### Implementation
Added a property to `NavigationOptions` which forwards input `NavigationMapView` instance to `NavigationView` (and in result in `NavigationViewController`. This instance is used instead of originally created `NavigationMapView` if provided.