### PR TITLE
Fix IndexedRouteResponse handling after rerouting

### DIFF
--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -597,6 +597,7 @@ extension RouteController: Router {
                 guard case let .route(routeOptions) = response.options else { return } //TODO: Can a match hit this codepoint?
                 strongSelf._routeProgress = RouteProgress(route: route, options: routeOptions, legIndex: 0)
                 strongSelf._routeProgress.currentLegProgress.stepIndex = 0
+                strongSelf.indexedRouteResponse = .init(routeResponse: response, routeIndex: 0)
                 strongSelf.announce(reroute: route, at: location, proactive: false)
                 
             case let .failure(error):


### PR DESCRIPTION
## Summary
Reroute does not update `indexedRouteResponse` and refresh uses old route's identifier to update route annotations. This provides unexpected speed limit, congestion information display.

## Detail

Reroute does not update [`indexedRouteResponse`](https://github.com/mapbox/mapbox-navigation-ios/blob/v2.0.0-beta.25/Sources/MapboxCoreNavigation/RouteController.swift#L39). `indexedRouteResponse.routeResponse.identifier` represents route's identifier and used [when refreshing](https://github.com/mapbox/mapbox-navigation-ios/blob/v2.0.0-beta.25/Sources/MapboxCoreNavigation/Router.swift#L173). 

Therefore, `indexedRouteResponse` needs to be updated [here](https://github.com/mapbox/mapbox-navigation-ios/blob/v2.0.0-beta.25/Sources/MapboxCoreNavigation/RouteController.swift#L584-L589).

## Screenshot
After the reroute, speed limit shows 90km/h but 1 min later it becomes 70km/h. This road is 90km/h and 70km/h is wrong.

https://user-images.githubusercontent.com/13183117/132643775-4662960c-4ce0-4a7d-9bc9-6f4158101a54.mp4

## Expected behavior
https://user-images.githubusercontent.com/13183117/132643913-755627bd-211f-4c36-9e5e-d882737c32c1.mp4










