### PR TITLE
Fix showsEndOfRouteFeedback before view is loaded

### DIFF
--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -145,9 +145,11 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
      */
     public var showsEndOfRouteFeedback: Bool {
         get {
-            arrivalController?.showsEndOfRoute ?? false
+            loadViewIfNeeded()
+            return arrivalController?.showsEndOfRoute ?? false
         }
         set {
+            loadViewIfNeeded()
             arrivalController?.showsEndOfRoute = newValue
         }
     }

--- a/Tests/MapboxNavigationTests/EndOfRouteFeedbackTests.swift
+++ b/Tests/MapboxNavigationTests/EndOfRouteFeedbackTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+import TestHelper
+import MapboxCoreNavigation
+@testable import MapboxNavigation
+import CoreLocation
+
+final class EndOfRouteFeedbackTests: XCTestCase {
+    func testDisableFeedback() {
+        let startLocation = CLLocationCoordinate2D(latitude: 32.714719, longitude: -117.149368)
+        let endLocation = CLLocationCoordinate2D(latitude: 32.714721,
+                                                 longitude: -117.149314)
+
+        let route = Fixture.route(between: startLocation, and: endLocation)
+        let options = NavigationRouteOptions(coordinates: [startLocation, endLocation])
+        let service = MapboxNavigationService(routeResponse: route.response,
+                                              routeIndex: 0,
+                                              routeOptions: options,
+                                              directions: .mocked,
+                                              locationSource: nil,
+                                              eventsManagerType: nil,
+                                              simulating: .never,
+                                              routerType: nil)
+
+        let viewController = NavigationViewController(navigationService: service)
+        viewController.showsEndOfRouteFeedback = false
+        XCTAssertFalse(viewController.showsEndOfRouteFeedback)
+        _ = viewController.view
+        XCTAssertFalse(viewController.showsEndOfRouteFeedback)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        guard let arrivalController = viewController.arrivalController else {
+            XCTFail("Arrival controller should load after view is loaded"); return
+        }
+
+        guard let endOfRouteView = arrivalController.navigationViewData.navigationView.endOfRouteView else {
+            return
+        }
+
+        XCTAssertTrue(endOfRouteView.isHidden)
+    }
+}


### PR DESCRIPTION
The problem is that `showsEndOfRouteFeedback` variable is set on `arrivalController` which is loaded in `viewDidLoad`. 
Some other properties trigger view load as well, so I think this is a reasonable fix for now. ﻿
