### PR TITLE
Fix bundle names retrieval in `URLSession.userAgent`.

### DIFF
--- a/Sources/MapboxCoreNavigation/URLSession.swift
+++ b/Sources/MapboxCoreNavigation/URLSession.swift
@@ -27,10 +27,22 @@ extension URLSession {
         let bundleComponents = bundles.compactMap { (bundle) -> String? in
             guard let name = bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundle?.bundleIdentifier else { return nil }
             var stringForShortVersion: String? {
+                #if SWIFT_PACKAGE
+                let mapboxNavigationName = "MapboxNavigation_MapboxNavigation"
+                #else
+                let mapboxNavigationName = "MapboxNavigation"
+                #endif
+
+                #if SWIFT_PACKAGE
+                let mapboxCoreNavigationName = "MapboxNavigation_MapboxCoreNavigation"
+                #else
+                let mapboxCoreNavigationName = "MapboxCoreNavigation"
+                #endif
+
                 switch name {
-                case "MapboxNavigation_MapboxNavigation":
+                case mapboxNavigationName:
                     return Bundle.string(forMapboxNavigationInfoDictionaryKey: "CFBundleShortVersionString")
-                case "MapboxNavigation_MapboxCoreNavigation":
+                case mapboxCoreNavigationName:
                     return Bundle.string(forMapboxCoreNavigationInfoDictionaryKey: "CFBundleShortVersionString")
                 default:
                     return bundle?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String

--- a/Sources/MapboxCoreNavigation/URLSession.swift
+++ b/Sources/MapboxCoreNavigation/URLSession.swift
@@ -26,19 +26,34 @@ extension URLSession {
 
         let bundleComponents = bundles.compactMap { (bundle) -> String? in
             guard let name = bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundle?.bundleIdentifier else { return nil }
+            
+            let defaultMapboxNavigationBundleName = "MapboxNavigation"
+            let defaultMapboxCoreNavigationBundleName = "MapboxCoreNavigation"
+            
+            #if SWIFT_PACKAGE
+            let mapboxNavigationName = "MapboxNavigation_MapboxNavigation"
+            #else
+            let mapboxNavigationName = defaultMapboxNavigationBundleName
+            #endif
+
+            #if SWIFT_PACKAGE
+            let mapboxCoreNavigationName = "MapboxNavigation_MapboxCoreNavigation"
+            #else
+            let mapboxCoreNavigationName = defaultMapboxCoreNavigationBundleName
+            #endif
+            
+            var bundleName: String {
+                switch name {
+                case mapboxNavigationName:
+                    return defaultMapboxNavigationBundleName
+                case mapboxCoreNavigationName:
+                    return defaultMapboxCoreNavigationBundleName
+                default:
+                    return name
+                }
+            }
+            
             var stringForShortVersion: String? {
-                #if SWIFT_PACKAGE
-                let mapboxNavigationName = "MapboxNavigation_MapboxNavigation"
-                #else
-                let mapboxNavigationName = "MapboxNavigation"
-                #endif
-
-                #if SWIFT_PACKAGE
-                let mapboxCoreNavigationName = "MapboxNavigation_MapboxCoreNavigation"
-                #else
-                let mapboxCoreNavigationName = "MapboxCoreNavigation"
-                #endif
-
                 switch name {
                 case mapboxNavigationName:
                     return Bundle.string(forMapboxNavigationInfoDictionaryKey: "CFBundleShortVersionString")
@@ -49,7 +64,7 @@ extension URLSession {
                 }
             }
             guard let version = stringForShortVersion else { return nil }
-            return "\(name)/\(version)"
+            return "\(bundleName)/\(version)"
         }
 
         let system: String

--- a/Sources/MapboxCoreNavigation/URLSession.swift
+++ b/Sources/MapboxCoreNavigation/URLSession.swift
@@ -8,13 +8,22 @@ extension URLSession {
      The user agent string for any HTTP requests performed directly within MapboxCoreNavigation or MapboxNavigation.
      */
     public static let userAgent: String = {
+        // Bundles in order from the application level on down
+        #if SWIFT_PACKAGE
         let bundles: [Bundle?] = [
-            // Bundles in order from the application level on down
+            .main,
+            .mapboxNavigationIfInstalled,
+            .mapboxCoreNavigation
+        ]
+        #else
+        let bundles: [Bundle?] = [
             .main,
             .mapboxNavigationIfInstalled,
             .mapboxCoreNavigation,
             .init(for: Directions.self),
         ]
+        #endif
+
         let bundleComponents = bundles.compactMap { (bundle) -> String? in
             guard let name = bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundle?.bundleIdentifier else { return nil }
             var stringForShortVersion: String? {

--- a/Sources/MapboxCoreNavigation/URLSession.swift
+++ b/Sources/MapboxCoreNavigation/URLSession.swift
@@ -19,12 +19,12 @@ extension URLSession {
             guard let name = bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundle?.bundleIdentifier else { return nil }
             var stringForShortVersion: String? {
                 switch name {
-                case "MapboxNavigation":
+                case "MapboxNavigation_MapboxNavigation":
                     return Bundle.string(forMapboxNavigationInfoDictionaryKey: "CFBundleShortVersionString")
-                case "MapboxCoreNavigation":
+                case "MapboxNavigation_MapboxCoreNavigation":
                     return Bundle.string(forMapboxCoreNavigationInfoDictionaryKey: "CFBundleShortVersionString")
                 default:
-                    return bundle?.object(forInfoDictionaryKey:"CFBundleShortVersionString") as? String
+                    return bundle?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
                 }
             }
             guard let version = stringForShortVersion else { return nil }


### PR DESCRIPTION
Closing #3312.

Result string previously looked like this when using SPM:
`Example/2.0.0 Example/2.0.0 iOS/14.5.0 (x86_64)`

Now it looks like this:
`Example/2.0.0 MapboxNavigation/2.0.0 MapboxCoreNavigation/2.0.0 Example/2.0.0 iOS/14.5.0 (x86_64)`