### PR TITLE
Fix buggy default MapboxNavigationService creation if custom one is provided

### DIFF
--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -425,11 +425,11 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
         
         let tileStoreLocation = navigationOptions?.tileStoreConfiguration.navigatorLocation ?? .default
-        let defaultNavigationService = MapboxNavigationService(routeResponse: routeResponse,
-                                                               routeIndex: routeIndex,
-                                                               routeOptions: routeOptions,
-                                                               tileStoreLocation: tileStoreLocation)
-        navigationService = navigationOptions?.navigationService ?? defaultNavigationService
+        navigationService = navigationOptions?.navigationService
+            ?? MapboxNavigationService(routeResponse: routeResponse,
+                                       routeIndex: routeIndex,
+                                       routeOptions: routeOptions,
+                                       tileStoreLocation: tileStoreLocation)
         navigationService.delegate = self
         
         NavigationSettings.shared.distanceUnit = routeOptions.locale.usesMetric ? .kilometer : .mile


### PR DESCRIPTION
A side effect of this is that the shared navigator is updated in
quick succession in Router initialization.

Discovered during #3195 QA. 
