### PR TITLE
Quick fix the refresh shows all route line during navigation.

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -562,7 +562,7 @@ open class NavigationMapView: UIView {
         if let legIndex = currentLegIndex {
             let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
             currentLineGradientStops = routeLineGradient(congestionFeatures, fractionTraveled: fractionTraveled)
-            pendingCoordinateForRouteLine = mostRecentUserCourseViewLocation?.coordinate ?? route.shape?.coordinates.first
+            pendingCoordinateForRouteLine = route.shape?.coordinates.first ?? mostRecentUserCourseViewLocation?.coordinate
         }
     }
     


### PR DESCRIPTION
### Description
This pr is to fix the route line shows all when refresh but the vanishing effect enabled.

### Implementation
Due to the following, when refresh happened, the `pendingCoordinateForRouteLine` will use the `mostRecentUserCourseViewLocation` which is the current location, thus the bottle neck distance limit will stop updating the `fractionTraveled`,  which lead to the route line shows all.

https://github.com/mapbox/mapbox-navigation-ios/blob/41ca049bd9efdb3ee91617cbc98d2f90152718f3/Sources/MapboxNavigation/NavigationMapView.swift#L565

To fix this issue, let the `pendingCoordinateForRouteLine` choose the route shape first coordinate to avoid this problem. Because the pending coordinate is aimed at stored some value for the distance limit check.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->