### PR TITLE
Update Mapbox Navigation dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 * The Mapbox Navigation SDK for iOS license has changed from the ISC License to the Mapbox Terms of Service. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * You can now install MapboxNavigation using Swift Package Manager, but you can no longer install it using Carthage. If you previously installed MapboxNavigation using Carthage, use Swift Package Manager instead. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
-* MapboxNavigation now depends on [MapboxMaps v10.0.0-rc.5](https://github.com/mapbox/mapbox-maps-ios/). ([#3162](https://github.com/mapbox/mapbox-navigation-ios/pull/3162))
-* MapboxNavigation now depends on MapboxNavigationNative v60.0.0. ([#3162](https://github.com/mapbox/mapbox-navigation-ios/pull/3162))
-* MapboxNavigation now depends on MapboxCommon v14.0.1. ([#3077](https://github.com/mapbox/mapbox-navigation-ios/pull/3077))
+* MapboxNavigation now depends on [MapboxMaps v10.0.0-rc.6](https://github.com/mapbox/mapbox-maps-ios/). ([#3248](https://github.com/mapbox/mapbox-navigation-ios/pull/3248))
+* MapboxNavigation now depends on MapboxNavigationNative v62.0.0. ([#3248](https://github.com/mapbox/mapbox-navigation-ios/pull/3248))
+* MapboxNavigation now depends on MapboxCommon v16.2.0. ([#3248](https://github.com/mapbox/mapbox-navigation-ios/pull/3248))
 * MapboxNavigation now depends on MapboxMobileEvents v1.0.2. ([#3039](https://github.com/mapbox/mapbox-navigation-ios/pull/3039))
 * MapboxCoreNavigation depends on MapboxDirections v2.0.0-beta.7 but no longer depends on MapboxAccounts. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808), [#2829](https://github.com/mapbox/mapbox-navigation-ios/pull/2829), [#2837](https://github.com/mapbox/mapbox-navigation-ios/pull/2837), [#3077](https://github.com/mapbox/mapbox-navigation-ios/pull/3077), [#3182](https://github.com/mapbox/mapbox-navigation-ios/pull/3182))
-* MapboxNavigation now depends on Turf v2.0.0-beta.1. ([#3077](https://github.com/mapbox/mapbox-navigation-ios/pull/3077))
+* MapboxNavigation now depends on Turf v2.0.0-rc.1. ([#3248](https://github.com/mapbox/mapbox-navigation-ios/pull/3248))
 * MapboxNavigation and MapboxCoreNavigation require iOS 11.0 or above to run. iOS 10._x_ is no longer supported. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Xcode 12.4 or above is now required for building this SDK from source.
 * Carthage v0.38 or above is now required for installing this SDK if you use Carthage. ([#3031](https://github.com/mapbox/mapbox-navigation-ios/pull/3031))

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "16.0.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 60.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" ~> 16.2.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 62.0
 github "mapbox/mapbox-directions-swift" "v2.0.0-beta.7"
-github "mapbox/turf-swift" "v2.0.0-beta.1"
+github "mapbox/turf-swift" "v2.0.0-rc.1"
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "16.0.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "60.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "16.2.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "62.0.0"
 github "Quick/Nimble" "v9.2.0"
 github "Quick/Quick" "v3.1.2"
 github "Udumft/SwiftCLI" "da19d2a16cd5aa838d8fb7256e28c171bc67dd82"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,10 +40,10 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 60.0"
+  s.dependency "MapboxNavigationNative", "~> 62.0"
   s.dependency "MapboxDirections-pre", "2.0.0-beta.7"
   s.dependency "MapboxMobileEvents", "~> 1.0.0" # Always specify a patch release if pre-v1.0
-  s.dependency "Turf", "2.0.0-beta.1"
+  s.dependency "Turf", "2.0.0-rc.1"
 
   s.swift_version = "5.0"
 end

--- a/MapboxNavigation-Documentation.podspec
+++ b/MapboxNavigation-Documentation.podspec
@@ -46,9 +46,9 @@ Pod::Spec.new do |s|
   s.frameworks = ['CarPlay']
 
   s.dependency "MapboxDirections-pre", "2.0.0-beta.7"
-  s.dependency "MapboxMaps", "10.0.0-rc.5"
+  s.dependency "MapboxMaps", "10.0.0-rc.6"
   s.dependency "MapboxMobileEvents", "~> 1.0.0"
-  s.dependency "MapboxNavigationNative", "~> 60.0"
+  s.dependency "MapboxNavigationNative", "~> 62.0"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "Turf", "2.0.0-beta.1"
   s.dependency "MapboxSpeech-pre", "2.0.0-alpha.1"

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "b8e510896bf064cf14d12624e071839d823ce013",
-          "version": "16.0.0"
+          "revision": "d2f66c3a218b0a360f02eb32b1bdb8c7f66327ce",
+          "version": "16.2.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "19276a02acb21e76fe6e030e2fd9d8691424f92c",
-          "version": "10.0.0-rc.5"
+          "revision": "877ba379f773b364385bc519f89764f6939c35bf",
+          "version": "10.0.0-rc.6"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "f809dd694b789a56ad2b99956cf124e1f633ab43",
-          "version": "10.0.0-rc.5"
+          "revision": "edb0eb646f9dd73a87798d1bc4812d35945667a5",
+          "version": "10.0.0-rc.6"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "545bad915c41cadd808c43baf62b51a2349ccb68",
-          "version": "60.0.0"
+          "revision": "23cddf80d97c8fd5c0f40b85e4ad7c91de023df7",
+          "version": "62.0.0"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "e460a117d2ac6b7a79a68c83ed75cb9a8acaeb6c",
-          "version": "2.0.0-beta.1"
+          "revision": "555458bd67acce7322c513ddd3647c9a904f4197",
+          "version": "2.0.0-rc.1"
         }
       }
     ]

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", "10.0.0-rc.5"
+  s.dependency "MapboxMaps", "10.0.0-rc.6"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech-pre", "2.0.0-alpha.1"
   s.dependency "MapboxMobileEvents", "~> 1.0.0" # Always specify a patch release if pre-v1.0

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "b8e510896bf064cf14d12624e071839d823ce013",
-          "version": "16.0.0"
+          "revision": "d2f66c3a218b0a360f02eb32b1bdb8c7f66327ce",
+          "version": "16.2.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "19276a02acb21e76fe6e030e2fd9d8691424f92c",
-          "version": "10.0.0-rc.5"
+          "revision": "877ba379f773b364385bc519f89764f6939c35bf",
+          "version": "10.0.0-rc.6"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "856c7438f98511e91bd1624a707a3174e236c9b8",
-          "version": "2.0.0-beta.6"
+          "revision": "f55782cc1d8db87a35043c20722af9a0fb23fc0e",
+          "version": "2.0.0-beta.7"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "f809dd694b789a56ad2b99956cf124e1f633ab43",
-          "version": "10.0.0-rc.5"
+          "revision": "edb0eb646f9dd73a87798d1bc4812d35945667a5",
+          "version": "10.0.0-rc.6"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "545bad915c41cadd808c43baf62b51a2349ccb68",
-          "version": "60.0.0"
+          "revision": "23cddf80d97c8fd5c0f40b85e4ad7c91de023df7",
+          "version": "62.0.0"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "e460a117d2ac6b7a79a68c83ed75cb9a8acaeb6c",
-          "version": "2.0.0-beta.1"
+          "revision": "555458bd67acce7322c513ddd3647c9a904f4197",
+          "version": "2.0.0-rc.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
     dependencies: [
         .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .exact("2.0.0-beta.7")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "60.0.0"),
-        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", .exact("10.0.0-rc.5")),
+        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "62.0.0"),
+        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", .exact("10.0.0-rc.6")),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0-alpha.1"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", from: "3.1.2"),

--- a/Sources/MapboxCoreNavigation/EHorizon/RoadObjectMatcher.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/RoadObjectMatcher.swift
@@ -92,10 +92,16 @@ final public class RoadObjectMatcher {
 
      - parameter point: Point representing the object.
      - parameter identifier: Unique identifier of the object.
+     - parameter heading: Heading of the provided point, which is going to be matched.
      */
-    public func match(point: CLLocationCoordinate2D, identifier: RoadObjectIdentifier) {
-        let point = MatchableGeometry(id: identifier, coordinates: [point].map(CLLocation.init))
-        native.matchPoints(forPoints: [point], useOnlyPreloadedTiles: false)
+    public func match(point: CLLocationCoordinate2D, identifier: RoadObjectIdentifier, heading: CLHeading? = nil) {
+        var trueHeading: NSNumber? = nil
+        if let heading = heading, heading.trueHeading >= 0.0 {
+            trueHeading = NSNumber(value: heading.trueHeading)
+        }
+        
+        let matchablePoint = MatchablePoint(id: identifier, coordinate: point, heading: trueHeading)
+        native.matchPoints(for: [matchablePoint], useOnlyPreloadedTiles: false)
     }
 
     /**

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -43,7 +43,6 @@ class NativeHandlersFactory {
     
     lazy var navigator: MapboxNavigationNative.Navigator = {
         MapboxNavigationNative.Navigator(config: configHandle,
-                                         runLoopExecutor: runloopExecutor,
                                          cache: cacheHandle,
                                          historyRecorder: historyRecorder)
     }()
@@ -114,9 +113,5 @@ class NativeHandlersFactory {
         return configFactoryType.build(for: settingsProfile,
                                        config: navigatorConfig,
                                        customConfig: customConfigJSON)
-    }()
-    
-    lazy var runloopExecutor: RunLoopExecutorHandle = {
-        RunLoopExecutorFactory.build()
     }()
 }

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,33 +1,33 @@
 PODS:
-  - MapboxCommon (16.0.0)
-  - MapboxCoreMaps (10.0.0-rc.5):
-    - MapboxCommon (~> 16.0.0)
+  - MapboxCommon (16.2.0)
+  - MapboxCoreMaps (10.0.0-rc.6):
+    - MapboxCommon (~> 16.2)
   - MapboxCoreNavigation (2.0.0-beta.21):
     - MapboxDirections-pre (= 2.0.0-beta.7)
     - MapboxMobileEvents (~> 1.0.0)
-    - MapboxNavigationNative (~> 60.0)
-    - Turf (= 2.0.0-beta.1)
+    - MapboxNavigationNative (~> 62.0)
+    - Turf (= 2.0.0-rc.1)
   - MapboxDirections-pre (2.0.0-beta.7):
     - Polyline (~> 5.0)
     - Turf (~> 2.0.0-beta.1)
-  - MapboxMaps (10.0.0-rc.5):
-    - MapboxCommon (= 16.0.0)
-    - MapboxCoreMaps (= 10.0.0-rc.5)
+  - MapboxMaps (10.0.0-rc.6):
+    - MapboxCommon (= 16.2.0)
+    - MapboxCoreMaps (= 10.0.0-rc.6)
     - MapboxMobileEvents (= 1.0.2)
-    - Turf (= 2.0.0-beta.1)
+    - Turf (= 2.0.0-rc.1)
   - MapboxMobileEvents (1.0.2)
   - MapboxNavigation (2.0.0-beta.21):
     - MapboxCoreNavigation (= 2.0.0-beta.21)
-    - MapboxMaps (= 10.0.0-rc.5)
+    - MapboxMaps (= 10.0.0-rc.6)
     - MapboxMobileEvents (~> 1.0.0)
     - MapboxSpeech-pre (= 2.0.0-alpha.1)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (60.0.0):
-    - MapboxCommon (~> 16.0)
+  - MapboxNavigationNative (62.0.0):
+    - MapboxCommon (~> 16.2)
   - MapboxSpeech-pre (2.0.0-alpha.1)
   - Polyline (5.0.2)
   - Solar-dev (3.0.1)
-  - Turf (2.0.0-beta.1)
+  - Turf (2.0.0-rc.1)
 
 DEPENDENCIES:
   - MapboxCoreNavigation (from `../../../`)
@@ -53,18 +53,18 @@ EXTERNAL SOURCES:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  MapboxCommon: 44430838b703d0b1b5032f3c8501c60c7c70d3cc
-  MapboxCoreMaps: 0aa69120a787fce64eb66ea1068a707fbc0a3c8b
-  MapboxCoreNavigation: d79eb0b5d0d35c9ebaadbc7ed9bc07faff58c0e4
+  MapboxCommon: 4fd3d1f439655efbe0108ecd45406924054071aa
+  MapboxCoreMaps: 045ecad9bb77931e221edc122a66848d778ea87c
+  MapboxCoreNavigation: 55fda440f3cd10e388ce83c7b926a4f8c1d3f614
   MapboxDirections-pre: 929a1a63063c9c97f88b793e70143d547eaed293
-  MapboxMaps: b966939712943f6af126aadf73b82b43c0535020
+  MapboxMaps: de9ac5e180c0a5957619a8642b96767108d2f9b4
   MapboxMobileEvents: 9775eb995e06cc3ea10894bf6ab111683c8e73e7
-  MapboxNavigation: 4cd5a5c46c9ec186f46b9509f85e5fe0c8782221
-  MapboxNavigationNative: 9f49640451eca820667c657475d412e1c990d41b
+  MapboxNavigation: 0ac7b61e90508fd382860d0cd73ebc658e7d107f
+  MapboxNavigationNative: 1c91a4ca1a963a17299640a89d88ce1a97a77f09
   MapboxSpeech-pre: aeb16de604d07ceb4195150c3359d5401bb298e6
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
-  Turf: 8851f941a6e6476ea200bf057d31cf21b2418467
+  Turf: 4efd14674a1a2f9527b7c0aadde8003a7b73b1be
 
 PODFILE CHECKSUM: ce6227c2aeeca0d51c521648629d4f06ae38a439
 


### PR DESCRIPTION
Update dependencies to Turf `v2.0.0-rc.1`, Mapbox Common `v16.2.0`, Mapbox Navigation Native `v62.0.0` and Mapbox Maps `v10.0.0-rc.6`.
