### PR TITLE
Add subgraph case to RoadObjectLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * Added `RoadObjectStore.addUserDefinedRoadObject(_:)`, `RoadObjectStore.removeUserDefinedRoadObject(identifier:)`, and `RoadObjectStore.removeAllUserDefinedRoadObjects()` for adding/removing user-defined road objects to the electronic horizon. ([#3004](https://github.com/mapbox/mapbox-navigation-ios/pull/3004))
 * Removed `Alert` enum, and `alert`, `distance`, `length`, `beginCoordinate`, `endCoordinate`, `beginSegmentIndex`, and `endSegmentIndex` properties from `RouteAlerts`. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
 * Added the `RouteAlerts.roadObject` property. ([#2991](https://github.com/mapbox/mapbox-navigation-ios/pull/2991))
+* Added the `RoadObjectLocation.subgraph` enum case and the corresponding `RoadGraph.SubgraphEdge` structure represeting edges in the subgraph. ([#3250](https://github.com/mapbox/mapbox-navigation-ios/pull/3250))
 
 ### Camera
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		3EA9371104016CD402547F1A /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA938479CF48D7AD1B6369B /* ImageCache.swift */; };
 		3EA937B1F4DF73EB004BA6BE /* InstructionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93230997B8D59E3B76C8C /* InstructionPresenter.swift */; };
 		3EA93A1FEFDDB709DE84BED9 /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA938BE5468824787100228 /* ImageRepository.swift */; };
+		414119FF26C5269A00402B5D /* RoadSubgraphEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414119FE26C5269A00402B5D /* RoadSubgraphEdge.swift */; };
 		4303A3992332CD6200B5737D /* UnimplementedLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4303A3982332CD6200B5737D /* UnimplementedLogging.swift */; };
 		4316D95C24340555000DD8F8 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4316D95B24340555000DD8F8 /* Match.swift */; };
 		439FFC252304BF54004C20AA /* GuidanceCardsSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439FFC242304BF54004C20AA /* GuidanceCardsSnapshotTests.swift */; };
@@ -629,6 +630,7 @@
 		3EA938479CF48D7AD1B6369B /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		3EA938BE5468824787100228 /* ImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		3EA93A10227A7DAF1861D9F5 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
+		414119FE26C5269A00402B5D /* RoadSubgraphEdge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoadSubgraphEdge.swift; sourceTree = "<group>"; };
 		4303A3982332CD6200B5737D /* UnimplementedLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnimplementedLogging.swift; sourceTree = "<group>"; };
 		4316D95B24340555000DD8F8 /* Match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Match.swift; sourceTree = "<group>"; };
 		439FFC242304BF54004C20AA /* GuidanceCardsSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCardsSnapshotTests.swift; sourceTree = "<group>"; };
@@ -1772,9 +1774,9 @@
 			children = (
 				2EFADFE8264C1F9200B618C4 /* DistancedRoadObject.swift */,
 				DA5F44FF25F07DE200F573EC /* ElectronicHorizonOptions.swift */,
+				2E50E0E5264E49EF009D3848 /* OpenLRIdentifier.swift */,
 				2EFADFEB264C1F9200B618C4 /* OpenLROrientation.swift */,
 				2EFADFEC264C1F9200B618C4 /* OpenLRSideOfRoad.swift */,
-				2E50E0E5264E49EF009D3848 /* OpenLRIdentifier.swift */,
 				DA5F44C325F07AB500F573EC /* RoadGraph.swift */,
 				DA5F44A925F07A6700F573EC /* RoadGraphEdge.swift */,
 				DA5F44B925F07AA500F573EC /* RoadGraphEdgeMetadata.swift */,
@@ -1788,9 +1790,10 @@
 				2E50E0DB264E49C8009D3848 /* RoadObjectMatcherDelegate.swift */,
 				2E50E0D1264E468B009D3848 /* RoadObjectMatcherError.swift */,
 				2EFADFEE264C1F9200B618C4 /* RoadObjectPosition.swift */,
-				DA5F44F425F07D3B00F573EC /* RoadObjectStore.swift */,
 				DA5F44F325F07D3A00F573EC /* RoadObjectsStoreDelegate.swift */,
+				DA5F44F425F07D3B00F573EC /* RoadObjectStore.swift */,
 				DA5F44A325F07A6500F573EC /* RoadObjectType.swift */,
+				414119FE26C5269A00402B5D /* RoadSubgraphEdge.swift */,
 			);
 			path = EHorizon;
 			sourceTree = "<group>";
