### PR TITLE
Extend ReplayLocationManager with new callbacks

### DIFF
--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -18,9 +18,10 @@ open class ReplayLocationManager: NavigationLocationManager {
     /**
      `locations` to be replayed.
      */
-    public var locations: [CLLocation]! {
+    public var locations: [CLLocation] {
         didSet {
             currentIndex = 0
+            verifyParameters()
         }
     }
     
@@ -47,10 +48,22 @@ open class ReplayLocationManager: NavigationLocationManager {
     var startDate: Date?
     
     private var synthesizedLocation: CLLocation?
+
+    /**
+     A handler that is called when `ReplayLocationManager` finished replaying `locations` and about to start from the
+     beginning. Return false to stop replaying `locations`.
+     */
+    var onReplayLoopCompleted: ((ReplayLocationManager) -> Bool)?
+
+    /**
+     A handler that is called on each replayed location along with the location index in `locations` array.
+     */
+    var onTick: ((_ index: Int, CLLocation) -> Void)?
     
     public init(locations: [CLLocation]) {
         self.locations = locations.sorted { $0.timestamp < $1.timestamp }
         super.init()
+        verifyParameters()
     }
     
     deinit {
@@ -60,6 +73,7 @@ open class ReplayLocationManager: NavigationLocationManager {
     override open func startUpdatingLocation() {
         startDate = Date()
         tick()
+        assert(!locations.isEmpty, "Replay doesn't work with empty locations.")
     }
     
     override open func stopUpdatingLocation() {
@@ -69,23 +83,35 @@ open class ReplayLocationManager: NavigationLocationManager {
     
     @objc internal func tick() {
         guard let startDate = startDate else { return }
+
         let location = locations[currentIndex]
         synthesizedLocation = location
         delegate?.locationManager?(self, didUpdateLocations: [location])
+        onTick?(currentIndex, location)
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(tick), object: nil)
         
-        if currentIndex < locations.count - 1 {
-            let nextLocation = locations[currentIndex+1]
-            let interval = nextLocation.timestamp.timeIntervalSince(location.timestamp) / TimeInterval(speedMultiplier)
-            let intervalSinceStart = Date().timeIntervalSince(startDate)+interval
-            let actualInterval = nextLocation.timestamp.timeIntervalSince(locations.first!.timestamp)
-            let diff = min(max(0, intervalSinceStart-actualInterval), 0.9) // Don't try to resync more than 0.9 seconds per location update
-            let syncedInterval = interval-diff
-            
-            perform(#selector(tick), with: nil, afterDelay: syncedInterval)
-            currentIndex += 1
-        } else {
-            currentIndex = 0
+        if currentIndex >= locations.count - 1 {
+            let startFromBeginning = onReplayLoopCompleted?(self) ?? true
+            if startFromBeginning {
+                currentIndex = 0
+            }
+            else {
+                return
+            }
         }
+        
+        let nextLocation = locations[currentIndex+1]
+        let interval = nextLocation.timestamp.timeIntervalSince(location.timestamp) / TimeInterval(speedMultiplier)
+        let intervalSinceStart = Date().timeIntervalSince(startDate)+interval
+        let actualInterval = nextLocation.timestamp.timeIntervalSince(locations.first!.timestamp)
+        let diff = min(max(0, intervalSinceStart-actualInterval), 0.9) // Don't try to resync more than 0.9 seconds per location update
+        let syncedInterval = interval-diff
+
+        perform(#selector(tick), with: nil, afterDelay: syncedInterval)
+        currentIndex += 1
+    }
+
+    private func verifyParameters() {
+        precondition(!locations.isEmpty)
     }
 }


### PR DESCRIPTION
`onTick` allows to get each replayed location with its index

`onReplayLoopCompleted` allows to stop replay after all locations
replayed.

Prevent crashes if incoming locations array is empty.