### PR TITLE
Introduce IdleTimerManager to streamline idle timer management and fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 * Fixed an issue where reusing `NavigationMapView` across multiple instances of `NavigationViewController` would result in a crash. ([#3222](https://github.com/mapbox/mapbox-navigation-ios/pull/3222)) 
 * Fixed missing feedback subtype description for `FeedbackType.incorrectVisual(subtype: .incorrectSpeedLimit)` and all "other" subtypes. ([#3238](https://github.com/mapbox/mapbox-navigation-ios/pull/3238))
 * Fixed an issue where the first location update was incorrectly generated in the `NavigationService.start()` method. ([#3239](https://github.com/mapbox/mapbox-navigation-ios/pull/3239/files))
+* Fixed an issue where `UIApplication.shared.isIdleTimerDisabled` was not properly set in some cases. ([#3245](https://github.com/mapbox/mapbox-navigation-ios/pull/3245))
 
 ## v1.4.1
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		E2C1CDB3265E43BC00E158E0 /* MapboxCoreNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5ADFBC91DDCC7840011824B /* MapboxCoreNavigation.framework */; };
 		E2C1CDB5265E43D500E158E0 /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDB4265E43D500E158E0 /* Quick.xcframework */; };
 		E2C1CDB7265E43E100E158E0 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDB6265E43E100E158E0 /* Nimble.xcframework */; };
+		E2C623A726CBFCE1005769FA /* OnMainQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C623A626CBFCE1005769FA /* OnMainQueue.swift */; };
 		E2C9D8A7268DCB7B005D8955 /* XCTestCase++.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C9D8A6268DCB7B005D8955 /* XCTestCase++.swift */; };
 		E2C9D8A9268DCE31005D8955 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C9D8A8268DCE31005D8955 /* XCTest.framework */; };
 		E2CC18F4265FA28900D61CBC /* Cedar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2CC18F3265FA28900D61CBC /* Cedar.framework */; };
@@ -937,6 +938,7 @@
 		E2C1CDAF265E22C100E158E0 /* MapboxCommon.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MapboxCommon.xcframework; path = Carthage/Build/MapboxCommon.xcframework; sourceTree = "<group>"; };
 		E2C1CDB4265E43D500E158E0 /* Quick.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Quick.xcframework; path = Carthage/Build/Quick.xcframework; sourceTree = "<group>"; };
 		E2C1CDB6265E43E100E158E0 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
+		E2C623A626CBFCE1005769FA /* OnMainQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnMainQueue.swift; sourceTree = "<group>"; };
 		E2C9D8A6268DCB7B005D8955 /* XCTestCase++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase++.swift"; sourceTree = "<group>"; };
 		E2C9D8A8268DCE31005D8955 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		E2CC18F3265FA28900D61CBC /* Cedar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cedar.framework; path = "Carthage/Checkouts/mapbox-events-ios/Frameworks/Cedar.framework"; sourceTree = "<group>"; };
@@ -1730,6 +1732,7 @@
 				5A39B9272498F9890026DFD1 /* PassiveLocationManager.swift */,
 				8A3A218F25EEC00200EDA999 /* CoreNavigationNavigator.swift */,
 				2E6656F8264EC912009463EE /* Result+Expected.swift */,
+				E2C623A626CBFCE1005769FA /* OnMainQueue.swift */,
 			);
 			name = MapboxCoreNavigation;
 			path = Sources/MapboxCoreNavigation;
@@ -2558,6 +2561,7 @@
 				2E50E0DC264E49C8009D3848 /* RoadObjectMatcherDelegate.swift in Sources */,
 				DA5F44BA25F07AA500F573EC /* RoadGraphEdgeMetadata.swift in Sources */,
 				DABA591525E58D5600D0C1DB /* Accounts.swift in Sources */,
