### PR TITLE
Fix unit tests for M1 chip

### DIFF
--- a/Sources/MapboxNavigation/FollowingCameraOptions.swift
+++ b/Sources/MapboxNavigation/FollowingCameraOptions.swift
@@ -5,7 +5,7 @@ import CoreLocation
  `NavigationViewportDataSource` in `NavigationCameraState.following` state.
  */
 public struct FollowingCameraOptions: Equatable {
-    
+
     /**
      Pitch, which will be taken into account when preparing `CameraOptions` during active guidance
      navigation.
@@ -62,7 +62,7 @@ public struct FollowingCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var zoomUpdatesAllowed = true
+    public var zoomUpdatesAllowed: Bool = true
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.bearing` property
@@ -72,7 +72,7 @@ public struct FollowingCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var bearingUpdatesAllowed = true
+    public var bearingUpdatesAllowed: Bool = true
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.pitch` property
@@ -82,7 +82,7 @@ public struct FollowingCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var pitchUpdatesAllowed = true
+    public var pitchUpdatesAllowed: Bool = true
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.padding` property
@@ -92,7 +92,7 @@ public struct FollowingCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var paddingUpdatesAllowed = true
+    public var paddingUpdatesAllowed: Bool = true
     
     /**
      Options, which allow to modify the framed route geometries based on the intersection density.
@@ -200,7 +200,7 @@ public struct BearingSmoothing: Equatable {
      
      Defaults to `true`.
      */
-    public var enabled = true
+    public var enabled: Bool = true
     
     /**
      Controls how much the bearing can deviate from the location's bearing, in degrees.
@@ -279,7 +279,7 @@ public struct PitchNearManeuver: Equatable {
      
      Defaults to `true`.
      */
-    public var enabled = true
+    public var enabled: Bool = true
     
     /**
      Threshold distance to the upcoming maneuver.

--- a/Sources/MapboxNavigation/FollowingCameraOptions.swift
+++ b/Sources/MapboxNavigation/FollowingCameraOptions.swift
@@ -11,15 +11,17 @@ public struct FollowingCameraOptions: Equatable {
      navigation.
      
      Defaults to `45.0` degrees.
+
+     - Invariant: Acceptable range of values is `0...85`.
      */
     public var defaultPitch: Double = 45.0 {
         didSet {
             if defaultPitch < 0.0 {
-                preconditionFailure("Lower bound of the pitch should not be lower than 0.0")
+                defaultPitch = 0
             }
             
             if defaultPitch > 85.0 {
-                preconditionFailure("Upper bound of the pitch should not be higher than 85.0")
+                defaultPitch = 85
             }
         }
     }
@@ -31,15 +33,13 @@ public struct FollowingCameraOptions: Equatable {
      Upper bound of the range will be also used as initial zoom level when active guidance navigation starts.
      
      Lower bound defaults to `10.50`, upper bound defaults to `16.35`.
+
+     - Invariant: Acceptable range of values is `0...22`.
      */
     public var zoomRange: ClosedRange<Double> = 10.50...16.35 {
         didSet {
-            if zoomRange.lowerBound < 0.0 {
-                preconditionFailure("Lower bound of the zoom range should not be lower than 0.0")
-            }
-            
-            if zoomRange.upperBound > 22.0 {
-                preconditionFailure("Upper bound of the zoom range should not be higher than 22.0")
+            if zoomRange.lowerBound < 0.0 || zoomRange.upperBound > 22.0 {
+                zoomRange = max(0, zoomRange.lowerBound)...min(22, zoomRange.upperBound)
             }
         }
     }

--- a/Sources/MapboxNavigation/OverviewCameraOptions.swift
+++ b/Sources/MapboxNavigation/OverviewCameraOptions.swift
@@ -34,7 +34,7 @@ public struct OverviewCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var centerUpdatesAllowed = true
+    public var centerUpdatesAllowed: Bool = true
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.zoom` property
@@ -44,7 +44,7 @@ public struct OverviewCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var zoomUpdatesAllowed = true
+    public var zoomUpdatesAllowed: Bool = true
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.bearing` property
@@ -54,7 +54,7 @@ public struct OverviewCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var bearingUpdatesAllowed = true
+    public var bearingUpdatesAllowed: Bool = true
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.pitch` property
@@ -64,7 +64,7 @@ public struct OverviewCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var pitchUpdatesAllowed = true
+    public var pitchUpdatesAllowed: Bool = true
     
     /**
      If `true`, `NavigationViewportDataSource` will continuously modify `CameraOptions.padding` property
@@ -74,7 +74,7 @@ public struct OverviewCameraOptions: Equatable {
      
      Defaults to `true`.
      */
-    public var paddingUpdatesAllowed = true
+    public var paddingUpdatesAllowed: Bool = true
     
     /**
      Initializes `OverviewCameraOptions` instance.

--- a/Sources/MapboxNavigation/OverviewCameraOptions.swift
+++ b/Sources/MapboxNavigation/OverviewCameraOptions.swift
@@ -11,15 +11,17 @@ public struct OverviewCameraOptions: Equatable {
      state.
      
      Defaults to `16.35`.
+
+     - Invariant: Acceptable range of values is 0...22.
      */
     public var maximumZoomLevel: Double = 16.35 {
         didSet {
             if maximumZoomLevel < 0.0 {
-                preconditionFailure("Maximum zoom level should not be lower than 0.0")
+                maximumZoomLevel = 0
             }
             
             if maximumZoomLevel > 22.0 {
-                preconditionFailure("Maximum zoom level should not be higher than 22.0")
+                maximumZoomLevel = 22
             }
         }
     }

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -604,36 +604,33 @@ class NavigationCameraTests: XCTestCase {
     
     func testNavigationCameraFollowingCameraOptionsZoomRanges() {
         let navigationMapView = NavigationMapView(frame: .zero)
-        let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource
+        guard let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource else {
+            XCTFail(); return
+        }
         
-        navigationViewportDataSource?.options.followingCameraOptions.zoomRange = 10.0...22.0
+        navigationViewportDataSource.options.followingCameraOptions.zoomRange = 10.0...22.0
         
-        let zoomRange = navigationViewportDataSource?.options.followingCameraOptions.zoomRange
-        XCTAssertEqual(zoomRange?.lowerBound, 10.0, "Lower bounds should be equal.")
-        XCTAssertEqual(zoomRange?.upperBound, 22.0, "Upper bounds should be equal.")
+        let zoomRange = navigationViewportDataSource.options.followingCameraOptions.zoomRange
+        XCTAssertEqual(zoomRange.lowerBound, 10.0, "Lower bounds should be equal.")
+        XCTAssertEqual(zoomRange.upperBound, 22.0, "Upper bounds should be equal.")
         
-        var appliedChanges = false
-        expect {
-            // It should only be possible to set zoom range levels from `0.0` to `22.0`.
-            navigationViewportDataSource?.options.followingCameraOptions.zoomRange = -1.0...100.0
-            appliedChanges = true
-        }.to(throwAssertion())
-        
-        XCTAssertFalse(appliedChanges, "Zoom range changes should not be applied.")
+        // It should only be possible to set zoom range levels from `0.0` to `22.0`.
+        navigationViewportDataSource.options.followingCameraOptions.zoomRange = -1.0...100.0
+        XCTAssertEqual(navigationViewportDataSource.options.followingCameraOptions.zoomRange,
+                       0...22)
     }
     
     func testNavigationCameraOverviewCameraOptionsMaximumZoomLevel() {
         let navigationMapView = NavigationMapView(frame: .zero)
-        let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource
+        guard let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource else {
+            XCTFail(); return
+        }
         
-        var appliedChanges = false
-        expect {
-            // It should only be possible to set maximum zoom level between `0.0` and `22.0`.
-            navigationViewportDataSource?.options.overviewCameraOptions.maximumZoomLevel = 23.0
-            appliedChanges = true
-        }.to(throwAssertion())
-        
-        XCTAssertFalse(appliedChanges, "Maximum zoom level changes should not be applied.")
+        // It should only be possible to set maximum zoom level between `0.0` and `22.0`.
+        navigationViewportDataSource.options.overviewCameraOptions.maximumZoomLevel = 23.0
+        XCTAssertEqual(navigationViewportDataSource.options.overviewCameraOptions.maximumZoomLevel, 22)
+        navigationViewportDataSource.options.overviewCameraOptions.maximumZoomLevel = -1
+        XCTAssertEqual(navigationViewportDataSource.options.overviewCameraOptions.maximumZoomLevel, 0)
     }
     
     func testNavigationViewportDataSourceOptionsInitializer() {


### PR DESCRIPTION
Instead of preconditions I used to default to save range of values so that the test don't crash.

I think the fix is an acceptable change. 