### PR TITLE
Do not show traffic by default in `CarPlayMapViewController`.

### DIFF
--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -191,6 +191,7 @@ public class CarPlayMapViewController: UIViewController {
         navigationMapView.delegate = self
         navigationMapView.mapView.mapboxMap.onNext(.styleLoaded) { _ in
             navigationMapView.localizeLabels()
+            navigationMapView.mapView.showsTraffic = false
         }
         
         navigationMapView.userLocationStyle = .puck2D()


### PR DESCRIPTION
### Description

To match `NavigationViewController`, `NavigationMapView` and `CarPlayNavigationViewController` behavior, `CarPlayMapViewController` should not show traffic.