### PR TITLE
Partially update the layer property instead of updating the whole layer.

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -179,35 +179,28 @@ extension NavigationMapView {
             return
         }
         
-        let mainRouteLayerGradient = self.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
+        let mainRouteLayerGradient = updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
         let mainRouteLayerGradientExpression = Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor)
-        
-        if let data = try? JSONEncoder().encode(mainRouteLayerGradientExpression.self),
-           let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) {
-            do {
-                try mapView.mapboxMap.style.setLayerProperty(for: mainRouteLayerIdentifier,
-                                                             property: "line-gradient",
-                                                             value: jsonObject)
-            } catch {
-                print("Failed to update main route line layer.")
-            }
-        }
+        setLayerLineGradient(for: mainRouteLayerIdentifier, exp: mainRouteLayerGradientExpression)
         
         let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveled)
         let mainRouteCasingLayerGradientExpression = Expression.routeLineGradientExpression(mainRouteCasingLayerGradient, lineBaseColor: routeCasingColor)
+        setLayerLineGradient(for: mainRouteCasingLayerIdentifier, exp: mainRouteCasingLayerGradientExpression)
         
-        if let data = try? JSONEncoder().encode(mainRouteCasingLayerGradientExpression.self),
+        pendingCoordinateForRouteLine = coordinate
+    }
+    
+    func setLayerLineGradient(for layerId: String, exp: Expression) {
+        if let data = try? JSONEncoder().encode(exp.self),
            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) {
             do {
-                try mapView.mapboxMap.style.setLayerProperty(for: mainRouteCasingLayerIdentifier,
+                try mapView.mapboxMap.style.setLayerProperty(for: layerId,
                                                              property: "line-gradient",
                                                              value: jsonObject)
             } catch {
-                print("Failed to update main route casing layer.")
+                print("Failed to update route line gradient.")
             }
         }
-        
-        pendingCoordinateForRouteLine = coordinate
     }
     
     func updateRouteLineGradientStops(fractionTraveled: Double, gradientStops: [Double: UIColor]) -> [Double: UIColor] {

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -179,18 +179,32 @@ extension NavigationMapView {
             return
         }
         
-        do {
-            try mapView.mapboxMap.style.updateLayer(withId: mainRouteLayerIdentifier) { (lineLayer: inout LineLayer) throws in
-                let mainRouteLayerGradient = self.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
-                lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor))
+        let mainRouteLayerGradient = self.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: currentLineGradientStops)
+        let mainRouteLayerGradientExpression = Expression.routeLineGradientExpression(mainRouteLayerGradient, lineBaseColor: trafficUnknownColor)
+        
+        if let data = try? JSONEncoder().encode(mainRouteLayerGradientExpression.self),
+           let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) {
+            do {
+                try mapView.mapboxMap.style.setLayerProperty(for: mainRouteLayerIdentifier,
+                                                             property: "line-gradient",
+                                                             value: jsonObject)
+            } catch {
+                print("Failed to update main route line layer.")
             }
-            
-            try mapView.mapboxMap.style.updateLayer(withId: mainRouteCasingLayerIdentifier) { (lineLayer: inout LineLayer) throws in
-                let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveled)
-                lineLayer.lineGradient = .expression(Expression.routeLineGradientExpression(mainRouteCasingLayerGradient, lineBaseColor: routeCasingColor))
+        }
+        
+        let mainRouteCasingLayerGradient = routeLineGradient(fractionTraveled: fractionTraveled)
+        let mainRouteCasingLayerGradientExpression = Expression.routeLineGradientExpression(mainRouteCasingLayerGradient, lineBaseColor: routeCasingColor)
+        
+        if let data = try? JSONEncoder().encode(mainRouteCasingLayerGradientExpression.self),
+           let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) {
+            do {
+                try mapView.mapboxMap.style.setLayerProperty(for: mainRouteCasingLayerIdentifier,
+                                                             property: "line-gradient",
+                                                             value: jsonObject)
+            } catch {
+                print("Failed to update main route casing layer.")
             }
-        } catch {
-            print("Failed to update main route line layer.")
         }
         
         pendingCoordinateForRouteLine = coordinate


### PR DESCRIPTION
### Description
This pr is to fix #3333 , to allow the route line gradient be updated through the `mapView.mapboxMap.style.setLayerProperty(for:property:value:)` with only the route line gradient expression transformed to JSON, instead of retrieving the whole line layer and the whole route line JSON object.