### PR TITLE
Fixes map ornaments position on non-fullscreen presentation

### DIFF
--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -354,7 +354,7 @@ extension NavigationMapView {
          */
         private func updateMapViewOrnaments() {
             let bottomBannerHeight = navigationViewData.navigationView.bottomBannerContainerView.bounds.height
-            let bottomBannerVerticalOffset = UIScreen.main.bounds.height - bottomBannerHeight - navigationViewData.navigationView.bottomBannerContainerView.frame.origin.y
+            let bottomBannerVerticalOffset = navigationViewData.navigationView.bounds.height - bottomBannerHeight - navigationViewData.navigationView.bottomBannerContainerView.frame.origin.y
             let defaultOffset: CGFloat = 10.0
             let x: CGFloat = defaultOffset
             let y: CGFloat = bottomBannerHeight + defaultOffset + bottomBannerVerticalOffset


### PR DESCRIPTION
Fixes #3093

The calculation assumed that navigation view is in full screen.

![Simulator Screen Shot - iPad Air 14 5 - 2021-07-27 at 12 27 49](https://user-images.githubusercontent.com/413986/127133050-a50f01a3-1463-4e3b-97fc-e8f0cd90d94e.png)