@@ -2514,6 +2517,7 @@
 			files = (
 				354A9BCB20EA9BDA00F03325 /* EventDetails.swift in Sources */,
 				DA5F44C625F07AB700F573EC /* RoadGraph.swift in Sources */,
+				414119FF26C5269A00402B5D /* RoadSubgraphEdge.swift in Sources */,
 				8D1A5CD2212DDFCD0059BA4A /* DispatchTimer.swift in Sources */,
 				C561735B1F182113005954F6 /* RouteStep.swift in Sources */,
 				2EFADFFE264C1F9200B618C4 /* OpenLRSideOfRoad.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/EHorizon/RoadObjectLocation.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/RoadObjectLocation.swift
@@ -36,6 +36,14 @@ public enum RoadObjectLocation {
     case polyline(path: RoadGraph.Path, shape: Turf.Geometry)
 
     /**
+     Location of an object represented as a subgraph.
+     - parameter enters: Positions of the subgraph enters.
+     - parameter exits: Positions of the subgraph exits.
+     - parameter edges: Edges of the subgraph associated by id.
+     */
+    case subgraph(enters: [RoadObjectPosition], exits: [RoadObjectPosition], edges: [RoadGraph.SubgraphEdge.Identifier: RoadGraph.SubgraphEdge])
+
+    /**
      Location of an object represented as an OpenLR line.
      - parameter path: Position of a line on a road graph.
      - parameter shape: Shape of a line.
@@ -84,6 +92,13 @@ public enum RoadObjectLocation {
         } else if native.isRouteAlert() {
             let location = native.getRouteAlert()
             self = .routeAlert(shape: Geometry(location.getShape()))
+        } else if native.isMatchedSubgraphLocation() {
+            let location = native.getMatchedSubgraphLocation()
+            let edges = location.getEdges()
+                .map { (id, edge) in (UInt(truncating: id), RoadGraph.SubgraphEdge(edge)) }
+            self = .subgraph(enters: location.getEnters().map(RoadObjectPosition.init),
+                             exits: location.getExits().map(RoadObjectPosition.init),
+                             edges: .init(uniqueKeysWithValues: edges))
         } else {
             preconditionFailure("RoadObjectLocation can't be constructed. Unknown type.")
         }

--- a/Sources/MapboxCoreNavigation/EHorizon/RoadSubgraphEdge.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/RoadSubgraphEdge.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Turf
+import MapboxNavigationNative
+
+extension RoadGraph {
+
+    /**
+     The `SubgraphEdge` represents a edge in the complex object which might be considered as a directed graph. The graph might contain loops. `innerEdgeIds` and `outerEdgeIds` properties contain edge ids, which allows to traverse the graph, obtain geometry and calculate different distances inside it.
+     */
+    public struct SubgraphEdge {
+
+        /**
+         Unique identifier of an edge.
+
+         Use a `RoadGraph` object to get more information about the edge with a given identifier.
+         */
+        public typealias Identifier = Edge.Identifier
+
+        /** Unique identifier of the edge. */
+        public let identifier: Identifier
+
+        /** The identifiers of edges in the subgraph from which the user could transition to this edge. */
+        public let innerEdgeIds: [Identifier]
+
+        /** The identifiers of edges in the subgraph to which the user could transition from this edge. */
+        public let outerEdgeIds: [Identifier]
+
+        /** The length of the edge mesured in meters. */
+        public let length: CLLocationDistance
+
+        /** The edge shape geometry. */
+        public let shape: Turf.Geometry
+
+        /**
+         Initializes a new `SubgraphEdge` object.
+
+         - parameter identifier: The unique identifier of an edge.
+         - parameter innerEdgeIds: The edges from which the user could transition to this edge.
+         - parameter outerEdgeIds: The edges to which the user could transition from this edge.
+         - parameter length: The length of the edge mesured in meters.
+         - parameter shape: The edge shape geometry.
+         */
+        public init(identifier: Identifier, innerEdgeIds: [Identifier], outerEdgeIds: [Identifier], length: CLLocationDistance, shape: Turf.Geometry) {
+            self.identifier = identifier
+            self.innerEdgeIds = innerEdgeIds
+            self.outerEdgeIds = outerEdgeIds
+            self.length = length
+            self.shape = shape
+        }
+
+        init(_ native: MapboxNavigationNative.SubgraphEdge) {
+            self.identifier = UInt(native.id)
+            self.innerEdgeIds = native.innerEdgeIds.map(UInt.init(truncating:))
+            self.outerEdgeIds = native.outerEdgeIds.map(UInt.init(truncating:))
+            self.length = native.length
+            self.shape = Turf.Geometry(native.shape)
+        }
+    }
+}

--- a/Sources/MapboxCoreNavigation/EHorizon/RoadSubgraphEdge.swift
+++ b/Sources/MapboxCoreNavigation/EHorizon/RoadSubgraphEdge.swift
@@ -5,7 +5,7 @@ import MapboxNavigationNative
 extension RoadGraph {
 
     /**
-     The `SubgraphEdge` represents a edge in the complex object which might be considered as a directed graph. The graph might contain loops. `innerEdgeIds` and `outerEdgeIds` properties contain edge ids, which allows to traverse the graph, obtain geometry and calculate different distances inside it.
+     The `SubgraphEdge` represents an edge in the complex object which might be considered as a directed graph. The graph might contain loops. `innerEdgeIds` and `outerEdgeIds` properties contain edge ids, which allows to traverse the graph, obtain geometry and calculate different distances inside it.
      */
     public struct SubgraphEdge {
 


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->

The case of subgraph was missing in the `RoadObjectLocation` enum. Without it, an app crashes in the `preconditionFailure`.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

I've also added a corresponding struct for subgraph edges. I would appreciate help with providing better in-code documentation for the new struct.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->