### PR TITLE
Only allow the current guidance card be highlighted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * Fixed an issue where some banner instructions were occasionally skipped. ([#3265](https://github.com/mapbox/mapbox-navigation-ios/pull/3265))
 * Improved the current road name label’s performance and fixed a potential crash when updating it. ([#3340](https://github.com/mapbox/mapbox-navigation-ios/pull/3340))
 * Fixed an issue where arrival guidance card appears too early. ([#3383](https://github.com/mapbox/mapbox-navigation-ios/pull/3383))
+* Fixed an issue where the non current guidance cards highlighted. ([#3442](https://github.com/mapbox/mapbox-navigation-ios/pull/3442))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/InstructionsCardCell.swift
+++ b/Sources/MapboxNavigation/InstructionsCardCell.swift
@@ -41,11 +41,11 @@ public class InstructionsCardCell: UICollectionViewCell {
         /* TODO: Smoothen animation here. */
     }
     
-    public func configure(for step: RouteStep, distance: CLLocationDistance, instruction: VisualInstructionBanner? = nil) {
+    public func configure(for step: RouteStep, distance: CLLocationDistance, instruction: VisualInstructionBanner? = nil, isCurrentCardStep: Bool = false) {
         addSubview(container)
         setupConstraints()
         container.prepareLayout()
-        container.updateInstruction(for: step, distance: distance, instruction: instruction)
+        container.updateInstruction(for: step, distance: distance, instruction: instruction, isCurrentCardStep: isCurrentCardStep)
     }
 }
 

--- a/Sources/MapboxNavigation/InstructionsCardContainerView.swift
+++ b/Sources/MapboxNavigation/InstructionsCardContainerView.swift
@@ -78,13 +78,13 @@ public class InstructionsCardContainerView: StylableView, InstructionsCardContai
     
     public weak var delegate: InstructionsCardContainerViewDelegate?
 
-    public func updateInstruction(for step: RouteStep, distance: CLLocationDistance, instruction: VisualInstructionBanner? = nil) {
+    public func updateInstruction(for step: RouteStep, distance: CLLocationDistance, instruction: VisualInstructionBanner? = nil, isCurrentCardStep: Bool = false) {
         instructionsCardView.updateDistanceFromCurrentLocation(distance)
         instructionsCardView.step = step
         
         guard let instruction = instruction ?? step.instructionsDisplayedAlongStep?.last else { return }
         updateInstruction(instruction)
-        updateInstructionCard(distance: distance)
+        updateInstructionCard(distance: distance, isCurrentCardStep: isCurrentCardStep)
     }
     
     public func updateInstruction(_ instruction: VisualInstructionBanner) {
@@ -94,8 +94,8 @@ public class InstructionsCardContainerView: StylableView, InstructionsCardContai
         nextBannerView.update(for: instruction)
     }
     
-    public func updateInstructionCard(distance: CLLocationDistance) {
-        let highlightEnabled = distance < InstructionsCardConstants.highlightDistance
+    public func updateInstructionCard(distance: CLLocationDistance, isCurrentCardStep: Bool = false) {
+        let highlightEnabled = isCurrentCardStep ? distance < InstructionsCardConstants.highlightDistance : false
         updateBackgroundColor(highlightEnabled: highlightEnabled)
         instructionsCardView.updateDistanceFromCurrentLocation(distance)
     }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -90,8 +90,9 @@ open class InstructionsCardViewController: UIViewController {
             let indexPath = indexPaths[index]
             if let container = instructionContainerView(at: indexPath), indexPath.row < remainingSteps.count {
                 let visibleStep = remainingSteps[indexPath.row]
-                let distance = currentCardStep == visibleStep ? legProgress.currentStepProgress.distanceRemaining : visibleStep.distance
-                container.updateInstructionCard(distance: distance)
+                let isCurrentCardStep = currentCardStep == visibleStep
+                let distance = isCurrentCardStep ? legProgress.currentStepProgress.distanceRemaining : visibleStep.distance
+                container.updateInstructionCard(distance: distance, isCurrentCardStep: isCurrentCardStep)
             }
         }
     }
@@ -280,7 +281,7 @@ extension InstructionsCardViewController: UICollectionViewDataSource {
         
         let step = steps[indexPath.row]
         if indexPath.row == 0 {
-            cell.configure(for: step, distance: distanceRemaining, instruction: self.currentInstruction)
+            cell.configure(for: step, distance: distanceRemaining, instruction: self.currentInstruction, isCurrentCardStep: true)
         } else {
             cell.configure(for: step, distance: step.distance)
         }


### PR DESCRIPTION
### Description
This pr is to fix #3441 by only allowing the current guidance card step highlighted.

### Implementation
Adding the check of the card step before the distance check, to see whether it's the current step. If false, don't allow the background color change.

### Screenshots or Gifs
![fxiedCard](https://user-images.githubusercontent.com/48976398/136091893-58f00aec-e7e6-4aa6-80b8-78e44966b476.png)


