### PR TITLE
Fix installation instructions in v1.x docsets

### DIFF
--- a/1.0.0-rc.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.0.0-rc.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -652,8 +652,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -673,7 +672,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.1/index.html
+++ b/1.0.0-rc.1/index.html
@@ -652,8 +652,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -673,7 +672,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.0.0-rc.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -634,8 +634,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -655,7 +654,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.2/index.html
+++ b/1.0.0-rc.2/index.html
@@ -634,8 +634,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -655,7 +654,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.3/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.0.0-rc.3/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -637,8 +637,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -658,7 +657,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.3/index.html
+++ b/1.0.0-rc.3/index.html
@@ -637,8 +637,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -658,7 +657,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.4/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.0.0-rc.4/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -637,8 +637,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -658,7 +657,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.4/index.html
+++ b/1.0.0-rc.4/index.html
@@ -637,8 +637,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -658,7 +657,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.5/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.0.0-rc.5/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0-rc.5/index.html
+++ b/1.0.0-rc.5/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.0.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.0.0/index.html
+++ b/1.0.0/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-alpha.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.1.0-alpha.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -634,8 +634,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -655,7 +654,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-alpha.1/index.html
+++ b/1.1.0-alpha.1/index.html
@@ -634,8 +634,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -655,7 +654,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-alpha.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.1.0-alpha.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-alpha.2/index.html
+++ b/1.1.0-alpha.2/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-beta.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.1.0-beta.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -672,8 +672,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -693,7 +692,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-beta.1/index.html
+++ b/1.1.0-beta.1/index.html
@@ -672,8 +672,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -693,7 +692,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-beta.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.1.0-beta.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-beta.2/index.html
+++ b/1.1.0-beta.2/index.html
@@ -657,8 +657,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -678,7 +677,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-rc.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.1.0-rc.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -660,8 +660,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -681,7 +680,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0-rc.1/index.html
+++ b/1.1.0-rc.1/index.html
@@ -660,8 +660,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -681,7 +680,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.1.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -672,8 +672,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -693,7 +692,7 @@
 <pre class="highlight shell"><code>rm -rf ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.1.0/index.html
+++ b/1.1.0/index.html
@@ -672,8 +672,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.1'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.1'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -693,7 +692,7 @@
 <pre class="highlight shell"><code>rm -rf ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.1"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.1
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-alpha.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.2.0-alpha.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -678,8 +678,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -699,7 +698,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-alpha.1/index.html
+++ b/1.2.0-alpha.1/index.html
@@ -678,8 +678,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -699,7 +698,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-alpha.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.2.0-alpha.2/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -675,8 +675,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -696,7 +695,7 @@
 <pre class="highlight shell"><code>rm -rf ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-alpha.2/index.html
+++ b/1.2.0-alpha.2/index.html
@@ -675,8 +675,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -696,7 +695,7 @@
 <pre class="highlight shell"><code>rm -rf ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-alpha.3/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.2.0-alpha.3/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -663,8 +663,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -684,7 +683,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-alpha.3/index.html
+++ b/1.2.0-alpha.3/index.html
@@ -663,8 +663,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -684,7 +683,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-beta.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.2.0-beta.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -692,8 +692,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -713,7 +712,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-beta.1/index.html
+++ b/1.2.0-beta.1/index.html
@@ -692,8 +692,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -713,7 +712,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-rc.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.2.0-rc.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0-rc.1/index.html
+++ b/1.2.0-rc.1/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.2.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.0/index.html
+++ b/1.2.0/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.2.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.2.1/index.html
+++ b/1.2.1/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.2'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.2'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.2"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.2
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.3.0-beta.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.3.0-beta.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.3'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.3"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.3
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.3.0-beta.1/index.html
+++ b/1.3.0-beta.1/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.3'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.3"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.3
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.3.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.3.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.3'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.3"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.3
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.3.0/index.html
+++ b/1.3.0/index.html
@@ -681,8 +681,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.3'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.3'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -702,7 +701,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.3"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.3
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.4.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.4.0/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -675,8 +675,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.4'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -696,7 +695,7 @@
 <pre class="highlight shell"><code>rm -rf ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.4"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.4
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.4.0/index.html
+++ b/1.4.0/index.html
@@ -675,8 +675,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.4'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -696,7 +695,7 @@
 <pre class="highlight shell"><code>rm -rf ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.4"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.4
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.4.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/1.4.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -675,8 +675,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.4'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -696,7 +695,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.4"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.4
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/1.4.1/index.html
+++ b/1.4.1/index.html
@@ -675,8 +675,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'1.4'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 1.4'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -696,7 +695,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "1.4"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 1.4
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/2.0.0-alpha.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
+++ b/2.0.0-alpha.1/docsets/MapboxNavigation.docset/Contents/Resources/Documents/index.html
@@ -659,8 +659,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'2.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'2.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 2.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -680,7 +679,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "2.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 2.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>

--- a/2.0.0-alpha.1/index.html
+++ b/2.0.0-alpha.1/index.html
@@ -659,8 +659,7 @@
 
 <p>where <em>PRIVATE_MAPBOX_API_TOKEN</em> is your Mapbox API token with the <code>DOWNLOADS:READ</code> scope. </p></li>
 <li><p>Create a <a href="https://guides.cocoapods.org/syntax/podfile.html">Podfile</a> with the following specification:</p>
-<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxCoreNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'2.0'</span>
-<span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="ss">:git</span> <span class="o">=&gt;</span> <span class="s1">'https://github.com/mapbox/mapbox-navigation-ios.git'</span><span class="p">,</span> <span class="ss">:tag</span> <span class="o">=&gt;</span> <span class="s1">'2.0'</span>
+<pre class="highlight ruby"><code><span class="n">pod</span> <span class="s1">'MapboxNavigation'</span><span class="p">,</span> <span class="s1">'~> 2.0'</span>
 </code></pre></li>
 <li><p>Run <code>pod repo update &amp;&amp; pod install</code> and open the resulting Xcode workspace.</p></li>
 </ol>
@@ -680,7 +679,7 @@
 <pre class="highlight shell"><code><span class="nb">rm</span> <span class="nt">-rf</span> ~/Library/Caches/carthage/ ~/Library/Caches/org.carthage.CarthageKit/binaries/<span class="o">{</span>MapboxAccounts,MapboxCommon-ios,MapboxNavigationNative,mapbox-ios-sdk-dynamic<span class="o">}</span>
 </code></pre></li>
 <li><p>Create a <a href="https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories">Cartfile</a> with the following dependency:</p>
-<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" "2.0"
+<pre class="highlight plaintext"><code>github "mapbox/mapbox-navigation-ios" ~> 2.0
 </code></pre></li>
 </ol>
 <h2 id='configuration' class='heading'>Configuration</h2>


### PR DESCRIPTION
From #2496 until 3781b2ac71ebf7780463e0bae0d46bad0a5a2409 / #3026 / 5a7d9fdaeea94fc8c9c21c979938781112e01e2c, corresponding to the v1._x_ series, the cover page of the API reference contained incorrect installation instructions for both CocoaPods and Carthage that conflated the syntaxes for versions and tags. This PR cleans up the generated docsets that were affected by that error.

/cc @mapbox/navigation-ios @ZiZasaurus @mapbox/docs