### PR TITLE
CarPlay vanishing route line

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -171,6 +171,8 @@ open class NavigationMapView: UIView {
             if routeLineTracksTraversal, let route = self.routes?.first {
                 initPrimaryRoutePoints(route: route)
                 setUpLineGradientStops(along: route)
+            } else {
+                removeLineGradientStops()
             }
         }
     }
@@ -575,6 +577,18 @@ open class NavigationMapView: UIView {
             currentLegCongestionLevels = route.legs[legIndex].segmentCongestionLevels
             let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
             currentLineGradientStops = routeLineGradient(congestionFeatures, fractionTraveled: fractionTraveled)
+        }
+    }
+    
+    /**
+     Stop the vanishing effect for route line when `routeLineTracksTraversal` disabled.
+     */
+    func removeLineGradientStops() {
+        fractionTraveled = 0.0
+        currentLegCongestionLevels = nil
+        currentLineGradientStops.removeAll()
+        if let routes = self.routes {
+            show(routes, legIndex: currentLegIndex)
         }
     }
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -162,11 +162,18 @@ open class NavigationMapView: UIView {
     var routePoints: RoutePoints?
     var routeLineGranularDistances: RouteLineGranularDistances?
     var routeRemainingDistancesIndex: Int?
-    var routeLineTracksTraversal: Bool = false
     var fractionTraveled: Double = 0.0
     var currentLegIndex: Int?
     var currentLegCongestionLevels: [CongestionLevel]?
     var currentLineGradientStops = [Double: UIColor]()
+    var routeLineTracksTraversal: Bool = false {
+        didSet {
+            if routeLineTracksTraversal, let route = self.routes?.first {
+                initPrimaryRoutePoints(route: route)
+                setUpLineGradientStops(along: route)
+            }
+        }
+    }
     
     var showsRoute: Bool {
         get {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -590,6 +590,10 @@ open class NavigationMapView: UIView {
         if let routes = self.routes {
             show(routes, legIndex: currentLegIndex)
         }
+        
+        routePoints = nil
+        routeLineGranularDistances = nil
+        routeRemainingDistancesIndex = nil
     }
 
     @discardableResult func addRouteLayer(_ route: Route,
@@ -860,8 +864,7 @@ open class NavigationMapView: UIView {
         mapView.mapboxMap.style.removeSources(sourceIdentifiers)
         
         routes = nil
-        routePoints = nil
-        routeLineGranularDistances = nil
+        removeLineGradientStops()
     }
     
     /**


### PR DESCRIPTION
### Description
- [x] fix #3200 
- [x] in case the `routeLineTracksTraversal` changed during navigation session, allow the route line update its color.

### Implementation
Due to the landing of the #3201, it needs the stored route location points to calculate useful `fractionTraveled`. We use the `navigationMapView.initPrimaryRoutePoints(route:)` in `navigationMapView.show(_:legIndex:)` to prepare for it in mobile. But in CarPlay, it would only be called if the route leg index change or rerouting. Thus the  route location points are not stored for the `fractionTraveled`. 

### Screenshots or Gifs
In the following .gif, it shows the we enable and disable the vanishing feature per 3 seconds during the navigation session.
![navSession](https://user-images.githubusercontent.com/48976398/129091015-b6c0e5c3-a894-49b1-94e2-0daf0dfcb2bc.gif)
