### PR TITLE
Fix retain cycle causing crash in RouteOverlayController on NavigationMapView reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@
 * Added optional `NavigationEventsManager.userInfo` property that can be sent with all navigation events. The new optional property contains application metadata, such as the application name and version, that is included in each event to help Mapbox triage and diagnose unexpected behavior. ([#3007](https://github.com/mapbox/mapbox-navigation-ios/pull/3007)).
 * Fixed an issue when `GenericRouteShield` images would ignore changing it's foreground color in favor of cached image. ([#3217](https://github.com/mapbox/mapbox-navigation-ios/pull/3217))
 * Fixed an issue when route line was sometimes invisilbe after starting active guidance session. ([#3205](https://github.com/mapbox/mapbox-navigation-ios/pull/3205))
+* Fixed an issue where reusing `NavigationMapView` across multiple instances of `NavigationViewController` would result in a crash. ([#3222](https://github.com/mapbox/mapbox-navigation-ios/pull/3222)) 
 
 ## v1.4.1
 

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -139,17 +139,17 @@ extension NavigationMapView {
         // MARK: - NavigationComponentDelegate implementation
         
         func navigationViewDidLoad(_ view: UIView) {
-            navigationMapView.mapView.mapboxMap.onNext(.styleLoaded) { [self] _ in
-                navigationMapView.localizeLabels()
-                navigationMapView.mapView.showsTraffic = false
+            navigationMapView.mapView.mapboxMap.onNext(.styleLoaded) { [weak self] _ in
+                self?.navigationMapView.localizeLabels()
+                self?.navigationMapView.mapView.showsTraffic = false
                 
                 // FIXME: In case when building highlighting feature is enabled due to style changes and no info currently being stored
                 // regarding building identification such highlighted building will disappear.
             }
             
             // Route line should be added to `MapView`, when its style changes.
-            navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [self] _ in
-                showRouteIfNeeded()
+            navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
+                self?.showRouteIfNeeded()
             }
         }
         


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->

This PR fixes a crash due to a retain cycle caused as part of `NavigationMapView` reuse across multiple instances of `NavigationViewController` which was made available with the injection work in #3186.

- [x] Updated Changelog

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

`RouteOverlayController.navigationViewDidLoad` defines two closures for handling map events. Each closure captures a strong reference to `self` which will result in a retain cycle if the referenced `NavigationMapView` object is used across multiple instances of `NavigationViewController`. The crash occurs on presentation of the _subsequent_ `NavigationViewController` 

Steps to reproduce this bug are:

1. Create an instance of `NavigationMapView`
2. Create and present an instance of `NavigationViewController` and inject the map view created in step 1.
3. Dismiss the instance of `NavigationViewController` ensuring the map view is still retained.
4. Create and present a second instance of `NavigationViewController` and inject the map view created in step 1.
5. Observe crash in `RouteOverlayController.showRouteIfNeeded` when `RouteOverlayController.navigationViewData` (which is implicitly unwrapped) is accessed. The crashing controller instance will be the one created by `NavigationViewController` in step 2.

Using `weak self` references breaks the retain cycle allowing `RouteOverlayController` to deinit when the owning `NavigationViewController` is deinit.

It's unclear to me at this point if the handlers added to `navigationMapView.mapView.mapboxMap` also need to be cleaned, but in the interim I believe this fix should address the more immediate crash.
