### PR TITLE
Location update source should be from routeController during active navigation.

### DIFF
--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -228,10 +228,6 @@ public class CarPlayManager: NSObject {
         let route = navigationService.route
         let routeOptions = navigationService.routeProgress.routeOptions
         
-        // Stop the background `PassiveLocationProvider` sending location and heading update `mapView` before turn-by-turn navigation session starts.
-        navigationMapView?.mapView.location.locationProvider.stopUpdatingLocation()
-        navigationMapView?.mapView.location.locationProvider.stopUpdatingHeading()
-        
         var trip = CPTrip(routes: [route], routeOptions: routeOptions, waypoints: routeOptions.waypoints)
         trip = delegate?.carPlayManager(self, willPreview: trip) ?? trip
         
@@ -601,6 +597,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         }
         
         let navigationMapView = carPlayMapViewController.navigationMapView
+        navigationMapView.mapView.location.locationProvider.stopUpdatingLocation()
         navigationMapView.removeRoutes()
         navigationMapView.removeWaypoints()
     }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -850,6 +850,8 @@ extension NavigationViewController: NavigationServiceDelegate {
             component.navigationService(service, willEndSimulating: progress, becauseOf: reason)
         }
         navigationMapView?.simulatesLocation = false
+        navigationMapView?.mapView.location.locationProvider.stopUpdatingHeading()
+        navigationMapView?.mapView.location.locationProvider.stopUpdatingLocation()
     }
     
     public func navigationService(_ service: NavigationService, didEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {
@@ -857,8 +859,6 @@ extension NavigationViewController: NavigationServiceDelegate {
             component.navigationService(service, didEndSimulating: progress, becauseOf: reason)
         }
         navigationMapView?.mapView.location.overrideLocationProvider(with: AppleLocationProvider())
-        navigationMapView?.mapView.location.locationProvider.startUpdatingHeading()
-        navigationMapView?.mapView.location.locationProvider.startUpdatingLocation()
     }
     
     private func checkTunnelState(at location: CLLocation, along progress: RouteProgress) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -417,6 +417,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         // Start the navigation service on presentation.
         navigationService.start()
+        navigationMapView?.mapView.location.locationProvider.stopUpdatingLocation()
         
         if let firstInstruction = navigationService.routeProgress.currentLegProgress.currentStepProgress.currentVisualInstruction {
             navigationService(navigationService,
@@ -850,8 +851,6 @@ extension NavigationViewController: NavigationServiceDelegate {
             component.navigationService(service, willEndSimulating: progress, becauseOf: reason)
         }
         navigationMapView?.simulatesLocation = false
-        navigationMapView?.mapView.location.locationProvider.stopUpdatingHeading()
-        navigationMapView?.mapView.location.locationProvider.stopUpdatingLocation()
     }
     
     public func navigationService(_ service: NavigationService, didEndSimulating progress: RouteProgress, becauseOf reason: SimulationIntent) {


### PR DESCRIPTION
### Description
The rerouting and wrong location update sending to the nav status could be related with two location update source during active navigation. One is from the `routeController`, when we setup the mapView for navigationMapView, when there's a `mostRecentUserCourseViewLocation` changed by the routeProgress, we force the locationProvider to feed a  location update as below:

https://github.com/mapbox/mapbox-navigation-ios/blob/b4f00ef4026f547756530a65ac318b3a511b6714/Sources/MapboxNavigation/NavigationMapView.swift#L341-L355

But at the same time, when it's in simulation mode or not, the default `AppleLocationProvider` is still sending location updates to the location consumers, which would trigger rerouting issue, and it may be different from our routeController.  Even though we nil out the `navigationMapView` in preview, but the `navigationMapView` during navigation is still affected by the background location update. Due to the singleton of the navigator, it would trigger several issues.

### Implementation
Stop the location and heading update from the locationProvider during active navigation from the background. We only feed the location Provider with the location update from the routeController. 

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->