### PR TITLE
Refactor SimulatedLocationManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Renamed `PassiveLocationManager.startUpdatingLocation(completionHandler:)` to `PassiveLocationProvider.startUpdatingLocation()`. This method now runs synchronously like `CLLocationManager.startUpdatingLocation()`. ([#2823](https://github.com/mapbox/mapbox-navigation-ios/pull/2823))
 * Added the `RouteController.startRecordingHistory()`, `RouteController.stopRecordingHistory(completionHandler:)`, `PassiveLocationManager.startRecordingHistory()`, and `PassiveLocationManager.stopRecordingHistory(completionHandler:)` methods for recording details about a trip for debugging purposes. ([#3157](https://github.com/mapbox/mapbox-navigation-ios/pull/3157))
 * Renamed `RouterDataSource.locationProvider` and `EventsManagerDataSource.locationProvider` properties to `RouterDataSource.locationManagerType` and `EventsManagerDataSource.locationManagerType` respectively. ([#3199](https://github.com/mapbox/mapbox-navigation-ios/pull/3199))
+* `SimulatedLocationManager` consumes less CPU on the main thread. You can specify a GCD queue that will be used for location calculations in the initializer. 
 
 ### Electronic horizon
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		110766AD26A5A64000832F01 /* PassiveNavigationEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110766AC26A5A64000832F01 /* PassiveNavigationEventDetails.swift */; };
-		11B3D6D626A60EBD0057C6F4 /* ActiveNavigationEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3D6D526A60EBD0057C6F4 /* ActiveNavigationEventDetails.swift */; };
 		1144426C26A73FBA00B0CECE /* FeedbackEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1144426B26A73FBA00B0CECE /* FeedbackEvent.swift */; };
+		11B3D6D626A60EBD0057C6F4 /* ActiveNavigationEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3D6D526A60EBD0057C6F4 /* ActiveNavigationEventDetails.swift */; };
 		11D1F89E269601150053A93F /* NativeHandlersFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F89D269601150053A93F /* NativeHandlersFactoryTests.swift */; };
 		11D1F8A02696048D0053A93F /* Dictionary+DeepMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F89F2696048D0053A93F /* Dictionary+DeepMerge.swift */; };
 		11D1F8A22696EBD40053A93F /* Dictionary+Equality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F8A12696EBD40053A93F /* Dictionary+Equality.swift */; };
@@ -344,6 +344,7 @@
 		DAF27248264E028B00C0AC37 /* Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF27247264E028B00C0AC37 /* Geometry.swift */; };
 		DAF27252264E02D800C0AC37 /* RoadObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF27251264E02D800C0AC37 /* RoadObject.swift */; };
 		DAFA92071F01735000A7FB09 /* DistanceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */; };
+		E20DF75B26B18ECB00F61AB1 /* DispatchQueue++.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20DF75A26B18ECB00F61AB1 /* DispatchQueue++.swift */; };
 		E23D8B6B269D7EE90094CEFA /* TilesetDescriptorFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23D8B6A269D7EE90094CEFA /* TilesetDescriptorFactoryTests.swift */; };
 		E26AB4FD269F7BCA00FD756B /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26AB4FC269F7BCA00FD756B /* TestCase.swift */; };
 		E2842798265B907C003F86E4 /* UnimplementedLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2842797265B907C003F86E4 /* UnimplementedLoggingTests.swift */; };
