### PR TITLE
Support instant puck change without lag.

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -253,21 +253,17 @@ open class NavigationMapView: UIView {
     }
     
     func setupUserLocation() {
-        mapView.mapboxMap.onNext(.styleLoaded) { [weak self] _ in
-            guard let self = self else { return }
-            switch self.userLocationStyle {
-            case .courseView((let courseView)):
-                self.mapView.location.options.puckType = nil
-                self.userCourseView = courseView
-                self.userCourseView.isHidden = false
-            case .puck2D(configuration: var configuration):
-                self.userCourseView.isHidden = true
-                self.mapView.location.options.puckType = .puck2D(configuration ?? Puck2DConfiguration())
-                configuration = configuration ?? Puck2DConfiguration()
-            case .puck3D(configuration: let configuration):
-                self.userCourseView.isHidden = true
-                self.mapView.location.options.puckType = .puck3D(configuration)
-            }
+        switch userLocationStyle {
+        case .courseView((let courseView)):
+            mapView.location.options.puckType = nil
+            userCourseView = courseView
+            userCourseView.isHidden = false
+        case .puck2D(configuration: let configuration):
+            userCourseView.isHidden = true
+            mapView.location.options.puckType = .puck2D(configuration ?? Puck2DConfiguration())
+        case .puck3D(configuration: let configuration):
+            userCourseView.isHidden = true
+            mapView.location.options.puckType = .puck3D(configuration)
         }
         mapView.location.options.puckBearingSource = .course
     }


### PR DESCRIPTION
### Description
This pr is to fix #3285 by removing the style loaded lag and to change the user location layer instantly.

### Implementation
Right now the map puck change doesn't need to wait for the style loaded.

### Screenshots or Gifs
This is what I use the resume button to toggle between the puck2D and the userCourseView. 

![puckChange](https://user-images.githubusercontent.com/48976398/130705237-dda53b1f-9b80-417c-9cf7-b725477164b2.gif)

