### PR TITLE
Generate prerelease podspecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Carthage/Checkouts
 .swiftpm/
 
 Examples/Swift/Navigation_Example.mobileprovision
+
+*-pre.podspec

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -45,6 +45,13 @@ step "Updating CocoaPods podspecs to version ${SEM_VERSION}…"
 
 find . -type f -name '*.podspec' -exec sed -i '' "s/^ *s.version *=.*$/  s.version = '${SEM_VERSION}'/" {} +
 
+if [[ $SHORT_VERSION != $SEM_VERSION ]]; then
+    step "Updating prerelease CocoaPods podspecs…"
+    cp MapboxCoreNavigation.podspec MapboxCoreNavigation-pre.podspec
+    cp MapboxNavigation.podspec MapboxNavigation-pre.podspec
+    sed -i '' -E "s/(\.name *= *\"[^\"]+)\"/\1-pre\"/g; s/(\.dependency *\"MapboxCoreNavigation)\"/\1-pre\"/g" *-pre.podspec
+fi
+
 step "Updating CocoaPods installation test fixture…"
 
 cd Tests/CocoaPodsTest/PodInstall/


### PR DESCRIPTION
With this change, the release script now generates a pair of prerelease podspecs if a prerelease version is being published. These podspecs can then be pushed to CocoaPods trunk under the `MapboxCoreNavigation-pre` and `MapboxNavigation-pre` names.

Fixes #3357.

/cc @mapbox/navigation-ios