### PR TITLE
Add `testRunningAnimators`. Fix crash in `NavigationCameraStateTransition.stopAnimators()`.

### DIFF
--- a/Sources/MapboxNavigation/NavigationCameraStateTransition.swift
+++ b/Sources/MapboxNavigation/NavigationCameraStateTransition.swift
@@ -54,6 +54,7 @@ public class NavigationCameraStateTransition: CameraStateTransition {
             camera.pitch = 0.0
             if let midPointZoom = camera.zoom {
                 let cameraOptions = CameraOptions(center: location,
+                                                  padding: padding,
                                                   anchor: screenCenterPoint,
                                                   zoom: CGFloat(midPointZoom),
                                                   bearing: bearing,
@@ -61,6 +62,7 @@ public class NavigationCameraStateTransition: CameraStateTransition {
                 
                 transitionFromHighZoomToMidpoint(cameraOptions) {
                     let cameraOptions = CameraOptions(center: location,
+                                                      padding: padding,
                                                       anchor: anchor,
                                                       zoom: CGFloat(zoom),
                                                       bearing: bearing,
@@ -228,8 +230,10 @@ public class NavigationCameraStateTransition: CameraStateTransition {
             animatorPadding
         ]
         
-        animators.forEach {
-            $0?.stopAnimation()
+        animators.compactMap({ $0 }).forEach {
+            if $0.isRunning {
+                $0.stopAnimation()
+            }
         }
     }
     

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -584,6 +584,21 @@ class NavigationCameraTests: XCTestCase {
         navigationCameraStateTransition.stopAnimators()
         
         wait(for: [followingExpectation], timeout: 5.0)
+        
+        // Anchor and padding animators are not created when performing transition to the
+        // `NavigationCameraState.following` state.
+        guard let animatorCenter = navigationCameraStateTransition.animatorCenter,
+              let animatorZoom = navigationCameraStateTransition.animatorZoom,
+              let animatorBearing = navigationCameraStateTransition.animatorBearing,
+              let animatorPitch = navigationCameraStateTransition.animatorPitch else {
+            XCTFail("Animators should be available.")
+            return
+        }
+        
+        XCTAssertFalse(animatorCenter.isRunning, "Center animator should not be running.")
+        XCTAssertFalse(animatorZoom.isRunning, "Zoom animator should not be running.")
+        XCTAssertFalse(animatorBearing.isRunning, "Bearing animator should not be running.")
+        XCTAssertFalse(animatorPitch.isRunning, "Pitch animator should not be running.")
     }
     
     // MARK: - Helper methods

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -560,6 +560,32 @@ class NavigationCameraTests: XCTestCase {
         XCTAssertEqual(cameraOptions?.bearing, expectedBearing, "Bearings should be equal.")
     }
     
+    func testRunningAnimators() {
+        let navigationMapView = NavigationMapView(frame: .zero)
+        
+        let navigationCameraStateTransition = NavigationCameraStateTransition(navigationMapView.mapView)
+        
+        let cameraOptions = CameraOptions(center: CLLocationCoordinate2D(latitude: 37.788443,
+                                                                         longitude: -122.4020258),
+                                          padding: .zero,
+                                          anchor: .zero,
+                                          zoom: 15.0,
+                                          bearing: 0.0,
+                                          pitch: 45.0)
+        
+        let followingExpectation = expectation(description: "Camera transition expectation.")
+        
+        navigationCameraStateTransition.transitionToFollowing(cameraOptions) {
+            followingExpectation.fulfill()
+        }
+        
+        // Attempt to stop animators right away to verify that no side effects occur. Based on Maps SDK
+        // behavior it should not be possible to stop animator, which has not started yet.
+        navigationCameraStateTransition.stopAnimators()
+        
+        wait(for: [followingExpectation], timeout: 5.0)
+    }
+    
     // MARK: - Helper methods
     
     func route(from file: String) -> Route? {


### PR DESCRIPTION
### Description

Closing #3263.