### PR TITLE
Fix the preview crash resulted from the table view scrolling quickly.

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -897,8 +897,7 @@ open class NavigationMapView: UIView {
      - parameter stepIndex: Zero-based index of the `RouteStep` which contains the maneuver.
      */
     public func addArrow(route: Route, legIndex: Int, stepIndex: Int) {
-        guard route.legs.indices.contains(legIndex),
-              route.legs[legIndex].steps.indices.contains(stepIndex),
+        guard route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex),
               let triangleImage = Bundle.mapboxNavigation.image(named: "triangle")?.withRenderingMode(.alwaysTemplate) else { return }
         
         do {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -897,7 +897,7 @@ open class NavigationMapView: UIView {
      - parameter stepIndex: Zero-based index of the `RouteStep` which contains the maneuver.
      */
     public func addArrow(route: Route, legIndex: Int, stepIndex: Int) {
-        guard route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex),
+        guard route.containsStep(at: legIndex, stepIndex: stepIndex),
               let triangleImage = Bundle.mapboxNavigation.image(named: "triangle")?.withRenderingMode(.alwaysTemplate) else { return }
         
         do {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -1104,7 +1104,7 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
     
     public func topBanner(_ banner: TopBannerViewController, didSelect legIndex: Int, stepIndex: Int, cell: StepTableViewCell) {
         let progress = navigationService.routeProgress
-        guard progress.route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex) else { return }
+        guard progress.route.containsStep(at: legIndex, stepIndex: stepIndex) else { return }
         let legProgress = RouteLegProgress(leg: progress.route.legs[legIndex], stepIndex: stepIndex)
         let step = legProgress.currentStep
         self.preview(step: step, in: banner, remaining: progress.remainingSteps, route: progress.route)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -1104,6 +1104,7 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
     
     public func topBanner(_ banner: TopBannerViewController, didSelect legIndex: Int, stepIndex: Int, cell: StepTableViewCell) {
         let progress = navigationService.routeProgress
+        guard stepIndex < progress.route.legs[legIndex].steps.count else { return }
         let legProgress = RouteLegProgress(leg: progress.route.legs[legIndex], stepIndex: stepIndex)
         let step = legProgress.currentStep
         self.preview(step: step, in: banner, remaining: progress.remainingSteps, route: progress.route)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -1104,7 +1104,7 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
     
     public func topBanner(_ banner: TopBannerViewController, didSelect legIndex: Int, stepIndex: Int, cell: StepTableViewCell) {
         let progress = navigationService.routeProgress
-        guard stepIndex < progress.route.legs[legIndex].steps.count else { return }
+        guard progress.route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex) else { return }
         let legProgress = RouteLegProgress(leg: progress.route.legs[legIndex], stepIndex: stepIndex)
         let step = legProgress.currentStep
         self.preview(step: step, in: banner, remaining: progress.remainingSteps, route: progress.route)

--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -155,6 +155,16 @@ extension Route {
             return LineString(coordinateList)
         }
     }
+    
+    /**
+     Returns true if both the legIndex and stepIndex are valid in the route.
+     */
+    func checkSelectedIndex(legIndex: Int, stepIndex: Int) -> Bool {
+        guard let stepCount = legs[safe: legIndex]?.steps.count,
+              stepIndex < stepCount,
+              stepIndex >= 0 else { return false }
+        return true
+    }
 }
 
 extension RouteStep {

--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -159,11 +159,8 @@ extension Route {
     /**
      Returns true if both the legIndex and stepIndex are valid in the route.
      */
-    func checkSelectedIndex(legIndex: Int, stepIndex: Int) -> Bool {
-        guard let stepCount = legs[safe: legIndex]?.steps.count,
-              stepIndex < stepCount,
-              stepIndex >= 0 else { return false }
-        return true
+    func containsStep(at legIndex: Int, stepIndex: Int) -> Bool {
+        return legs[safe: legIndex]?.steps.indices.contains(stepIndex) ?? false
     }
 }
 

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -192,18 +192,24 @@ public class StepsViewController: UIViewController {
 extension StepsViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        let legIndex = indexPath.section
         let cell = tableView.cellForRow(at: indexPath) as! StepTableViewCell
         // Since as we progress, steps are removed from the list, we need to map the row the user tapped to the actual step on the leg.
         // If the user selects a step on future leg, all steps are going to be there.
         var stepIndex: Int
-        if indexPath.section > 0 {
+        if legIndex > 0 {
             stepIndex = indexPath.row
         } else {
             stepIndex = indexPath.row + routeProgress.currentLegProgress.stepIndex
             // For the current leg, we need to know the upcoming step.
-            stepIndex += indexPath.row + 1 > sections[indexPath.section].count ? 0 : 1
+            stepIndex += indexPath.row + 1 > sections[legIndex].count ? 0 : 1
         }
-        delegate?.stepsViewController(self, didSelect: indexPath.section, stepIndex: stepIndex, cell: cell)
+        
+        if let stepCount = routeProgress.route.legs[safe: legIndex]?.steps.count {
+            guard stepIndex < stepCount else { return }
+        }
+
+        delegate?.stepsViewController(self, didSelect: legIndex, stepIndex: stepIndex, cell: cell)
     }
 }
 

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -205,7 +205,7 @@ extension StepsViewController: UITableViewDelegate {
             stepIndex += indexPath.row + 1 > sections[legIndex].count ? 0 : 1
         }
         
-        guard checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex) else { return }
+        guard routeProgress.route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex) else { return }
         delegate?.stepsViewController(self, didSelect: legIndex, stepIndex: stepIndex, cell: cell)
     }
 }
@@ -250,12 +250,6 @@ extension StepsViewController: UITableViewDataSource {
         // Hide cell separator if it’s the last row in a section
         let isLastRowInSection = indexPath.row == sections[indexPath.section].count - 1
         cell.separatorView.isHidden = isLastRowInSection
-    }
-    
-    func checkSelectedIndex(legIndex: Int, stepIndex: Int) -> Bool {
-        guard let stepCount = routeProgress.route.legs[safe: legIndex]?.steps.count,
-              stepIndex < stepCount else { return false }
-        return true
     }
 
     public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -202,10 +202,12 @@ extension StepsViewController: UITableViewDelegate {
         } else {
             stepIndex = indexPath.row + routeProgress.currentLegProgress.stepIndex
             // For the current leg, we need to know the upcoming step.
-            stepIndex += indexPath.row + 1 > sections[legIndex].count ? 0 : 1
+            if sections[legIndex].indices.contains(indexPath.row) {
+                stepIndex += 1
+            }
         }
         
-        guard routeProgress.route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex) else { return }
+        guard routeProgress.route.containsStep(at: legIndex, stepIndex: stepIndex) else { return }
         delegate?.stepsViewController(self, didSelect: legIndex, stepIndex: stepIndex, cell: cell)
     }
 }

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -205,10 +205,7 @@ extension StepsViewController: UITableViewDelegate {
             stepIndex += indexPath.row + 1 > sections[legIndex].count ? 0 : 1
         }
         
