### PR TITLE
Fix issue, when user puck goes offscreen in some cases.

### DIFF
--- a/Sources/MapboxNavigation/NavigationViewportDataSource.swift
+++ b/Sources/MapboxNavigation/NavigationViewportDataSource.swift
@@ -225,8 +225,7 @@ public class NavigationViewportDataSource: ViewportDataSource {
                 if let boundingBox = BoundingBox(from: coordinatesToManeuver + coordinatesForManeuverFraming) {
                     let coordinates = [
                         center,
-                        boundingBox.northEast,
-                        boundingBox.southWest
+                        [boundingBox.northEast, boundingBox.southWest].centerCoordinate
                     ]
                     
                     let centerLineString = LineString(coordinates)


### PR DESCRIPTION
PR fixes an issue, which resulted in user puck going offscreen when there are sharp maneuvers.

Issue was caused by https://github.com/mapbox/mapbox-navigation-ios/pull/3275 (center coordinate of the bounding box should be used, instead of two coordinates of the bounding box itself).

/cc @bamx23 