### PR TITLE
Allow the resume button to stop preview for top banner and guidance cards

### DIFF
--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -56,22 +56,6 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
         navigationMapView.navigationCamera.moveToOverview()
     }
     
-    @objc func recenter(_ sender: AnyObject) {
-        recenter(sender, completion: nil)
-    }
-    
-    func recenter(_ sender: AnyObject, completion: ((CameraController, CLLocation) -> ())?) {
-        guard let location = navigationMapView.mostRecentUserCourseViewLocation else { return }
-        
-        navigationMapView.moveUserLocation(to: location)
-        completion?(self, location)
-        
-        navigationMapView.navigationCamera.follow()
-        navigationMapView.addArrow(route: router.route,
-                                   legIndex: router.routeProgress.legIndex,
-                                   stepIndex: router.routeProgress.currentLegProgress.stepIndex + 1)
-    }
-    
     func center(on step: RouteStep,
                 route: Route,
                 legIndex: Int,
@@ -147,7 +131,6 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     
     func navigationViewDidLoad(_: UIView) {
         navigationViewData.navigationView.overviewButton.addTarget(self, action: #selector(overview(_:)), for: .touchUpInside)
-        navigationViewData.navigationView.resumeButton.addTarget(self, action: #selector(recenter(_:)), for: .touchUpInside)
         
         self.navigationMapView.userCourseView.isHidden = false
         self.navigationViewData.navigationView.resumeButton.isHidden = true

--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -56,6 +56,25 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
         navigationMapView.navigationCamera.moveToOverview()
     }
     
+    @objc func recenter(_ sender: AnyObject) {
+        recenter(sender, completion: nil)
+    }
+    
+    func recenter(_ sender: AnyObject, completion: ((CameraController, CLLocation) -> ())?) {
+        guard let location = navigationMapView.mostRecentUserCourseViewLocation else { return }
+
+        navigationMapView.moveUserLocation(to: location)
+        completion?(self, location)
+
+        navigationMapView.navigationCamera.follow()
+        navigationMapView.addArrow(route: router.route,
+                                   legIndex: router.routeProgress.legIndex,
+                                   stepIndex: router.routeProgress.currentLegProgress.stepIndex + 1)
+        
+        let navigationViewController = navigationViewData.containerViewController as? NavigationViewController
+        navigationViewController?.navigationComponents.compactMap({ $0 as? NavigationMapInteractionObserver }).forEach { $0.navigationViewController(didCenterOn: location) }
+    }
+    
     func center(on step: RouteStep,
                 route: Route,
                 legIndex: Int,
@@ -131,6 +150,7 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     
     func navigationViewDidLoad(_: UIView) {
         navigationViewData.navigationView.overviewButton.addTarget(self, action: #selector(overview(_:)), for: .touchUpInside)
+        navigationViewData.navigationView.resumeButton.addTarget(self, action: #selector(recenter(_:)), for: .touchUpInside)
         
         self.navigationMapView.userCourseView.isHidden = false
         self.navigationViewData.navigationView.resumeButton.isHidden = true

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -517,25 +517,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         navigationMapView?.navigationCamera.follow()
     }
     
-    func setupResumeButton() {
-        navigationView.resumeButton.addTarget(self, action: #selector(recenter(_:)), for: .touchUpInside)
-    }
-    
-    @objc func recenter(_ sender: AnyObject) {
-        guard let location = navigationMapView?.mostRecentUserCourseViewLocation else { return }
-        
-        navigationMapView?.moveUserLocation(to: location)
-        
-        navigationMapView?.navigationCamera.follow()
-        navigationMapView?.addArrow(route: router.route,
-                                   legIndex: router.routeProgress.legIndex,
-                                   stepIndex: router.routeProgress.currentLegProgress.stepIndex + 1)
-        
-        navigationComponents.compactMap({ $0 as? NavigationMapInteractionObserver }).forEach {
-            $0.navigationViewController(didCenterOn: location)
-        }
-    }
-    
     func addTopBanner(_ navigationOptions: NavigationOptions?) -> ContainerViewController {
         let topBanner = navigationOptions?.topBanner ?? {
             let viewController: TopBannerViewController = .init()
@@ -593,7 +574,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         setupNavigationService()
         setupVoiceController()
         setupNavigationCamera()
-        setupResumeButton()
     }
     
     open override func viewWillAppear(_ animated: Bool) {
@@ -1043,7 +1023,7 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
             banner.displayStepsTable()
             
             if banner.isDisplayingPreviewInstructions {
-                recenter(self)
+                cameraController?.recenter(self)
             }
         default:
             break
@@ -1116,7 +1096,7 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
     }
     
     public func topBanner(_ banner: TopBannerViewController, didDisplayStepsController: StepsViewController) {
-        recenter(self)
+        cameraController?.recenter(self)
     }
 }
 


### PR DESCRIPTION
### Description
This pr is to fix #3232 by allow the resume button to stop the preview of top instruction banner and guidance cards

### Implementation
Allow the `navigationViewController` to call its components when resume button is pressed and a recenter is going on.

### Screenshots or Gifs
![resume](https://user-images.githubusercontent.com/48976398/128947040-bb2c625d-a143-4c69-a5f6-c8c0def8ea39.gif)
