### PR TITLE
Migrate Turf GeoJSON usage to GeoJSONObject and JSONValue

### DIFF
--- a/Example/ViewController+FreeDrive.swift
+++ b/Example/ViewController+FreeDrive.swift
@@ -81,13 +81,15 @@ extension ViewController {
         do {
             let style = navigationMapView.mapView.mapboxMap.style
             if style.sourceExists(withId: trackStyledFeature.sourceIdentifier) {
+                let feature = Feature(geometry: .lineString(trackStyledFeature.lineString))
                 try style.updateGeoJSONSource(withId: trackStyledFeature.sourceIdentifier,
-                                              geoJSON: Feature(geometry: .lineString(trackStyledFeature.lineString)))
+                                              geoJSON: .feature(feature))
             }
             
             if style.sourceExists(withId: rawTrackStyledFeature.sourceIdentifier) {
+                let feature = Feature(geometry: .lineString(rawTrackStyledFeature.lineString))
                 try style.updateGeoJSONSource(withId: rawTrackStyledFeature.sourceIdentifier,
-                                              geoJSON: Feature(geometry: .lineString(rawTrackStyledFeature.lineString)))
+                                              geoJSON: .feature(feature))
             }
         } catch {
             NSLog("Error occured while performing operation with source: \(error.localizedDescription).")

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "682841464136f8c66e04afe5dbd01ab51a3a56f2",
-          "version": "2.1.0"
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "0630439888c94657a235ffcd5977d6047ef3c87b",
-          "version": "2.0.1"
+          "revision": "fb7a26374e8570ff5c68142e5c83406d6abae0d8",
+          "version": "2.0.2"
         }
       },
       {
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": "main",
-          "revision": "312a5f9a746dd12e7bfed417110e1ff0382d45e4",
+          "revision": "de3800d042e0c095321fefac4cbc6c03d40b75c1",
           "version": null
         }
       },
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "555458bd67acce7322c513ddd3647c9a904f4197",
-          "version": "2.0.0-rc.1"
+          "revision": "007896bb945432d4683e114fcf2f089edff4ceeb",
+          "version": "2.0.0-rc.2"
         }
       }
     ]

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -346,6 +346,7 @@
 		DA2A01F025F308B100AAB4C6 /* RoadGraphPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2A01EF25F308B100AAB4C6 /* RoadGraphPath.swift */; };
 		DA3525702010A5210048DDFC /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DA35256E2010A5200048DDFC /* Localizable.stringsdict */; };
 		DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA443DDD2278C90E00ED1307 /* CPTrip.swift */; };
+		DA4A8EC02704FF950071C85C /* EventLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A8EBF2704FF950071C85C /* EventLocation.swift */; };
 		DA5F44AC25F07A6800F573EC /* RoadGraphPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44A525F07A6500F573EC /* RoadGraphPosition.swift */; };
 		DA5F44B025F07A6800F573EC /* RoadGraphEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44A925F07A6700F573EC /* RoadGraphEdge.swift */; };
 		DA5F44BA25F07AA500F573EC /* RoadGraphEdgeMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F44B925F07AA500F573EC /* RoadGraphEdgeMetadata.swift */; };
@@ -885,6 +886,7 @@
 		DA352572201143BA0048DDFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Navigation.strings; sourceTree = "<group>"; };
 		DA352573201143D30048DDFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA443DDD2278C90E00ED1307 /* CPTrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPTrip.swift; sourceTree = "<group>"; };
+		DA4A8EBF2704FF950071C85C /* EventLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLocation.swift; sourceTree = "<group>"; };
 		DA545ABC1FA9941F0090908E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA545AC01FA9A15A0090908E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA545AC21FA9A16D0090908E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1190,6 +1192,7 @@
 				C5CFE4871EF2FD4C006F48E8 /* MMEEventsManager.swift */,
 				354A9BC520EA991900F03325 /* SessionState.swift */,
 				417D127626E24D0800E0AB16 /* FreeDriveEventDetails.swift */,
+				DA4A8EBF2704FF950071C85C /* EventLocation.swift */,
 			);
 			name = Events;
 			sourceTree = "<group>";
