### PR TITLE
GenericRouteShield caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 * Fixed an issue where a subclass of `NavigationRouteOptions` would turn into an ordinary `RouteOptions` when rerouting the user. ([#3192](https://github.com/mapbox/mapbox-navigation-ios/pull/3192))
 * Renamed `RouteOptions.without(waypoint:)` to `RouteOptions.without(_:)`. ([#3192](https://github.com/mapbox/mapbox-navigation-ios/pull/3192))
 * Added optional `NavigationEventsManager.userInfo` property that can be sent with all navigation events. The new optional property contains application metadata, such as the application name and version, that is included in each event to help Mapbox triage and diagnose unexpected behavior. ([#3007](https://github.com/mapbox/mapbox-navigation-ios/pull/3007)).
+* Fixed an issue when `GenericRouteShield` images would ignore changing it's foreground color in favor of cached image. ([#3217](https://github.com/mapbox/mapbox-navigation-ios/pull/3217))
 
 ## v1.4.1
 

--- a/Sources/MapboxNavigation/GenericRouteShield.swift
+++ b/Sources/MapboxNavigation/GenericRouteShield.swift
@@ -112,7 +112,7 @@ public class GenericRouteShield: StylableView {
                 currentTraitCollection.perform(performAsCurrentSelector, with: colorCopyingBlock)
             }
         }
-        let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
+        let criticalProperties: [AnyHashable?] = [dataSource.font.pointSize, dataSource.textColor, backgroundColor, foregroundColor, proxy.borderWidth, proxy.cornerRadius]
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))
     }
 }


### PR DESCRIPTION
### Description
There is a known issue about Route shield images being cached without addressing it's actual foreground color. This PR updates the caching key to resolve that.

### Implementation
Added `dataSource.textColor` to the cache key calculation. This value is related to the cache, as [it is used when generating a shield image](https://github.com/mapbox/mapbox-navigation-ios/blob/main/Sources/MapboxNavigation/InstructionPresenter.swift#L182).
