### PR TITLE
Fix the tilt of the `UserHaloCourseView`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Added the `UserHaloCourseView.haloBorderWidth` property for changing the width of the ring around the halo view. ([#3309](https://github.com/mapbox/mapbox-navigation-ios/pull/3309))
 * Fixed an issue where setting `UserPuckCourseView.puckColor` in a `Style` subclass had no effect. ([#3306](https://github.com/mapbox/mapbox-navigation-ios/pull/3306))
 * Fixed a memory leak in `UserCourseView`. ([#3120](https://github.com/mapbox/mapbox-navigation-ios/issues/3120))
+* Fixed the pitch issue of `UserHaloCourseView` when map tilted during active guidance navigation. ([#3407](https://github.com/mapbox/mapbox-navigation-ios/issues/3407))
 
 #### Route overlay
 

--- a/Sources/MapboxNavigation/UserCourseView.swift
+++ b/Sources/MapboxNavigation/UserCourseView.swift
@@ -21,6 +21,8 @@ public extension CourseUpdatable {
             let angle = CGFloat(CLLocationDegrees(direction - location.course).toRadians())
             if let self = self as? UserPuckCourseView {
                 self.puckView.layer.setAffineTransform(CGAffineTransform.identity.rotated(by: -angle))
+            } else if !(self is UserHaloCourseView) {
+                self.layer.setAffineTransform(CGAffineTransform.identity.rotated(by: -angle))
             }
             
             // `UserCourseView` pitch is changed only during transition to the overview mode.

--- a/Sources/MapboxNavigation/UserCourseView.swift
+++ b/Sources/MapboxNavigation/UserCourseView.swift
@@ -12,12 +12,16 @@ public protocol CourseUpdatable where Self: UIView {
 }
 
 public extension CourseUpdatable {
-    
+    /**
+     Transforms the location of the user location indicator layer.
+     */
     func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, navigationCameraState: NavigationCameraState) {
         let duration: TimeInterval = animated ? 1 : 0
         UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveLinear], animations: {
             let angle = CGFloat(CLLocationDegrees(direction - location.course).toRadians())
-            self.layer.setAffineTransform(CGAffineTransform.identity.rotated(by: -angle))
+            if let self = self as? UserPuckCourseView {
+                self.puckView.layer.setAffineTransform(CGAffineTransform.identity.rotated(by: -angle))
+            }
             
             // `UserCourseView` pitch is changed only during transition to the overview mode.
             let pitch = CGFloat(navigationCameraState == .transitionToOverview ? 0.0 : CLLocationDegrees(pitch).toRadians())
@@ -48,27 +52,6 @@ open class UserPuckCourseView: UIView, CourseUpdatable {
     }
     /// Time interval, after which Puck is considered 100% 'stale'
     public var staleInterval: TimeInterval = 60
-    
-    /**
-     Transforms the location of the user puck.
-     */
-    public func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, navigationCameraState: NavigationCameraState) {
-        let duration: TimeInterval = animated ? 1 : 0
-        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveLinear], animations: {
-            let angle = CGFloat(CLLocationDegrees(direction - location.course).toRadians())
-            self.puckView.layer.setAffineTransform(CGAffineTransform.identity.rotated(by: -angle))
-            
-            // `UserCourseView` pitch is changed only during transition to the overview mode.
-            let pitch = CGFloat(navigationCameraState == .transitionToOverview ? 0.0 : CLLocationDegrees(pitch).toRadians())
-            var transform = CATransform3DRotate(CATransform3DIdentity, pitch, 1.0, 0, 0)
-            
-            let isCameraFollowing = navigationCameraState == .following
-            let scale = CGFloat(isCameraFollowing ? 1.0 : 0.5)
-            transform = CATransform3DScale(transform, scale, scale, 1)
-            transform.m34 = -1.0 / 1000 // (-1 / distance to projection plane)
-            self.layer.sublayerTransform = transform
-        }, completion: nil)
-    }
     
     // Sets the color on the user puck
     @objc public dynamic var puckColor: UIColor = #colorLiteral(red: 0.149, green: 0.239, blue: 0.341, alpha: 1) {

--- a/Sources/MapboxNavigation/UserHaloCourseView.swift
+++ b/Sources/MapboxNavigation/UserHaloCourseView.swift
@@ -61,24 +61,6 @@ open class UserHaloCourseView: UIView, CourseUpdatable {
         haloView.backgroundColor = .clear
         addSubview(haloView)
     }
-    
-    /**
-     Transforms the location of the user halo course view.
-     */
-    public func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, navigationCameraState: NavigationCameraState) {
-        let duration: TimeInterval = animated ? 1 : 0
-        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveLinear], animations: {
-            // `UserHaloCourseView` pitch is changed only during transition to the overview mode.
-            let pitch = CGFloat(navigationCameraState == .transitionToOverview ? 0.0 : CLLocationDegrees(pitch).toRadians())
-            var transform = CATransform3DRotate(CATransform3DIdentity, pitch, 1.0, 0, 0)
-
-            let isCameraFollowing = navigationCameraState == .following
-            let scale = CGFloat(isCameraFollowing ? 1.0 : 0.5)
-            transform = CATransform3DScale(transform, scale, scale, 1)
-            transform.m34 = -1.0 / 1000 // (-1 / distance to projection plane)
-            self.layer.sublayerTransform = transform
-        }, completion: nil)
-    }
 }
 
 class UserHaloStyleKitView: UIView {

--- a/Sources/MapboxNavigation/UserHaloCourseView.swift
+++ b/Sources/MapboxNavigation/UserHaloCourseView.swift
@@ -61,6 +61,24 @@ open class UserHaloCourseView: UIView, CourseUpdatable {
         haloView.backgroundColor = .clear
         addSubview(haloView)
     }
+    
+    /**
+     Transforms the location of the user halo course view.
+     */
+    public func update(location: CLLocation, pitch: CGFloat, direction: CLLocationDegrees, animated: Bool, navigationCameraState: NavigationCameraState) {
+        let duration: TimeInterval = animated ? 1 : 0
+        UIView.animate(withDuration: duration, delay: 0, options: [.beginFromCurrentState, .curveLinear], animations: {
+            // `UserHaloCourseView` pitch is changed only during transition to the overview mode.
+            let pitch = CGFloat(navigationCameraState == .transitionToOverview ? 0.0 : CLLocationDegrees(pitch).toRadians())
+            var transform = CATransform3DRotate(CATransform3DIdentity, pitch, 1.0, 0, 0)
+
+            let isCameraFollowing = navigationCameraState == .following
+            let scale = CGFloat(isCameraFollowing ? 1.0 : 0.5)
+            transform = CATransform3DScale(transform, scale, scale, 1)
+            transform.m34 = -1.0 / 1000 // (-1 / distance to projection plane)
+            self.layer.sublayerTransform = transform
+        }, completion: nil)
+    }
 }
 
 class UserHaloStyleKitView: UIView {


### PR DESCRIPTION
### Description
This pr is to fix #3406 to allow the `UserHaloCourseView` of the approximate location circle could tilt at the same angle of the camera and `mapView` during the active guidance navigation.

### Implementation
This issue is fixed by allowing the `haloView` of the `UserHaloCourseView` to receive the pitch transform.

### Screenshots or Gifs
![fixedHalo](https://user-images.githubusercontent.com/48976398/134976452-f8b4c4be-13db-44a2-b9f6-c5ec828ea8f2.gif)