@@ -2630,6 +2633,7 @@
 				8A3A219025EEC00200EDA999 /* CoreNavigationNavigator.swift in Sources */,
 				2E50E0DC264E49C8009D3848 /* RoadObjectMatcherDelegate.swift in Sources */,
 				DA5F44BA25F07AA500F573EC /* RoadGraphEdgeMetadata.swift in Sources */,
+				DA4A8EC02704FF950071C85C /* EventLocation.swift in Sources */,
 				DABA591525E58D5600D0C1DB /* Accounts.swift in Sources */,
 				8AFF2D2326F137CB008267BF /* RoadObjectKind.swift in Sources */,
 				118D883426F8CA0700B2ED7B /* FeedbackEvent.swift in Sources */,

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": "main",
-          "revision": "312a5f9a746dd12e7bfed417110e1ff0382d45e4",
+          "revision": "de3800d042e0c095321fefac4cbc6c03d40b75c1",
           "version": null
         }
       },
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "555458bd67acce7322c513ddd3647c9a904f4197",
-          "version": "2.0.0-rc.1"
+          "revision": "007896bb945432d4683e114fcf2f089edff4ceeb",
+          "version": "2.0.0-rc.2"
         }
       }
     ]

--- a/Sources/MapboxCoreNavigation/CLLocation.swift
+++ b/Sources/MapboxCoreNavigation/CLLocation.swift
@@ -4,25 +4,6 @@ import MapboxNavigationNative
 import Turf
 
 extension CLLocation {
-    
-    /// Returns a dictionary representation of the location.
-    public var dictionaryRepresentation: [String: Any] {
-        var locationDictionary: [String: Any] = [:]
-        locationDictionary["lat"] = coordinate.latitude
-        locationDictionary["lng"] = coordinate.longitude
-        locationDictionary["altitude"] = altitude
-        locationDictionary["timestamp"] = timestamp.ISO8601
-        locationDictionary["horizontalAccuracy"] = horizontalAccuracy
-        locationDictionary["verticalAccuracy"] = verticalAccuracy
-        if #available(iOS 13.4, *) {
-            locationDictionary["courseAccuracy"] = courseAccuracy
-        }
-        locationDictionary["course"] = course
-        locationDictionary["speed"] = speed
-        locationDictionary["speedAccuracy"] = speedAccuracy
-        return locationDictionary
-    }
-    
     convenience init(_ location: FixLocation) {
         if #available(iOS 13.4, *) {
             self.init(coordinate: location.coordinate,

--- a/Sources/MapboxCoreNavigation/EventLocation.swift
+++ b/Sources/MapboxCoreNavigation/EventLocation.swift
@@ -1,0 +1,103 @@
+import Foundation
+import CoreLocation
+
+/**
+ A JSON-compatible representation of a `CLLocation` object for inclusion in an event.
+ */
+struct EventLocation {
+    /// - seealso: `CLLocation.coordinate`
+    let coordinate: CLLocationCoordinate2D
+    /// - seealso: `CLLocation.altitude`
+    let altitude: CLLocationDistance
+    
+    /// - seealso: `CLLocation.timestamp`
+    let timestamp: Date
+    
+    /// - seealso: `CLLocation.horizontalAccuracy`
+    let horizontalAccuracy: CLLocationAccuracy
+    /// - seealso: `CLLocation.verticalAccuracy`
+    let verticalAccuracy: CLLocationAccuracy
+    
+    /// - seealso: `CLLocation.courseAccuracy`
+    let courseAccuracy: CLLocationDirectionAccuracy?
+    /// - seealso: `CLLocation.course`
+    let course: CLLocationDirection
+    
+    /// - seealso: `CLLocation.speed`
+    let speed: CLLocationSpeed
+    /// - seealso: `CLLocation.speedAccuracy`
+    let speedAccuracy: CLLocationSpeedAccuracy
+    
+    /**
+     Initializes an event location consistent with the given location object.
+     */
+    init(_ location: CLLocation) {
+        coordinate = location.coordinate
+        altitude = location.altitude
+        
+        timestamp = location.timestamp
+        
+        horizontalAccuracy = location.horizontalAccuracy
+        verticalAccuracy = location.verticalAccuracy
+        
+        if #available(iOS 13.4, *) {
+            courseAccuracy = location.courseAccuracy
+        } else {
+            courseAccuracy = nil
+        }
+        course = location.course
+        
+        speed = location.speed
+        speedAccuracy = location.speedAccuracy
+    }
+    
+    /// Returns a dictionary representation of the location.
+    public var dictionaryRepresentation: [String: Any] {
+        var locationDictionary: [String: Any] = [
+            "lat": coordinate.latitude,
+            "lng": coordinate.longitude,
+            "altitude": altitude,
+            "timestamp": timestamp.ISO8601,
+            "horizontalAccuracy": horizontalAccuracy,
+            "verticalAccuracy": verticalAccuracy,
+            "course": course,
+            "speed": speed,
+            "speedAccuracy": speedAccuracy,
+        ]
+        if #available(iOS 13.4, *) {
+            locationDictionary["courseAccuracy"] = courseAccuracy
+        }
+        return locationDictionary
+    }
+}
+
+extension EventLocation: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case latitude = "lat"
+        case longitude = "lng"
+        case altitude
+        case timestamp
+        case horizontalAccuracy
+        case verticalAccuracy
+        case courseAccuracy
+        case course
+        case speed
+        case speedAccuracy
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(coordinate.latitude, forKey: .latitude)
+        try container.encode(coordinate.longitude, forKey: .longitude)
+        try container.encode(altitude, forKey: .altitude)
+        try container.encode(timestamp.ISO8601, forKey: .timestamp)
+        try container.encode(horizontalAccuracy, forKey: .horizontalAccuracy)
+        try container.encode(verticalAccuracy, forKey: .verticalAccuracy)
+        if #available(iOS 13.4, *) {
+            try container.encodeIfPresent(courseAccuracy, forKey: .courseAccuracy)
+        }
+        try container.encode(course, forKey: .course)
+        try container.encode(speed, forKey: .speed)
+        try container.encode(speedAccuracy, forKey: .speedAccuracy)
+    }
+}

