### PR TITLE
Reimplement label localization atop Expression (redux)

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -130,6 +130,9 @@ class ViewController: UIViewController {
         
         if navigationMapView == nil {
             navigationMapView = NavigationMapView(frame: view.bounds)
+            navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
+                self?.navigationMapView.localizeLabels()
+            }
         }
     }
     

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -189,7 +189,7 @@ public class CarPlayMapViewController: UIViewController {
     func setupNavigationMapView() {
         let navigationMapView = NavigationMapView(frame: UIScreen.main.bounds, navigationCameraType: .carPlay)
         navigationMapView.delegate = self
-        navigationMapView.mapView.mapboxMap.onNext(.styleLoaded) { _ in
+        navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { _ in
             navigationMapView.localizeLabels()
         }
         

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -188,13 +188,10 @@ public class CarPlayNavigationViewController: UIViewController {
                                                                                              viewportDataSourceType: .active)
         navigationMapView.translatesAutoresizingMaskIntoConstraints = false
         
-        navigationMapView.mapView.mapboxMap.onNext(.styleLoaded) { [weak self] _ in
+        // Reapply runtime styling changes each time the style changes.
+        navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
             self?.navigationMapView?.localizeLabels()
             self?.navigationMapView?.mapView.showsTraffic = false
-        }
-        
-        // Route line should be added to `MapView`, when its style changes.
-        navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
             self?.updateRouteOnMap()
         }
         

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1351,8 +1351,15 @@ open class NavigationMapView: UIView {
     
     // MARK: - Road labels localization methods
     
+    /**
+     Attempts to localize labels into the system’s preferred language.
+     
+     This method automatically modifies the `SymbolLayer.textField` property of any symbol style layer whose source is the <a href="https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#overview">Mapbox Streets source</a>. The user can set the system’s preferred language in Settings, General Settings, Language & Region.
+     
+     This method avoids localizing road labels into the system’s preferred language, in an effort to match road signage. The turn banner always displays road names and exit destinations in the local language. If this `NavigationMapView` stands alone outside a `NavigationViewController`, you should call the `MapboxMap.onEvery(_:handler:)` on `mapView`, passing in `MapEvents.EventKind.styleLoaded`, and call this method inside the closure. The map view embedded in `NavigationViewController` is localized automatically, so you do not need to call this method on the value of `NavigationViewController.navigationMapView`.
+     */
     public func localizeLabels() {
-        // TODO: Implement ability to localize road labels.
+        mapView.localizeLabels(into: .nationalizedCurrent)
     }
     
     // MARK: - Route voice instructions methods

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1356,10 +1356,11 @@ open class NavigationMapView: UIView {
      
      This method automatically modifies the `SymbolLayer.textField` property of any symbol style layer whose source is the <a href="https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#overview">Mapbox Streets source</a>. The user can set the system’s preferred language in Settings, General Settings, Language & Region.
      
-     This method avoids localizing road labels into the system’s preferred language, in an effort to match road signage. The turn banner always displays road names and exit destinations in the local language. If this `NavigationMapView` stands alone outside a `NavigationViewController`, you should call the `MapboxMap.onEvery(_:handler:)` on `mapView`, passing in `MapEvents.EventKind.styleLoaded`, and call this method inside the closure. The map view embedded in `NavigationViewController` is localized automatically, so you do not need to call this method on the value of `NavigationViewController.navigationMapView`.
+     This method avoids localizing road labels into the system’s preferred language, in an effort to match road signage and the turn banner, which always display road names and exit destinations in the local language. If this `NavigationMapView` stands alone outside a `NavigationViewController`, you should call the `MapboxMap.onEvery(_:handler:)` on `mapView`, passing in `MapEvents.EventKind.styleLoaded`, and call this method inside the closure. The map view embedded in `NavigationViewController` is localized automatically, so you do not need to call this method on the value of `NavigationViewController.navigationMapView`.
      */
     public func localizeLabels() {
-        mapView.localizeLabels(into: .nationalizedCurrent)
+        guard let preferredLocale = VectorSource.preferredMapboxStreetsLocale(for: .nationalizedCurrent) else { return }
+        mapView.localizeLabels(into: preferredLocale)
     }
     
     // MARK: - Route voice instructions methods

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -203,12 +203,7 @@ extension NavigationMapView {
                     let identifiers = mapView.tileSetIdentifiers(mapboxStreetsSource.id,
                                                                  sourceType: mapboxStreetsSource.type.rawValue)
                     if VectorSource.isMapboxStreets(identifiers) {
-                        let roadLabelLayerIdentifiersByTileSetIdentifier = [
-                            "mapbox.mapbox-streets-v8": "road",
-                            "mapbox.mapbox-streets-v7": "road_label",
-                        ]
-                        
-                        return identifiers.compactMap({ roadLabelLayerIdentifiersByTileSetIdentifier[$0] }).first
+                        return identifiers.compactMap({ VectorSource.roadLabelLayerIdentifiersByTileSetIdentifier[$0] }).first
                     }
                     
                     return nil

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -149,17 +149,13 @@ extension NavigationMapView {
         // MARK: - NavigationComponentDelegate implementation
         
         func navigationViewDidLoad(_ view: UIView) {
-            navigationMapView.mapView.mapboxMap.onNext(.styleLoaded) { [weak self] _ in
+            navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
                 self?.navigationMapView.localizeLabels()
                 self?.navigationMapView.mapView.showsTraffic = false
+                self?.showRouteIfNeeded()
                 
                 // FIXME: In case when building highlighting feature is enabled due to style changes and no info currently being stored
                 // regarding building identification such highlighted building will disappear.
-            }
-            
-            // Route line should be added to `MapView`, when its style changes.
-            navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
-                self?.showRouteIfNeeded()
             }
         }
         

--- a/Sources/MapboxNavigation/VectorSource.swift
+++ b/Sources/MapboxNavigation/VectorSource.swift
@@ -1,9 +1,14 @@
-
 import Foundation
 import MapboxMaps
 
 
 extension VectorSource {
+    /// A dictionary associating known tile set identifiers with identifiers of source layers that contain road names.
+    static let roadLabelLayerIdentifiersByTileSetIdentifier = [
+        "mapbox.mapbox-streets-v8": "road",
+        "mapbox.mapbox-streets-v7": "road_label",
+    ]
+    
     /**
      Method, which returns a boolean value indicating whether the tile source is a supported version of the Mapbox Streets source.
      */

--- a/Sources/MapboxNavigation/VectorSource.swift
+++ b/Sources/MapboxNavigation/VectorSource.swift
@@ -15,4 +15,56 @@ extension VectorSource {
     static func isMapboxStreets(_ identifiers: [String]) -> Bool {
         return identifiers.contains("mapbox.mapbox-streets-v8") || identifiers.contains("mapbox.mapbox-streets-v7")
     }
+    
+    /**
+     An array of locales for which Mapbox Streets source v8 has a [dedicated name field](https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#name-text--name_lang-code-text).
+     */
+    static let mapboxStreetsLocales = ["ar", "de", "en", "es", "fr", "it", "ja", "ko", "pt", "ru", "vi", "zh-Hans", "zh-Hant"].map(Locale.init(identifier:))
+    
+    /**
+     Returns the BCP 47 language tag supported by Mapbox Streets source v8 that is most preferred according to the given preferences.
+     */
+    static func preferredMapboxStreetsLocalization(among preferences: [String]) -> String? {
+        let preferredLocales = preferences.map(Locale.init(identifier:))
+        let acceptsEnglish = preferredLocales.contains { $0.languageCode == "en" }
+        var availableLocales = mapboxStreetsLocales
+        if !acceptsEnglish {
+            availableLocales.removeAll { $0.languageCode == "en" }
+        }
+        
+        let mostSpecificLanguage = Bundle.preferredLocalizations(from: availableLocales.map { $0.identifier },
+                                                                 forPreferences: preferences)
+            .max { $0.count > $1.count }
+        
+        // `Bundle.preferredLocalizations(from:forPreferences:)` is just returning the first localization it could find.
+        if let mostSpecificLanguage = mostSpecificLanguage, !preferredLocales.contains(where: { $0.languageCode == Locale(identifier: mostSpecificLanguage).languageCode }) {
+            return nil
+        }
+        
+        return mostSpecificLanguage
+    }
+    
+    /**
+     Returns the locale supported by Mapbox Streets source v8 that is most preferred for the given locale.
+     
+     - parameter locale: The locale to match. To use the system’s preferred language, if supported, specify `nil`. To use the local language, specify a locale with the identifier `mul`.
+     */
+    static func preferredMapboxStreetsLocale(for locale: Locale?) -> Locale? {
+        guard locale?.languageCode != "mul" else {
+            // FIXME: Unlocalization not yet implemented: https://github.com/mapbox/mapbox-maps-ios/issues/653
+            return nil
+        }
+        
+        let preferences: [String]
+        if let locale = locale {
+            preferences = [locale.identifier]
+        } else {
+            preferences = Locale.preferredLanguages
+        }
+        
+        guard let preferredLocalization = VectorSource.preferredMapboxStreetsLocalization(among: preferences) else {
+            return nil
+        }
+        return Locale(identifier: preferredLocalization)
+    }
 }

--- a/Tests/MapboxNavigationTests/MapViewTests.swift
+++ b/Tests/MapboxNavigationTests/MapViewTests.swift
@@ -250,7 +250,37 @@ class MapViewTests: XCTestCase {
         mapView.localizeLabels(into: Locale(identifier: "zh-Hans-CN"))
         assert(roadLabelProperty: "name_en", placeLabelProperty: "name_zh")
         
+        // https://github.com/mapbox/mapbox-maps-ios/issues/655
         expect { mapView.localizeLabels(into: Locale(identifier: "tlh")) }
             .to(throwAssertion(), description: "Localization into Klingon should not be supported. 🖖")
+    }
+    
+    func testPreferredMapboxStreetsLocale() {
+        // https://github.com/mapbox/mapbox-maps-ios/issues/653
+        XCTAssertNil(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "mul")),
+                     "Local language not yet implemented.")
+        
+        XCTAssertEqual(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "es")),
+                       Locale(identifier: "es"),
+                       "Exact match should be supported.")
+        
+        XCTAssertEqual(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "en-US")),
+                       Locale(identifier: "en"),
+                       "Extraneous region codes should be removed.")
+        XCTAssertEqual(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "en-Latn")),
+                       Locale(identifier: "en"),
+                       "Extraneous script codes should be removed.")
+        
+        XCTAssertEqual(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "zh-Hans-CN")),
+                       Locale(identifier: "zh-Hans"),
+                       "Extraneous region codes should be removed.")
+        XCTAssertEqual(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "zh-Hant-HK")),
+                       Locale(identifier: "zh-Hant"),
+                       "Extraneous region codes should be removed.")
+        
+        XCTAssertNil(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "frm")),
+                     "Middle French not supported despite sharing prefix with French.")
+        XCTAssertNil(VectorSource.preferredMapboxStreetsLocale(for: Locale(identifier: "tlh")),
+                     "Klingon not yet implemented. 🖖")
     }
 }


### PR DESCRIPTION
Restored the `NavigationMapView.localizeLabels()` implementation for automatically localizing map labels into the user’s language. The previous implementation was removed as part of upgrading to map SDK v10 in #2808, because it relied on [an NSExpression-based localization feature](https://github.com/mapbox/mapbox-gl-native-ios/blob/ddf8e35970d1a8a46171bd798bcfa8f22d2760e0/platform/darwin/src/NSExpression%2BMGLAdditions.mm#L1494-L1637) in map SDK v6._x_. This implementation continues to be based on the map SDK’s built-in label localization functionality rather than reinventing the wheel as in #2933.

/cc @mapbox/navigation-ios @neelmistry94 @tobrun