### PR TITLE
Add SPM `MapboxCoreNavigation` integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,7 @@ jobs:
       - *add-github-to-known-hosts
       - run:
           name: Build SPM Core integration test
-          command: cd Tests/SPMTest/CoreSPMTest && xcodebuild -scheme CoreSPMTest -destination "platform=iOS Simulator,OS=15,name=iPhone 12 Pro Max" build
+          command: cd Tests/SPMTest/CoreSPMTest && xcodebuild -scheme CoreSPMTest -destination "platform=iOS Simulator,OS=15.0,name=iPhone 13 Pro Max" build
       
 
 workflows:
@@ -657,7 +657,7 @@ workflows:
           device: "iPhone 12 Pro Max"          
           context: Slack Orb
       - spm-core-integration-test-job:
-          name: "Xcode 13; iOS 15; SPM Core test"
+          name: "Xcode 13; iOS 15.0; SPM Core test"
       - ios-trigger-metrics:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,14 +570,14 @@ jobs:
           
   spm-core-integration-test-job:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.0.0"
     steps:
       - checkout
       - *prepare-netrc-file
       - *add-github-to-known-hosts
       - run:
           name: Build SPM Core integration test
-          command: cd Tests/SPMTest/CoreSPMTest && xcodebuild -scheme CoreSPMTest -destination "platform=iOS Simulator,OS=14.5,name=iPhone 12 Pro Max" build | xcpretty
+          command: cd Tests/SPMTest/CoreSPMTest && xcodebuild -scheme CoreSPMTest -destination "platform=iOS Simulator,OS=14.5,name=iPhone 12 Pro Max" build
       
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,6 +567,17 @@ jobs:
       - run:
           name: Generating MapboxNavigation API Diff
           command: ./scripts/swift-api-diff/.build/release/swift-api-diff diff $CIRCLE_WORKING_DIRECTORY/old_api/navigation_log.json -i $CIRCLE_WORKING_DIRECTORY/new_api/navigation_log.json
+          
+  spm-core-integration-test-job:
+    macos:
+      xcode: "12.5.1"
+    steps:
+      - checkout
+      - *prepare-netrc-file
+      - *add-github-to-known-hosts
+      - run:
+          name: Build SPM Core integration test
+          command: cd Tests/SPMTest/CoreSPMTest && xcodebuild -scheme CoreSPMTest -destination "platform=iOS Simulator,OS=14.5,name=iPhone 12 Pro Max" build | xcpretty
       
 
 workflows:
@@ -645,6 +656,8 @@ workflows:
           iOS: "14.5"          
           device: "iPhone 12 Pro Max"          
           context: Slack Orb
+      - spm-core-integration-test-job:
+          name: "Xcode 12.5.1; iOS 14.5; SPM Core test"
       - ios-trigger-metrics:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,7 @@ jobs:
       - *add-github-to-known-hosts
       - run:
           name: Build SPM Core integration test
-          command: cd Tests/SPMTest/CoreSPMTest && xcodebuild -scheme CoreSPMTest -destination "platform=iOS Simulator,OS=14.5,name=iPhone 12 Pro Max" build
+          command: cd Tests/SPMTest/CoreSPMTest && xcodebuild -scheme CoreSPMTest -destination "platform=iOS Simulator,OS=15,name=iPhone 12 Pro Max" build
       
 
 workflows:
@@ -657,7 +657,7 @@ workflows:
           device: "iPhone 12 Pro Max"          
           context: Slack Orb
       - spm-core-integration-test-job:
