### PR TITLE
Rename RouterDataSource.locationProvider to locationManagerType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * Improved performance and decreased memory usage when downloading routing tiles. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Renamed `PassiveLocationManager.startUpdatingLocation(completionHandler:)` to `PassiveLocationProvider.startUpdatingLocation()`. This method now runs synchronously like `CLLocationManager.startUpdatingLocation()`. ([#2823](https://github.com/mapbox/mapbox-navigation-ios/pull/2823))
 * Added the `RouteController.startRecordingHistory()`, `RouteController.stopRecordingHistory(completionHandler:)`, `PassiveLocationManager.startRecordingHistory()`, and `PassiveLocationManager.stopRecordingHistory(completionHandler:)` methods for recording details about a trip for debugging purposes. ([#3157](https://github.com/mapbox/mapbox-navigation-ios/pull/3157))
+* Renamed `RouterDataSource.locationProvider` and `EventsManagerDataSource.locationProvider` properties to `RouterDataSource.locationManagerType` and `EventsManagerDataSource.locationManagerType` respectively. ([#3199](https://github.com/mapbox/mapbox-navigation-ios/pull/3199))
 
 ### Electronic horizon
 

--- a/Sources/MapboxCoreNavigation/ActiveNavigationEventDetails.swift
+++ b/Sources/MapboxCoreNavigation/ActiveNavigationEventDetails.swift
@@ -60,7 +60,7 @@ struct ActiveNavigationEventDetails: NavigationEventDetails {
         startTimestamp = session.departureTimestamp
         sdkIdentifier = defaultInterface ? "mapbox-navigation-ui-ios" : "mapbox-navigation-ios"
         profile = dataSource.routeProgress.routeOptions.profileIdentifier.rawValue
-        simulation = dataSource.locationProvider is SimulatedLocationManager.Type
+        simulation = dataSource.locationManagerType is SimulatedLocationManager.Type
         
         sessionIdentifier = session.identifier.uuidString
         originalRequestIdentifier = session.originalRoute?.routeIdentifier
@@ -104,7 +104,7 @@ struct ActiveNavigationEventDetails: NavigationEventDetails {
         
         rerouteCount = session.numberOfReroutes
         
-        locationEngine = String(describing: dataSource.locationProvider)
+        locationEngine = String(describing: dataSource.locationManagerType)
         locationManagerDesiredAccuracy = dataSource.desiredAccuracy
         
         stepIndex = dataSource.routeProgress.currentLegProgress.stepIndex

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -5,11 +5,6 @@ import Polyline
 import MapboxMobileEvents
 import Turf
 
-protocol RouteControllerDataSource: AnyObject {
-    var location: CLLocation? { get }
-    var locationProvider: NavigationLocationManager.Type { get }
-}
-
 @available(*, deprecated, renamed: "RouteController")
 open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationManagerDelegate {
     

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -24,7 +24,7 @@ public protocol EventsManagerDataSource: AnyObject {
     var routeProgress: RouteProgress { get }
     var router: Router { get }
     var desiredAccuracy: CLLocationAccuracy { get }
-    var locationProvider: NavigationLocationManager.Type { get }
+    var locationManagerType: NavigationLocationManager.Type { get }
 }
 
 /**

--- a/Sources/MapboxCoreNavigation/NavigationLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationLocationManager.swift
@@ -26,7 +26,7 @@ open class NavigationLocationManager: CLLocationManager {
 }
 
 extension NavigationLocationManager: RouterDataSource {
-    public var locationProvider: NavigationLocationManager.Type {
+    public var locationManagerType: NavigationLocationManager.Type {
         return type(of: self)
     }
 }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -537,7 +537,7 @@ extension MapboxNavigationService {
 
 //MARK: RouterDataSource
 extension MapboxNavigationService {
-    public var locationProvider: NavigationLocationManager.Type {
+    public var locationManagerType: NavigationLocationManager.Type {
         return type(of: locationManager)
     }
 }

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -9,7 +9,7 @@ public protocol RouterDataSource: AnyObject {
     /**
      The location provider for the `Router.` This class is designated as the object that will provide location updates when requested.
      */
-    var locationProvider: NavigationLocationManager.Type { get }
+    var locationManagerType: NavigationLocationManager.Type { get }
 }
 
 /**

--- a/Sources/TestHelper/NavigationServiceTestDoubles.swift
+++ b/Sources/TestHelper/NavigationServiceTestDoubles.swift
@@ -10,7 +10,7 @@ public class RouteControllerDataSourceFake: RouterDataSource {
         return manager.location
     }
 
-    public var locationProvider: NavigationLocationManager.Type {
+    public var locationManagerType: NavigationLocationManager.Type {
         return type(of: manager)
     }
 }

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -73,7 +73,7 @@ extension RouteControllerTests: RouterDataSource {
         return replayManager?.location
     }
     
-    var locationProvider: NavigationLocationManager.Type {
+    var locationManagerType: NavigationLocationManager.Type {
         return NavigationLocationManager.self
     }
 }


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->

This PR:
- [x] Resolves #3146 by renaming a `locationProvider` property on `RouterDataSource` protocol;
- [x] Renames the same property on `EventsManagerDataSource` protocol (thought about combining two protocols, but that doesn't solve any outstanding problem and restricts expansion);
- [x] Removes unused `RouteControllerDataSource` protocol (found by similar property).

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->