--- a/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
@@ -266,8 +266,12 @@ open class NavigationEventsManager {
     func navigationFeedbackEventWithLocationsAdded(event: CoreFeedbackEvent) -> [String: Any] {
         var eventDictionary = event.eventDictionary
         eventDictionary["feedbackId"] = event.identifier.uuidString
-        eventDictionary["locationsBefore"] = sessionState.pastLocations.allObjects.filter { $0.timestamp <= event.timestamp}.map {$0.dictionaryRepresentation}
-        eventDictionary["locationsAfter"] = sessionState.pastLocations.allObjects.filter {$0.timestamp > event.timestamp}.map {$0.dictionaryRepresentation}
+        eventDictionary["locationsBefore"] = sessionState.pastLocations.allObjects
+            .filter { $0.timestamp <= event.timestamp }
+            .map { EventLocation($0).dictionaryRepresentation }
+        eventDictionary["locationsAfter"] = sessionState.pastLocations.allObjects
+            .filter { $0.timestamp > event.timestamp }
+            .map { EventLocation($0).dictionaryRepresentation }
         return eventDictionary
     }
     

--- a/Sources/MapboxCoreNavigation/FreeDriveEventDetails.swift
+++ b/Sources/MapboxCoreNavigation/FreeDriveEventDetails.swift
@@ -74,7 +74,9 @@ struct FreeDriveEventDetails: GlobalEventDetails {
         try container.encode(NavigationEventsManager.applicationSessionIdentifier, forKey: .navigatorSessionIdentifier)
         try container.encodeIfPresent(appMetadata, forKey: .appMetadata)
         try container.encodeIfPresent(event, forKey: .event)
-        try container.encodeIfPresent(location?.dictionaryRepresentation, forKey: .location)
+        if let location = location.flatMap(EventLocation.init(_:)) {
+            try container.encode(location, forKey: .location)
+        }
         try container.encodeIfPresent(startTimestamp?.ISO8601, forKey: .startTimestamp)
     }
 }