+				E2C623A726CBFCE1005769FA /* OnMainQueue.swift in Sources */,
 				C5C94C1C1DDCD2340097296A /* LegacyRouteController.swift in Sources */,
 				3A8187C924BDAE9C00708F19 /* URLSession.swift in Sources */,
 				359574A81F28CC5A00838209 /* CLLocation.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/OnMainQueue.swift
+++ b/Sources/MapboxCoreNavigation/OnMainQueue.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/**
+ If on main thread then perform `work` block immediately, otherwise asynchrounsly perform `work` block on the main queue.
+ */
+@_spi(MapboxInternal)
+public func onMainAsync(_ work: @escaping () -> Void) {
+    if Thread.isMainThread {
+        work()
+    }
+    else {
+        DispatchQueue.main.async(execute: work)
+    }
+}
+
+/**
+ If on main thread then performs a work item.
+ If on non-main thread then performs the work item synchronously on main queue.
+
+ - returns: The return value of the item in the work parameter.
+ */
+@_spi(MapboxInternal)
+public func onMainQueueSync<T>(execute work: () throws -> T) rethrows -> T {
+    if Thread.isMainThread {
+        return try work()
+    }
+    else {
+        return try DispatchQueue.main.sync {
+            try work()
+        }
+    }
+}

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -180,6 +180,7 @@ public class CarPlayManager: NSObject {
     }
     
     private weak var navigationService: NavigationService?
+    private var idleTimerCancellable: IdleTimerManager.Cancellable?
     
     internal var mapTemplateProvider: MapTemplateProvider
     