-          name: "Xcode 12.5.1; iOS 14.5; SPM Core test"
+          name: "Xcode 13; iOS 15; SPM Core test"
       - ios-trigger-metrics:
           filters:
             branches:

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest.xcodeproj/project.pbxproj
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest.xcodeproj/project.pbxproj
@@ -1,0 +1,376 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		11BB92CE26F3824800FA9B68 /* CoreSPMTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BB92CD26F3824800FA9B68 /* CoreSPMTestApp.swift */; };
+		11BB92D026F3824800FA9B68 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BB92CF26F3824800FA9B68 /* ContentView.swift */; };
+		11BB92D226F3824900FA9B68 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 11BB92D126F3824900FA9B68 /* Assets.xcassets */; };
+		11BB92D526F3824900FA9B68 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 11BB92D426F3824900FA9B68 /* Preview Assets.xcassets */; };
+		11D7BDBE26F3844200AB275C /* MapboxCoreNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = 11D7BDBD26F3844200AB275C /* MapboxCoreNavigation */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		11BB92CA26F3824800FA9B68 /* CoreSPMTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CoreSPMTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		11BB92CD26F3824800FA9B68 /* CoreSPMTestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSPMTestApp.swift; sourceTree = "<group>"; };
+		11BB92CF26F3824800FA9B68 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		11BB92D126F3824900FA9B68 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		11BB92D426F3824900FA9B68 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		11BB92D626F3824900FA9B68 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		11BB92DC26F3829800FA9B68 /* mapbox-navigation-ios */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "mapbox-navigation-ios"; path = ../../../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		11BB92C726F3824800FA9B68 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11D7BDBE26F3844200AB275C /* MapboxCoreNavigation in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		11BB92C126F3824800FA9B68 = {
+			isa = PBXGroup;
+			children = (
+				11BB92CC26F3824800FA9B68 /* CoreSPMTest */,
+				11BB92CB26F3824800FA9B68 /* Products */,
+				11D7BDBC26F3844200AB275C /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		11BB92CB26F3824800FA9B68 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				11BB92CA26F3824800FA9B68 /* CoreSPMTest.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		11BB92CC26F3824800FA9B68 /* CoreSPMTest */ = {
+			isa = PBXGroup;
+			children = (
+				11BB92DC26F3829800FA9B68 /* mapbox-navigation-ios */,
+				11BB92CD26F3824800FA9B68 /* CoreSPMTestApp.swift */,
+				11BB92CF26F3824800FA9B68 /* ContentView.swift */,
+				11BB92D126F3824900FA9B68 /* Assets.xcassets */,
+				11BB92D626F3824900FA9B68 /* Info.plist */,
+				11BB92D326F3824900FA9B68 /* Preview Content */,
+			);
+			path = CoreSPMTest;
+			sourceTree = "<group>";
+		};
+		11BB92D326F3824900FA9B68 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				11BB92D426F3824900FA9B68 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		11D7BDBC26F3844200AB275C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		11BB92C926F3824800FA9B68 /* CoreSPMTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 11BB92D926F3824900FA9B68 /* Build configuration list for PBXNativeTarget "CoreSPMTest" */;
+			buildPhases = (
+				11BB92C626F3824800FA9B68 /* Sources */,
+				11BB92C726F3824800FA9B68 /* Frameworks */,
+				11BB92C826F3824800FA9B68 /* Resources */,
+				11D7BDBF26F3887700AB275C /* Apply Mapbox token */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CoreSPMTest;
+			packageProductDependencies = (
+				11D7BDBD26F3844200AB275C /* MapboxCoreNavigation */,
+			);
+			productName = CoreSPMTest;
+			productReference = 11BB92CA26F3824800FA9B68 /* CoreSPMTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		11BB92C226F3824800FA9B68 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					11BB92C926F3824800FA9B68 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+				};
+			};
+			buildConfigurationList = 11BB92C526F3824800FA9B68 /* Build configuration list for PBXProject "CoreSPMTest" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 11BB92C126F3824800FA9B68;
+			productRefGroup = 11BB92CB26F3824800FA9B68 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				11BB92C926F3824800FA9B68 /* CoreSPMTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		11BB92C826F3824800FA9B68 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11BB92D526F3824900FA9B68 /* Preview Assets.xcassets in Resources */,
+				11BB92D226F3824900FA9B68 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		11D7BDBF26F3887700AB275C /* Apply Mapbox token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Apply Mapbox token";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This Run Script build phase helps to keep the navigation SDK’s developers from exposing their own access tokens during development. See <https://www.mapbox.com/help/ios-private-access-token/> for more information. If you are developing an application privately, you may add the MGLMapboxAccessToken key directly to your Info.plist file and delete this build phase.\n\ntoken_file=~/.mapbox\ntoken_file2=~/mapbox\ntoken=\"$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MBXAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://www.mapbox.com/account/access-tokens/'\n  echo \"warning: Get an access token from <https://www.mapbox.com/account/access-tokens/>, then create a new file at $token_file or $token_file2 that contains the access token.\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		11BB92C626F3824800FA9B68 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11BB92D026F3824800FA9B68 /* ContentView.swift in Sources */,
+				11BB92CE26F3824800FA9B68 /* CoreSPMTestApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		11BB92D726F3824900FA9B68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		11BB92D826F3824900FA9B68 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		11BB92DA26F3824900FA9B68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"CoreSPMTest/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = CoreSPMTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.CoreSPMTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		11BB92DB26F3824900FA9B68 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"CoreSPMTest/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = CoreSPMTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.CoreSPMTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		11BB92C526F3824800FA9B68 /* Build configuration list for PBXProject "CoreSPMTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				11BB92D726F3824900FA9B68 /* Debug */,
+				11BB92D826F3824900FA9B68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		11BB92D926F3824900FA9B68 /* Build configuration list for PBXNativeTarget "CoreSPMTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				11BB92DA26F3824900FA9B68 /* Debug */,
+				11BB92DB26F3824900FA9B68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		11D7BDBD26F3844200AB275C /* MapboxCoreNavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MapboxCoreNavigation;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 11BB92C226F3824800FA9B68 /* Project object */;
+}

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Assets.xcassets/Contents.json
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/ContentView.swift
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/ContentView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import MapboxCoreNavigation
+import MapboxDirections
+import CoreLocation
+
+struct ContentView: View {
+    var body: some View {
+        Button("Request route") {
+            let routeOptions = RouteOptions(coordinates: [
+                CLLocationCoordinate2D(latitude: 10, longitude: 10),
+                CLLocationCoordinate2D(latitude: 11, longitude: 11)
+            ])
+            Directions.shared.calculate(routeOptions) { _, result in
+                switch result {
+                case .success:
+                    print("Success")
+                case .failure:
+                    print("Failure")
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/ContentView.swift
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/ContentView.swift
@@ -5,18 +5,24 @@ import CoreLocation
 
 struct ContentView: View {
     var body: some View {
-        Button("Request route") {
-            let routeOptions = RouteOptions(coordinates: [
-                CLLocationCoordinate2D(latitude: 10, longitude: 10),
-                CLLocationCoordinate2D(latitude: 11, longitude: 11)
-            ])
-            Directions.shared.calculate(routeOptions) { _, result in
-                switch result {
-                case .success:
-                    print("Success")
-                case .failure:
-                    print("Failure")
+        VStack(spacing: 14) {
+            Button("Request route") {
+                let routeOptions = RouteOptions(coordinates: [
+                    CLLocationCoordinate2D(latitude: 10, longitude: 10),
+                    CLLocationCoordinate2D(latitude: 11, longitude: 11)
+                ])
+                Directions.shared.calculate(routeOptions) { _, result in
+                    switch result {
+                    case .success:
+                        print("Success")
+                    case .failure:
+                        print("Failure")
+                    }
                 }
+            }
+            Button("Send CarPlay event") {
+                let eventsManager = NavigationEventsManager()
+                eventsManager.sendCarPlayConnectEvent()
             }
         }
     }

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/CoreSPMTestApp.swift
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/CoreSPMTestApp.swift
@@ -1,0 +1,11 @@
+
+import SwiftUI
+
+@main
+struct CoreSPMTestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Info.plist
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Tests/SPMTest/CoreSPMTest/CoreSPMTest/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Adds a CI build step to make sure that an application builds with only `MapboxCoreNavigation` dependency.