-        if let stepCount = routeProgress.route.legs[safe: legIndex]?.steps.count {
-            guard stepIndex < stepCount else { return }
-        }
-
+        guard checkSelectedIndex(legIndex: legIndex, stepIndex: stepIndex) else { return }
         delegate?.stepsViewController(self, didSelect: legIndex, stepIndex: stepIndex, cell: cell)
     }
 }
@@ -253,6 +250,12 @@ extension StepsViewController: UITableViewDataSource {
         // Hide cell separator if it’s the last row in a section
         let isLastRowInSection = indexPath.row == sections[indexPath.section].count - 1
         cell.separatorView.isHidden = isLastRowInSection
+    }
+    
+    func checkSelectedIndex(legIndex: Int, stepIndex: Int) -> Bool {
+        guard let stepCount = routeProgress.route.legs[safe: legIndex]?.steps.count,
+              stepIndex < stepCount else { return false }
+        return true
     }
 
     public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/Tests/MapboxNavigationTests/RouteTests.swift
+++ b/Tests/MapboxNavigationTests/RouteTests.swift
@@ -79,7 +79,7 @@ class RouteTests: TestCase {
         }
     }
     
-    func testCheckSelectedIndex() {
+    func testContainsStep() {
         guard let route = response.routes?.first else {
             XCTFail("Failed to get route.")
             return
@@ -87,11 +87,11 @@ class RouteTests: TestCase {
 
         var legIndex = route.legs.count - 1
         var stepsIndex = route.legs[legIndex].steps.count
-        XCTAssertFalse(route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the step index when it's larger than or equal to the steps count.")
+        XCTAssertFalse(route.containsStep(at: legIndex, stepIndex: stepsIndex), "Failed to check the step index when it's larger than or equal to the steps count.")
         
         legIndex = route.legs.count
         stepsIndex = 0
-        XCTAssertFalse(route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the leg index when it's larger than or equal to the legs count.")
+        XCTAssertFalse(route.containsStep(at: legIndex, stepIndex: stepsIndex), "Failed to check the leg index when it's larger than or equal to the legs count.")
         
     }
 }

--- a/Tests/MapboxNavigationTests/RouteTests.swift
+++ b/Tests/MapboxNavigationTests/RouteTests.swift
@@ -78,4 +78,20 @@ class RouteTests: TestCase {
             XCTAssertLessThan(lastIndexedCoordinate!.coordinate.distance(to: maneuverPolyline.coordinates.last!), 1, "End of maneuver polyline for step \(stepIndex) is \(lastIndexedCoordinate!.coordinate.distance(to: maneuverPolyline.coordinates.last!)) away from outlet from intersection.")
         }
     }
+    
+    func testCheckSelectedIndex() {
+        guard let route = response.routes?.first else {
+            XCTFail("Failed to get route.")
+            return
+        }
+
+        var legIndex = route.legs.count - 1
+        var stepsIndex = route.legs[legIndex].steps.count
+        XCTAssertFalse(route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the step index when it's larger than or equal to the steps count.")
+        
+        legIndex = route.legs.count
+        stepsIndex = 0
+        XCTAssertFalse(route.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the leg index when it's larger than or equal to the legs count.")
+        
+    }
 }

--- a/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -61,6 +61,21 @@ class StepsViewControllerTests: TestCase {
             }
         }
     }
+    
+    func testCheckSelectedIndex() {
+        let dataSource = RouteControllerDataSourceFake()
+        let routeController = RouteController(alongRouteAtIndex: 0, in: response, options: Constants.options, dataSource: dataSource)
+        let stepsViewController = StepsViewController(routeProgress: routeController.routeProgress)
+        
+        var legIndex = routeController.route.legs.count - 1
+        var stepsIndex = routeController.route.legs[legIndex].steps.count
+        XCTAssertFalse(stepsViewController.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the step index when it's larger than or equal to the steps count.")
+        
+        legIndex = routeController.route.legs.count
+        stepsIndex = 0
+        XCTAssertFalse(stepsViewController.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the leg index when it's larger than or equal to the legs count.")
+        
+    }
 }
 
 extension StepsViewControllerTests {

--- a/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -61,21 +61,6 @@ class StepsViewControllerTests: TestCase {
             }
         }
     }
-    
-    func testCheckSelectedIndex() {
-        let dataSource = RouteControllerDataSourceFake()
-        let routeController = RouteController(alongRouteAtIndex: 0, in: response, options: Constants.options, dataSource: dataSource)
-        let stepsViewController = StepsViewController(routeProgress: routeController.routeProgress)
-        
-        var legIndex = routeController.route.legs.count - 1
-        var stepsIndex = routeController.route.legs[legIndex].steps.count
-        XCTAssertFalse(stepsViewController.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the step index when it's larger than or equal to the steps count.")
-        
-        legIndex = routeController.route.legs.count
-        stepsIndex = 0
-        XCTAssertFalse(stepsViewController.checkSelectedIndex(legIndex: legIndex, stepIndex: stepsIndex), "Failed to check the leg index when it's larger than or equal to the legs count.")
-        
-    }
 }
 
 extension StepsViewControllerTests {


### PR DESCRIPTION
### Description
This pr is to fix #3062 and #3234 by adding the check when we select the banner instruction for preview.

### Implementation
The crash reported from #3062 , #3234 and a recent crash from user are all resulted from the call of the following:
https://github.com/mapbox/mapbox-navigation-ios/blob/8257c395745e18255e391978e387034f00086290/Sources/MapboxNavigation/StepsViewController.swift#L192-L206
And then we need to form a `RouetLegProgress` to preview the step as:
https://github.com/mapbox/mapbox-navigation-ios/blob/8257c395745e18255e391978e387034f00086290/Sources/MapboxNavigation/NavigationViewController.swift#L1104-L1106

But the issue is that if we scroll the table quickly, during when the `routeProgress` changed and reload the table view data, or the `routeProgress` received in the table view is different from the `routeProgress` in the `navigationService`, there's a chance that the `stepIndex` would be out of range of the current chosen leg steps count. 

So fat the safest way is to add check for the `stepIndex` and the steps count in both the table view select and before the initialization `RouetLegProgress` for preview.