### PR TITLE
Copyedit feedback categories

### DIFF
--- a/Sources/MapboxCoreNavigation/PassiveNavigationFeedbackType.swift
+++ b/Sources/MapboxCoreNavigation/PassiveNavigationFeedbackType.swift
@@ -49,8 +49,8 @@ public enum PassiveNavigationFeedbackType: FeedbackType {
             return "incorrect_speed_limit"
         case .roadIssue(subtype: .streetPermanentlyBlockedOff):
             return "street_permanently_blocked_off"
-        case .roadIssue(subtype: .streetTemporaryBlockedOff):
-            return "street_temporary_blocked_off"
+        case .roadIssue(subtype: .streetTemporarilyBlockedOff):
+            return "street_temporarily_blocked_off"
         case .roadIssue(subtype: .missingRoad):
             return "missing_road"
         case .wrongTraffic(subtype: .congestion):
@@ -86,7 +86,7 @@ public enum PassiveNavigationRoadIssueSubtype: CaseIterable {
     case streetPermanentlyBlockedOff
     
     /// The user is unable to follow the route due to a temporary closure.
-    case streetTemporaryBlockedOff
+    case streetTemporarilyBlockedOff
     
     /// The map data is incorrect or outdated, the user isn’t able to follow any route based on that road.
     case missingRoad

--- a/Sources/MapboxNavigation/Feedback/PassiveNavigationFeedbackType+FeedbackItem.swift
+++ b/Sources/MapboxNavigation/Feedback/PassiveNavigationFeedbackType+FeedbackItem.swift
@@ -13,8 +13,8 @@ extension PassiveNavigationFeedbackType {
             return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_INCORRECT_VISUAL_STREET_NAME_INCORRECT", bundle: .mapboxNavigation, value: "Street name incorrect", comment: "Specific route feedback for incorrect street name.")
         case .roadIssue(subtype: .missingRoad):
             return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_MISSING_ROAD", bundle: .mapboxNavigation, value: "Missing road", comment: "Feedback that map shows a non-existant road.")
-        case .roadIssue(subtype: .streetTemporaryBlockedOff):
-            return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_TEMPORARY_BLOCKED_OFF", bundle: .mapboxNavigation, value: "Street temporary blocked off", comment: "Feedback that a street is temporary blocked off.")
+        case .roadIssue(subtype: .streetTemporarilyBlockedOff):
+            return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_TEMPORARILY_BLOCKED_OFF", bundle: .mapboxNavigation, value: "Street temporarily blocked off", comment: "Feedback that a street is temporarily blocked off.")
         case .roadIssue(subtype: .streetPermanentlyBlockedOff):
             return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_PERMANENTLY_BLOCKED_OFF", bundle: .mapboxNavigation, value: "Street permanently blocked off", comment: "Feedback that a street is permanently blocked off.")
         case .wrongTraffic(subtype: .congestion):
@@ -24,7 +24,7 @@ extension PassiveNavigationFeedbackType {
         case .wrongTraffic(subtype: .noTraffic):
             return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_WRONG_TRAFFIC_NO_TRAFFIC", bundle: .mapboxNavigation, value: "No traffic", comment: "Feedback that there is no traffic on the road.")
         case .incorrectVisual(subtype: .none):
-            return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_INCORRECT_VISUAL", bundle: .mapboxNavigation, value: "Incorrect visual", comment: "General category of feedback where something looks incorrect.")
+            return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_INCORRECT_VISUAL", bundle: .mapboxNavigation, value: "Looks incorrect", comment: "General category of feedback where something looks incorrect.")
         case .roadIssue(subtype: .none):
             return NSLocalizedString("PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE", bundle: .mapboxNavigation, value: "Road issue", comment: "General category of feedback where there is an issue on the road.")
         case .wrongTraffic(subtype: .none):

--- a/Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
+++ b/Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
@@ -143,7 +143,7 @@
 "PASSIVE_NAVIGATION_FEEDBACK_BAD_GPS" = "Bad GPS";
 
 /* General category of feedback where something looks incorrect. */
-"PASSIVE_NAVIGATION_FEEDBACK_INCORRECT_VISUAL" = "Incorrect visual";
+"PASSIVE_NAVIGATION_FEEDBACK_INCORRECT_VISUAL" = "Looks incorrect";
 
 /* Specific route feedback that a speed limit is incorrect. */
 "PASSIVE_NAVIGATION_FEEDBACK_INCORRECT_VISUAL_INCORRECT_SPEED_LIMIT" = "Speed limit incorrect";
@@ -161,7 +161,7 @@
 "PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_PERMANENTLY_BLOCKED_OFF" = "Street permanently blocked off";
 
 /* Feedback that a street is temporary blocked off. */
-"PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_TEMPORARY_BLOCKED_OFF" = "Street temporary blocked off";
+"PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_TEMPORARILY_BLOCKED_OFF" = "Street temporarily blocked off";
 
 /* Feedback that there is a congestion on the road. */
 "PASSIVE_NAVIGATION_FEEDBACK_WRONG_TRAFFIC_CONGESTION" = "Congestion";


### PR DESCRIPTION
A couple of the feedback categories added in #3323 for passive navigation are misspelled or otherwise inconsistent with analogous feedback categories for active turn-by-turn navigation.

/cc @mapbox/navigation-ios