### PR TITLE
Make navigation camera options more restrictive.

### DIFF
--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
-          "version": "2.0.0"
+          "revision": "0630439888c94657a235ffcd5977d6047ef3c87b",
+          "version": "2.0.1"
         }
       },
       {

--- a/Sources/MapboxNavigation/FollowingCameraOptions.swift
+++ b/Sources/MapboxNavigation/FollowingCameraOptions.swift
@@ -109,6 +109,13 @@ public struct FollowingCameraOptions: Equatable {
      */
     public var pitchNearManeuver: PitchNearManeuver = PitchNearManeuver()
     
+    /**
+     Initializes `FollowingCameraOptions` instance.
+     */
+    public init() {
+        // No-op
+    }
+    
     public static func == (lhs: FollowingCameraOptions, rhs: FollowingCameraOptions) -> Bool {
         return lhs.defaultPitch == rhs.defaultPitch &&
             lhs.zoomRange == rhs.zoomRange &&
@@ -158,6 +165,13 @@ public struct IntersectionDensity: Equatable {
      */
     public var minimumDistanceBetweenIntersections: CLLocationDistance = 20.0
     
+    /**
+     Initializes `IntersectionDensity` instance.
+     */
+    public init() {
+        // No-op
+    }
+    
     public static func == (lhs: IntersectionDensity, rhs: IntersectionDensity) -> Bool {
         return lhs.enabled == rhs.enabled &&
             lhs.averageDistanceMultiplier == rhs.averageDistanceMultiplier &&
@@ -188,6 +202,13 @@ public struct BearingSmoothing: Equatable {
      Defaults to `45.0` degrees.
      */
     public var maximumBearingSmoothingAngle: CLLocationDirection = 45.0
+    
+    /**
+     Initializes `BearingSmoothing` instance.
+     */
+    public init() {
+        // No-op
+    }
     
     public static func == (lhs: BearingSmoothing, rhs: BearingSmoothing) -> Bool {
         return lhs.enabled == rhs.enabled &&
@@ -224,6 +245,13 @@ public struct GeometryFramingAfterManeuver: Equatable {
      */
     public var distanceToFrameAfterManeuver: CLLocationDistance = 100.0
     
+    /**
+     Initializes `GeometryFramingAfterManeuver` instance.
+     */
+    public init() {
+        // No-op
+    }
+    
     public static func == (lhs: GeometryFramingAfterManeuver, rhs: GeometryFramingAfterManeuver) -> Bool {
         return lhs.enabled == rhs.enabled &&
             lhs.distanceToCoalesceCompoundManeuvers == rhs.distanceToCoalesceCompoundManeuvers &&
@@ -249,6 +277,13 @@ public struct PitchNearManeuver: Equatable {
      Defaults to `180.0` meters.
      */
     public var triggerDistanceToManeuver: CLLocationDistance = 180.0
+    
+    /**
+     Initializes `PitchNearManeuver` instance.
+     */
+    public init() {
+        // No-op
+    }
     
     public static func == (lhs: PitchNearManeuver, rhs: PitchNearManeuver) -> Bool {
         return lhs.enabled == rhs.enabled &&

--- a/Sources/MapboxNavigation/FollowingCameraOptions.swift
+++ b/Sources/MapboxNavigation/FollowingCameraOptions.swift
@@ -12,7 +12,17 @@ public struct FollowingCameraOptions: Equatable {
      
      Defaults to `45.0` degrees.
      */
-    public var defaultPitch: Double = 45.0
+    public var defaultPitch: Double = 45.0 {
+        didSet {
+            if defaultPitch < 0.0 {
+                preconditionFailure("Lower bound of the pitch should not be lower than 0.0")
+            }
+            
+            if defaultPitch > 85.0 {
+                preconditionFailure("Upper bound of the pitch should not be higher than 85.0")
+            }
+        }
+    }
     
     /**
      Zoom levels range, which will be used when producing camera frame in `NavigationCameraState.following`

--- a/Sources/MapboxNavigation/FollowingCameraOptions.swift
+++ b/Sources/MapboxNavigation/FollowingCameraOptions.swift
@@ -15,20 +15,24 @@ public struct FollowingCameraOptions {
     public var defaultPitch: Double = 45.0
     
     /**
-     Minimum zoom, which will be used when producing camera frame in `NavigationCameraState.following`
+     Zoom levels range, which will be used when producing camera frame in `NavigationCameraState.following`
      state.
      
-     Defaults to `10.50`.
-     */
-    public var minimumZoomLevel: Double = 10.50
-    
-    /**
-     Maximum zoom, which will be used when producing camera frame in `NavigationCameraState.following`
-     state. It will be also used as initial value when active guidance navigation starts.
+     Upper bound of the range will be also used as initial zoom level when active guidance navigation starts.
      
-     Defaults to `16.35`.
+     Lower bound defaults to `10.50`, upper bound defaults to `16.35`.
      */
-    public var maximumZoomLevel: Double = 16.35
+    public var zoomRange: ClosedRange<Double> = 10.50...16.35 {
+        didSet {
+            if zoomRange.lowerBound < 0.0 {
+                preconditionFailure("Lower bound of the zoom range should not be lower than 0.0")
+            }
+            
+            if zoomRange.upperBound > 22.0 {
+                preconditionFailure("Upper bound of the zoom range should not be lower than 0.0")
+            }
+        }
+    }
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.center` property

--- a/Sources/MapboxNavigation/FollowingCameraOptions.swift
+++ b/Sources/MapboxNavigation/FollowingCameraOptions.swift
@@ -4,7 +4,7 @@ import CoreLocation
  Options, which are used to control what `CameraOptions` parameters will be modified by
  `NavigationViewportDataSource` in `NavigationCameraState.following` state.
  */
-public struct FollowingCameraOptions {
+public struct FollowingCameraOptions: Equatable {
     
     /**
      Pitch, which will be taken into account when preparing `CameraOptions` during active guidance
@@ -108,6 +108,20 @@ public struct FollowingCameraOptions {
      Options, which allow to modify the framed route geometries when approaching a maneuver.
      */
     public var pitchNearManeuver: PitchNearManeuver = PitchNearManeuver()
+    
+    public static func == (lhs: FollowingCameraOptions, rhs: FollowingCameraOptions) -> Bool {
+        return lhs.defaultPitch == rhs.defaultPitch &&
+            lhs.zoomRange == rhs.zoomRange &&
+            lhs.centerUpdatesAllowed == rhs.centerUpdatesAllowed &&
+            lhs.zoomUpdatesAllowed == rhs.zoomUpdatesAllowed &&
+            lhs.bearingUpdatesAllowed == rhs.bearingUpdatesAllowed &&
+            lhs.pitchUpdatesAllowed == rhs.pitchUpdatesAllowed &&
+            lhs.paddingUpdatesAllowed == rhs.paddingUpdatesAllowed &&
+            lhs.intersectionDensity == rhs.intersectionDensity &&
+            lhs.bearingSmoothing == rhs.bearingSmoothing &&
+            lhs.geometryFramingAfterManeuver == rhs.geometryFramingAfterManeuver &&
+            lhs.pitchNearManeuver == rhs.pitchNearManeuver
+    }
 }
 
 /**
@@ -116,7 +130,7 @@ public struct FollowingCameraOptions {
  By default the whole remainder of the step is framed, while `IntersectionDensity` options shrink
  that geometry to increase the zoom level.
  */
-public struct IntersectionDensity {
+public struct IntersectionDensity: Equatable {
     
     /**
      Controls whether additional coordinates after the upcoming maneuver will be framed
@@ -143,13 +157,19 @@ public struct IntersectionDensity {
      Defaults to `20.0` meters.
      */
     public var minimumDistanceBetweenIntersections: CLLocationDistance = 20.0
+    
+    public static func == (lhs: IntersectionDensity, rhs: IntersectionDensity) -> Bool {
+        return lhs.enabled == rhs.enabled &&
+            lhs.averageDistanceMultiplier == rhs.averageDistanceMultiplier &&
+            lhs.minimumDistanceBetweenIntersections == rhs.minimumDistanceBetweenIntersections
+    }
 }
 
 /**
  Options, which allow to modify `CameraOptions.bearing` property based on information about
  bearing of an upcoming maneuver.
  */
-public struct BearingSmoothing {
+public struct BearingSmoothing: Equatable {
     
     /**
      Controls whether bearing smoothing will be performed or not.
@@ -168,13 +188,18 @@ public struct BearingSmoothing {
      Defaults to `45.0` degrees.
      */
     public var maximumBearingSmoothingAngle: CLLocationDirection = 45.0
+    
+    public static func == (lhs: BearingSmoothing, rhs: BearingSmoothing) -> Bool {
+        return lhs.enabled == rhs.enabled &&
+            lhs.maximumBearingSmoothingAngle == rhs.maximumBearingSmoothingAngle
+    }
 }
 
 /**
  Options, which allow to modify framed route geometries by appending additional coordinates after
  maneuver to extend the view.
  */
-public struct GeometryFramingAfterManeuver {
+public struct GeometryFramingAfterManeuver: Equatable {
     
     /**
      Controls whether additional coordinates after the upcoming maneuver will be framed
@@ -198,12 +223,18 @@ public struct GeometryFramingAfterManeuver {
      Defaults to `100.0` meters.
      */
     public var distanceToFrameAfterManeuver: CLLocationDistance = 100.0
+    
+    public static func == (lhs: GeometryFramingAfterManeuver, rhs: GeometryFramingAfterManeuver) -> Bool {
+        return lhs.enabled == rhs.enabled &&
+            lhs.distanceToCoalesceCompoundManeuvers == rhs.distanceToCoalesceCompoundManeuvers &&
+            lhs.distanceToFrameAfterManeuver == rhs.distanceToFrameAfterManeuver
+    }
 }
 
 /**
  Options, which allow to modify the framed route geometries when approaching a maneuver.
  */
-public struct PitchNearManeuver {
+public struct PitchNearManeuver: Equatable {
     
     /**
      Controls whether `CameraOptions.pitch` will be set to `0.0` near upcoming maneuver.
@@ -218,4 +249,9 @@ public struct PitchNearManeuver {
      Defaults to `180.0` meters.
      */
     public var triggerDistanceToManeuver: CLLocationDistance = 180.0
+    
+    public static func == (lhs: PitchNearManeuver, rhs: PitchNearManeuver) -> Bool {
+        return lhs.enabled == rhs.enabled &&
+            lhs.triggerDistanceToManeuver == rhs.triggerDistanceToManeuver
+    }
 }

--- a/Sources/MapboxNavigation/FollowingCameraOptions.swift
+++ b/Sources/MapboxNavigation/FollowingCameraOptions.swift
@@ -29,7 +29,7 @@ public struct FollowingCameraOptions {
             }
             
             if zoomRange.upperBound > 22.0 {
-                preconditionFailure("Upper bound of the zoom range should not be lower than 0.0")
+                preconditionFailure("Upper bound of the zoom range should not be higher than 22.0")
             }
         }
     }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -549,7 +549,7 @@ open class NavigationMapView: UIView {
         guard let navigationViewportDataSource = navigationCamera.viewportDataSource as? NavigationViewportDataSource else { return }
         
         mapView.mapboxMap.setCamera(to: CameraOptions(center: coordinate,
-                                                   zoom: CGFloat(navigationViewportDataSource.options.followingCameraOptions.maximumZoomLevel)))
+                                                      zoom: CGFloat(navigationViewportDataSource.options.followingCameraOptions.zoomRange.upperBound)))
         moveUserLocation(to: CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude))
     }
     

--- a/Sources/MapboxNavigation/NavigationViewportDataSource.swift
+++ b/Sources/MapboxNavigation/NavigationViewportDataSource.swift
@@ -245,16 +245,16 @@ public class NavigationViewportDataSource: ViewportDataSource {
                                                        maxPitch: followingCameraOptions.defaultPitch,
                                                        edgeInsets: viewportPadding,
                                                        defaultZoomLevel: defaultZoomLevel,
-                                                       maxZoomLevel: followingCameraOptions.maximumZoomLevel,
-                                                       minZoomLevel: followingCameraOptions.minimumZoomLevel)
+                                                       maxZoomLevel: followingCameraOptions.zoomRange.upperBound,
+                                                       minZoomLevel: followingCameraOptions.zoomRange.lowerBound)
                 
                 followingCarPlayCamera.zoom = self.zoom(coordinatesToManeuver + coordinatesForManeuverFraming,
                                                         pitch: pitch,
                                                         maxPitch: followingCameraOptions.defaultPitch,
                                                         edgeInsets: carPlayCameraPadding,
                                                         defaultZoomLevel: defaultZoomLevel,
-                                                        maxZoomLevel: followingCameraOptions.maximumZoomLevel,
-                                                        minZoomLevel: followingCameraOptions.minimumZoomLevel)
+                                                        maxZoomLevel: followingCameraOptions.zoomRange.upperBound,
+                                                        minZoomLevel: followingCameraOptions.zoomRange.lowerBound)
             }
             
             if options.followingCameraOptions.bearingUpdatesAllowed {

--- a/Sources/MapboxNavigation/NavigationViewportDataSourceOptions.swift
+++ b/Sources/MapboxNavigation/NavigationViewportDataSourceOptions.swift
@@ -4,7 +4,7 @@ import Foundation
  Options, which give the ability to control whether certain `CameraOptions` will be generated
  by `NavigationViewportDataSource` or can be provided by user directly.
  */
-public struct NavigationViewportDataSourceOptions {
+public struct NavigationViewportDataSourceOptions: Equatable {
     
     /**
      Options, which are used to control what `CameraOptions` parameters will be modified by
@@ -17,4 +17,31 @@ public struct NavigationViewportDataSourceOptions {
      `NavigationViewportDataSource` in `NavigationCameraState.overview` state.
      */
     public var overviewCameraOptions = OverviewCameraOptions()
+    
+    /**
+     Initializes `NavigationViewportDataSourceOptions` instance.
+     */
+    public init() {
+        // No-op
+    }
+    
+    /**
+     Initializes `NavigationViewportDataSourceOptions` instance.
+     
+     - parameter followingCameraOptions: `FollowingCameraOptions` instance, which contains
+     `CameraOptions` parameters, which in turn will be used by `NavigationViewportDataSource` in
+     `NavigationCameraState.following` state.
+     - parameter overviewCameraOptions: `OverviewCameraOptions` instance, which contains
+     `CameraOptions` parameters, which it turn will be used by `NavigationViewportDataSource` in
+     `NavigationCameraState.overview` state.
+     */
+    public init(_ followingCameraOptions: FollowingCameraOptions, overviewCameraOptions: OverviewCameraOptions) {
+        self.followingCameraOptions = followingCameraOptions
+        self.overviewCameraOptions = overviewCameraOptions
+    }
+    
+    public static func == (lhs: NavigationViewportDataSourceOptions, rhs: NavigationViewportDataSourceOptions) -> Bool {
+        return lhs.followingCameraOptions == rhs.followingCameraOptions &&
+            lhs.overviewCameraOptions == rhs.overviewCameraOptions
+    }
 }

--- a/Sources/MapboxNavigation/OverviewCameraOptions.swift
+++ b/Sources/MapboxNavigation/OverviewCameraOptions.swift
@@ -74,6 +74,13 @@ public struct OverviewCameraOptions: Equatable {
      */
     public var paddingUpdatesAllowed = true
     
+    /**
+     Initializes `OverviewCameraOptions` instance.
+     */
+    public init() {
+        // No-op
+    }
+    
     public static func == (lhs: OverviewCameraOptions, rhs: OverviewCameraOptions) -> Bool {
         return lhs.maximumZoomLevel == rhs.maximumZoomLevel &&
             lhs.zoomUpdatesAllowed == rhs.zoomUpdatesAllowed &&

--- a/Sources/MapboxNavigation/OverviewCameraOptions.swift
+++ b/Sources/MapboxNavigation/OverviewCameraOptions.swift
@@ -12,7 +12,17 @@ public struct OverviewCameraOptions {
      
      Defaults to `16.35`.
      */
-    public var maximumZoomLevel: Double = 16.35
+    public var maximumZoomLevel: Double = 16.35 {
+        didSet {
+            if maximumZoomLevel < 0.0 {
+                preconditionFailure("Maximum zoom level should not be lower than 0.0")
+            }
+            
+            if maximumZoomLevel > 22.0 {
+                preconditionFailure("Maximum zoom level should not be higher than 22.0")
+            }
+        }
+    }
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.center` property

--- a/Sources/MapboxNavigation/OverviewCameraOptions.swift
+++ b/Sources/MapboxNavigation/OverviewCameraOptions.swift
@@ -4,7 +4,7 @@ import Foundation
  Options, which are used to control what `CameraOptions` parameters will be modified by
  `NavigationViewportDataSource` in `NavigationCameraState.overview` state.
  */
-public struct OverviewCameraOptions {
+public struct OverviewCameraOptions: Equatable {
     
     /**
      Maximum zoom level, which will be used when producing camera frame in `NavigationCameraState.overview`
@@ -73,4 +73,12 @@ public struct OverviewCameraOptions {
      Defaults to `true`.
      */
     public var paddingUpdatesAllowed = true
+    
+    public static func == (lhs: OverviewCameraOptions, rhs: OverviewCameraOptions) -> Bool {
+        return lhs.maximumZoomLevel == rhs.maximumZoomLevel &&
+            lhs.zoomUpdatesAllowed == rhs.zoomUpdatesAllowed &&
+            lhs.bearingUpdatesAllowed == rhs.bearingUpdatesAllowed &&
+            lhs.pitchUpdatesAllowed == rhs.pitchUpdatesAllowed &&
+            lhs.paddingUpdatesAllowed == rhs.paddingUpdatesAllowed
+    }
 }

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -618,6 +618,20 @@ class NavigationCameraTests: XCTestCase {
         XCTAssertFalse(appliedChanges, "Zoom range changes should not be applied.")
     }
     
+    func testNavigationCameraOverviewCameraOptionsMaximumZoomLevel() {
+        let navigationMapView = NavigationMapView(frame: .zero)
+        let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource
+        
+        var appliedChanges = false
+        expect {
+            // It should only be possible to set maximum zoom level between `0.0` and `22.0`.
+            navigationViewportDataSource?.options.overviewCameraOptions.maximumZoomLevel = 23.0
+            appliedChanges = true
+        }.to(throwAssertion())
+        
+        XCTAssertFalse(appliedChanges, "Maximum zoom level changes should not be applied.")
+    }
+    
     // MARK: - Helper methods
     
     func route(from file: String) -> Route? {

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -608,6 +608,10 @@ class NavigationCameraTests: XCTestCase {
         
         navigationViewportDataSource?.options.followingCameraOptions.zoomRange = 10.0...22.0
         
+        let zoomRange = navigationViewportDataSource?.options.followingCameraOptions.zoomRange
+        XCTAssertEqual(zoomRange?.lowerBound, 10.0, "Lower bounds should be equal.")
+        XCTAssertEqual(zoomRange?.upperBound, 22.0, "Upper bounds should be equal.")
+        
         var appliedChanges = false
         expect {
             // It should only be possible to set zoom range levels from `0.0` to `22.0`.

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -636,6 +636,33 @@ class NavigationCameraTests: XCTestCase {
         XCTAssertFalse(appliedChanges, "Maximum zoom level changes should not be applied.")
     }
     
+    func testNavigationViewportDataSourceOptionsInitializer() {
+        // `NavigationViewportDataSourceOptions` initializers should be available for public usage.
+        let navigationViewportDataSourceOptions = NavigationViewportDataSourceOptions()
+        
+        let navigationMapView = NavigationMapView(frame: .zero)
+        let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource
+        navigationViewportDataSource?.options = navigationViewportDataSourceOptions
+        
+        XCTAssertEqual(navigationViewportDataSource?.options,
+                       navigationViewportDataSourceOptions,
+                       "NavigationViewportDataSourceOptions instances should be equal.")
+        
+        let followingCameraOptions = FollowingCameraOptions()
+        let overviewCameraOptions = OverviewCameraOptions()
+        
+        let modifiedNavigationViewportDataSourceOptions = NavigationViewportDataSourceOptions(followingCameraOptions,
+                                                                                              overviewCameraOptions: overviewCameraOptions)
+        
+        XCTAssertEqual(modifiedNavigationViewportDataSourceOptions.followingCameraOptions,
+                       followingCameraOptions,
+                       "FollowingCameraOptions instances should be equal.")
+        
+        XCTAssertEqual(modifiedNavigationViewportDataSourceOptions.overviewCameraOptions,
+                       overviewCameraOptions,
+                       "OverviewCameraOptions instances should be equal.")
+    }
+    
     // MARK: - Helper methods
     
     func route(from file: String) -> Route? {

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Turf
 import MapboxMaps
 import MapboxDirections
+import Nimble
 
 @testable import TestHelper
 @testable import MapboxNavigation
@@ -599,6 +600,22 @@ class NavigationCameraTests: XCTestCase {
         XCTAssertFalse(animatorZoom.isRunning, "Zoom animator should not be running.")
         XCTAssertFalse(animatorBearing.isRunning, "Bearing animator should not be running.")
         XCTAssertFalse(animatorPitch.isRunning, "Pitch animator should not be running.")
+    }
+    
+    func testNavigationCameraFollowingCameraOptionsZoomRanges() {
+        let navigationMapView = NavigationMapView(frame: .zero)
+        let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource
+        
+        navigationViewportDataSource?.options.followingCameraOptions.zoomRange = 10.0...22.0
+        
+        var appliedChanges = false
+        expect {
+            // It should only be possible to set zoom range levels from `0.0` to `22.0`.
+            navigationViewportDataSource?.options.followingCameraOptions.zoomRange = -1.0...100.0
+            appliedChanges = true
+        }.to(throwAssertion())
+        
+        XCTAssertFalse(appliedChanges, "Zoom range changes should not be applied.")
     }
     
     // MARK: - Helper methods


### PR DESCRIPTION
### Description

Change `minimumZoomLevel` and `maximumZoomLevel` with closed range in `FollowingCameraOptions`.

Closing #3281.