@@ -283,10 +284,9 @@ extension CarPlayManager: CPApplicationDelegate {
         interfaceController.delegate = self
         self.interfaceController = interfaceController
 
-        if let shouldDisableIdleTimer = delegate?.carPlayManagerShouldDisableIdleTimer(self) {
-            UIApplication.shared.isIdleTimerDisabled = shouldDisableIdleTimer
-        } else {
-            UIApplication.shared.isIdleTimerDisabled = true
+        let shouldDisableIdleTimer = delegate?.carPlayManagerShouldDisableIdleTimer(self) ?? true
+        if shouldDisableIdleTimer {
+            idleTimerCancellable = IdleTimerManager.shared.disableIdleTimer()
         }
 
         let carPlayMapViewController = CarPlayMapViewController(styles: styles)
@@ -318,11 +318,7 @@ extension CarPlayManager: CPApplicationDelegate {
 
         eventsManager.sendCarPlayDisconnectEvent()
 
-        if let shouldDisableIdleTimer = delegate?.carPlayManagerShouldDisableIdleTimer(self) {
-            UIApplication.shared.isIdleTimerDisabled = !shouldDisableIdleTimer
-        } else {
-            UIApplication.shared.isIdleTimerDisabled = false
-        }
+        idleTimerCancellable = nil
     }
 
     func mapTemplate(for interfaceController: CPInterfaceController) -> CPMapTemplate {
@@ -864,10 +860,9 @@ extension CarPlayManager {
         interfaceController.delegate = self
         self.interfaceController = interfaceController
 
-        if let shouldDisableIdleTimer = delegate?.carPlayManagerShouldDisableIdleTimer(self) {
-            UIApplication.shared.isIdleTimerDisabled = shouldDisableIdleTimer
-        } else {
-            UIApplication.shared.isIdleTimerDisabled = true
+        let shouldDisableIdleTimer = delegate?.carPlayManagerShouldDisableIdleTimer(self) ?? true
+        if shouldDisableIdleTimer {
+            idleTimerCancellable = IdleTimerManager.shared.disableIdleTimer()
         }
 
         let carPlayMapViewController = CarPlayMapViewController(styles: styles)
@@ -897,11 +892,7 @@ extension CarPlayManager {
 
         eventsManager.sendCarPlayDisconnectEvent()
 
-        if let shouldDisableIdleTimer = delegate?.carPlayManagerShouldDisableIdleTimer(self) {
-            UIApplication.shared.isIdleTimerDisabled = !shouldDisableIdleTimer
-        } else {
-            UIApplication.shared.isIdleTimerDisabled = false
-        }
+        idleTimerCancellable = nil
     }
 }
 

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -254,7 +254,7 @@ public extension CarPlayManagerDelegate {
      */
     func carPlayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
-        return false
+        return true
     }
 
     /**

--- a/Sources/MapboxNavigation/IdleTimerManager.swift
+++ b/Sources/MapboxNavigation/IdleTimerManager.swift
@@ -1,0 +1,61 @@
+import Foundation
+import UIKit
+@_spi(MapboxInternal) import MapboxCoreNavigation
+
+/// Manages `UIApplication.shared.isIdleTimerDisabled`. Thread-safe.
+final class IdleTimerManager {
+    /// While a cancellable isn't cancelled, the idle timer is disabled. A cancellable is cancelled on deallocation.
+    final class Cancellable {
+        private let onCancel: () -> Void
+
+        fileprivate init(_ onCancel: @escaping () -> Void) {
+            self.onCancel = onCancel
+        }
+
+        deinit {
+            onCancel()
+        }
+    }
+
+    static let shared: IdleTimerManager = .init()
+
+    private let lock: NSLock = .init()
+    /// Number of currently non cancelled `IdleTimerManager.Cancellable` instances.
+    private var _cancellablesCount: Int = 0 {
+        didSet {
+            _updateIdleTimer()
+        }
+    }
+
+    private init() {}
+
+    /**
+     Disables idle timer `UIApplication.shared.isIdleTimerDisabled`
+     while there is at least one non-cancelled `IdleTimerManager.Cancellable` instance.
+
+     - Returns: An instance of cancellable that you should retain until you want the idle timer to be disabled.
+     */
+    func disableIdleTimer() -> IdleTimerManager.Cancellable {
+        let cancellable = Cancellable {
+            self.changeCancellablesCount(delta: -1)
+        }
+        changeCancellablesCount(delta: 1)
+        return cancellable
+    }
+
+    private func _updateIdleTimer() {
+        let isIdleTimerDisabled = _cancellablesCount > 0
+
+        onMainAsync {
+            UIApplication.shared.isIdleTimerDisabled = isIdleTimerDisabled
+        }
+    }
+
+    private func changeCancellablesCount(delta: Int) {
+        lock.lock(); defer {
+            lock.unlock()
+        }
+        _cancellablesCount += delta
+    }
+}
+

--- a/Tests/MapboxCoreNavigationTests/IdleTimerManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/IdleTimerManagerTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import XCTest
+import TestHelper
+@testable import MapboxNavigation
+
+final class IdleTimerSpy: IdleTimer {
+    private let lock: NSLock = .init()
+    var isDisabled: Bool = false
+
+    func setDisabled(_ disabled: Bool) {
+        lock.lock(); defer {
+            lock.unlock()
+        }
+        isDisabled = disabled
+    }
+}
+
+final class IdleTimerManagerTests: TestCase {
+    private var idleManager: IdleTimerManager!
+    private var idleTimer: IdleTimerSpy!
+
+    override func setUp() {
+        super.setUp()
+        idleTimer = IdleTimerSpy()
+        idleManager = .init(idleTimer: idleTimer)
+    }
+
+    func testOneRequestToDisable() {
+        withExtendedLifetime(idleManager.disableIdleTimer()) {
+            XCTAssertEqual(idleTimer.isDisabled, true)
+        }
+        XCTAssertEqual(idleTimer.isDisabled, false)
+    }
+
+    func testMultipleRequestsToDisable() {
+        withExtendedLifetime(idleManager.disableIdleTimer()) {
+            XCTAssertEqual(idleTimer.isDisabled, true)
+            withExtendedLifetime(idleManager.disableIdleTimer()) {
+                XCTAssertEqual(idleTimer.isDisabled, true)
+            }
+            XCTAssertEqual(idleTimer.isDisabled, true)
+        }
+        XCTAssertEqual(idleTimer.isDisabled, false)
+    }
+
+    func testThreadSafety() {
+        let lock: NSLock = .init()
+        var cancellables: [IdleTimerManager.Cancellable] = []
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            lock.lock(); defer {
+                lock.unlock()
+            }
+            cancellables.append(idleManager.disableIdleTimer())
+        }
+
+        expectation(description: "Idle Timer Disabled") {
+            !self.idleTimer.isDisabled
+        }
+
+        DispatchQueue.global().async {
+            cancellables.removeAll()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+}


### PR DESCRIPTION
fixes #3227

I drafted a POC of how idle timer can look like. Then naming is temporary, but for some reason I really like to use token here :)

Given that behaviour in CarPlayManager is very confusing and contradicts itself, I've change the logic to the following:
- If `carPlayManagerShouldDisableIdleTimer` returns true: idle timer is disabled while CarPlay is active, otherwise, do nothing. 
- If NavigationViewController is visible: disable idle timer. 

Does this sound reasonable to you? Should the logic be different? 