### PR TITLE
Disable filtering by navigation status origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,9 +144,10 @@
 * Fixed an issue when route line was sometimes invisilbe after starting active guidance session. ([#3205](https://github.com/mapbox/mapbox-navigation-ios/pull/3205))
 * Fixed an issue where reusing `NavigationMapView` across multiple instances of `NavigationViewController` would result in a crash. ([#3222](https://github.com/mapbox/mapbox-navigation-ios/pull/3222)) 
 * Fixed missing feedback subtype description for `FeedbackType.incorrectVisual(subtype: .incorrectSpeedLimit)` and all "other" subtypes. ([#3238](https://github.com/mapbox/mapbox-navigation-ios/pull/3238))
-* Fixed an issue where the first location update was incorrectly generated in the `NavigationService.start()` method. ([#3239](https://github.com/mapbox/mapbox-navigation-ios/pull/3239/files))
+* Fixed an issue where the first location update was incorrectly generated in the `NavigationService.start()` method. ([#3239](https://github.com/mapbox/mapbox-navigation-ios/pull/3239))
 * Fixed an issue where `UIApplication.shared.isIdleTimerDisabled` was not properly set in some cases. ([#3245](https://github.com/mapbox/mapbox-navigation-ios/pull/3245))
 * Added the `Notification.Name.currentRoadNameDidChange` to detect the road name posted by `RouteController`. ([#3266](https://github.com/mapbox/mapbox-navigation-ios/pull/3266))
+* Fixes an issue when not all navigation status events were handled, leading to missing banner instructions. ([#3265](https://github.com/mapbox/mapbox-navigation-ios/pull/3265))
 
 ## v1.4.1
 

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -281,7 +281,6 @@ extension Navigator: ElectronicHorizonObserver {
 
 extension Navigator: NavigatorObserver {
     func onStatus(for origin: NavigationStatusOrigin, status: NavigationStatus) {
-        guard origin == .locationUpdate else { return }
         let userInfo: [Navigator.NotificationUserInfoKey: Any] = [
             .originKey: origin,
             .statusKey: status,

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -619,9 +619,9 @@ class NavigationServiceTests: TestCase {
             waitForNavNativeCallbacks()
 
             if index < 31 {
-                XCTAssert(routeController.routeProgress.legIndex == 0)
+                XCTAssertEqual(routeController.routeProgress.legIndex,0)
             } else {
-                XCTAssert(routeController.routeProgress.legIndex == 1)
+                XCTAssertEqual(routeController.routeProgress.legIndex, 1)
             }
         }
         

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -618,7 +618,7 @@ class NavigationServiceTests: TestCase {
             
             waitForNavNativeCallbacks()
 
-            if index < 32 {
+            if index < 31 {
                 XCTAssert(routeController.routeProgress.legIndex == 0)
             } else {
                 XCTAssert(routeController.routeProgress.legIndex == 1)


### PR DESCRIPTION
Fixed #3260

We are not supposed to filter out navigation statuses as per NavNative team. Android doesn't filter them out either. 
If it breaking any functionality, we must fix it without filtering out all the events.