@@ -468,8 +469,8 @@
 
 /* Begin PBXFileReference section */
 		110766AC26A5A64000832F01 /* PassiveNavigationEventDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassiveNavigationEventDetails.swift; sourceTree = "<group>"; };
-		11B3D6D526A60EBD0057C6F4 /* ActiveNavigationEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveNavigationEventDetails.swift; sourceTree = "<group>"; };
 		1144426B26A73FBA00B0CECE /* FeedbackEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackEvent.swift; sourceTree = "<group>"; };
+		11B3D6D526A60EBD0057C6F4 /* ActiveNavigationEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveNavigationEventDetails.swift; sourceTree = "<group>"; };
 		11D1F89D269601150053A93F /* NativeHandlersFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeHandlersFactoryTests.swift; sourceTree = "<group>"; };
 		11D1F89F2696048D0053A93F /* Dictionary+DeepMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+DeepMerge.swift"; sourceTree = "<group>"; };
 		11D1F8A12696EBD40053A93F /* Dictionary+Equality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Equality.swift"; sourceTree = "<group>"; };
@@ -909,6 +910,7 @@
 		DAFEB36D2093A11F00A86A83 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DAFEB36E2093A3E000A86A83 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DAFEB36F2093A3EF00A86A83 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ko; path = Resources/ko.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		E20DF75A26B18ECB00F61AB1 /* DispatchQueue++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue++.swift"; sourceTree = "<group>"; };
 		E23D8B6A269D7EE90094CEFA /* TilesetDescriptorFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TilesetDescriptorFactoryTests.swift; sourceTree = "<group>"; };
 		E26AB4FC269F7BCA00FD756B /* TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		E27A21F22654FB6800AA935F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1585,6 +1587,7 @@
 		C5ADFBCB1DDCC7840011824B /* MapboxCoreNavigation */ = {
 			isa = PBXGroup;
 			children = (
+				E20DF75926B18ECB00F61AB1 /* Utils */,
 				2BE701A4253760B300F46E4E /* RouteAlerts */,
 				DA5F446325F0744C00F573EC /* EHorizon */,
 				354A9BC920EA9BC100F03325 /* Events */,
@@ -1695,6 +1698,14 @@
 				DA5F44A325F07A6500F573EC /* RoadObjectType.swift */,
 			);
 			path = EHorizon;
+			sourceTree = "<group>";
+		};
+		E20DF75926B18ECB00F61AB1 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				E20DF75A26B18ECB00F61AB1 /* DispatchQueue++.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		E2D1494F265CF97D008135A3 /* CarPlayTestHelper */ = {
@@ -2472,6 +2483,7 @@
 				DA5F44F525F07D3B00F573EC /* RoadObjectsStoreDelegate.swift in Sources */,
 				DA5F44C725F07AB700F573EC /* RoadName.swift in Sources */,
 				DA5F44AC25F07A6800F573EC /* RoadGraphPosition.swift in Sources */,
+				E20DF75B26B18ECB00F61AB1 /* DispatchQueue++.swift in Sources */,
 				2E50E0E6264E49EF009D3848 /* OpenLRIdentifier.swift in Sources */,
 				353E69041EF0C4E5007B2AE5 /* SimulatedLocationManager.swift in Sources */,
 				DA5F450025F07DE200F573EC /* ElectronicHorizonOptions.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/EventDetails.swift
+++ b/Sources/MapboxCoreNavigation/EventDetails.swift
@@ -85,10 +85,8 @@ protocol NavigationEventDetails: EventDetails {
 extension NavigationEventDetails {
     var audioType: String { AVAudioSession.sharedInstance().audioType }
     var applicationState: UIApplication.State {
-        if Thread.isMainThread {
-            return UIApplication.shared.applicationState
-        } else {
-            return DispatchQueue.main.sync { UIApplication.shared.applicationState }
+        onMainQueueSync {
+            UIApplication.shared.applicationState
         }
     }
     var batteryLevel: Int { UIDevice.current.batteryLevel >= 0 ? Int(UIDevice.current.batteryLevel * 100) : -1 }

--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -53,10 +53,10 @@ open class SimulatedLocationManager: NavigationLocationManager {
     private let configuration: Configuration
 
     internal var currentDistance: CLLocationDistance
+    private let queue: DispatchQueue
     private var currentSpeed: CLLocationSpeed
     private let accuracy: DispatchTimeInterval = .milliseconds(50)
     private let updateInterval: DispatchTimeInterval = .milliseconds(1000)
-    private let queue: DispatchQueue
     private var timer: DispatchTimer!
     
     private var locations: [SimulatedLocation] = []
@@ -201,7 +201,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
     }
     
     internal func tick() {
-        let (routeShape, currentDistance, shape, expectedSegmentTravelTimes, speedMultiplier, configuration) = DispatchQueue.main.sync {
+        let (routeShape, currentDistance, shape, expectedSegmentTravelTimes, speedMultiplier, configuration) = onMainQueueSync {
                     (
                         self.routeShape,
                         self.currentDistance,
@@ -221,7 +221,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
         guard let lookAheadCoordinate = polyline.coordinateFromStart(distance: currentDistance + 10) else { return }
         guard let closestCoordinate = polyline.closestCoordinate(to: newCoordinate) else { return }
         
-        let closestLocation = DispatchQueue.main.sync { self.locations[closestCoordinate.index] }
+        let closestLocation = onMainQueueSync { self.locations[closestCoordinate.index] }
         let distanceToClosest = closestLocation.distance(from: CLLocation(newCoordinate))
         
         let distance = min(max(distanceToClosest, 10), configuration.safeDistance)
@@ -243,7 +243,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
         }
 
         let course = newCoordinate.direction(to: lookAheadCoordinate).wrap(min: 0, max: 360)
-        DispatchQueue.main.async {
+        onMainQueueSync {
             let location = CLLocation(coordinate: newCoordinate,
                                       altitude: 0,
                                       horizontalAccuracy: configuration.horizontalAccuracy,

--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -30,19 +30,20 @@ fileprivate class SimulatedLocation: CLLocation {
  */
 open class SimulatedLocationManager: NavigationLocationManager {
     internal var currentDistance: CLLocationDistance = 0
-    fileprivate var currentSpeed: CLLocationSpeed = 30
-    fileprivate let accuracy: DispatchTimeInterval = .milliseconds(50)
-    let updateInterval: DispatchTimeInterval = .milliseconds(1000)
-    fileprivate var timer: DispatchTimer!
+    private var currentSpeed: CLLocationSpeed = 30
+    private let accuracy: DispatchTimeInterval = .milliseconds(50)
+    private let updateInterval: DispatchTimeInterval = .milliseconds(1000)
+    private var timer: DispatchTimer!
     
-    fileprivate var locations: [SimulatedLocation]!
-    fileprivate var routeShape: LineString!
+    private var locations: [SimulatedLocation] = []
+    private var routeShape: LineString?
     
     /**
      Specify the multiplier to use when calculating speed based on the RouteLeg’s `expectedSegmentTravelTimes`.
      */
     public var speedMultiplier: Double = 1
-    fileprivate var simulatedLocation: CLLocation?
+    private var simulatedLocation: CLLocation?
+    
     override open var location: CLLocation? {
         get {
             return simulatedLocation

--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -103,6 +103,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
      Initalizes a new `SimulatedLocationManager` with the given route.
      
      - parameter route: The initial route.
+     - parameter queue: A GCD queue which is used to calculate simulated locations.
      - returns: A `SimulatedLocationManager`
      */
     public convenience init(route: Route, configuration: Configuration = .default, queue: DispatchQueue = defaultQueue) {
@@ -113,6 +114,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
      Initalizes a new `SimulatedLocationManager` with the given routeProgress.
      
      - parameter routeProgress: The routeProgress of the current route.
+     - parameter queue: A GCD queue which is used to calculate simulated locations.
      - returns: A `SimulatedLocationManager`
      */
     public convenience init(routeProgress: RouteProgress, configuration: Configuration = .default, queue: DispatchQueue = defaultQueue) {
@@ -123,6 +125,14 @@ open class SimulatedLocationManager: NavigationLocationManager {
         self.init(route: routeProgress.route, currentDistance: currentDistance, currentSpeed: currentSpeed, configuration: configuration, queue: queue)
     }
 
+    /**
+     Initalizes a new `SimulatedLocationManager` instance with the given route and initial state.
+     - Parameters:
+       - route: The initial route.
+       - currentDistance: The initial distance from the beginning of the route.
+       - currentSpeed: The initial speed of the simulation.
+       - queue: A GCD queue which is used to calculate simulated locations.
+     */
     public init(route: Route, currentDistance: CLLocationDistance, currentSpeed: CLLocationSpeed, configuration: Configuration = .default, queue: DispatchQueue = defaultQueue) {
         self.route = route
         self.currentDistance = currentDistance

--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -109,13 +109,18 @@ open class SimulatedLocationManager: NavigationLocationManager {
 
     private func postInit() {
         reset()
-        
-        self.timer = DispatchTimer(countdown: .milliseconds(0), repeating: updateInterval, accuracy: accuracy, executingOn: .main) { [weak self] in
+
+        self.timer = DispatchTimer(countdown: .milliseconds(0),
+                                   repeating: updateInterval,
+                                   accuracy: accuracy,
+                                   executingOn: .main) { [weak self] in
             self?.tick()
         }
         
-        NotificationCenter.default.addObserver(self, selector: #selector(didReroute(_:)), name: .routeControllerDidReroute, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(progressDidChange(_:)), name: .routeControllerProgressDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didReroute(_:)),
+                                               name: .routeControllerDidReroute, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(progressDidChange(_:)),
+                                               name: .routeControllerProgressDidChange, object: nil)
     }
     
     private func reset() {
@@ -183,7 +188,9 @@ open class SimulatedLocationManager: NavigationLocationManager {
             let distance = shape.coordinates[closestCoordinateOnRoute.index].distance(to: nextCoordinateOnRoute)
             currentSpeed =  max(distance / time, 2)
         } else {
-            currentSpeed = calculateCurrentSpeed(distance: distance, coordinatesNearby: coordinatesNearby, closestLocation: closestLocation)
+            currentSpeed = calculateCurrentSpeed(distance: distance,
+                                                 coordinatesNearby: coordinatesNearby,
+                                                 closestLocation: closestLocation)
         }
         
         let location = CLLocation(coordinate: newCoordinate,
@@ -202,7 +209,9 @@ open class SimulatedLocationManager: NavigationLocationManager {
                                                         speedMultiplier: speedMultiplier)
     }
     
-    private func calculateCurrentSpeed(distance: CLLocationDistance, coordinatesNearby: [CLLocationCoordinate2D]? = nil, closestLocation: SimulatedLocation) -> CLLocationSpeed {
+    private func calculateCurrentSpeed(distance: CLLocationDistance,
+                                       coordinatesNearby: [CLLocationCoordinate2D]? = nil,
+                                       closestLocation: SimulatedLocation) -> CLLocationSpeed {
         // More than 10 nearby coordinates indicates that we are in a roundabout or similar complex shape.
         if let coordinatesNearby = coordinatesNearby, coordinatesNearby.count >= 10 {
             return minimumSpeed
@@ -214,7 +223,10 @@ open class SimulatedLocationManager: NavigationLocationManager {
         // Base speed on previous or upcoming turn penalty
         else {
             let reversedTurnPenalty = maximumTurnPenalty - closestLocation.turnPenalty
-            return reversedTurnPenalty.scale(minimumIn: minimumTurnPenalty, maximumIn: maximumTurnPenalty, minimumOut: minimumSpeed, maximumOut: maximumSpeed)
+            return reversedTurnPenalty.scale(minimumIn: minimumTurnPenalty,
+                                             maximumIn: maximumTurnPenalty,
+                                             minimumOut: minimumSpeed,
+                                             maximumOut: maximumSpeed)
         }
     }
 }
@@ -261,7 +273,9 @@ extension Array where Element == CLLocationCoordinate2D {
         for (coordinate, nextCoordinate) in zip(prefix(upTo: endIndex - 1), suffix(from: 1)) {
             let currentCoordinate = locations.isEmpty ? first! : coordinate
             let course = coordinate.direction(to: nextCoordinate).wrap(min: 0, max: 360)
-            let turnPenalty = currentCoordinate.direction(to: coordinate).difference(from: coordinate.direction(to: nextCoordinate))
+            let turnPenalty = currentCoordinate
+                .direction(to: coordinate)
+                .difference(from: coordinate.direction(to: nextCoordinate))
             let location = SimulatedLocation(coordinate: coordinate,
                                              altitude: 0,
                                              horizontalAccuracy: horizontalAccuracy,

--- a/Sources/MapboxCoreNavigation/Utils/DispatchQueue++.swift
+++ b/Sources/MapboxCoreNavigation/Utils/DispatchQueue++.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// If on main thread then performs a work item. If on non-main thread then performs the work item synchronously on main queue.
+/// - returns: The return value of the item in the work parameter.
+func onMainQueueSync<T>(execute work: () throws -> T) rethrows -> T {
+    if Thread.isMainThread {
+        return try work()
+    }
+    else {
+        return try DispatchQueue.main.sync {
+            try work()
+        }
+    }
+}

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -708,8 +708,7 @@ class NavigationServiceTests: TestCase {
     }
     
     func waitForNavNativeCallbacks(timeout: TimeInterval = 0.1) {
-        let waitExpectation = expectation(description: "Waiting for the NatNative callback")
-        _ = XCTWaiter.wait(for: [waitExpectation], timeout: timeout)
+        RunLoop.current.run(until: Date() + timeout)
     }
 }
 


### PR DESCRIPTION
Review by commits.

- [x] SimulatedLocationManager.tick method is performed on a GCD queue. The user can specify which queue to use.
- [x] SimulatedLocationManager.init methods are improved with one designated initialiser and two convenience initialiser. Before it was two designated initialisers. 
- [x] Reduce the number of force unwraps
- [x] All changes backward compatible.
- [x] The constants used by `SimulatedLocationManager` can now be specified in the configuration. I haven't provide a documentation for this configuration, maybe I should. 

Main commits: a04444c52f6d6565176cfa38dd63b0c60b25ef32 13f920652fc1f3d9e5e61eba7b1f25d2c27b9831 0ef83134810fa0b8b635177f1cd4e38b3e163ef2

All commits are self contained. 