### PR TITLE
Add distance check to prevent vanishing route line update when users go off the route.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Fixed an issue where `UserPuckCourseView` is trimmed when using custom frame for `UserLocationStyle.courseView(_:)`. ([#3601](https://github.com/mapbox/mapbox-navigation-ios/pull/3601))
 * Fixed an issue where route line blinks when style is changed during active navigation. ([#3613](https://github.com/mapbox/mapbox-navigation-ios/pull/3613))
 * Fixed an issue where route line missing traffic colors after refresh or rerouting. ([#3622](https://github.com/mapbox/mapbox-navigation-ios/pull/3622))
-* Fixed an issue when user goes offline and the route line grows back when `NavigationViewController.routeLineTracksTraversal` was enabled. Added global variable `OffRouteDistanceUpdateThreshold` as the distance threshold. When the distance of user location to the route is larger than the `OffRouteDistanceUpdateThreshold`, the vanishing effect of route line would stop until the new route line gets generated. ([#3385](https://github.com/mapbox/mapbox-navigation-ios/pull/3385))
+* Fixed an issue when user goes offline and the route line grows back when `NavigationViewController.routeLineTracksTraversal` enabled. When the distance of user location to the route is larger than certain distance threshold, the vanishing effect of route line would stop until the new route line gets generated. ([#3385](https://github.com/mapbox/mapbox-navigation-ios/pull/3385))
 
 ### Banners and guidance instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fixed an issue where `UserPuckCourseView` is trimmed when using custom frame for `UserLocationStyle.courseView(_:)`. ([#3601](https://github.com/mapbox/mapbox-navigation-ios/pull/3601))
 * Fixed an issue where route line blinks when style is changed during active navigation. ([#3613](https://github.com/mapbox/mapbox-navigation-ios/pull/3613))
 * Fixed an issue where route line missing traffic colors after refresh or rerouting. ([#3622](https://github.com/mapbox/mapbox-navigation-ios/pull/3622))
+* Fixed an issue when user goes offline and the route line grows back when `NavigationViewController.routeLineTracksTraversal` was enabled. Added global variable `OffRouteDistanceUpdateThreshold` as the distance threshold. When the distance of user location to the route is larger than the `OffRouteDistanceUpdateThreshold`, the vanishing effect of route line would stop until the new route line gets generated. ([#3385](https://github.com/mapbox/mapbox-navigation-ios/pull/3385))
 
 ### Banners and guidance instructions
 

--- a/Sources/MapboxNavigation/Constants.swift
+++ b/Sources/MapboxNavigation/Constants.swift
@@ -46,6 +46,11 @@ public let NavigationViewMinimumVolumeForWarning: Float = 0.3
  */
 public var GradientCongestionFadingDistance: CLLocationDistance = 30.0
 
+/**
+ The maximum distance threshold of vanishing route line update. When the user's location to the route line is larger than the threshold, the user is off the route and the route line won't be updated.
+ */
+public var OffRouteDistanceUpdateThreshold: CLLocationDistance = 15.0
+
 extension Notification.Name {
     /**
      Posted when `StyleManager` applies a style that was triggered by change of time of day, or when entering or exiting a tunnel.

--- a/Sources/MapboxNavigation/Constants.swift
+++ b/Sources/MapboxNavigation/Constants.swift
@@ -46,11 +46,6 @@ public let NavigationViewMinimumVolumeForWarning: Float = 0.3
  */
 public var GradientCongestionFadingDistance: CLLocationDistance = 30.0
 
-/**
- The maximum distance threshold of vanishing route line update. When the user's location to the route line is larger than the threshold, the user is off the route and the route line won't be updated.
- */
-public var OffRouteDistanceUpdateThreshold: CLLocationDistance = 15.0
-
 extension Notification.Name {
     /**
      Posted when `StyleManager` applies a style that was triggered by change of time of day, or when entering or exiting a tunnel.

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -128,6 +128,10 @@ extension NavigationMapView {
         guard granularDistances.distanceArray.indices.contains(upcomingIndex) else { return 0.0 }
 
         var coordinates = [CLLocationCoordinate2D]()
+        
+        /**
+         Takes the passed 10 points and the upcoming point of route to form a sliced polyline for distance calculation, incase of the curved shape of route.
+         */
         for index in max(0, upcomingIndex - 10)...upcomingIndex  {
             let point = granularDistances.distanceArray[index].point
             coordinates.append(point)

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -60,7 +60,9 @@ extension NavigationMapView {
             removeRoutes()
         } else {
             updateUpcomingRoutePointIndex(routeProgress: routeProgress)
+            offRouteDistanceCheckEnabled = false
             travelAlongRouteLine(to: coordinate)
+            offRouteDistanceCheckEnabled = true
         }
     }
     
@@ -122,6 +124,24 @@ extension NavigationMapView {
         return RouteLineGranularDistances(distance: distance, distanceArray: indexArray.compactMap{ $0 })
     }
     
+    func findDistanceToNearestPointOnCurrentLine(coordinate: CLLocationCoordinate2D, granularDistances: RouteLineGranularDistances, upcomingIndex: Int) -> CLLocationDistance {
+        guard granularDistances.distanceArray.indices.contains(upcomingIndex) else { return 0.0 }
+
+        var coordinates = [CLLocationCoordinate2D]()
+        for index in max(0, upcomingIndex - 10)...upcomingIndex  {
+            let point = granularDistances.distanceArray[index].point
+            coordinates.append(point)
+        }
+
+        let polyline = LineString(coordinates)
+
+        if let closestCoordinateOnRoute = polyline.closestCoordinate(to: coordinate)?.coordinate {
+            return coordinate.distance(to: closestCoordinateOnRoute)
+        } else {
+            return 0.0
+        }
+    }
+    
     /**
      Updates the fractionTraveled along the route line from the origin point to the indicated point.
      
@@ -133,6 +153,13 @@ extension NavigationMapView {
               index < granularDistances.distanceArray.endIndex else { return }
         let traveledIndex = granularDistances.distanceArray[index]
         let upcomingPoint = traveledIndex.point
+        
+        if index > 0 && offRouteDistanceCheckEnabled {
+            let distanceToLine = findDistanceToNearestPointOnCurrentLine(coordinate: coordinate, granularDistances: granularDistances, upcomingIndex: index + 1)
+            if distanceToLine > OffRouteDistanceUpdateThreshold {
+                return
+            }
+        }
         
         /**
          Take the remaining distance from the upcoming point on the route and extends it by the exact position of the puck.

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1218,6 +1218,11 @@ open class NavigationMapView: UIView {
     var offRouteDistanceCheckEnabled: Bool = true
     
     /**
+     The maximum distance threshold of vanishing route line update. When the user's location to the route line is larger than the threshold, the user is off the route and the route line won't be updated.
+     */
+    var OffRouteDistanceUpdateThreshold: CLLocationDistance = 15.0
+    
+    /**
      `MapView`, which is added on top of `NavigationMapView` and allows to render navigation related components.
      */
     public private(set) var mapView: MapView!

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1215,6 +1215,7 @@ open class NavigationMapView: UIView {
     var routeRemainingDistancesIndex: Int?
     var fractionTraveled: Double = 0.0
     var currentLegIndex: Int?
+    var offRouteDistanceCheckEnabled: Bool = true
     
     /**
      `MapView`, which is added on top of `NavigationMapView` and allows to render navigation related components.

--- a/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
+++ b/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
@@ -296,7 +296,10 @@ class VanishingRouteLineTests: TestCase {
         // https://github.com/mapbox/mapbox-navigation-android/blob/0478c43781fdf7489f10f22c0055fadf181970f6/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt#L814
         
         let route = getMultilegRoute()
-        let coordinate = route.shape!.coordinates[15]
+        guard let coordinate = route.shape?.coordinates[15] else {
+            XCTFail("Coordinate is invalid.")
+            return
+        }
         let granularDistances = navigationMapView.calculateGranularDistances(route.shape!.coordinates)!
         
         // It's to test the distance calculation from user location to pre-existing route line.
@@ -317,7 +320,7 @@ class VanishingRouteLineTests: TestCase {
         setUpCameraZoom(at: 16.0)
         
         // When the distance of user location to pre-existing route line is larger than the `offRouteDistanceCheckEnabled`,
-        // the route line is expcted to stop updating until a new route line gets generated.
+        // the route line is expected to stop updating until a new route line gets generated.
         let expectedFractionTraveled = 0.0
         navigationMapView.updateFractionTraveled(coordinate: coordinate)
         XCTAssertTrue(expectedFractionTraveled == navigationMapView.fractionTraveled, "Failed to stop updating fractionTraveled when user off the route line.")


### PR DESCRIPTION
### Description

This pr is to fix #3319 by adding the distance check of user location to pre-defined route. When the distance from user location to pre-defined route larger than `OffRouteDistanceUpdateThreshold`, the vanishing route line would stop updating until the rerouting event triggered to generate a new route line.

`OffRouteDistanceUpdateThreshold` is public and defaults to 15m. The `OffRouteDistanceUpdateThreshold` should be larger than the driving distance per second according to the speed. Otherwise, in some edge cases, such as in big turn or driving too fast, it would see the normal driving as off line behavior and stop updating the vanishing effect. Because the normal driving speed is 60km/h, it's safe to set the `OffRouteDistanceUpdateThreshold` between `15m ~ 20m`.

### Implementation
Add the `navigationMapView.findDistanceToNearestPointOnCurrentLine(coordinate:granularDistances:upcomingIndex)` to calculate the distance from the coordinate to the stored route line coordinates with the upcoming index. 

Because during the route refresh and rerouting event, the route line coordinates and upcoming index may be changed and result in a large distance calculated. The `navigationMapView.offRouteDistanceCheckDisabled` is introduced to control whether to disable the distance check. So during the refresh and rerouting event the distance check is disabled. After the new route line is displayed and coordinates stored, before the next location update comes in, the distance check would be enabled again.

### Screenshots or Gifs
As following, when `OffRouteDistanceUpdateThreshold` set to `15m`, when the distance from user location is larger than the pre-defined route, the vanishing effect would stop, which fix #3319 . But when the rerouting event triggered and a new route line generated, the vanishing effect would start again.
![reroute_15_1](https://user-images.githubusercontent.com/48976398/141597809-8256df24-6479-488a-aae1-7c1f277f1ec0.gif)

When `OffRouteDistanceUpdateThreshold` set to `15m`, and user is away from the pre-defined route, but distance is less than 15m, the vanishing effect would continue, which shows as the following that the route line grows back for `1 second`. Because the threshold is 15m, while the distance calculated is `12m`.
![reroute_15_2](https://user-images.githubusercontent.com/48976398/141597874-e248f637-1b0f-4a63-a59c-62521f21bae9.gif)

Then we decrease the threshold of `OffRouteDistanceUpdateThreshold` to `10m`, we could see that under the same situation, the off route driving is detected. So there's no more `1 second` growing back route line behavior.
![reroute_10_2](https://user-images.githubusercontent.com/48976398/141598017-a73c5838-635d-41a5-be9f-4a0a8a1d10f3.gif)


