### PR TITLE
To improve the vanishing route line when rerouting happens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Fixed an issue where route line disappears when changing `MapView` style. ([#3136](https://github.com/mapbox/mapbox-navigation-ios/pull/3136))
 * Added `NavigationOptions.navigationMapView` property to allow customization or reusing possibilities for `NavigationViewController.navigationMapView` ([#3186](https://github.com/mapbox/mapbox-navigation-ios/pull/3186)).
 * Renamed the `NavigationMapView.updateRoute(_:)` method to `NavigationMapView.travelAlongRouteLine(to:)`. Improved the performance of updating the route line to change color at the user’s location as they progress along the route. ([#3201](https://github.com/mapbox/mapbox-navigation-ios/pull/3201)).
+* Fixed an issue when user passed destination and the route line grows back when `routeLineTracksTraversal` enabled. ([#3255](https://github.com/mapbox/mapbox-navigation-ios/pull/3255))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * Fixed an issue where route line disappears when changing `MapView` style. ([#3136](https://github.com/mapbox/mapbox-navigation-ios/pull/3136))
 * Added `NavigationOptions.navigationMapView` property to allow customization or reusing possibilities for `NavigationViewController.navigationMapView` ([#3186](https://github.com/mapbox/mapbox-navigation-ios/pull/3186)).
 * Renamed the `NavigationMapView.updateRoute(_:)` method to `NavigationMapView.travelAlongRouteLine(to:)`. Improved the performance of updating the route line to change color at the user’s location as they progress along the route. ([#3201](https://github.com/mapbox/mapbox-navigation-ios/pull/3201)).
-* Fixed an issue when user passed destination and the route line grows back when `routeLineTracksTraversal` enabled. ([#3255](https://github.com/mapbox/mapbox-navigation-ios/pull/3255))
+* Fixed an issue when user passed destination and the route line grows back when `NavigationViewController.routeLineTracksTraversal` is enabled. ([#3255](https://github.com/mapbox/mapbox-navigation-ios/pull/3255))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -50,6 +50,7 @@ class ArrivalController: NavigationComponentDelegate {
             return
         }
         
+        navigationMapView.removeRoutes()
         embedEndOfRoute(into: viewController, onDismiss: onDismiss)
         endOfRouteViewController.destination = destination
         navigationViewData.navigationView.endOfRouteView?.isHidden = false

--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -50,7 +50,6 @@ class ArrivalController: NavigationComponentDelegate {
             return
         }
         
-        navigationMapView.removeRoutes()
         embedEndOfRoute(into: viewController, onDismiss: onDismiss)
         endOfRouteViewController.destination = destination
         navigationViewData.navigationView.endOfRouteView?.isHidden = false

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -251,6 +251,10 @@ public class CarPlayNavigationViewController: UIViewController {
                                                selector: #selector(rerouted(_:)),
                                                name: .routeControllerDidReroute,
                                                object: service.router)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(refresh(_:)),
+                                               name: .routeControllerDidRefreshRoute,
+                                               object: service.router)
         
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(visualInstructionDidChange(_:)),
@@ -265,6 +269,9 @@ public class CarPlayNavigationViewController: UIViewController {
         
         NotificationCenter.default.removeObserver(self,
                                                   name: .routeControllerDidReroute,
+                                                  object: nil)
+        NotificationCenter.default.removeObserver(self,
+                                                  name: .routeControllerDidRefreshRoute,
                                                   object: nil)
         
         NotificationCenter.default.removeObserver(self,
@@ -329,10 +336,6 @@ public class CarPlayNavigationViewController: UIViewController {
             if routeProgress.isFinalLeg && routeProgress.currentLegProgress.distanceRemaining <= 0.0 {
                 navigationMapView?.removeRoutes()
             }
-            
-            if routeProgress.currentLeg.segmentCongestionLevels != navigationMapView?.currentLegCongestionLevels {
-                navigationMapView?.setUpLineGradientStops(along: routeProgress.route)
-            }
             navigationMapView?.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
             navigationMapView?.travelAlongRouteLine(to: location.coordinate)
         }
@@ -340,6 +343,18 @@ public class CarPlayNavigationViewController: UIViewController {
     
     @objc func rerouted(_ notification: NSNotification) {
         updateRouteOnMap()
+    }
+    
+    @objc func refresh(_ notification: NSNotification) {
+        let progress = navigationService.routeProgress
+        let legIndex = progress.legIndex
+        let coordinate = navigationService.router.location?.coordinate
+        
+        navigationMapView?.show([progress.route], legIndex: legIndex)
+        if routeLineTracksTraversal {
+            navigationMapView?.updateUpcomingRoutePointIndex(routeProgress: progress)
+            navigationMapView?.travelAlongRouteLine(to: coordinate)
+        }
     }
     
     func updateRouteOnMap() {

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -319,10 +319,6 @@ public class CarPlayNavigationViewController: UIViewController {
             speedLimitView.speedLimit = routeProgress.currentLegProgress.currentSpeedLimit
         }
         
-        if routeProgress.isFinalLeg && routeProgress.currentLegProgress.distanceRemaining <= 0.0 {
-            navigationMapView?.removeRoutes()
-        }
-        
         if legIndex != currentLegIndexMapped {
             navigationMapView?.showWaypoints(on: routeProgress.route, legIndex: legIndex)
             navigationMapView?.show([routeProgress.route], legIndex: legIndex)
@@ -330,6 +326,10 @@ public class CarPlayNavigationViewController: UIViewController {
         }
         
         if routeLineTracksTraversal {
+            if routeProgress.isFinalLeg && routeProgress.currentLegProgress.distanceRemaining <= 0.0 {
+                navigationMapView?.removeRoutes()
+            }
+            
             if routeProgress.currentLeg.segmentCongestionLevels != navigationMapView?.currentLegCongestionLevels {
                 navigationMapView?.setUpLineGradientStops(along: routeProgress.route)
             }

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -251,6 +251,7 @@ public class CarPlayNavigationViewController: UIViewController {
                                                selector: #selector(rerouted(_:)),
                                                name: .routeControllerDidReroute,
                                                object: service.router)
+        
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(refresh(_:)),
                                                name: .routeControllerDidRefreshRoute,
@@ -270,6 +271,7 @@ public class CarPlayNavigationViewController: UIViewController {
         NotificationCenter.default.removeObserver(self,
                                                   name: .routeControllerDidReroute,
                                                   object: nil)
+        
         NotificationCenter.default.removeObserver(self,
                                                   name: .routeControllerDidRefreshRoute,
                                                   object: nil)

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -319,6 +319,10 @@ public class CarPlayNavigationViewController: UIViewController {
             speedLimitView.speedLimit = routeProgress.currentLegProgress.currentSpeedLimit
         }
         
+        if routeProgress.isFinalLeg && routeProgress.currentLegProgress.distanceRemaining <= 0.0 {
+            navigationMapView?.removeRoutes()
+        }
+        
         if legIndex != currentLegIndexMapped {
             navigationMapView?.showWaypoints(on: routeProgress.route, legIndex: legIndex)
             navigationMapView?.show([routeProgress.route], legIndex: legIndex)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -571,6 +571,7 @@ open class NavigationMapView: UIView {
      */
     func removeLineGradientStops() {
         fractionTraveled = 0.0
+        currentLegIndex = nil
         currentLegCongestionLevels = nil
         currentLineGradientStops.removeAll()
         if let routes = self.routes {

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -121,11 +121,6 @@ extension NavigationMapView {
             let stepIndex = progress.currentLegProgress.stepIndex
             
             navigationMapView.updatePreferredFrameRate(for: progress)
-            
-            if progress.isFinalLeg && progress.currentLegProgress.distanceRemaining <= 0.0 {
-                navigationMapView.removeRoutes()
-            }
-            
             if currentLegIndexMapped != legIndex {
                 navigationMapView.showWaypoints(on: route, legIndex: legIndex)
                 navigationMapView.show([route], legIndex: legIndex)
@@ -143,6 +138,10 @@ extension NavigationMapView {
             }
             
             if routeLineTracksTraversal {
+                if progress.isFinalLeg && progress.currentLegProgress.distanceRemaining <= 0.0 {
+                    navigationMapView.removeRoutes()
+                }
+                
                 if progress.currentLeg.segmentCongestionLevels != navigationMapView.currentLegCongestionLevels {
                     navigationMapView.setUpLineGradientStops(along: progress.route)
                 }

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -141,10 +141,6 @@ extension NavigationMapView {
                 if progress.isFinalLeg && progress.currentLegProgress.distanceRemaining <= 0.0 {
                     navigationMapView.removeRoutes()
                 }
-                
-                if progress.currentLeg.segmentCongestionLevels != navigationMapView.currentLegCongestionLevels {
-                    navigationMapView.setUpLineGradientStops(along: progress.route)
-                }
                 navigationMapView.updateUpcomingRoutePointIndex(routeProgress: progress)
                 navigationMapView.travelAlongRouteLine(to: location.coordinate)
             }

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -121,6 +121,11 @@ extension NavigationMapView {
             let stepIndex = progress.currentLegProgress.stepIndex
             
             navigationMapView.updatePreferredFrameRate(for: progress)
+            
+            if progress.isFinalLeg && progress.currentLegProgress.distanceRemaining <= 0.0 {
+                navigationMapView.removeRoutes()
+            }
+            
             if currentLegIndexMapped != legIndex {
                 navigationMapView.showWaypoints(on: route, legIndex: legIndex)
                 navigationMapView.show([route], legIndex: legIndex)


### PR DESCRIPTION
### Description
This pr is to fix #3254 and #3267

### Implementation
According to https://github.com/mapbox/mapbox-navigation-ios/issues/3254#issuecomment-901269168, the issue happened because when the user passed the destination, the route still exits because `fractionTraveled` not set to `1.0`. 

To avoid the `grow back` effect when user passed the destination and keep moving forward, while the `routeProgress` still sending update, we check whether we has passed the final leg waypoint and then remove the route. Thus if there's a rerouting event happened later, it would not generate a new route instead.

### Screenshots or Gifs
![destination](https://user-images.githubusercontent.com/48976398/129952455-f01fa4e4-fc34-4019-bade-34648870ae30.gif)

