### PR TITLE
Use snapped location for reroutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 * Fixes an issue where the user would be rerouted even if `NavigationViewControllerDelegate.navigationViewController(_:shouldRerouteFrom:)` returned `false`. To implement reroute after arrival behavior, return `true` from this method and `false` from `NavigationViewControllerDelegate.navigationViewController(_:shouldPreventReroutesWhenArrivingAt:)`, then set `NavigationViewController.showsEndOfRouteFeedback` to `false`. ([#3195](https://github.com/mapbox/mapbox-navigation-ios/pull/3195))
 * Added `UserHaloCourseView.haloBorderWidth`, which allows to change border of the ring around halo view. ([#3309](https://github.com/mapbox/mapbox-navigation-ios/pull/3309))
 * Fixed an issue where the `RouteController.indexedRouteResponse` property would remain unchanged after the user is rerouted. ([#3344](https://github.com/mapbox/mapbox-navigation-ios/pull/3344]))
-* Rerouting now uses the snapped location, instead of raw location. ([#](https://github.com/mapbox/mapbox-navigation-ios/pull/))
+* Rerouting now uses the snapped location, instead of raw location. ([#3361](https://github.com/mapbox/mapbox-navigation-ios/pull/3361))
 
 ### Electronic horizon
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * Fixes an issue where the user would be rerouted even if `NavigationViewControllerDelegate.navigationViewController(_:shouldRerouteFrom:)` returned `false`. To implement reroute after arrival behavior, return `true` from this method and `false` from `NavigationViewControllerDelegate.navigationViewController(_:shouldPreventReroutesWhenArrivingAt:)`, then set `NavigationViewController.showsEndOfRouteFeedback` to `false`. ([#3195](https://github.com/mapbox/mapbox-navigation-ios/pull/3195))
 * Added `UserHaloCourseView.haloBorderWidth`, which allows to change border of the ring around halo view. ([#3309](https://github.com/mapbox/mapbox-navigation-ios/pull/3309))
 * Fixed an issue where the `RouteController.indexedRouteResponse` property would remain unchanged after the user is rerouted. ([#3344](https://github.com/mapbox/mapbox-navigation-ios/pull/3344]))
+* Rerouting now uses the snapped location, instead of raw location. ([#](https://github.com/mapbox/mapbox-navigation-ios/pull/))
 
 ### Electronic horizon
 

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -278,7 +278,7 @@ open class RouteController: NSObject {
         updateRoadName(status: status)
         
         if willReroute {
-            reroute(from: location, along: routeProgress)
+            reroute(from: CLLocation(status.location), along: routeProgress)
         }
 
         if status.routeState != .complete {

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -253,7 +253,8 @@ class MapboxCoreNavigationTests: TestCase {
             XCTAssertEqual(notification.userInfo?.count, 1)
             
             let location = notification.userInfo![RouteController.NotificationUserInfoKey.locationKey] as! CLLocation
-            return offRouteLocations.contains(location)
+            // location is a map-matched location, so we don't know it in advance
+            return offRouteLocations[0].distance(from: location) < 10
         }
         
         navigation.start()

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -254,7 +254,7 @@ class MapboxCoreNavigationTests: TestCase {
             
             let location = notification.userInfo![RouteController.NotificationUserInfoKey.locationKey] as! CLLocation
             // location is a map-matched location, so we don't know it in advance
-            return offRouteLocations[0].distance(from: location) < 10
+            return offRouteLocations.first(where: { $0.distance(from: location) < 10 }) != nil
         }
         
         navigation.start()


### PR DESCRIPTION
In the case of off-route, we have to send the initial coordinate to Directions API. Currently we use the raw location for it (i.e. we get bearing and coordinate from the system) what can lead to awful use experience (route built in the wrong direction, problems on parallel roads, etc). For directions API requests we should always use coordinate, bearing, and other parameters provided by map matcher(i.e. by NN).

