### PR TITLE
Remove unnecessary Navigator status pulling from updateRouteLeg method

### DIFF
--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -227,9 +227,7 @@ open class RouteController: NSObject {
     /// updateRouteLeg is used to notify nav-native of the developer changing the active route-leg.
     private func updateRouteLeg(to value: Int) {
         let legIndex = UInt32(value)
-        if navigator.changeRouteLeg(forRoute: 0, leg: legIndex), let status = navigator.getStatus() {
-            updateIndexes(status: status, progress: routeProgress)
-        }
+        navigator.changeRouteLeg(forRoute: 0, leg: legIndex)
     }
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -225,9 +225,9 @@ open class RouteController: NSObject {
     }
     
     /// updateRouteLeg is used to notify nav-native of the developer changing the active route-leg.
-    private func updateRouteLeg(to value: Int) {
-        let legIndex = UInt32(value)
-        navigator.changeRouteLeg(forRoute: 0, leg: legIndex)
+    private func updateRouteLeg(to legIndex: Int) {
+        precondition(legIndex >= 0, "Leg index can't be negative")
+        navigator.changeRouteLeg(forRoute: 0, leg: UInt32(legIndex))
     }
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {


### PR DESCRIPTION
After navigator.changeRouteLeg, a new navigator status will be generated with origin equal to changeRouteLeg where we update indexes anyway.

Related comment: https://github.com/mapbox/mapbox-navigation-ios/pull/3265#discussion_r690553574