### PR TITLE
Suport gradient for congestion color change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,9 @@
 * Renamed the `NavigationMapView.updateRoute(_:)` method to `NavigationMapView.travelAlongRouteLine(to:)`. Improved the performance of updating the route line to change color at the user’s location as they progress along the route. ([#3201](https://github.com/mapbox/mapbox-navigation-ios/pull/3201)).
 * Fixed an issue when user passed destination and the route line grows back when `NavigationViewController.routeLineTracksTraversal` is enabled. ([#3255](https://github.com/mapbox/mapbox-navigation-ios/pull/3255))
 * The `NavigationMapView.userLocationStyle` now supports instant user location indicator change without style loaded lag. ([#3295](https://github.com/mapbox/mapbox-navigation-ios/pull/3295))
+<<<<<<< HEAD
 * Fixed incorrect color-coded traffic congestion along the route line and incorrect speeds in the speed limit view after some time had elapsed after rerouting. ([#3344](https://github.com/mapbox/mapbox-navigation-ios/pull/3344]))
-* Added the `NavigationMapView.showFadingCongestionColor` property to show blending color between different congestion levels on route lines, and the global variable `GradientCongestionblendingDistance` to adjust the distance of blending color segment. ([#3307](https://github.com/mapbox/mapbox-navigation-ios/pull/3307))
+* By default, there is no longer a subtle crossfade between traffic congestion segments along a route line. To reenable this crossfade, set the `NavigationMapView.crossfadesCongestionSegments` property to `true`. You can also adjust the length of this crossfade using the global variable `GradientCongestionFadingDistance`. ([#3307](https://github.com/mapbox/mapbox-navigation-ios/pull/3307))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@
 * Renamed the `NavigationMapView.updateRoute(_:)` method to `NavigationMapView.travelAlongRouteLine(to:)`. Improved the performance of updating the route line to change color at the user’s location as they progress along the route. ([#3201](https://github.com/mapbox/mapbox-navigation-ios/pull/3201)).
 * Fixed an issue when user passed destination and the route line grows back when `NavigationViewController.routeLineTracksTraversal` is enabled. ([#3255](https://github.com/mapbox/mapbox-navigation-ios/pull/3255))
 * The `NavigationMapView.userLocationStyle` now supports instant user location indicator change without style loaded lag. ([#3295](https://github.com/mapbox/mapbox-navigation-ios/pull/3295))
-<<<<<<< HEAD
 * Fixed incorrect color-coded traffic congestion along the route line and incorrect speeds in the speed limit view after some time had elapsed after rerouting. ([#3344](https://github.com/mapbox/mapbox-navigation-ios/pull/3344]))
 * By default, there is no longer a subtle crossfade between traffic congestion segments along a route line. To reenable this crossfade, set the `NavigationMapView.crossfadesCongestionSegments` property to `true`. You can also adjust the length of this crossfade using the global variable `GradientCongestionFadingDistance`. ([#3307](https://github.com/mapbox/mapbox-navigation-ios/pull/3307))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Fixed an issue when user passed destination and the route line grows back when `NavigationViewController.routeLineTracksTraversal` is enabled. ([#3255](https://github.com/mapbox/mapbox-navigation-ios/pull/3255))
 * The `NavigationMapView.userLocationStyle` now supports instant user location indicator change without style loaded lag. ([#3295](https://github.com/mapbox/mapbox-navigation-ios/pull/3295))
 * Fixed incorrect color-coded traffic congestion along the route line and incorrect speeds in the speed limit view after some time had elapsed after rerouting. ([#3344](https://github.com/mapbox/mapbox-navigation-ios/pull/3344]))
+* Added the `NavigationMapView.showFadingCongestionColor` property to show blending color between different congestion levels on route lines, and the global variable `GradientCongestionblendingDistance` to adjust the distance of blending color segment. ([#3307](https://github.com/mapbox/mapbox-navigation-ios/pull/3307))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/Constants.swift
+++ b/Sources/MapboxNavigation/Constants.swift
@@ -43,7 +43,7 @@ public let NavigationViewMinimumVolumeForWarning: Float = 0.3
 /**
  The distance of blending color between two different congestion level segment in meters.
  */
-public var GradientCongestionblendingDistance: Double = 30.0
+public var GradientCongestionBlendingDistance: Double = 30.0
 
 extension Notification.Name {
     /**

--- a/Sources/MapboxNavigation/Constants.swift
+++ b/Sources/MapboxNavigation/Constants.swift
@@ -40,6 +40,11 @@ public let CongestionAttribute = "congestion"
  */
 public let NavigationViewMinimumVolumeForWarning: Float = 0.3
 
+/**
+ The distance of blending color between two different congestion level segment in meters.
+ */
+public let gradientCongestionblendingDistance: Double = 30.0
+
 extension Notification.Name {
     /**
      Posted when `StyleManager` applies a style that was triggered by change of time of day, or when entering or exiting a tunnel.

--- a/Sources/MapboxNavigation/Constants.swift
+++ b/Sources/MapboxNavigation/Constants.swift
@@ -43,7 +43,7 @@ public let NavigationViewMinimumVolumeForWarning: Float = 0.3
 /**
  The distance of blending color between two different congestion level segment in meters.
  */
-public let gradientCongestionblendingDistance: Double = 30.0
+public var GradientCongestionblendingDistance: Double = 30.0
 
 extension Notification.Name {
     /**

--- a/Sources/MapboxNavigation/Constants.swift
+++ b/Sources/MapboxNavigation/Constants.swift
@@ -41,9 +41,9 @@ public let CongestionAttribute = "congestion"
 public let NavigationViewMinimumVolumeForWarning: Float = 0.3
 
 /**
- The distance of blending color between two different congestion level segment in meters.
+ The distance of fading color change between two different congestion level segments in meters.
  */
-public var GradientCongestionBlendingDistance: Double = 30.0
+public var GradientCongestionFadingDistance: CLLocationDistance = 30.0
 
 extension Notification.Name {
     /**

--- a/Sources/MapboxNavigation/Expression.swift
+++ b/Sources/MapboxNavigation/Expression.swift
@@ -10,11 +10,19 @@ extension Expression {
         }
     }
     
-    static func routeLineGradientExpression(_ gradientStops: [Double: UIColor], lineBaseColor: UIColor) -> Expression {
-        return Exp(.step) {
-            Exp(.lineProgress)
-            lineBaseColor
-            gradientStops
+    static func routeLineGradientExpression(_ gradientStops: [Double: UIColor], lineBaseColor: UIColor, isSoft: Bool = false) -> Expression {
+        if isSoft {
+            return Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.lineProgress)
+                gradientStops
+            }
+        } else {
+            return Exp(.step) {
+                Exp(.lineProgress)
+                lineBaseColor
+                gradientStops
+            }
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -180,7 +180,7 @@ extension NavigationMapView {
         }
         
         let mainRouteLayerGradient = updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
-        let mainRouteLayerGradientExpression = Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor, isSoft: showFadingCongestionColor)
+        let mainRouteLayerGradientExpression = Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor, isSoft: crossfadesCongestionSegments)
         setLayerLineGradient(for: mainRouteLayerIdentifier, exp: mainRouteLayerGradientExpression)
         
         let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveled)
@@ -244,7 +244,8 @@ extension NavigationMapView {
 
                 let lineString = feature.geometry.value as? LineString
                 guard let distance = lineString?.distance() else { return gradientStops }
-                let stopGap = max(min(GradientCongestionBlendingDistance, distance * 0.1) / routeDistance, 0.0000000000000002)
+                let minimumPercentGap = 0.0000000000000002
+                let stopGap = (routeDistance > 0.0) ? max(min(GradientCongestionFadingDistance, distance * 0.1) / routeDistance, minimumPercentGap) : minimumPercentGap
                 
                 if index == congestionFeatures.startIndex {
                     minimumSegment = (0.0, associatedFeatureColor)

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -244,7 +244,7 @@ extension NavigationMapView {
 
                 let lineString = feature.geometry.value as? LineString
                 guard let distance = lineString?.distance() else { return gradientStops }
-                let stopGap = max(min(gradientCongestionblendingDistance, distance * 0.1) / routeDistance, 0.0000000000000002)
+                let stopGap = max(min(GradientCongestionblendingDistance, distance * 0.1) / routeDistance, 0.0000000000000002)
                 
                 if index == congestionFeatures.startIndex {
                     distanceTraveled = distanceTraveled + distance

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -204,7 +204,7 @@ extension NavigationMapView {
     }
     
     func updateRouteLineGradientStops(fractionTraveled: Double, gradientStops: [Double: UIColor]) -> [Double: UIColor] {
-        // minimumSegment records the nearest smaller or equal stop and associated congestion color of the `fractionTraveled`, and then apply it's color to the `fractionTraveled` stop.
+        // minimumSegment records the nearest smaller or equal stop and associated congestion color of the `fractionTraveled`, and then apply its color to the `fractionTraveled` stop.
         var minimumSegment: (Double, UIColor) = (0.0, trafficUnknownColor)
         var filteredGradientStops = [Double: UIColor]()
         
@@ -232,8 +232,8 @@ extension NavigationMapView {
         
         if let congestionFeatures = congestionFeatures {
             let routeDistance = congestionFeatures.compactMap({ ($0.geometry.value as? LineString)?.distance() }).reduce(0, +)
-            // minimumSegment records the nearest smaller or equal stop and associated congestion color of the `fractionTraveled`, and then apply it's color to the `fractionTraveled` stop.
-            var minimumSegment: (Double, UIColor) = (0.0, .clear)
+            // minimumSegment records the nearest smaller or equal stop and associated congestion color of the `fractionTraveled`, and then apply its color to the `fractionTraveled` stop.
+            var minimumSegment: (Double, UIColor) = isMain ? (0.0, .trafficUnknown) : (0.0, .alternativeTrafficUnknown)
 
             for (index, feature) in congestionFeatures.enumerated() {
                 var associatedFeatureColor = routeCasingColor

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -57,11 +57,11 @@ open class NavigationMapView: UIView {
     public var showsCongestionForAlternativeRoutes: Bool = false
     
     /**
-     Controls whether to show fading gradient congestion color on route lines. Defaults to `false`.
+     Controls whether to show fading gradient color on route lines between two different congestion level segments. Defaults to `false`.
      
-     If `true`, the congestion level in the route line will be shown as fading gradient color instead of abrupt and steep change.
+     If `true`, the congestion level change between two segments in the route line will be shown as fading gradient color instead of abrupt and steep change.
      */
-    public var showFadingCongestionColor: Bool = false
+    public var crossfadesCongestionSegments: Bool = false
 
     @objc dynamic public var trafficUnknownColor: UIColor = .trafficUnknown
     @objc dynamic public var trafficLowColor: UIColor = .trafficLow
@@ -568,7 +568,7 @@ open class NavigationMapView: UIView {
     func setUpLineGradientStops(along route: Route) {
         if let legIndex = currentLegIndex {
             let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
-            currentLineGradientStops = routeLineGradient(congestionFeatures, fractionTraveled: fractionTraveled, isSoft: showFadingCongestionColor)
+            currentLineGradientStops = routeLineGradient(congestionFeatures, fractionTraveled: fractionTraveled, isSoft: crossfadesCongestionSegments)
             pendingCoordinateForRouteLine = route.shape?.coordinates.first ?? mostRecentUserCourseViewLocation?.coordinate
         }
     }
@@ -621,26 +621,26 @@ open class NavigationMapView: UIView {
                 if !currentLineGradientStops.isEmpty {
                     lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(currentLineGradientStops,
                                                                                                   lineBaseColor: trafficUnknownColor,
-                                                                                                  isSoft: showFadingCongestionColor)))
+                                                                                                  isSoft: crossfadesCongestionSegments)))
                 } else {
                     let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
                     let gradientStops = routeLineGradient(congestionFeatures,
                                                           fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0,
-                                                          isSoft: showFadingCongestionColor)
+                                                          isSoft: crossfadesCongestionSegments)
                     
                     lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops,
                                                                                                   lineBaseColor: trafficUnknownColor,
-                                                                                                  isSoft: showFadingCongestionColor)))
+                                                                                                  isSoft: crossfadesCongestionSegments)))
                 }
             } else {
                 if showsCongestionForAlternativeRoutes {
                     let gradientStops = routeLineGradient(route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels),
                                                           fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0,
                                                           isMain: false,
-                                                          isSoft: showFadingCongestionColor)
+                                                          isSoft: crossfadesCongestionSegments)
                     lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops,
                                                                                                   lineBaseColor: alternativeTrafficUnknownColor,
-                                                                                                  isSoft: showFadingCongestionColor)))
+                                                                                                  isSoft: crossfadesCongestionSegments)))
                 } else {
                     lineLayer?.lineColor = .constant(.init(color: routeAlternateColor))
                 }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -619,7 +619,9 @@ open class NavigationMapView: UIView {
             
             if isMainRoute {
                 if !currentLineGradientStops.isEmpty {
-                    lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(currentLineGradientStops, lineBaseColor: trafficUnknownColor)))
+                    lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(currentLineGradientStops,
+                                                                                                  lineBaseColor: trafficUnknownColor,
+                                                                                                  isSoft: showFadingCongestionColor)))
                 } else {
                     let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
                     let gradientStops = routeLineGradient(congestionFeatures,

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -392,6 +392,32 @@ class NavigationMapViewTests: TestCase {
         XCTAssertEqual(routeLineGradient[fractionTraveledNextDown], navigationMapView.traversedRouteColor)
     }
     
+    func testUpdateSoftRouteLineGradient() {
+        let route = loadRoute(from: "route-with-road-classes-single-congestion")
+        let congestions = route.congestionFeatures()
+        var fractionTraveled = 0.0
+        var lineGradient = navigationMapView.routeLineGradient(congestions, fractionTraveled: fractionTraveled, isMain: true, isSoft: true)
+        XCTAssertEqual(2, lineGradient.keys.count)
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.trafficUnknownColor)
+        XCTAssertEqual(lineGradient[1.0], navigationMapView.trafficUnknownColor)
+        
+        lineGradient = [
+            0.0: navigationMapView.trafficSevereColor,
+            0.295: navigationMapView.trafficSevereColor,
+            0.305: navigationMapView.trafficModerateColor,
+            0.695: navigationMapView.trafficModerateColor,
+            0.705: navigationMapView.trafficHeavyColor,
+            1.0: navigationMapView.trafficHeavyColor
+        ]
+        fractionTraveled = 0.3
+        let nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient)
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficSevereColor)
+        XCTAssertEqual(lineGradient[0.305], navigationMapView.trafficModerateColor)
+    }
+    
     func testUpdateRouteLineGradient() {
         let route = loadRoute(from: "route-with-road-classes-single-congestion")
         let congestions = route.congestionFeatures()

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -392,9 +392,9 @@ class NavigationMapViewTests: TestCase {
         XCTAssertEqual(routeLineGradient[fractionTraveledNextDown], navigationMapView.traversedRouteColor)
     }
     
-    func testUpdateSoftRouteLineGradient() {
+    func testSoftRouteLineGradient() {
         let route = loadRoute(from: "route-with-road-classes-single-congestion")
-        let congestions = route.congestionFeatures()
+        var congestions = route.congestionFeatures()
         var fractionTraveled = 0.0
         var lineGradient = navigationMapView.routeLineGradient(congestions, fractionTraveled: fractionTraveled, isMain: true, isSoft: true)
         XCTAssertEqual(2, lineGradient.keys.count)
@@ -416,6 +416,13 @@ class NavigationMapViewTests: TestCase {
         XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficSevereColor)
         XCTAssertEqual(lineGradient[0.305], navigationMapView.trafficModerateColor)
+        
+        congestions = [Turf.Feature]()
+        lineGradient = navigationMapView.routeLineGradient(congestions, fractionTraveled: fractionTraveled, isMain: true, isSoft: true)
+        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
+        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)
+        
     }
     
     func testUpdateRouteLineGradient() {

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -131,6 +131,7 @@ custom_categories:
       - RouteLineWidthByZoomLevel
       - NavigationMapViewMinimumDistanceForOverheadZooming
       - NavigationViewMinimumVolumeForWarning
+      - GradientCongestionFadingDistance
       - RouteControllerIncorrectCourseMultiplier
       - RouteControllerLinkedInstructionBufferMultiplier
       - RouteControllerMaximumSpeedForUsingCurrentStep


### PR DESCRIPTION
### Description
This pr is to allow the developer to choose the route line gradient color change style between the fading one and the steep change one.

### Implementation
- [x] Added the `NavigationMapView.showFadingCongestionColor` property to show blending color between different congestion levels on route lines, which defaults to `false` to show the steep change effect.
- [X]  Added the global variable `GradientCongestionBlendingDistance` to adjust the distance of blending color segment. The blending distance of two congestion level would between the `GradientCongestionblendingDistance` and the 10% of the congestion level distance.
- [X] Add test to cover the `NavigationMapView.routeLineGradient(_:fractionTraveled:isMain:isSoft)` and the soft gradient route line gradient update.
- [x] Update the ChangeLog.

### Screenshots or Gifs
To show the fading color gradient between different traffic congestion level, set `navigationMapView.crossfadesCongestionSegments =  true` as below
![gradient](https://user-images.githubusercontent.com/48976398/131742941-561e2701-f720-4f94-9667-82495c746fa2.png)

To show the fading color gradient between different traffic congestion level during active guidance navigation,  set `navigationViewController.navigationMapView.crossfadesCongestionSegments =  true` as below
![blending](https://user-images.githubusercontent.com/48976398/131416953-7b633b96-892a-4755-a5ef-3454426462ca.gif)



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->