### PR TITLE
Fix MapboxCoreNavigation compilation on Xcode 13b3

### DIFF
--- a/Sources/MapboxCoreNavigation/ActiveNavigationEventDetails.swift
+++ b/Sources/MapboxCoreNavigation/ActiveNavigationEventDetails.swift
@@ -5,6 +5,7 @@ import AVFoundation
 import MapboxDirections
 import MapboxMobileEvents
 
+@available(iOSApplicationExtension, unavailable)
 struct ActiveNavigationEventDetails: NavigationEventDetails {
     let coordinate: CLLocationCoordinate2D?
     let distance: CLLocationDistance?

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -287,6 +287,7 @@ extension PassiveLocationManager {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension MapboxNavigationService {
     /**
      Keys in the user info dictionaries of various notifications posted by instances of `NavigationService`.

--- a/Sources/MapboxCoreNavigation/EventDetails.swift
+++ b/Sources/MapboxCoreNavigation/EventDetails.swift
@@ -82,6 +82,7 @@ protocol NavigationEventDetails: EventDetails {
     var totalTimeInBackground: TimeInterval { get set }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension NavigationEventDetails {
     var audioType: String { AVAudioSession.sharedInstance().audioType }
     var applicationState: UIApplication.State {

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -5,6 +5,7 @@ import Polyline
 import MapboxMobileEvents
 import Turf
 
+@available(iOSApplicationExtension, unavailable)
 @available(*, deprecated, renamed: "RouteController")
 open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationManagerDelegate {
     

--- a/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/NavigationEventsManager.swift
@@ -30,6 +30,7 @@ public protocol EventsManagerDataSource: AnyObject {
 /**
  The `NavigationEventsManager` is responsible for being the liaison between MapboxCoreNavigation and the Mapbox telemetry framework.
  */
+@available(iOSApplicationExtension, unavailable)
 open class NavigationEventsManager {
     static let applicationSessionIdentifier = UUID()
     

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -35,6 +35,7 @@ public enum SimulationMode: Int {
  
  If you use a navigation service by itself, outside of `NavigationViewController`, call `start()` when the user is ready to begin navigating along the route.
  */
+@available(iOSApplicationExtension, unavailable)
 public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, EventsManagerDataSource {
     /**
      The location manager for the service. This will be the object responsible for notifying the service of GPS updates.
@@ -120,6 +121,7 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
  
  If you use a navigation service by itself, outside of `NavigationViewController`, call `start()` when the user is ready to begin navigating along the route.
  */
+@available(iOSApplicationExtension, unavailable)
 public class MapboxNavigationService: NSObject, NavigationService {
     typealias DefaultRouter = RouteController
 
@@ -397,6 +399,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension MapboxNavigationService: CLLocationManagerDelegate {
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
         router.locationManager?(manager, didUpdateHeading: newHeading)
@@ -444,6 +447,7 @@ extension MapboxNavigationService: CLLocationManagerDelegate {
 }
 
 //MARK: - RouteControllerDelegate
+@available(iOSApplicationExtension, unavailable)
 extension MapboxNavigationService: RouterDelegate {
     typealias Default = RouteController.DefaultBehavior
     
@@ -525,6 +529,8 @@ extension MapboxNavigationService: RouterDelegate {
 }
 
 //MARK: EventsManagerDataSource Logic
+
+@available(iOSApplicationExtension, unavailable)
 extension MapboxNavigationService {
     public var routeProgress: RouteProgress {
         return router.routeProgress
@@ -536,6 +542,8 @@ extension MapboxNavigationService {
 }
 
 //MARK: RouterDataSource
+
+@available(iOSApplicationExtension, unavailable)
 extension MapboxNavigationService {
     public var locationManagerType: NavigationLocationManager.Type {
         return type(of: locationManager)

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -15,6 +15,7 @@ import os.log
  - seealso: NavigationViewControllerDelegate
  - seealso: RouterDelegate
  */
+@available(iOSApplicationExtension, unavailable)
 public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Returns whether the navigation service should be allowed to calculate a new route.
@@ -204,6 +205,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     func navigationService(_ service: NavigationService, didEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent)
 }
 
+@available(iOSApplicationExtension, unavailable)
 public extension NavigationServiceDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.

--- a/Sources/MapboxCoreNavigation/PassiveNavigationEventDetails.swift
+++ b/Sources/MapboxCoreNavigation/PassiveNavigationEventDetails.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreLocation
 
+@available(iOSApplicationExtension, unavailable)
 struct PassiveNavigationEventDetails: NavigationEventDetails {
     let coordinate: CLLocationCoordinate2D?
     let created = Date()

--- a/Sources/MapboxCoreNavigation/ScreenCapture.swift
+++ b/Sources/MapboxCoreNavigation/ScreenCapture.swift
@@ -36,6 +36,7 @@ extension UIImage {
 
 #endif
 
+@available(iOSApplicationExtension, unavailable)
 func captureScreen(scaledToFit width: CGFloat) -> Data? {
     #if os(iOS)
         guard let image = UIApplication.shared.keyWindow?.capture()?.scaled(toFit: width) else { return nil }


### PR DESCRIPTION
MapboxNavigation cannot be fixed due to MapboxMaps that needs to get the fix first.

This is a regression due to a new rule in Xcode 13b3:

Linking Swift packages from application extension targets or watchOS applications no longer emits unresolvable warnings about linking to libraries not safe for use in application extensions. This means that code referencing APIs annotated as unavailable for use in app extensions must now themselves be annotated as unavailable for use in application extensions, in order to allow that code to be used in both apps and app extensions. (66928265)

https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes