### PR TITLE
Allow guidance cards to receive the instruction update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * Fixed an issue where `GenericRouteShield` images would ignore changing its foreground color in favor of a cached image. ([#3217](https://github.com/mapbox/mapbox-navigation-ios/pull/3217))
 * Fixed an issue where some banner instructions were occasionally skipped. ([#3265](https://github.com/mapbox/mapbox-navigation-ios/pull/3265))
 * Improved the current road name label’s performance and fixed a potential crash when updating it. ([#3340](https://github.com/mapbox/mapbox-navigation-ios/pull/3340))
+* Fixed an issue where arrival guidance card appears too early. ([#3383](https://github.com/mapbox/mapbox-navigation-ios/pull/3383))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/InstructionsCardCell.swift
+++ b/Sources/MapboxNavigation/InstructionsCardCell.swift
@@ -41,11 +41,11 @@ public class InstructionsCardCell: UICollectionViewCell {
         /* TODO: Smoothen animation here. */
     }
     
-    public func configure(for step: RouteStep, distance: CLLocationDistance) {
+    public func configure(for step: RouteStep, distance: CLLocationDistance, instruction: VisualInstructionBanner? = nil) {
         addSubview(container)
         setupConstraints()
         container.prepareLayout()
-        container.updateInstruction(for: step, distance: distance)
+        container.updateInstruction(for: step, distance: distance, instruction: instruction)
     }
 }
 

--- a/Sources/MapboxNavigation/InstructionsCardContainerView.swift
+++ b/Sources/MapboxNavigation/InstructionsCardContainerView.swift
@@ -185,16 +185,19 @@ public class InstructionsCardContainerView: StylableView {
         return firstLayer
     }
     
-    public func updateInstruction(for step: RouteStep, distance: CLLocationDistance) {
+    public func updateInstruction(for step: RouteStep, distance: CLLocationDistance, instruction: VisualInstructionBanner? = nil) {
         instructionsCardView.updateDistanceFromCurrentLocation(distance)
-        instructionsCardView.step = step
+        if instruction == nil {
+            instructionsCardView.step = step
+        }
         
-        guard let instruction = step.instructionsDisplayedAlongStep?.last else { return }
+        guard let instruction = instruction ?? step.instructionsDisplayedAlongStep?.last else { return }
         updateInstruction(instruction)
         updateInstructionCard(distance: distance)
     }
     
     public func updateInstruction(_ instruction: VisualInstructionBanner) {
+        instructionsCardView.update(for: instruction)
         lanesView.update(for: instruction)
         nextBannerView.instructionDelegate = self
         nextBannerView.update(for: instruction)

--- a/Sources/MapboxNavigation/InstructionsCardContainerView.swift
+++ b/Sources/MapboxNavigation/InstructionsCardContainerView.swift
@@ -187,9 +187,7 @@ public class InstructionsCardContainerView: StylableView {
     
     public func updateInstruction(for step: RouteStep, distance: CLLocationDistance, instruction: VisualInstructionBanner? = nil) {
         instructionsCardView.updateDistanceFromCurrentLocation(distance)
-        if instruction == nil {
-            instructionsCardView.step = step
-        }
+        instructionsCardView.step = step
         
         guard let instruction = instruction ?? step.instructionsDisplayedAlongStep?.last else { return }
         updateInstruction(instruction)

--- a/Sources/MapboxNavigation/InstructionsCardView.swift
+++ b/Sources/MapboxNavigation/InstructionsCardView.swift
@@ -5,11 +5,7 @@ import MapboxDirections
 /// :nodoc:
 public class InstructionsCardView: BaseInstructionsBannerView {
     
-    var step: RouteStep! {
-        didSet {
-            self.updateInstruction(for: step)
-        }
-    }
+    var step: RouteStep!
     var distanceFromCurrentLocation: CLLocationDistance!
     var gradientLayer: CAGradientLayer!
     var highlightDistance: CLLocationDistance = InstructionsCardConstants.highlightDistance

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -171,7 +171,7 @@ open class InstructionsCardViewController: UIViewController {
         }
     }
     
-    func updateCurrentVisibleInstructionCard(for instruction: VisualInstructionBanner) {
+    open func updateCurrentVisibleInstructionCard(for instruction: VisualInstructionBanner) {
         guard let remainingStepsCount = routeProgress?.currentLegProgress.remainingSteps.endIndex else { return }
         let indexPath = IndexPath(row: 0, section: 0)
         if let container = instructionContainerView(at: indexPath), indexPath.row < remainingStepsCount {
@@ -220,13 +220,7 @@ open class InstructionsCardViewController: UIViewController {
             return nil
         }
         
-        if let instructionsCardContainerView = cell.subviews[1] as? InstructionsCardContainerView {
-            return instructionsCardContainerView
-        } else if let instructionsCardContainerView = cell.subviews[0] as? InstructionsCardContainerView {
-            return instructionsCardContainerView
-        } else {
-            return nil
-        }
+        return cell.subviews.compactMap{$0 as? InstructionsCardContainerView}.first
     }
     
     fileprivate func snappedIndexPath() -> IndexPath {
@@ -306,11 +300,9 @@ extension InstructionsCardViewController: UICollectionViewDataSource {
         
         let step = steps[indexPath.row]
         if indexPath.row == 0 {
-            let distance = distanceRemaining
-            cell.configure(for: step, distance: distance, instruction: self.currentInstruction)
+            cell.configure(for: step, distance: distanceRemaining, instruction: self.currentInstruction)
         } else {
-            let distance = step.distance
-            cell.configure(for: step, distance: distance)
+            cell.configure(for: step, distance: step.distance)
             
         }
         

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -174,7 +174,7 @@ open class InstructionsCardViewController: UIViewController {
     open func updateCurrentVisibleInstructionCard(for instruction: VisualInstructionBanner) {
         guard let remainingStepsCount = routeProgress?.currentLegProgress.remainingSteps.endIndex else { return }
         let indexPath = IndexPath(row: 0, section: 0)
-        if let container = instructionContainerView(at: indexPath), indexPath.row < remainingStepsCount {
+        if indexPath.row < remainingStepsCount, let container = instructionContainerView(at: indexPath) {
             container.updateInstruction(instruction)
         }
     }
@@ -220,7 +220,7 @@ open class InstructionsCardViewController: UIViewController {
             return nil
         }
         
-        return cell.subviews.compactMap{$0 as? InstructionsCardContainerView}.first
+        return cell.subviews.compactMap{ $0 as? InstructionsCardContainerView }.first
     }
     
     fileprivate func snappedIndexPath() -> IndexPath {
@@ -303,7 +303,6 @@ extension InstructionsCardViewController: UICollectionViewDataSource {
             cell.configure(for: step, distance: distanceRemaining, instruction: self.currentInstruction)
         } else {
             cell.configure(for: step, distance: step.distance)
-            
         }
         
         return cell


### PR DESCRIPTION
### Description
This pr is to fix #3243 and #3381 to allow the guidance cards receiving the `VisualInstructionBanner` update and distance update from `navigationService` .

### Implementation
To fix #3381 , the `InstructionsCardViewController.updateCurrentVisibleInstructionCard(for:)` is added to pass the `VisualInstructionBanner` to the current active guidance card. In case the `VisualInstructionBanner` notification arrives before the guidance card configuration and set up, it's stored to prepare for the configuration of the first step.

The #3243 is caused by the sequence change of subviews of the `instructionCollectionView` during the active navigation. Thus we loop through its subviews for the casting instead of the fixed position.

### Screenshots or Gifs
![guidanceCards](https://user-images.githubusercontent.com/48976398/134241100-58d72360-c113-419f-a00b-435a4c35c92b.gif)

