### PR TITLE
Change tap gesture recognizer assignee

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -393,7 +393,7 @@ open class NavigationMapView: UIView {
         // Gesture recognizer, which is used to detect taps on route line and waypoint.
         let mapViewTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didReceiveTap(sender:)))
         mapViewTapGestureRecognizer.delegate = self
-        mapView.addGestureRecognizer(mapViewTapGestureRecognizer)
+        addGestureRecognizer(mapViewTapGestureRecognizer)
     }
     
     /**


### PR DESCRIPTION
### Description
`NavigationMapView` [implements tap gesture](https://github.com/mapbox/mapbox-navigation-ios/blob/v2.0.0-beta.23/Sources/MapboxNavigation/NavigationMapView.swift#L396) to support alternative route. This `UITapGestureRecognizer` [implements a delegate](https://github.com/mapbox/mapbox-navigation-ios/blob/v2.0.0-beta.23/Sources/MapboxNavigation/NavigationMapView.swift#L1489) so that user code's tap gesture can be handled.

The problem is when some `MapView` option is changed such as `gestures.options.pitchEnabled`, it overwrites the delegate in the step below and user code's gesture code is not called any more.

1. https://github.com/mapbox/mapbox-maps-ios/blob/v10.0.0-rc.6/Sources/MapboxMaps/Gestures/GestureManager.swift#L15
2. https://github.com/mapbox/mapbox-maps-ios/blob/v10.0.0-rc.6/Sources/MapboxMaps/Gestures/GestureManager.swift#L113
3. https://github.com/mapbox/mapbox-maps-ios/blob/v10.0.0-rc.6/Sources/MapboxMaps/Gestures/GestureManager.swift#L124

Instead, if `NavigationMapView` assign the tap gesture to itself, this issue does not happen.

### Implementation

Before: 

```swift
mapView.addGestureRecognizer(mapViewTapGestureRecognizer)
```

After:

```swift
addGestureRecognizer(mapViewTapGestureRecognizer)
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
No images

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->