### PR TITLE
Improve the performance of vanishing route line feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 * If you need to customize the appearance of the user location indicator, you can subclass `UserPuckCourseView` and `UserHaloCourseView` as a starting point. ([#2968](https://github.com/mapbox/mapbox-navigation-ios/pull/2968))
 * Fixed an issue where route line disappears when changing `MapView` style. ([#3136](https://github.com/mapbox/mapbox-navigation-ios/pull/3136))
 * Added `NavigationOptions.navigationMapView` property to allow customization or reusing possibilities for `NavigationViewController.navigationMapView` ([#3186](https://github.com/mapbox/mapbox-navigation-ios/pull/3186)).
-* Improved the performance for vanishing route line by reducing calculation for route line update. Replaced `NavigationMapView.updateRoute(_:)` with `NavigationMapView.updateVanishingRouteLine(coordinate:)` to update the vanishing route line, and keep the route line vanishing point synced with the user location. ([#3201](https://github.com/mapbox/mapbox-navigation-ios/pull/3201)).
+* Renamed the `NavigationMapView.updateRoute(_:)` method to `NavigationMapView.travelAlongRouteLine(to:)`. Improved the performance of updating the route line to change color at the user’s location as they progress along the route. ([#3201](https://github.com/mapbox/mapbox-navigation-ios/pull/3201)).
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * If you need to customize the appearance of the user location indicator, you can subclass `UserPuckCourseView` and `UserHaloCourseView` as a starting point. ([#2968](https://github.com/mapbox/mapbox-navigation-ios/pull/2968))
 * Fixed an issue where route line disappears when changing `MapView` style. ([#3136](https://github.com/mapbox/mapbox-navigation-ios/pull/3136))
 * Added `NavigationOptions.navigationMapView` property to allow customization or reusing possibilities for `NavigationViewController.navigationMapView` ([#3186](https://github.com/mapbox/mapbox-navigation-ios/pull/3186)).
+* Improved the performance for vanishing route line by reducing calculation for route line update. Replaced `NavigationMapView.updateRoute(_:)` with `NavigationMapView.updateVanishingRouteLine(coordinate:)` to update the vanishing route line, and keep the route line vanishing point synced with the user location. ([#3201](https://github.com/mapbox/mapbox-navigation-ios/pull/3201)).
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -95,6 +95,7 @@ public class CarPlayNavigationViewController: UIViewController {
     var mapTemplate: CPMapTemplate
     var carFeedbackTemplate: CPGridTemplate!
     var carInterfaceController: CPInterfaceController
+    var currentLegIndexMapped: Int = 0
 
     // MARK: - Initialization methods
     
@@ -140,6 +141,7 @@ public class CarPlayNavigationViewController: UIViewController {
         observeNotifications(navigationService)
         updateManeuvers(navigationService.routeProgress)
         navigationService.start()
+        currentLegIndexMapped = navigationService.router.routeProgress.legIndex
     }
     
     override public func viewWillDisappear(_ animated: Bool) {
@@ -290,6 +292,8 @@ public class CarPlayNavigationViewController: UIViewController {
             return
         }
         
+        let legIndex = routeProgress.legIndex
+        
         // Update the user puck
         navigationMapView?.updatePreferredFrameRate(for: routeProgress)
         navigationMapView?.moveUserLocation(to: location, animated: true)
@@ -313,6 +317,12 @@ public class CarPlayNavigationViewController: UIViewController {
         if let speedLimitView = speedLimitView {
             speedLimitView.signStandard = routeProgress.currentLegProgress.currentStep.speedLimitSignStandard
             speedLimitView.speedLimit = routeProgress.currentLegProgress.currentSpeedLimit
+        }
+        
+        if legIndex != currentLegIndexMapped {
+            navigationMapView?.showWaypoints(on: routeProgress.route, legIndex: legIndex)
+            navigationMapView?.show([routeProgress.route], legIndex: legIndex)
+            currentLegIndexMapped = legIndex
         }
         
         if routeLineTracksTraversal {

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -316,9 +316,11 @@ public class CarPlayNavigationViewController: UIViewController {
         }
         
         if routeLineTracksTraversal {
+            if routeProgress.currentLeg.segmentCongestionLevels != navigationMapView?.currentLegCongestionLevels {
+                navigationMapView?.setUpLineGradientStops(along: routeProgress.route)
+            }
             navigationMapView?.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
-            navigationMapView?.updateTraveledRouteLine(location.coordinate)
-            navigationMapView?.updateRoute(routeProgress)
+            navigationMapView?.updateVanishingRouteLine(coordinate: location.coordinate)
         }
     }
     
@@ -574,7 +576,6 @@ public class CarPlayNavigationViewController: UIViewController {
                                               comment: "Title on continue button in CarPlay")
         
         let continueAlert = CPAlertAction(title: continueTitle, style: .default) { (action) in
-            self.navigationService.router.advanceLegIndex()
             self.carInterfaceController.dismissTemplate(animated: true)
             self.updateRouteOnMap()
         }

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -330,7 +330,7 @@ public class CarPlayNavigationViewController: UIViewController {
                 navigationMapView?.setUpLineGradientStops(along: routeProgress.route)
             }
             navigationMapView?.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
-            navigationMapView?.updateVanishingRouteLine(coordinate: location.coordinate)
+            navigationMapView?.travelAlongRouteLine(to: location.coordinate)
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -146,10 +146,11 @@ extension NavigationMapView {
     }
     
     /**
-     Updates the route line appearance from the origin point to the indicated point
-     - parameter coordinate: current position of the puck
+     Updates the fractionTraveled along the route line from the origin point to the indicated point.
+     
+     - parameter coordinate: Current position of the user location.
      */
-    func updateTraveledRouteLine(_ coordinate: CLLocationCoordinate2D?) {
+    func updateFractionTraveled(_ coordinate: CLLocationCoordinate2D?) {
         guard let granularDistances = routeLineGranularDistances,let index = routeRemainingDistancesIndex, let location = coordinate else { return }
         guard index < granularDistances.distanceArray.endIndex else { return }
         let traveledIndex = granularDistances.distanceArray[index]
@@ -166,7 +167,6 @@ extension NavigationMapView {
         if granularDistances.distance >= remainingDistance {
             let offSet = (1.0 - remainingDistance / granularDistances.distance)
             if offSet >= 0 {
-                preFractionTraveled = fractionTraveled
                 fractionTraveled = offSet
             }
         }
@@ -175,15 +175,19 @@ extension NavigationMapView {
     /**
      Updates the route style layer and its casing style layer to gradually disappear as the user location puck travels along the displayed route.
      
+     - parameter coordinate: Current position of the user location.
      - parameter routeProgress: Current route progress.
      */
-    public func updateRoute(_ routeProgress: RouteProgress) {
-        let mainRouteLayerIdentifier = routeProgress.route.identifier(.route(isMainRoute: true))
-        let mainRouteCasingLayerIdentifier = routeProgress.route.identifier(.routeCasing(isMainRoute: true))
+    public func updateVanishingRouteLine(coordinate: CLLocationCoordinate2D?) {
+        updateFractionTraveled(coordinate)
+        
+        guard let route = routes?.first else { return }
+        
+        let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
+        let mainRouteCasingLayerIdentifier = route.identifier(.routeCasing(isMainRoute: true))
         
         if fractionTraveled >= 1.0 {
             // In case if route was fully travelled - remove main route and its casing.
-            
             do {
                 try mapView.mapboxMap.style.removeLayer(withId: mainRouteLayerIdentifier)
                 try mapView.mapboxMap.style.removeLayer(withId: mainRouteCasingLayerIdentifier)
@@ -192,42 +196,48 @@ extension NavigationMapView {
             }
             
             fractionTraveled = 0.0
-            preFractionTraveled = 0.0
             return
         }
         
-        vanishingRouteLineUpdateTimer?.invalidate()
-        vanishingRouteLineUpdateTimer = nil
-        
-        let traveledDifference = fractionTraveled - preFractionTraveled
-        if traveledDifference == 0.0 {
-            return
-        }
-        
-        let congestionSegments = routeProgress.route.congestionFeatures(legIndex: currentLegIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
-        
-        updateRouteLine(congestionSegments:congestionSegments, layerIdentifier: mainRouteLayerIdentifier, fractionTraveledUpdate: fractionTraveled)
-        updateRouteLine(layerIdentifier: mainRouteCasingLayerIdentifier, fractionTraveledUpdate: fractionTraveled)
-    }
-    
-    func updateRouteLine(congestionSegments: [Turf.Feature]? = nil, layerIdentifier: String, fractionTraveledUpdate: Double) {
-        do {
-            if let congestionSegments = congestionSegments {
-                try mapView.mapboxMap.style.updateLayer(withId: layerIdentifier) { (lineLayer: inout LineLayer) throws in
-                    let mainRouteLayerGradient = self.routeLineGradient(congestionSegments,
-                                                                        fractionTraveled: fractionTraveledUpdate)
+        if !currentLineGradientStops.isEmpty {
+            do {
+                try mapView.mapboxMap.style.updateLayer(withId: mainRouteLayerIdentifier) { (lineLayer: inout LineLayer) throws in
+                    let mainRouteLayerGradient = self.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
                     lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor))
                 }
-            } else {
-                try mapView.mapboxMap.style.updateLayer(withId: layerIdentifier) { (lineLayer: inout LineLayer) throws in
-                    let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveledUpdate)
-                    
+                
+                try mapView.mapboxMap.style.updateLayer(withId: mainRouteCasingLayerIdentifier) { (lineLayer: inout LineLayer) throws in
+                    let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveled)
                     lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient, lineBaseColor: routeCasingColor))
                 }
+            } catch {
+                print("Failed to update main route line layer.")
             }
-        } catch {
-            print("Failed to update main route line layer.")
         }
+        
+    }
+    
+    func updateRouteLineGradientStops(fractionTraveled: Double, gradientStops: [Double: UIColor]) -> [Double: UIColor] {
+        var filteredGradientStops = gradientStops.filter { key, value in
+            return key >= fractionTraveled
+        }
+        filteredGradientStops[0.0] = traversedRouteColor
+        
+        let  nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        if nextDownFractionTraveled >= 0.0 {
+            filteredGradientStops[nextDownFractionTraveled] = traversedRouteColor
+        }
+        
+        // Find the nearest smaller stop than the `fractionTraveled` and apply its color to the `fractionTraveled` till the next stop.
+        let sortedStops = gradientStops.keys.sorted()
+        if let minStop = sortedStops.last(where: { $0 <= fractionTraveled }),
+           minStop != 0.0 {
+            filteredGradientStops[fractionTraveled] = gradientStops[minStop]
+        } else {
+            filteredGradientStops[fractionTraveled] = trafficUnknownColor
+        }
+
+        return filteredGradientStops
     }
     
     func routeLineGradient(_ congestionFeatures: [Turf.Feature]? = nil, fractionTraveled: Double, isMain: Bool = true) -> [Double: UIColor] {

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -150,7 +150,7 @@ extension NavigationMapView {
      
      - parameter coordinate: Current position of the user location.
      */
-    func updateFractionTraveled(_ coordinate: CLLocationCoordinate2D?) {
+    func updateFractionTraveled(coordinate: CLLocationCoordinate2D?) {
         guard let granularDistances = routeLineGranularDistances,let index = routeRemainingDistancesIndex, let location = coordinate else { return }
         guard index < granularDistances.distanceArray.endIndex else { return }
         let traveledIndex = granularDistances.distanceArray[index]
@@ -176,10 +176,9 @@ extension NavigationMapView {
      Updates the route style layer and its casing style layer to gradually disappear as the user location puck travels along the displayed route.
      
      - parameter coordinate: Current position of the user location.
-     - parameter routeProgress: Current route progress.
      */
-    public func updateVanishingRouteLine(coordinate: CLLocationCoordinate2D?) {
-        updateFractionTraveled(coordinate)
+    public func travelAlongRouteLine(to coordinate: CLLocationCoordinate2D?) {
+        updateFractionTraveled(coordinate: coordinate)
         
         guard let route = routes?.first else { return }
         

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -198,20 +198,18 @@ extension NavigationMapView {
             return
         }
         
-        if !currentLineGradientStops.isEmpty {
-            do {
-                try mapView.mapboxMap.style.updateLayer(withId: mainRouteLayerIdentifier) { (lineLayer: inout LineLayer) throws in
-                    let mainRouteLayerGradient = self.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
-                    lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor))
-                }
-                
-                try mapView.mapboxMap.style.updateLayer(withId: mainRouteCasingLayerIdentifier) { (lineLayer: inout LineLayer) throws in
-                    let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveled)
-                    lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient, lineBaseColor: routeCasingColor))
-                }
-            } catch {
-                print("Failed to update main route line layer.")
+        do {
+            try mapView.mapboxMap.style.updateLayer(withId: mainRouteLayerIdentifier) { (lineLayer: inout LineLayer) throws in
+                let mainRouteLayerGradient = self.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
+                lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor))
             }
+            
+            try mapView.mapboxMap.style.updateLayer(withId: mainRouteCasingLayerIdentifier) { (lineLayer: inout LineLayer) throws in
+                let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveled)
+                lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient, lineBaseColor: routeCasingColor))
+            }
+        } catch {
+            print("Failed to update main route line layer.")
         }
         
     }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -334,7 +334,7 @@ open class NavigationMapView: UIView {
             case .courseView:
                 self.moveUserLocation(to: location)
                 if self.routeLineTracksTraversal {
-                    self.updateVanishingRouteLine(coordinate: location.coordinate)
+                    self.travelAlongRouteLine(to: location.coordinate)
                 }
             default:
                 if self.simulatesLocation, let locationProvider = self.mapView.location.locationProvider {
@@ -371,13 +371,11 @@ open class NavigationMapView: UIView {
         let isHidden = userCourseView.isHidden
         switch userLocationStyle {
         case .courseView(let courseView):
-            userCourseView = reducedAccuracyActivatedMode
-                ? UserHaloCourseView(frame: frame)
-                : courseView
-        default:
-            userCourseView = reducedAccuracyActivatedMode
-            ? UserHaloCourseView(frame: frame)
-            : UserPuckCourseView(frame: frame)
+            userCourseView = reducedAccuracyActivatedMode ? UserHaloCourseView(frame: frame) : courseView
+        case .puck2D(_):
+            userCourseView = reducedAccuracyActivatedMode ? UserHaloCourseView(frame: frame) : UserPuckCourseView(frame: frame)
+        case .puck3D(_):
+            userCourseView = reducedAccuracyActivatedMode ? UserHaloCourseView(frame: frame) : UserPuckCourseView(frame: frame)
         }
         userCourseView.isHidden = isHidden
     }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -883,8 +883,6 @@ extension NavigationViewController: NavigationServiceDelegate {
             component.navigationService(service, didEndSimulating: progress, becauseOf: reason)
         }
         navigationMapView?.mapView.location.overrideLocationProvider(with: AppleLocationProvider())
-        navigationMapView?.mapView.location.locationProvider.startUpdatingHeading()
-        navigationMapView?.mapView.location.locationProvider.startUpdatingLocation()
     }
     
     private func checkTunnelState(at location: CLLocation, along progress: RouteProgress) {

--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -44,13 +44,13 @@ extension Route {
     }
     
     func congestionFeatures(legIndex: Int? = nil,
-                            isAlternativeRoute: Bool = false,
                             roadClassesWithOverriddenCongestionLevels: Set<MapboxStreetsRoadClass>? = nil) -> [Feature] {
         guard let coordinates = shape?.coordinates, let shape = shape else { return [] }
         var features: [Feature] = []
         
         for (index, leg) in legs.enumerated() {
             let legFeatures: [Feature]
+            let currentLegAttribute = (legIndex != nil) ? index == legIndex : true
             
             if let congestionLevels = leg.segmentCongestionLevels, congestionLevels.count < coordinates.count {
                 // The last coordinate of the preceding step, is shared with the first coordinate of the next step, we don't need both.
@@ -70,8 +70,7 @@ extension Route {
                     var feature = Feature(geometry: .lineString(LineString(congestionSegment.0)))
                     feature.properties = [
                         CongestionAttribute: String(describing: congestionSegment.1),
-                        "isAlternativeRoute": isAlternativeRoute,
-                        CurrentLegAttribute: (legIndex != nil) ? index == legIndex : true
+                        CurrentLegAttribute: currentLegAttribute
                     ]
                     
                     return feature
@@ -79,8 +78,7 @@ extension Route {
             } else {
                 var feature = Feature(geometry: .lineString(LineString(shape.coordinates)))
                 feature.properties = [
-                    "isAlternativeRoute": isAlternativeRoute,
-                    CurrentLegAttribute: (legIndex != nil) ? index == legIndex : true
+                    CurrentLegAttribute: currentLegAttribute
                 ]
                 legFeatures = [feature]
             }

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -48,7 +48,7 @@ extension NavigationMapView {
         
         internal func locationUpdate(newLocation: Location) {
             if routeLineTracksTraversal {
-                navigationMapView.updateVanishingRouteLine(coordinate: newLocation.coordinate)
+                navigationMapView.travelAlongRouteLine(to: newLocation.coordinate)
             }
         }
         
@@ -89,7 +89,7 @@ extension NavigationMapView {
             navigationMapView.show([routeProgress.route], legIndex: routeProgress.legIndex)
             if routeLineTracksTraversal {
                 navigationMapView.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
-                navigationMapView.updateVanishingRouteLine(coordinate: router.location?.coordinate)
+                navigationMapView.travelAlongRouteLine(to: router.location?.coordinate)
             }
         }
         
@@ -111,7 +111,7 @@ extension NavigationMapView {
             
             if routeLineTracksTraversal {
                 navigationMapView.updateUpcomingRoutePointIndex(routeProgress: router.routeProgress)
-                navigationMapView.updateVanishingRouteLine(coordinate: location?.coordinate)
+                navigationMapView.travelAlongRouteLine(to: location?.coordinate)
             }
         }
         
@@ -142,7 +142,7 @@ extension NavigationMapView {
                     navigationMapView.setUpLineGradientStops(along: progress.route)
                 }
                 navigationMapView.updateUpcomingRoutePointIndex(routeProgress: progress)
-                navigationMapView.updateVanishingRouteLine(coordinate: location.coordinate)
+                navigationMapView.travelAlongRouteLine(to: location.coordinate)
             }
         }
         

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -357,10 +357,42 @@ class NavigationMapViewTests: TestCase {
         var lineGradient = navigationMapView.routeLineGradient(congestions, fractionTraveled: 0.0, isMain: true)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.trafficUnknownColor)
         
-        let fractionTraveled = 0.5
-        let nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        var fractionTraveled = 0.5
+        var nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
         lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient)
 
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)
+        
+        let nexDownModerateFraction = Double(CGFloat(0.3).nextDown)
+        let nexDownHeavyFraction = Double(CGFloat(0.4).nextDown)
+        lineGradient = [
+            0.0: navigationMapView.trafficSevereColor,
+            nexDownModerateFraction: navigationMapView.trafficSevereColor,
+            0.3: navigationMapView.trafficModerateColor,
+            nexDownHeavyFraction: navigationMapView.trafficModerateColor,
+            0.4: navigationMapView.trafficHeavyColor
+        ]
+        
+        fractionTraveled = 0.35
+        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient)
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficModerateColor)
+        
+        fractionTraveled = 0.45
+        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient)
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficHeavyColor)
+        
+        lineGradient = [Double:UIColor]()
+        fractionTraveled = 0.45
+        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -127,7 +127,7 @@ class NavigationMapViewTests: TestCase {
 
         navigationMapView.initPrimaryRoutePoints(route: route)
         navigationMapView.updateUpcomingRoutePointIndex(routeProgress: testRouteProgress)
-        navigationMapView.updateFractionTraveled(targetPoint)
+        navigationMapView.updateFractionTraveled(coordinate: targetPoint)
 
         let expectedTraveledFraction = 0.06383308537010246
 
@@ -374,6 +374,13 @@ class NavigationMapViewTests: TestCase {
             nexDownHeavyFraction: navigationMapView.trafficModerateColor,
             0.4: navigationMapView.trafficHeavyColor
         ]
+        
+        fractionTraveled = 0.3
+        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient)
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficModerateColor)
         
         fractionTraveled = 0.35
         nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -127,7 +127,7 @@ class NavigationMapViewTests: TestCase {
 
         navigationMapView.initPrimaryRoutePoints(route: route)
         navigationMapView.updateUpcomingRoutePointIndex(routeProgress: testRouteProgress)
-        navigationMapView.updateTraveledRouteLine(targetPoint)
+        navigationMapView.updateFractionTraveled(targetPoint)
 
         let expectedTraveledFraction = 0.06383308537010246
 
@@ -349,6 +349,21 @@ class NavigationMapViewTests: TestCase {
         congestions.enumerated().forEach {
             XCTAssertEqual(congestionLevel($0.element), expectedCongestionLevels[$0.offset])
         }
+    }
+    
+    func testUpdateRouteLineGradient() {
+        let route = loadRoute(from: "route-with-road-classes-single-congestion")
+        let congestions = route.congestionFeatures()
+        var lineGradient = navigationMapView.routeLineGradient(congestions, fractionTraveled: 0.0, isMain: true)
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.trafficUnknownColor)
+        
+        let fractionTraveled = 0.5
+        let nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient)
+
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)
     }
     
     func testRoadClassesWithOverriddenCongestionLevelsRemovesDuplicates() {


### PR DESCRIPTION
### Description
This pr is to fix #3141  to improve the performance, reduce calculation and battery usage as below.

|                                                  | previous                     | now                                                                                |
|--------------------------------------------------|------------------------------|----------------------------------------------------------------------------------------|
| calculate route congestion features frequency    | by frame rate                | when refresh(/30s in Example), route leg change, or route congestion level info change |
| update route line gradient method per frame rate | generate route line gradient | update route line gradient                                                             |
| generate route line gradient frequency           | by frame rate                | when refresh(/30s in Example), route leg change, or route congestion level info change |
| update route line gradient                       |                              | truncate the existing line gradient to a smaller size                                  |

### Implementation
- [x] Calculate the current route leg congestion features only when it's changed and `routeLineTracksTraversal` enabled.
- [x] Remove `Timer` related parameters for vanishing route line implementation.
- [x] Replace the `navigationMapView.updateRoute(_:)` with `navigationMapView.updateVanishingRouteLine(coordinate::)` to keep the vanishing route line better synced with `routeProgress` update and location update, even if the frame rate is low.
- [x]  Fix the [issue](https://github.com/mapbox/mapbox-navigation-ios/issues/3126#issuecomment-887041529) cause by delegate mix of route layer and casing layer shape in adding layers. 
- [x] Update the vanishing route line when routeProgress update and refreshed, to keep the route line better synced under low frame rate.
- [x] Update the line gradient stops instead of re-calculating them during vanishing route line, to reduce the calculation.
- [x]  Remove the usage of the `isAlternativeRoute` parameter, fix #3170 
- [x] Fix the `rerouting` and `index` issue with removing the forcefully feeding `mapView` with location update when in non-simulation mode and default `userCourseView` used, and stop to call the navigation service of leg index update in CarPlay.
- [x] Fix the leg index change in `CarPlay` after arrival of intermediate waypoint, which may lead to navigator confused about the status.
- [x] Fix the issue when leg index change, the `CarPlay` doesn't change the styling of route line and the `waypoint`.
- [x] Update tests and documentation
- [x] Update the changeLog.

### Screenshots or Gifs

![routeLine](https://user-images.githubusercontent.com/48976398/127586531-3d70ca03-0673-4429-a62e-336ac2983602.gif)