--- a/Sources/MapboxNavigation/Feature.swift
+++ b/Sources/MapboxNavigation/Feature.swift
@@ -10,12 +10,7 @@ extension Feature {
         case .string(let identifier):
             return Int64(identifier)
         case .number(let identifier):
-            switch identifier {
-            case .double(let identifier):
-                return Int64(identifier)
-            case .int(let identifier):
-                return Int64(identifier)
-            }
+            return Int64(identifier)
         }
     }
 }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -739,8 +739,8 @@ open class NavigationMapView: UIView {
         for (waypointIndex, waypoint) in waypoints.enumerated() {
             var feature = Feature(geometry: .point(Point(waypoint.coordinate)))
             feature.properties = [
-                "waypointCompleted": waypointIndex < legIndex,
-                "name": waypointIndex + 1
+                "waypointCompleted": .boolean(waypointIndex < legIndex),
+                "name": .number(Double(waypointIndex + 1)),
             ]
             features.append(feature)
         }
@@ -754,7 +754,7 @@ open class NavigationMapView: UIView {
                 let waypointSourceIdentifier = NavigationMapView.SourceIdentifier.waypointSource
                 
                 if mapView.mapboxMap.style.sourceExists(withId: waypointSourceIdentifier) {
-                    try mapView.mapboxMap.style.updateGeoJSONSource(withId: waypointSourceIdentifier, geoJSON: shape)
+                    try mapView.mapboxMap.style.updateGeoJSONSource(withId: waypointSourceIdentifier, geoJSON: .featureCollection(shape))
                 } else {
                     var waypointSource = GeoJSONSource()
                     waypointSource.data = .featureCollection(shape)
@@ -936,7 +936,7 @@ open class NavigationMapView: UIView {
                 var arrowLayer = LineLayer(id: NavigationMapView.LayerIdentifier.arrowLayer)
                 if mapView.mapboxMap.style.sourceExists(withId: NavigationMapView.SourceIdentifier.arrowSource) {
                     let geoJSON = Feature(geometry: .lineString(shaftPolyline))
-                    try mapView.mapboxMap.style.updateGeoJSONSource(withId: NavigationMapView.SourceIdentifier.arrowSource, geoJSON: geoJSON)
+                    try mapView.mapboxMap.style.updateGeoJSONSource(withId: NavigationMapView.SourceIdentifier.arrowSource, geoJSON: .feature(geoJSON))
                 } else {
                     arrowLayer.minZoom = Double(minimumZoomLevel)
                     arrowLayer.lineCap = .constant(.butt)
@@ -962,7 +962,7 @@ open class NavigationMapView: UIView {
                 if mapView.mapboxMap.style.sourceExists(withId: NavigationMapView.SourceIdentifier.arrowStrokeSource) {
                     let geoJSON = Feature(geometry: .lineString(shaftPolyline))
                     try mapView.mapboxMap.style.updateGeoJSONSource(withId: NavigationMapView.SourceIdentifier.arrowStrokeSource,
-                                                                    geoJSON: geoJSON)
+                                                                    geoJSON: .feature(geoJSON))
                 } else {
                     arrowStrokeLayer.minZoom = arrowLayer.minZoom
                     arrowStrokeLayer.lineCap = arrowLayer.lineCap
@@ -983,7 +983,7 @@ open class NavigationMapView: UIView {
                 if mapView.mapboxMap.style.sourceExists(withId: NavigationMapView.SourceIdentifier.arrowSymbolSource) {
                     let geoJSON = Feature.init(geometry: Geometry.point(point))
                     try mapView.mapboxMap.style.updateGeoJSONSource(withId: NavigationMapView.SourceIdentifier.arrowSymbolSource,
-                                                                    geoJSON: geoJSON)
+                                                                    geoJSON: .feature(geoJSON))
                     
                     try mapView.mapboxMap.style.setLayerProperty(for: NavigationMapView.LayerIdentifier.arrowSymbolLayer,
                                                                  property: "icon-rotate",
@@ -1224,7 +1224,13 @@ open class NavigationMapView: UIView {
             }
 
             // set the feature attributes which will be used in styling the symbol style layer
-            feature.properties = ["selected": index == 0, "tailPosition": tailPosition.rawValue, "text": labelText, "imageName": imageName, "sortOrder": index == 0 ? index : -index]
+            feature.properties = [
+                "selected": .boolean(index == 0),
+                "tailPosition": .number(Double(tailPosition.rawValue)),
+                "text": .string(labelText),
+                "imageName": .string(imageName),
+                "sortOrder": .number(Double(index == 0 ? index : -index)),
+            ]
 
             features.append(feature)
         }
@@ -1245,7 +1251,7 @@ open class NavigationMapView: UIView {
         
         let routeDurationAnnotationsSourceIdentifier = NavigationMapView.SourceIdentifier.routeDurationAnnotationsSource
         if style.sourceExists(withId: routeDurationAnnotationsSourceIdentifier) {
-            try style.updateGeoJSONSource(withId: routeDurationAnnotationsSourceIdentifier, geoJSON: features)
+            try style.updateGeoJSONSource(withId: routeDurationAnnotationsSourceIdentifier, geoJSON: .featureCollection(features))
         } else {
             var dataSource = GeoJSONSource()
             dataSource.data = .featureCollection(features)
@@ -1382,7 +1388,7 @@ open class NavigationMapView: UIView {
                     
                     var feature = Feature(geometry: .point(Point(coordinateFromStart)))
                     feature.properties = [
-                        "instruction": instruction.text
+                        "instruction": .string(instruction.text),
                     ]
                     featureCollection.features.append(feature)
                 }
@@ -1391,7 +1397,7 @@ open class NavigationMapView: UIView {
         
         do {
             if mapView.mapboxMap.style.sourceExists(withId: NavigationMapView.SourceIdentifier.voiceInstructionSource) {
-                try mapView.mapboxMap.style.updateGeoJSONSource(withId: NavigationMapView.SourceIdentifier.voiceInstructionSource, geoJSON: featureCollection)
+                try mapView.mapboxMap.style.updateGeoJSONSource(withId: NavigationMapView.SourceIdentifier.voiceInstructionSource, geoJSON: .featureCollection(featureCollection))
             } else {
                 var source = GeoJSONSource()
                 source.data = .featureCollection(featureCollection)

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -267,7 +267,7 @@ extension NavigationMapView {
 
                     for queriedFeature in queriedFeatures {
                         // Calculate the Levenshtein–Damerau edit distance between the road name from status and the feature property road name, and then use the smallest one for the road label.
-                        if let roadName = queriedFeature.feature?.properties?["name"] as? String,
+                        if case let .string(roadName) = queriedFeature.feature?.properties?["name"],
                            let roadNameFromStatus = self.roadNameFromStatus {
                             let stringEditDistance = roadNameFromStatus.minimumEditDistance(to: roadName)
                             if stringEditDistance < minimumEditDistance {
@@ -281,16 +281,12 @@ extension NavigationMapView {
                         var lineStrings: [LineString] = []
                         
                         if let feature = queriedFeature.feature {
-                            switch feature.geometry.type {
-                            case .LineString:
-                                if let lineString = feature.geometry.value as? LineString {
-                                    lineStrings.append(lineString)
-                                }
-                            case .MultiLineString:
-                                if let multiLineString = feature.geometry.value as? MultiLineString {
-                                    for coordinates in multiLineString.coordinates {
-                                        lineStrings.append(LineString(coordinates))
-                                    }
+                            switch feature.geometry {
+                            case .lineString(let lineString):
+                                lineStrings.append(lineString)
+                            case .multiLineString(let multiLineString):
+                                for coordinates in multiLineString.coordinates {
+                                    lineStrings.append(LineString(coordinates))
                                 }
                             default:
                                 break

--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -70,8 +70,8 @@ extension Route {
                 legFeatures = mergedCongestionSegments.map { (congestionSegment: CongestionSegment) -> Feature in
                     var feature = Feature(geometry: .lineString(LineString(congestionSegment.0)))
                     feature.properties = [
-                        CongestionAttribute: String(describing: congestionSegment.1),
-                        CurrentLegAttribute: currentLegAttribute
+                        CongestionAttribute: .string(congestionSegment.1.rawValue),
+                        CurrentLegAttribute: .boolean(currentLegAttribute),
                     ]
                     
                     return feature
@@ -79,7 +79,7 @@ extension Route {
             } else {
                 var feature = Feature(geometry: .lineString(LineString(shape.coordinates)))
                 feature.properties = [
-                    CurrentLegAttribute: currentLegAttribute
+                    CurrentLegAttribute: .boolean(currentLegAttribute),
                 ]
                 legFeatures = [feature]
             }

--- a/Sources/MapboxNavigation/WayNameView.swift
+++ b/Sources/MapboxNavigation/WayNameView.swift
@@ -71,15 +71,15 @@ open class WayNameView: UIView {
         var currentShieldName: NSAttributedString?, currentRoadName: String?
         var didSetup = false
         
-        if let ref = feature.properties?["ref"] as? String,
-           let shield = feature.properties?["shield"] as? String,
-           let reflen = feature.properties?["reflen"] as? Int {
+        if case let .string(ref) = feature.properties?["ref"],
+           case let .string(shield) = feature.properties?["shield"],
+           case let .number(reflen) = feature.properties?["reflen"] {
             let textColor = roadShieldTextColor(line: feature) ?? .black
-            let imageName = "\(shield)-\(reflen)"
+            let imageName = "\(shield)-\(Int(reflen))"
             currentShieldName = roadShieldAttributedText(for: ref, textColor: textColor, style: style, imageName: imageName)
         }
         
-        if let roadName = feature.properties?["name"] as? String, !roadName.isEmpty {
+        if case let .string(roadName) = feature.properties?["name"], !roadName.isEmpty {
             currentRoadName = roadName
             self.text = roadName
             didSetup = true
@@ -96,12 +96,12 @@ open class WayNameView: UIView {
     }
     
     private func roadShieldTextColor(line: Turf.Feature) -> UIColor? {
-        guard let shield = line.properties?["shield"] as? String else {
+        guard case let .string(shield) = line.properties?["shield"] else {
             return nil
         }
         
         // shield_text_color is present in Mapbox Streets source v8 but not v7.
-        guard let shieldTextColor = line.properties?["shield_text_color"] as? String else {
+        guard case let .string(shieldTextColor) = line.properties?["shield_text_color"] else {
             let currentShield = HighwayShield.RoadType(rawValue: shield)
             return currentShield?.textColor
         }

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -176,7 +176,7 @@ class NavigationMapViewTests: TestCase {
     }
     
     func congestionLevel(_ feature: Turf.Feature) -> CongestionLevel? {
-        guard let congestionLevel = feature.properties?["congestion"] as? String else { return nil }
+        guard case let .string(congestionLevel) = feature.properties?["congestion"] else { return nil }
         
         return CongestionLevel(rawValue: congestionLevel)
     }
@@ -365,7 +365,7 @@ class NavigationMapViewTests: TestCase {
         let congestionSegment: CongestionSegment = (coordinates, CongestionLevel.low)
         var feature = Feature(geometry: .lineString(LineString(congestionSegment.0)))
         feature.properties = [
-            CongestionAttribute: String(describing: congestionSegment.1),
+            CongestionAttribute: .string(String(describing: congestionSegment.1)),
             CurrentLegAttribute: true
         ]
         let congestionFeatures:[Turf.Feature] = [feature]


### PR DESCRIPTION
Migrated Turf GeoJSON usage to GeoJSONObject and JSONValue. Factored out EventLocation to begin migrating some ad-hoc event dictionaries to Codable structs.

Depends on mapbox/turf-swift#154, mapbox/mapbox-maps-ios#715, and #3413. There are no additional public-facing changes on top of the Turf changes.

/cc @mapbox/navigation-ios