### PR TITLE
inTunnels simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * The `NavigationService.router` and `MapboxNavigationService.router` properties are no longer unsafe-unowned. ([#3055](https://github.com/mapbox/mapbox-navigation-ios/pull/3055))
 * Fixed unnecessary rerouting when calling the `NavigationService.start()` method. ([#3239](https://github.com/mapbox/mapbox-navigation-ios/pull/3239))
 * Fixed an issue where `RouteController` or `PassiveLocationManager` sometimes snapped the user’s location assuming a path that violated a turn restriction. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
+* Added `SimulationMode.inTunnels` to enable simulating user location when loosing GPS signal while traversing tunnels. Simulation mode for default navigation service now can be configured using `NavigationOptons.simulationMode`. ([#3314](https://github.com/mapbox/mapbox-navigation-ios/pull/3314))
 * Improved performance and decreased memory usage when downloading routing tiles. ([#2808](https://github.com/mapbox/mapbox-navigation-ios/pull/2808))
 * Fixed a crash when navigating along a route 0 meters long (for example, because two waypoints snap to the same location). ([#3387](https://github.com/mapbox/mapbox-navigation-ios/pull/3387))
 

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -49,7 +49,7 @@ class CustomViewController: UIViewController {
                                                     routeIndex: indexedUserRouteResponse!.routeIndex,
                                                     routeOptions: userRouteOptions!,
                                                     locationSource: locationManager,
-                                                    simulating: simulateLocation ? .always : .onPoorGPS)
+                                                    simulating: simulateLocation ? .always : .inTunnels)
         
         navigationMapView.mapView.ornaments.options.compass.visibility = .hidden
         

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -525,7 +525,7 @@ class ViewController: UIViewController {
     }
 
     func navigationService(response: RouteResponse, routeIndex: Int, options: RouteOptions) -> NavigationService {
-        let mode: SimulationMode = simulationButton.isSelected ? .always : .onPoorGPS
+        let mode: SimulationMode = simulationButton.isSelected ? .always : .inTunnels
         
         return MapboxNavigationService(routeResponse: response, routeIndex: routeIndex, routeOptions: options, simulating: mode)
     }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -24,6 +24,11 @@ public enum SimulationMode: Int {
      A setting of `.never` will never enable the location simulator, regardless of circumstances.
      */
     case never
+    
+    /**
+     A setting of `.inTunnels` will enable simulation when two conditions are met: we do not recieve a location update after the `poorGPSPatience` threshold has elapsed and SDK detects current location as a [tunnel](https://wiki.openstreetmap.org/wiki/Key:tunnel).
+     */
+    case inTunnels
 }
 
 /**
@@ -126,7 +131,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     // MARK: Simulating Traversing
     
     /**
-     The default time interval before beginning simulation when the `.onPoorGPS` simulation option is enabled.
+     The default time interval before beginning simulation when the `.onPoorGPS` or `.inTunnels` simulation options are enabled.
      */
     static let defaultPoorGPSPatience: Double = 2.5 //seconds
     
@@ -147,7 +152,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
             switch simulationMode {
             case .always:
                 simulate()
-            case .onPoorGPS:
+            case .onPoorGPS, .inTunnels:
                 poorGPSTimer.arm()
             case .never:
                 poorGPSTimer.disarm()
@@ -201,7 +206,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     
     private func resetGPSCountdown() {
         //Sanity check: if we're not on this mode, we have no business here.
-        guard simulationMode == .onPoorGPS else { return }
+        guard simulationMode == .onPoorGPS || simulationMode == .inTunnels else { return }
         
         // Immediately end simulation if it is occuring.
         if isSimulating {
@@ -251,7 +256,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         nativeLocationSource.stopUpdatingHeading()
         nativeLocationSource.stopUpdatingLocation()
         
-        if [.always, .onPoorGPS].contains(simulationMode) {
+        if [.always, .onPoorGPS, .inTunnels].contains(simulationMode) {
             endSimulation()
         }
         
@@ -293,17 +298,19 @@ public class MapboxNavigationService: NSObject, NavigationService {
                          directions: Directions? = nil,
                          locationSource: NavigationLocationManager? = nil,
                          eventsManagerType: NavigationEventsManager.Type? = nil,
-                         simulating simulationMode: SimulationMode = .onPoorGPS,
+                         simulating simulationMode: SimulationMode? = nil,
                          routerType: Router.Type? = nil) {
         nativeLocationSource = locationSource ?? NavigationLocationManager()
         self.directions = directions ?? NavigationSettings.shared.directions
-        self.simulationMode = simulationMode
+        self.simulationMode = simulationMode ?? .inTunnels
         super.init()
         resumeNotifications()
         
         _poorGPSTimer = DispatchTimer(countdown: poorGPSPatience.dispatchInterval)  { [weak self] in
-            guard let mode = self?.simulationMode, mode == .onPoorGPS else { return }
-            self?.simulate(intent: .poorGPS)
+            guard let self = self,
+                  self.simulationMode == .onPoorGPS ||
+                    (self.simulationMode == .inTunnels && self.isInTunnel(at: self.router.location!, along: self.routeProgress)) else { return }
+            self.simulate(intent: .poorGPS)
         }
         
         let routerType = routerType ?? DefaultRouter.self
@@ -364,7 +371,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     private var nativeLocationSource: NavigationLocationManager
     
     /**
-     The active location simulator. Only used during `SimulationOption.always` and `SimluatedLocationManager.onPoorGPS`. If there is no simulation active, this property is `nil`.
+     The active location simulator. Only used during `SimulationOption.always`, `SimluatedLocationManager.onPoorGPS` and `SimluatedLocationManager.inTunnels`. If there is no simulation active, this property is `nil`.
      */
     private var simulatedLocationSource: SimulatedLocationManager?
     
@@ -437,7 +444,7 @@ extension MapboxNavigationService: CLLocationManagerDelegate {
         guard let location = locations.last else { return }
         
         //If this is a good organic update, reset the timer.
-        if simulationMode == .onPoorGPS,
+        if simulationMode == .onPoorGPS || simulationMode == .inTunnels,
             manager == nativeLocationSource,
             location.isQualified {
             //If the timer is disarmed, arm it. This is a good update.

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -604,7 +604,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
 
         mapTemplate.hideTripPreviews()
         
-        let desiredSimulationMode: SimulationMode = simulatesLocations ? .always : .onPoorGPS
+        let desiredSimulationMode: SimulationMode = simulatesLocations ? .always : .inTunnels
         
         let navigationService = self.navigationService ??
             delegate?.carPlayManager(self, navigationServiceFor: routeResponse,

--- a/Sources/MapboxNavigation/NavigationOptions.swift
+++ b/Sources/MapboxNavigation/NavigationOptions.swift
@@ -57,7 +57,7 @@ open class NavigationOptions: NavigationCustomizable {
     /**
      The simulation mode type. Used for setting the simulation mode of the navigation service.
      
-     If set to `nil` will default to `.inTunnels`.
+     If set to `nil` will default to `.inTunnels`. This setting will be ignored if custom `navigationService` instance was provided.
      */
     open var simulationMode: SimulationMode?
     

--- a/Sources/MapboxNavigation/NavigationOptions.swift
+++ b/Sources/MapboxNavigation/NavigationOptions.swift
@@ -54,6 +54,13 @@ open class NavigationOptions: NavigationCustomizable {
      */
     open var navigationMapView: NavigationMapView?
     
+    /**
+     The simulation mode type. Used for setting the simulation mode of the navigation service.
+     
+     If set to `nil` will default to `.inTunnels`.
+     */
+    open var simulationMode: SimulationMode?
+    
     // This makes the compiler happy.
     required public init() {
         // do nothing
@@ -70,7 +77,7 @@ open class NavigationOptions: NavigationCustomizable {
      - parameter predictiveCacheOptions: Configuration for predictive caching. These options control how the `PredictiveCacheManager` will try to proactively fetch data related to the route. A `nil` value disables the feature.
      - parameter navigationMapView: Custom `NavigationMapView` instance to supersede the default one.
      */
-    public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil, predictiveCacheOptions: PredictiveCacheOptions? = nil, navigationMapView: NavigationMapView? = nil) {
+    public convenience init(styles: [Style]? = nil, navigationService: NavigationService? = nil, voiceController: RouteVoiceController? = nil, topBanner: ContainerViewController? = nil, bottomBanner: ContainerViewController? = nil, predictiveCacheOptions: PredictiveCacheOptions? = nil, navigationMapView: NavigationMapView? = nil, simulationMode: SimulationMode? = nil) {
         self.init()
         self.styles = styles
         self.navigationService = navigationService
@@ -79,6 +86,7 @@ open class NavigationOptions: NavigationCustomizable {
         self.bottomBanner = bottomBanner
         self.predictiveCacheOptions = predictiveCacheOptions
         self.navigationMapView = navigationMapView
+        self.simulationMode = simulationMode
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -435,7 +435,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         navigationService = navigationOptions?.navigationService
             ?? MapboxNavigationService(routeResponse: routeResponse,
                                        routeIndex: routeIndex,
-                                       routeOptions: routeOptions)
+                                       routeOptions: routeOptions,
+                                       simulating: navigationOptions?.simulationMode)
         navigationService.delegate = self
         
         NavigationSettings.shared.distanceUnit = routeOptions.locale.usesMetric ? .kilometer : .mile

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -390,13 +390,13 @@ class CarPlayManagerSpec: QuickSpec {
                     manager!.simulatesLocations = false
                 }
 
-                it("starts navigation with a navigation service with simulation set to onPoorGPS by default") {
+                it("starts navigation with a navigation service with simulation set to inTunnels by default") {
                     action()
 
                     expect(delegate!.navigationInitiated).to(beTrue())
                     let service: MapboxNavigationService = delegate!.currentService! as! MapboxNavigationService
 
-                    expect(service.simulationMode).to(equal(.onPoorGPS))
+                    expect(service.simulationMode).to(equal(.inTunnels))
                 }
             }
         }


### PR DESCRIPTION
### Description
Resolves #3216 
Adds new simulation mode, to kick the simulation while loosing GPS signal while traversing tunnels. Also exposes simulation setting though `NavigationOptions`.

### Implementation
PR adds new enum case, updates default settings to use `.inTunnels` instead previous default `.onPoorGPS` and adds additional property to `NavigationOptions`.