### PR TITLE
Fix the tail work of the road name label based on status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 * Fixed missing feedback subtype description for `FeedbackType.incorrectVisual(subtype: .incorrectSpeedLimit)` and all "other" subtypes. ([#3238](https://github.com/mapbox/mapbox-navigation-ios/pull/3238))
 * Fixed an issue where the first location update was incorrectly generated in the `NavigationService.start()` method. ([#3239](https://github.com/mapbox/mapbox-navigation-ios/pull/3239/files))
 * Fixed an issue where `UIApplication.shared.isIdleTimerDisabled` was not properly set in some cases. ([#3245](https://github.com/mapbox/mapbox-navigation-ios/pull/3245))
+* Added the `Notification.Name.currentRoadNameDidChange` to detect the road name posted by `RouteController`. ([#3266](https://github.com/mapbox/mapbox-navigation-ios/pull/3266))
 
 ## v1.4.1
 

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -193,7 +193,7 @@ public extension Notification.Name {
      
      The user info dictionary contains the key `RouteController.NotificationUserInfoKey.roadNameKey`.
      */
-    static let routeControllerRoadName: Notification.Name = .init(rawValue: "RouteControllerRoadName")
+    static let currentRoadNameDidChange: Notification.Name = .init(rawValue: "CurrentRoadNameDidChange")
  
 }
 
@@ -246,7 +246,7 @@ extension RouteController {
         public static let isProactiveKey: NotificationUserInfoKey = .init(rawValue: "RouteControllerDidFindFasterRoute")
         
         /**
-         A key in the user info dictionary of a `Notification.Name.routeControllerRoadName` notification. The corresponding value is a `NSString` object representing the current road name.
+         A key in the user info dictionary of a `Notification.Name.currentRoadNameDidChange` notification. The corresponding value is a `NSString` object representing the current road name.
          */
         public static let roadNameKey: NotificationUserInfoKey = .init(rawValue: "roadName")
     }

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -361,7 +361,7 @@ open class RouteController: NSObject {
     
     func updateRoadName(status: NavigationStatus) {
         let roadName = status.roadName
-        NotificationCenter.default.post(name: .routeControllerRoadName, object: self, userInfo: [
+        NotificationCenter.default.post(name: .currentRoadNameDidChange, object: self, userInfo: [
             NotificationUserInfoKey.roadNameKey: roadName
         ])
     }

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -74,7 +74,7 @@ extension NavigationMapView {
                                                    object: nil)
             NotificationCenter.default.addObserver(self,
                                                    selector: #selector(didUpdateRoadNameFromStatus),
-                                                   name: .routeControllerRoadName,
+                                                   name: .currentRoadNameDidChange,
                                                    object: nil)
         }
         
@@ -83,7 +83,7 @@ extension NavigationMapView {
                                                       name: UIDevice.orientationDidChangeNotification,
                                                       object: nil)
             NotificationCenter.default.removeObserver(self,
-                                                      name: .routeControllerRoadName,
+                                                      name: .currentRoadNameDidChange,
                                                       object: nil)
         }
         
@@ -92,8 +92,7 @@ extension NavigationMapView {
         }
         
         @objc func didUpdateRoadNameFromStatus(_ notification: Notification) {
-            guard let roadName = notification.userInfo?[RouteController.NotificationUserInfoKey.roadNameKey] as? String else { return }
-            roadNameFromStatus = roadName
+            roadNameFromStatus = notification.userInfo?[RouteController.NotificationUserInfoKey.roadNameKey] as? String
         }
         
         // MARK: - Methods


### PR DESCRIPTION
### Description
This pr is to address some comments in #3257 

### Implementation
- [x] Replace the notification key name of `routeControllerRoadName` with `currentRoadNameDidChange`.
- [x]  Avoid the unnamed road name issue.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->