### PR TITLE
Rerouting avoiding Dangerous Maneuvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@
 ### Other changes
 
 * Added the `RouterDelegate.router(_:initialManeuverBufferWhenReroutingFrom:)` method and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to configure rerouting buffering. ([#3454](https://github.com/mapbox/mapbox-navigation-ios/pull/3454))
-* Added `RouterDelegate.router(_:, requestSourceForReroutingWith:)` and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to provide customization for rerouting mechanism by providing a user-defined route as a reroute. ([#3472](https://github.com/mapbox/mapbox-navigation-ios/pull/3472))
+* Added `RouterDelegate.router(_:requestBehaviorForReroutingWith:)` and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to provide customization for rerouting mechanism by providing a user-defined route as a reroute. ([#3472](https://github.com/mapbox/mapbox-navigation-ios/pull/3472))
 
 ## v2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 ### Other changes
 
 * Added the `RouterDelegate.router(_:initialManeuverBufferWhenReroutingFrom:)` method and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to configure rerouting buffering. ([#3454](https://github.com/mapbox/mapbox-navigation-ios/pull/3454))
+* Added `RouterDelegate.router(_:, requestSourceForReroutingWith:)` and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to provide customization for rerouting mechanism by providing a user-defined route as a reroute. ([#3472](https://github.com/mapbox/mapbox-navigation-ios/pull/3472))
 
 ## v2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 
 ### Other changes
 
-* Added `RouterDelegate.router(_:, maneuverOffsetWhenReroutingFrom:)` and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to expose configuration of safe distance marging when reroute occures.  ([#3454](https://github.com/mapbox/mapbox-navigation-ios/pull/3454))
+* Added the `RouterDelegate.router(_:initialManeuverBufferWhenReroutingFrom:)` method and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to configure rerouting buffering. ([#3454](https://github.com/mapbox/mapbox-navigation-ios/pull/3454))
 
 ## v2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@
 * Fixed an issue where the user interface did not necessarily display distances in the same units as the route by default. `NavigationRouteOptions` and `NavigationMatchOptions` now set `DirectionsOptions.distanceMeasurementSystem` to a default value matching the `NavigationSettings.distanceUnit` property. ([#3541](https://github.com/mapbox/mapbox-navigation-ios/pull/3541))
 * Introduced `RoutingProvider` to parameterize routing fetching and refreshing during active guidance sessions.  `Directions.calculateWithCache(options:completionHandler:)` and `Directions.calculateOffline(options:completionHandler)` functionality is deprecated by `MapboxRoutingProvider`. It is now recommended to use `MapboxRoutingProvider` to request or refresh routes instead of `Directions` object but you may also provide your own `RoutingProvider` implementation to `NavigationService`, `RouteController` or `LegacyRouteController`. Using `directions` property of listed above entities is discouraged, you should use corresponding `routingProvider` instead, albeit `Directions` also implements the protocol. ([#3261](https://github.com/mapbox/mapbox-navigation-ios/pull/3261))
 
+### Other changes
+
+* Added `RouterDelegate.router(_:, maneuverOffsetWhenReroutingFrom:)` and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to expose configuration of safe distance marging when reroute occures.  ([#3454](https://github.com/mapbox/mapbox-navigation-ios/pull/3454))
+
 ## v2.0.1
 
 * Added the `Notification.Name.didArriveAtWaypoint` constant for notifications posted when the user arrives at a waypoint. ([#3514](https://github.com/mapbox/mapbox-navigation-ios/pull/3514))

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -656,4 +656,14 @@ extension ViewController: NavigationViewControllerDelegate {
         dismissActiveNavigationViewController()
         clearNavigationMapView()
     }
+    
+    func navigationViewController(_ navigationViewController: NavigationViewController, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+        
+        guard let currentSpeed = navigationViewController.navigationService.router.location?.speed else {
+            return .default
+        }
+        
+        // allowing at least 8 seconds for user to react to new route
+        return .radius(currentSpeed * 8)
+    }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -657,7 +657,7 @@ extension ViewController: NavigationViewControllerDelegate {
         clearNavigationMapView()
     }
     
-    func navigationViewController(_ navigationViewController: NavigationViewController, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
         
         guard let currentSpeed = navigationViewController.navigationService.router.location?.speed else {
             return .default

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -657,13 +657,13 @@ extension ViewController: NavigationViewControllerDelegate {
         clearNavigationMapView()
     }
     
-    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         
         guard let currentSpeed = navigationViewController.navigationService.router.location?.speed else {
-            return .default
+            return nil
         }
         
         // allowing at least 8 seconds for user to react to new route
-        return .radius(currentSpeed * 8)
+        return currentSpeed * 8
     }
 }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -555,8 +555,8 @@ extension MapboxNavigationService: RouterDelegate {
         return delegate?.navigationService(self, initialManeuverBufferWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
     }
     
-    public func router(_ router: Router, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
-        return delegate?.navigationService(self, requestSourceForReroutingWith: options) ?? .default
+    public func router(_ router: Router, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior {
+        return delegate?.navigationService(self, requestBehaviorForReroutingWith: options) ?? .default
     }
     
     public func router(_ router: Router, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -1,6 +1,7 @@
 import UIKit
 import CoreLocation
 import MapboxDirections
+import Turf
 
 /**
  A navigation service coordinates various nonvisual components that track the user as they navigate along a predetermined route. You use `MapboxNavigationService`, which conforms to this protocol, either as part of `NavigationViewController` or by itself as part of a custom user interface. A navigation service calls methods on its `delegate`, which conforms to the `NavigationServiceDelegate` protocol, whenever significant events or decision points occur along the route.
@@ -550,7 +551,7 @@ extension MapboxNavigationService: RouterDelegate {
         delegate?.navigationService(self, willRerouteFrom: location)
     }
     
-    public func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+    public func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         //ask our consumer
         return delegate?.navigationService(self, initialManeuverBufferWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
     }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -550,9 +550,9 @@ extension MapboxNavigationService: RouterDelegate {
         delegate?.navigationService(self, willRerouteFrom: location)
     }
     
-    public func router(_ router: Router, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+    public func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
         //ask our consumer
-        return delegate?.navigationService(self, maneuverOffsetWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
+        return delegate?.navigationService(self, initialManeuverBufferWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
     }
     
     

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -555,6 +555,10 @@ extension MapboxNavigationService: RouterDelegate {
         return delegate?.navigationService(self, initialManeuverBufferWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
     }
     
+    public func router(_ router: Router, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+        return delegate?.navigationService(self, requestSourceForReroutingWith: options) ?? .default
+    }
+    
     public func router(_ router: Router, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
         //notify the events manager that the route has changed
         eventsManager.reportReroute(progress: router.routeProgress, proactive: proactive)

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -552,7 +552,6 @@ extension MapboxNavigationService: RouterDelegate {
     }
     
     public func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
-        //ask our consumer
         return delegate?.navigationService(self, initialManeuverBufferWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
     }
     

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -550,6 +550,12 @@ extension MapboxNavigationService: RouterDelegate {
         delegate?.navigationService(self, willRerouteFrom: location)
     }
     
+    public func router(_ router: Router, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+        //ask our consumer
+        return delegate?.navigationService(self, maneuverOffsetWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
+    }
+    
+    
     public func router(_ router: Router, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
         //notify the events manager that the route has changed
         eventsManager.reportReroute(progress: router.routeProgress, proactive: proactive)

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -555,7 +555,6 @@ extension MapboxNavigationService: RouterDelegate {
         return delegate?.navigationService(self, initialManeuverBufferWhenReroutingFrom: location) ?? Default.reroutingManeuverRadius
     }
     
-    
     public func router(_ router: Router, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
         //notify the events manager that the route has changed
         eventsManager.reportReroute(progress: router.routeProgress, proactive: proactive)

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -43,7 +43,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Configures distance (in meters) before the first maneuver in requested reroute.
      
-     If implemented, this method allows to override set `RouteOptions.avoidManeuversInOriginRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
+     If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
      This method is called after `navigationService(_:willRerouteFrom:)` is called, and before `navigationService(_:didRerouteAlong:)` is called.
      

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -33,7 +33,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately before the navigation service calculates a new route.
      
-     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:maneuverOffsetWhenReroutingFrom:)` is called.
+     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:initialManeuverBufferWhenReroutingFrom:)` is called.
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
@@ -49,9 +49,9 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      
      - parameter router: The router that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `ReroutingManeuverOffset` value which overrides or leaves maneuvers offset as it was originally set.
+     - returns: `ReroutingManeuverBuffer` value which overrides or leaves maneuvers offset as it was originally set.
      */
-    func navigationService(_ service: NavigationService, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset
+    func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -67,7 +67,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the navigation service receives a new route.
      
-     This method is called after `navigationService(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationService(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter route: The new route.
@@ -77,7 +77,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the navigation service fails to receive a new route.
      
-     This method is called after `navigationService(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationService(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -242,7 +242,7 @@ public extension NavigationServiceDelegate {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
-    func navigationService(_ service: NavigationService, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+    func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.reroutingManeuverRadius
     }

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -33,12 +33,25 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately before the navigation service calculates a new route.
      
-     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:didRerouteAlong:)` is called.
+     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:maneuverOffsetWhenReroutingFrom:)` is called.
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
      */
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation)
+    
+    /**
+     Configures distance (in meters) before the first maneuver in requested reroute.
+     
+     If implemented, this method allows to override set `RouteOptions.avoidManeuversInOriginRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
+     
+     This method is called after `navigationService(_:willRerouteFrom:)` is called, and before `navigationService(_:didRerouteAlong:)` is called.
+     
+     - parameter router: The router that has detected the need to calculate a new route.
+     - parameter location: The user’s current location.
+     - returns: `ReroutingManeuverOffset` value which overrides or leaves maneuvers offset as it was originally set.
+     */
+    func navigationService(_ service: NavigationService, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -54,7 +67,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the navigation service receives a new route.
      
-     This method is called after `navigationService(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationService(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter route: The new route.
@@ -64,7 +77,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the navigation service fails to receive a new route.
      
-     This method is called after `navigationService(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationService(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -229,6 +242,10 @@ public extension NavigationServiceDelegate {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    func navigationService(_ service: NavigationService, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+        logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
+        return MapboxNavigationService.Default.reroutingManeuverRadius
+    }
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -246,6 +246,7 @@ public extension NavigationServiceDelegate {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.reroutingManeuverRadius
     }
+    
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreLocation
 import MapboxDirections
 import os.log
+import Turf
 
 /**
  A navigation service delegate interacts with one or more `NavigationService` instances (such as `MapboxNavigationService` objects) during turn-by-turn navigation. This protocol is the main way that your application can synchronize its state with the SDK’s location-related functionality. Each of the protocol’s methods is optional.
@@ -49,9 +50,9 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      
      - parameter router: The router that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `ReroutingManeuverBuffer` value which overrides or leaves maneuvers offset as it was originally set.
+     - returns: `LocationDistance` value which overrides (by passing a non-nil value) or leaves maneuvers offset as it was originally set (by passing `nil`).
      */
-    func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer
+    func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance?
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -242,7 +243,7 @@ public extension NavigationServiceDelegate {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
-    func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+    func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.reroutingManeuverRadius
     }

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -38,6 +38,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
+     - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
      */
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation)
     
@@ -46,13 +47,28 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      
      If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
-     This method is called after `navigationService(_:willRerouteFrom:)` is called, and before `navigationService(_:didRerouteAlong:)` is called.
+     This method is called after `navigationService(_:willRerouteFrom:)` is called, and before `navigationService(_:requestSourceForReroutingWith:)` is called.
      
-     - parameter router: The router that has detected the need to calculate a new route.
+     - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
      - returns: `LocationDistance` value which overrides (by passing a non-nil value) or leaves maneuvers offset as it was originally set (by passing `nil`).
      */
     func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance?
+    
+    /**
+     Called when the navigation service calculates a new route.
+
+     This method allows customizing the rerouting by providing custom `RouteResponse`. SDK will then treat it as if it was fetched as usual and apply as a reroute.
+     
+     - note: Multiple method calls will not interrupt the first ongoing request.
+     
+     This method is called after `navigationService(_:initialManeuverBufferWhenReroutingFrom:)` is called, and before `navigationService(_:didRerouteAlong:)` is called.
+     
+     - parameter service: The navigation service that will calculate a new route.
+     - parameter location: The user’s current location.
+     - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
+     */
+    func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -68,7 +84,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the navigation service receives a new route.
      
-     This method is called after `navigationService(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationService(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter route: The new route.
@@ -78,7 +94,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the navigation service fails to receive a new route.
      
-     This method is called after `navigationService(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationService(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -243,9 +259,20 @@ public extension NavigationServiceDelegate {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return MapboxNavigationService.Default.reroutingManeuverRadius
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+        logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
+        return .default
     }
     
     /**

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -38,7 +38,6 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
      */
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation)
     
@@ -47,7 +46,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      
      If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
-     This method is called after `navigationService(_:willRerouteFrom:)` is called, and before `navigationService(_:requestSourceForReroutingWith:)` is called.
+     This method is called after `navigationService(_:willRerouteFrom:)` is called, and before `navigationService(_:requestBehaviorForReroutingWith:)` is called.
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
@@ -65,10 +64,10 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      This method is called after `navigationService(_:initialManeuverBufferWhenReroutingFrom:)` is called, and before `navigationService(_:didRerouteAlong:)` is called.
      
      - parameter service: The navigation service that will calculate a new route.
-     - parameter location: The user’s current location.
+     - parameter options: `RouteOptions` that are supposed to be used for route calculation.
      - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
      */
-    func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest
+    func navigationService(_ service: NavigationService, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -84,7 +83,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the navigation service receives a new route.
      
-     This method is called after `navigationService(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationService(_:requestBehaviorForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter route: The new route.
@@ -94,7 +93,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the navigation service fails to receive a new route.
      
-     This method is called after `navigationService(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationService(_:requestBehaviorForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -270,7 +269,7 @@ public extension NavigationServiceDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
-    func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+    func navigationService(_ service: NavigationService, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return .default
     }

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -23,7 +23,7 @@ import os.log
 open class RouteController: NSObject {
     public enum DefaultBehavior {
         public static let shouldRerouteFromLocation: Bool = true
-        public static let reroutingManeuverRadius: ReroutingManeuverOffset = .default
+        public static let reroutingManeuverRadius: ReroutingManeuverBuffer = .default
         public static let shouldDiscardLocation: Bool = false
         public static let didArriveAtWaypoint: Bool = true
         public static let shouldPreventReroutesWhenArrivingAtWaypoint: Bool = true

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -23,6 +23,7 @@ import os.log
 open class RouteController: NSObject {
     public enum DefaultBehavior {
         public static let shouldRerouteFromLocation: Bool = true
+        public static let reroutingManeuverRadius: ReroutingManeuverOffset = .default
         public static let shouldDiscardLocation: Bool = false
         public static let didArriveAtWaypoint: Bool = true
         public static let shouldPreventReroutesWhenArrivingAtWaypoint: Bool = true

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -23,7 +23,7 @@ import os.log
 open class RouteController: NSObject {
     public enum DefaultBehavior {
         public static let shouldRerouteFromLocation: Bool = true
-        public static let reroutingManeuverRadius: ReroutingManeuverBuffer = .default
+        public static let reroutingManeuverRadius: LocationDistance? = nil
         public static let shouldDiscardLocation: Bool = false
         public static let didArriveAtWaypoint: Bool = true
         public static let shouldPreventReroutesWhenArrivingAtWaypoint: Bool = true

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -25,7 +25,15 @@ open class RouteProgress: Codable {
         self.calculateLegsCongestion()
     }
     
-    func reroutingOptions(from location: CLLocation) -> RouteOptions {
+    /**
+     Current `RouteOptions`, optimized for rerouting.
+     
+     This method is useful for implementing custom rerouting. Resulting `RouteOptions` skip passed waypoints and include current user heading if possible.
+     
+     - parameter location: Current user location. Treated as route origin for rerouting.
+     - returns: Modified `RouteOptions`.
+     */
+    public func reroutingOptions(from location: CLLocation) -> RouteOptions {
         let oldOptions = routeOptions
         let user = Waypoint(coordinate: location.coordinate)
 

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -337,7 +337,7 @@ extension InternalRouter where Self: Router {
         let options = progress.reroutingOptions(from: origin)
         
         if isRerouting {
-            switch (delegate?.router(self, maneuverOffsetWhenReroutingFrom: origin) ?? RouteController.DefaultBehavior.reroutingManeuverRadius) {
+            switch (delegate?.router(self, initialManeuverBufferWhenReroutingFrom: origin) ?? RouteController.DefaultBehavior.reroutingManeuverRadius) {
             case .disabled:
                 options.initialManeuverAvoidanceRadius = nil
             case .radius(let distance):

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -365,7 +365,7 @@ extension InternalRouter where Self: Router {
             }
         }
         
-        switch delegate?.router(self, requestSourceForReroutingWith: options) {
+        switch delegate?.router(self, requestBehaviorForReroutingWith: options) {
         case .default, .none:
             routeTask = routingProvider.calculateRoutes(options: options) {(session, result) in
                 parseResult(session, result)

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -339,9 +339,9 @@ extension InternalRouter where Self: Router {
         if isRerouting {
             switch (delegate?.router(self, maneuverOffsetWhenReroutingFrom: origin) ?? RouteController.DefaultBehavior.reroutingManeuverRadius) {
             case .disabled:
-                options.avoidManeuversInOriginRadius = nil
+                options.initialManeuverAvoidanceRadius = nil
             case .radius(let distance):
-                options.avoidManeuversInOriginRadius = distance
+                options.initialManeuverAvoidanceRadius = distance
             case .default:
                 // do nothing
                 break

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -338,11 +338,13 @@ extension InternalRouter where Self: Router {
         
         if isRerouting {
             switch (delegate?.router(self, initialManeuverBufferWhenReroutingFrom: origin) ?? RouteController.DefaultBehavior.reroutingManeuverRadius) {
-            case .disabled:
-                options.initialManeuverAvoidanceRadius = nil
-            case .radius(let distance):
-                options.initialManeuverAvoidanceRadius = distance
-            case .default:
+            case .some(let distance):
+                if distance == 0 {
+                    options.initialManeuverAvoidanceRadius = nil
+                } else {
+                    options.initialManeuverAvoidanceRadius = distance
+                }
+            case .none:
                 // do nothing
                 break
             }

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -336,6 +336,18 @@ extension InternalRouter where Self: Router {
         routeTask?.cancel()
         let options = progress.reroutingOptions(from: origin)
         
+        if isRerouting {
+            switch (delegate?.router(self, maneuverOffsetWhenReroutingFrom: origin) ?? RouteController.DefaultBehavior.reroutingManeuverRadius) {
+            case .disabled:
+                options.avoidManeuversInOriginRadius = nil
+            case .radius(let distance):
+                options.avoidManeuversInOriginRadius = distance
+            case .default:
+                // do nothing
+                break
+            }
+        }
+        
         lastRerouteLocation = origin
         
         routeTask = routingProvider.calculateRoutes(options: options) {(session, result) in

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -6,7 +6,7 @@ import Turf
 /**
  Configuration for offsetting first route maneuver during rerouting.
  */
-public enum ReroutingManeuverOffset {
+public enum ReroutingManeuverBuffer {
     /**
      Leaves original `RouteOptions.initialManeuverAvoidanceRadius` to be used for rerouting attempt.
      */
@@ -49,7 +49,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately before the router calculates a new route.
      
-     This method is called after `router(_:shouldRerouteFrom:)` is called, and before `router(_:maneuverOffsetWhenReroutingFrom:)` is called.
+     This method is called after `router(_:shouldRerouteFrom:)` is called, and before `router(_:initialManeuverBufferWhenReroutingFrom:)` is called.
      
      - parameter router: The router that will calculate a new route.
      - parameter location: The user’s current location.
@@ -65,9 +65,9 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
      
      - parameter router: The router that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `ReroutingManeuverOffset` value which overrides or leaves maneuvers offset as it was originally set.
+     - returns: `ReroutingManeuverBuffer` value which overrides or leaves maneuvers offset as it was originally set.
      */
-    func router(_ router: Router, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset
+    func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -83,7 +83,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the router receives a new route.
      
-     This method is called after `router(_:maneuverOffsetWhenReroutingFrom:)` method is called.
+     This method is called after `router(_:initialManeuverBufferWhenReroutingFrom:)` method is called.
      
      - parameter router: The router that has calculated a new route.
      - parameter route: The new route.
@@ -93,7 +93,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the router fails to receive a new route.
      
-     This method is called after `router(_:maneuverOffsetWhenReroutingFrom:)`.
+     This method is called after `router(_:initialManeuverBufferWhenReroutingFrom:)`.
      
      - parameter router: The router that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -194,7 +194,7 @@ public extension RouterDelegate {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
     }
     
-    func router(_ router: Router, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+    func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
         return RouteController.DefaultBehavior.reroutingManeuverRadius
     }

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -8,7 +8,7 @@ import Turf
  */
 public enum ReroutingManeuverOffset {
     /**
-     Leaves original `RouteOptions.avoidManeuversInOriginRadius` to be used for rerouting attempt.
+     Leaves original `RouteOptions.initialManeuverAvoidanceRadius` to be used for rerouting attempt.
      */
     case `default`
     /**
@@ -18,7 +18,7 @@ public enum ReroutingManeuverOffset {
     /**
      Sets offset radius (in meters).
      
-     Equivalent to setting `RouteOptions.avoidManeuversInOriginRadius` to the same radius at the beginning.
+     Equivalent to setting `RouteOptions.initialManeuverAvoidanceRadius` to the same radius at the beginning.
      */
     case radius(LocationDistance)
 }
@@ -59,7 +59,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Configures distance (in meters) before the first maneuver in requested reroute.
      
-     If implemented, this method allows to override set `RouteOptions.avoidManeuversInOriginRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
+     If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
      This method is called after `router(_:willRerouteFrom:)` is called, and before `router(_:didRerouteAlong:)` is called.
      

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -4,29 +4,9 @@ import MapboxDirections
 import Turf
 
 /**
- Configuration for offsetting first route maneuver during rerouting.
- */
-public enum ReroutingManeuverBuffer {
-    /**
-     Leaves original `RouteOptions.initialManeuverAvoidanceRadius` to be used for rerouting attempt.
-     */
-    case `default`
-    /**
-     Disables offsetting the maneuver.
-     */
-    case disabled
-    /**
-     Sets offset radius (in meters).
-     
-     Equivalent to setting `RouteOptions.initialManeuverAvoidanceRadius` to the same radius at the beginning.
-     */
-    case radius(LocationDistance)
-}
-
-/**
  Configuration for a source to get new `Route` when rerouting occurs.
  */
-public enum ReroutingRequest {
+public enum ReroutingRequestBehavior {
     public typealias ReroutingRequestData = (options: RouteOptions, result: Result<RouteResponse, DirectionsError>)
     
     /**
@@ -80,7 +60,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
      
      If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
-     This method is called after `router(_:willRerouteFrom:)` is called, and before `router(_:requestSourceForReroutingWith:)` is called.
+     This method is called after `router(_:willRerouteFrom:)` is called, and before `router(_:requestBehaviorForReroutingWith:)` is called.
      
      - parameter router: The router that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
@@ -98,10 +78,10 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
      This method is called after `router(_:initialManeuverBufferWhenReroutingFrom:)` is called, and before `router(_:didRerouteAlong:)` is called.
      
      - parameter router: The router that will calculate a new route.
-     - parameter location: The user’s current location.
+     - parameter options: `RouteOptions` that are supposed to be used for route calculation.
      - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
      */
-    func router(_ router: Router, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest
+    func router(_ router: Router, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -117,7 +97,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the router receives a new route.
      
-     This method is called after `router(_:requestSourceForReroutingWith:)` method is called.
+     This method is called after `router(_:requestBehaviorForReroutingWith:)` method is called.
      
      - parameter router: The router that has calculated a new route.
      - parameter route: The new route.
@@ -127,7 +107,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the router fails to receive a new route.
      
-     This method is called after `router(_:requestSourceForReroutingWith:)`.
+     This method is called after `router(_:requestBehaviorForReroutingWith:)`.
      
      - parameter router: The router that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -233,7 +213,7 @@ public extension RouterDelegate {
         return RouteController.DefaultBehavior.reroutingManeuverRadius
     }
     
-    func router(_ router: Router, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+    func router(_ router: Router, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
         return .default
     }

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -4,26 +4,6 @@ import MapboxDirections
 import Turf
 
 /**
- Configuration for offsetting first route maneuver during rerouting.
- */
-public enum ReroutingManeuverBuffer {
-    /**
-     Leaves original `RouteOptions.initialManeuverAvoidanceRadius` to be used for rerouting attempt.
-     */
-    case `default`
-    /**
-     Disables offsetting the maneuver.
-     */
-    case disabled
-    /**
-     Sets offset radius (in meters).
-     
-     Equivalent to setting `RouteOptions.initialManeuverAvoidanceRadius` to the same radius at the beginning.
-     */
-    case radius(LocationDistance)
-}
-
-/**
  A router delegate interacts with one or more `Router` instances, such as `RouteController` objects, during turn-by-turn navigation. This protocol is similar to `NavigationServiceDelegate`, which is the main way that your application can synchronize its state with the SDK’s location-related functionality. Normally, you should not need to make a class conform to the `RouterDelegate` protocol or call any of its methods directly, but you would need to call this protocol’s methods if you implement a custom `Router` class.
  
  `MapboxNavigationService` is the only concrete implementation of a router delegate. Implement the `NavigationServiceDelegate` protocol instead to be notified when various significant events occur along the route tracked by a `NavigationService`.
@@ -65,9 +45,9 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
      
      - parameter router: The router that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `ReroutingManeuverBuffer` value which overrides or leaves maneuvers offset as it was originally set.
+     - returns: `LocationDistance` value which overrides (by passing a non-nil value) or leaves maneuvers offset as it was originally set (by passing `nil`).
      */
-    func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer
+    func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance?
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -194,7 +174,7 @@ public extension RouterDelegate {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
     }
     
-    func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+    func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
         return RouteController.DefaultBehavior.reroutingManeuverRadius
     }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -724,7 +724,7 @@ extension NavigationViewController: NavigationServiceDelegate {
         delegate?.navigationViewController(self, willRerouteFrom: location)
     }
     
-    public func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+    public func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         return delegate?.navigationViewController(self, initialManeuverBufferWhenReroutingFrom: location) ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
     

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -728,8 +728,8 @@ extension NavigationViewController: NavigationServiceDelegate {
         return delegate?.navigationViewController(self, initialManeuverBufferWhenReroutingFrom: location) ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
     
-    public func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
-        return delegate?.navigationViewController(self, requestSourceForReroutingWith:options) ?? .default
+    public func navigationService(_ service: NavigationService, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior {
+        return delegate?.navigationViewController(self, requestBehaviorForReroutingWith:options) ?? .default
     }
     
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -724,6 +724,10 @@ extension NavigationViewController: NavigationServiceDelegate {
         delegate?.navigationViewController(self, willRerouteFrom: location)
     }
     
+    public func navigationService(_ service: NavigationService, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+        return delegate?.navigationViewController(self, maneuverOffsetWhenReroutingFrom: location) ?? RouteController.DefaultBehavior.reroutingManeuverRadius
+    }
+    
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
         for component in navigationComponents {
             component.navigationService(service, didRerouteAlong: route, at: location, proactive: proactive)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -718,7 +718,7 @@ extension NavigationViewController: NavigationServiceDelegate {
     
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         for component in navigationComponents {
-            component.navigationService(service, willRerouteFrom: location)
+            _ = component.navigationService(service, willRerouteFrom: location)
         }
         
         delegate?.navigationViewController(self, willRerouteFrom: location)
@@ -726,6 +726,10 @@ extension NavigationViewController: NavigationServiceDelegate {
     
     public func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         return delegate?.navigationViewController(self, initialManeuverBufferWhenReroutingFrom: location) ?? RouteController.DefaultBehavior.reroutingManeuverRadius
+    }
+    
+    public func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+        return delegate?.navigationViewController(self, requestSourceForReroutingWith:options) ?? .default
     }
     
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -724,8 +724,8 @@ extension NavigationViewController: NavigationServiceDelegate {
         delegate?.navigationViewController(self, willRerouteFrom: location)
     }
     
-    public func navigationService(_ service: NavigationService, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
-        return delegate?.navigationViewController(self, maneuverOffsetWhenReroutingFrom: location) ?? RouteController.DefaultBehavior.reroutingManeuverRadius
+    public func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+        return delegate?.navigationViewController(self, initialManeuverBufferWhenReroutingFrom: location) ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
     
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -103,7 +103,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Configures distance (in meters) before the first maneuver in requested reroute.
      
-     If implemented, this method allows to override set `RouteOptions.avoidManeuversInOriginRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
+     If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
      This method is called after `navigationViewController(_:willRerouteFrom:)` is called, and before `navigationViewController(_:didRerouteAlong:)` is called.
      

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -93,7 +93,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called immediately before the navigation view controller calculates a new route.
      
-     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:maneuverOffsetWhenReroutingFrom:)` is called.
+     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` is called.
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
      - parameter location: The user’s current location.
@@ -109,14 +109,14 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      
      - parameter router: The router that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `ReroutingManeuverOffset` value which overrides or leaves maneuvers offset as it was originally set.
+     - returns: `ReroutingManeuverBuffer` value which overrides or leaves maneuvers offset as it was originally set.
      */
-    func navigationViewController(_ navigationViewController: NavigationViewController, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset
+    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer
     
     /**
      Called immediately after the navigation view controller receives a new route.
      
-     This method is called after `navigationViewController(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter route: The new route.
@@ -126,7 +126,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called when the navigation view controller fails to receive a new route.
      
-     This method is called after `navigationViewController(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -293,7 +293,7 @@ public extension NavigationViewControllerDelegate {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
-    func navigationViewController(_ navigationViewController: NavigationViewController, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return RouteController.DefaultBehavior.reroutingManeuverRadius
     }

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -101,7 +101,6 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?)
     
@@ -110,7 +109,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      
      If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
-     This method is called after `navigationViewController(_:willRerouteFrom:)` is called, and before `navigationViewController(_:requestSourceForReroutingWith:)` is called.
+     This method is called after `navigationViewController(_:willRerouteFrom:)` is called, and before `navigationViewController(_:requestBehaviorForReroutingWith:)` is called.
      
      - parameter navigationViewController: The navigation view controller that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
@@ -128,14 +127,14 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      This method is called after `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` is called, and before `navigationViewController(_:didRerouteAlong:)` is called.
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
-     - parameter location: The user’s current location.
+     - parameter options: `RouteOptions` that are supposed to be used for route calculation.
      - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
      */
-    func navigationViewController(_ navigationViewController: NavigationViewController, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest
+    func navigationViewController(_ navigationViewController: NavigationViewController, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior
     /**
      Called immediately after the navigation view controller receives a new route.
      
-     This method is called after `navigationViewController(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationViewController(_:requestBehaviorForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter route: The new route.
@@ -145,7 +144,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called when the navigation view controller fails to receive a new route.
      
-     This method is called after `navigationViewController(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationViewController(_:requestBehaviorForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -323,7 +322,7 @@ public extension NavigationViewControllerDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
-    func navigationViewController(_ navigationViewController: NavigationViewController, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+    func navigationViewController(_ navigationViewController: NavigationViewController, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return .default
     }

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -93,10 +93,15 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called immediately before the navigation view controller calculates a new route.
      
+     This method also allows customizing the rerouting by providing custom `RouteResponse`. SDK will then treat it as if it was fetched as usual and apply as a reroute.
+     
+     - note: Multiple method calls will not interrupt the first ongoing request.
+     
      This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` is called.
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
      - parameter location: The user’s current location.
+     - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?)
     
@@ -105,18 +110,32 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      
      If implemented, this method allows to override set `RouteOptions.initialManeuverAvoidanceRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
      
-     This method is called after `navigationViewController(_:willRerouteFrom:)` is called, and before `navigationViewController(_:didRerouteAlong:)` is called.
+     This method is called after `navigationViewController(_:willRerouteFrom:)` is called, and before `navigationViewController(_:requestSourceForReroutingWith:)` is called.
      
-     - parameter router: The router that has detected the need to calculate a new route.
+     - parameter navigationViewController: The navigation view controller that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
      - returns: `LocationDistance` value which overrides (by passing a non-nil value) or leaves maneuvers offset as it was originally set (by passing `nil`).
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance?
     
     /**
+     Called when the navigation view controller calculates a new route.
+
+     This method allows customizing the rerouting by providing custom `RouteResponse`. SDK will then treat it as if it was fetched as usual and apply as a reroute.
+     
+     - note: Multiple method calls will not interrupt the first ongoing request.
+     
+     This method is called after `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` is called, and before `navigationViewController(_:didRerouteAlong:)` is called.
+     
+     - parameter navigationViewController: The navigation view controller that will calculate a new route.
+     - parameter location: The user’s current location.
+     - returns: `.default` to let the SDK handle retrieving new `Route`, or `.custom` to provide your own reroute.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest
+    /**
      Called immediately after the navigation view controller receives a new route.
      
-     This method is called after `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationViewController(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter route: The new route.
@@ -126,7 +145,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called when the navigation view controller fails to receive a new route.
      
-     This method is called after `navigationViewController(_:initialManeuverBufferWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationViewController(_:requestSourceForReroutingWith:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -293,9 +312,20 @@ public extension NavigationViewControllerDelegate {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return RouteController.DefaultBehavior.reroutingManeuverRadius
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+        return .default
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -93,7 +93,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called immediately before the navigation view controller calculates a new route.
      
-     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:didRerouteAlong:)` is called.
+     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:maneuverOffsetWhenReroutingFrom:)` is called.
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
      - parameter location: The user’s current location.
@@ -101,9 +101,22 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?)
     
     /**
+     Configures distance (in meters) before the first maneuver in requested reroute.
+     
+     If implemented, this method allows to override set `RouteOptions.avoidManeuversInOriginRadius` value which is useful when adjusting reroute according to current user velocity in order to avoid dangerous maneuvers in the beginning of the route.
+     
+     This method is called after `navigationViewController(_:willRerouteFrom:)` is called, and before `navigationViewController(_:didRerouteAlong:)` is called.
+     
+     - parameter router: The router that has detected the need to calculate a new route.
+     - parameter location: The user’s current location.
+     - returns: `ReroutingManeuverOffset` value which overrides or leaves maneuvers offset as it was originally set.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset
+    
+    /**
      Called immediately after the navigation view controller receives a new route.
      
-     This method is called after `navigationViewController(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationViewController(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter route: The new route.
@@ -113,7 +126,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called when the navigation view controller fails to receive a new route.
      
-     This method is called after `navigationViewController(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationViewController(_:maneuverOffsetWhenReroutingFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -278,6 +291,11 @@ public extension NavigationViewControllerDelegate {
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+    }
+    
+    func navigationViewController(_ navigationViewController: NavigationViewController, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+        return RouteController.DefaultBehavior.reroutingManeuverRadius
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -109,9 +109,9 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      
      - parameter router: The router that has detected the need to calculate a new route.
      - parameter location: The user’s current location.
-     - returns: `ReroutingManeuverBuffer` value which overrides or leaves maneuvers offset as it was originally set.
+     - returns: `LocationDistance` value which overrides (by passing a non-nil value) or leaves maneuvers offset as it was originally set (by passing `nil`).
      */
-    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer
+    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance?
     
     /**
      Called immediately after the navigation view controller receives a new route.
@@ -293,7 +293,7 @@ public extension NavigationViewControllerDelegate {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
-    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+    func navigationViewController(_ navigationViewController: NavigationViewController, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return RouteController.DefaultBehavior.reroutingManeuverRadius
     }

--- a/Sources/TestHelper/DirectionsSpy.swift
+++ b/Sources/TestHelper/DirectionsSpy.swift
@@ -6,6 +6,7 @@ public class DirectionsSpy: Directions {
     /// Callback fired when there is a request to caclulate a new route.
     public var onCalculateRoute: (() -> Void)?
     public var lastCalculateOptionsCompletion: RouteCompletionHandler?
+    public var lastCalculateOptions: DirectionsOptions?
     
     override public func calculate(_ options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> URLSessionDataTask {
         assert(false, "Not ready to handle \(#function)")
@@ -14,6 +15,7 @@ public class DirectionsSpy: Directions {
     
     override public func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> URLSessionDataTask {
         lastCalculateOptionsCompletion = completionHandler
+        lastCalculateOptions = options
         onCalculateRoute?()
         return DummyURLSessionDataTask()
     }

--- a/Sources/TestHelper/NavigationServiceTestDoubles.swift
+++ b/Sources/TestHelper/NavigationServiceTestDoubles.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreLocation
 import MapboxCoreNavigation
 import MapboxDirections
+import Turf
 
 public class RouteControllerDataSourceFake: RouterDataSource {
     let manager = NavigationLocationManager()
@@ -31,6 +32,16 @@ public class NavigationServiceDelegateSpy: NavigationServiceDelegate {
         recentMessages.append(#function)
     }
 
+    public func navigationService(_ service: NavigationService, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
+        recentMessages.append(#function)
+        return RouteController.DefaultBehavior.reroutingManeuverRadius
+    }
+
+    public func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+        recentMessages.append(#function)
+        return .default
+    }
+    
     public func navigationService(_ service: NavigationService, shouldDiscard location: CLLocation) -> Bool {
         recentMessages.append(#function)
         return false

--- a/Sources/TestHelper/NavigationServiceTestDoubles.swift
+++ b/Sources/TestHelper/NavigationServiceTestDoubles.swift
@@ -37,7 +37,7 @@ public class NavigationServiceDelegateSpy: NavigationServiceDelegate {
         return RouteController.DefaultBehavior.reroutingManeuverRadius
     }
 
-    public func navigationService(_ service: NavigationService, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+    public func navigationService(_ service: NavigationService, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior {
         recentMessages.append(#function)
         return .default
     }

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -20,7 +20,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onDidArriveAt: ((Waypoint) -> Bool)?
     public var onShouldPreventReroutesWhenArrivingAt: ((Waypoint) -> Bool)?
     public var onRouterShouldDisableBatteryMonitoring: (() -> Bool)?
-    public var onManeuverOffsetWhenRerouting: (() -> ReroutingManeuverOffset)?
+    public var onManeuverBufferWhenRerouting: (() -> ReroutingManeuverBuffer)?
 
     public init() {}
 
@@ -38,8 +38,8 @@ public final class RouterDelegateSpy: RouterDelegate {
         onWillRerouteFrom?(location)
     }
     
-    public func router(_ router: Router, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
-        return onManeuverOffsetWhenRerouting?() ?? RouteController.DefaultBehavior.reroutingManeuverRadius
+    public func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+        return onManeuverBufferWhenRerouting?() ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
 
     public func router(_ router: Router,

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -2,6 +2,7 @@ import Foundation
 import MapboxCoreNavigation
 import CoreLocation
 import MapboxDirections
+import Turf
 
 public final class RouterDelegateSpy: RouterDelegate {
     public var onDidRefresh: ((RouteProgress) -> Void)?
@@ -19,6 +20,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onDidArriveAt: ((Waypoint) -> Bool)?
     public var onShouldPreventReroutesWhenArrivingAt: ((Waypoint) -> Bool)?
     public var onRouterShouldDisableBatteryMonitoring: (() -> Bool)?
+    public var onManeuverOffsetWhenRerouting: (() -> ReroutingManeuverOffset)?
 
     public init() {}
 
@@ -34,6 +36,10 @@ public final class RouterDelegateSpy: RouterDelegate {
     public func router(_ router: Router,
                        willRerouteFrom location: CLLocation) {
         onWillRerouteFrom?(location)
+    }
+    
+    public func router(_ router: Router, maneuverOffsetWhenReroutingFrom location: CLLocation) -> ReroutingManeuverOffset {
+        return onManeuverOffsetWhenRerouting?() ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
 
     public func router(_ router: Router,

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -21,6 +21,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onShouldPreventReroutesWhenArrivingAt: ((Waypoint) -> Bool)?
     public var onRouterShouldDisableBatteryMonitoring: (() -> Bool)?
     public var onManeuverBufferWhenRerouting: (() -> LocationDistance?)?
+    public var onReroutingRequest: ((RouteOptions) -> ReroutingRequest)?
 
     public init() {}
 
@@ -42,6 +43,10 @@ public final class RouterDelegateSpy: RouterDelegate {
         return onManeuverBufferWhenRerouting?() ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
 
+    public func router(_ router: Router, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+        return onReroutingRequest?(options) ?? .default
+    }
+    
     public func router(_ router: Router,
                        shouldDiscard location: CLLocation) -> Bool {
         return onShouldDiscard?(location) ?? RouteController.DefaultBehavior.shouldDiscardLocation

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -20,7 +20,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onDidArriveAt: ((Waypoint) -> Bool)?
     public var onShouldPreventReroutesWhenArrivingAt: ((Waypoint) -> Bool)?
     public var onRouterShouldDisableBatteryMonitoring: (() -> Bool)?
-    public var onManeuverBufferWhenRerouting: (() -> ReroutingManeuverBuffer)?
+    public var onManeuverBufferWhenRerouting: (() -> LocationDistance?)?
 
     public init() {}
 
@@ -38,7 +38,7 @@ public final class RouterDelegateSpy: RouterDelegate {
         onWillRerouteFrom?(location)
     }
     
-    public func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> ReroutingManeuverBuffer {
+    public func router(_ router: Router, initialManeuverBufferWhenReroutingFrom location: CLLocation) -> LocationDistance? {
         return onManeuverBufferWhenRerouting?() ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
 

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -21,7 +21,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onShouldPreventReroutesWhenArrivingAt: ((Waypoint) -> Bool)?
     public var onRouterShouldDisableBatteryMonitoring: (() -> Bool)?
     public var onManeuverBufferWhenRerouting: (() -> LocationDistance?)?
-    public var onReroutingRequest: ((RouteOptions) -> ReroutingRequest)?
+    public var onReroutingRequest: ((RouteOptions) -> ReroutingRequestBehavior)?
 
     public init() {}
 
@@ -43,7 +43,7 @@ public final class RouterDelegateSpy: RouterDelegate {
         return onManeuverBufferWhenRerouting?() ?? RouteController.DefaultBehavior.reroutingManeuverRadius
     }
 
-    public func router(_ router: Router, requestSourceForReroutingWith options: RouteOptions) -> ReroutingRequest {
+    public func router(_ router: Router, requestBehaviorForReroutingWith options: RouteOptions) -> ReroutingRequestBehavior {
         return onReroutingRequest?(options) ?? .default
     }
     

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -503,6 +503,8 @@ class NavigationServiceTests: TestCase {
 
         // MARK: It tells the delegate & posts a didReroute notification
         wait(for: [didRerouteNotificationExpectation], timeout: 3)
+        XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:initialManeuverBufferWhenReroutingFrom:)"))
+        XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:requestSourceForReroutingWith:)"))
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:didRerouteAlong:at:proactive:)"))
 
         // MARK: On the next call to `locationManager(_, didUpdateLocations:)`

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -504,7 +504,7 @@ class NavigationServiceTests: TestCase {
         // MARK: It tells the delegate & posts a didReroute notification
         wait(for: [didRerouteNotificationExpectation], timeout: 3)
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:initialManeuverBufferWhenReroutingFrom:)"))
-        XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:requestSourceForReroutingWith:)"))
+        XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:requestBehaviorForReroutingWith:)"))
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:didRerouteAlong:at:proactive:)"))
 
         // MARK: On the next call to `locationManager(_, didUpdateLocations:)`

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -194,15 +194,16 @@ class RouteControllerTests: TestCase {
             return 500
         }
         
-        let calculateRouteCalled = expectation(description: "Calculate route called")
-        calculateRouteCalled.assertForOverFulfill = false
+        let radiusOverriden = expectation(description: "Dangerous maneuver radius should be changed.")
+        radiusOverriden.assertForOverFulfill = false
         
         MapboxRoutingProvider.__testRoutesStub = { (options, completionHandler) in
-            XCTAssertTrue(options.initialManeuverAvoidanceRadius == 500)
             DispatchQueue.main.async {
                 completionHandler(Directions.Session(options, .mocked),
                                   .success(routeResponse))
-                calculateRouteCalled.fulfill()
+                if options.initialManeuverAvoidanceRadius == 500 {
+                    radiusOverriden.fulfill()
+                }
             }
             return nil
         }

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -185,7 +185,7 @@ class RouteControllerTests: TestCase {
         locationManager.delegate = routeController
 
         routerDelegateSpy.onManeuverBufferWhenRerouting = {
-            return .radius(500)
+            return 500
         }
         
         let calculateRouteCalled = expectation(description: "Calculate route called")

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -202,6 +202,62 @@ class RouteControllerTests: TestCase {
         locationManager.startUpdatingLocation()
         waitForExpectations(timeout: TimeInterval(replyLocations.count) / speedMultiplier + 1, handler: nil)
     }
+    
+    func testReroutingWithCustomRoute() {
+        let origin = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let destination = CLLocationCoordinate2D(latitude: 0.001, longitude: 0.001)
+
+        let routeResponse = Fixture.route(between: origin, and: destination).response
+        let routeCoordinates = Fixture.generateCoordinates(between: origin, and: destination, count: 10)
+
+        let overshootingDestination = CLLocationCoordinate2D(latitude: 0.002, longitude: 0.002)
+        let replyLocations = Fixture.generateCoordinates(between: origin, and: overshootingDestination, count: 11).map {
+            CLLocation(coordinate: $0)
+        }.shiftedToPresent()
+
+        var newRoute: Route?
+        
+        let directions = DirectionsSpy()
+
+        let navOptions = NavigationRouteOptions(coordinates: routeCoordinates)
+        
+        let routeController = RouteController(alongRouteAtIndex: 0,
+                                              in: routeResponse,
+                                              options: navOptions,
+                                              directions: directions,
+                                              dataSource: self)
+
+        let routerDelegateSpy = RouterDelegateSpy()
+        routeController.delegate = routerDelegateSpy
+
+        let locationManager = ReplayLocationManager(locations: replyLocations)
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+
+        routerDelegateSpy.onReroutingRequest = { options in
+            return .custom {
+                let coordinate = options.waypoints.first!.coordinate
+                let newResponse = Fixture.route(between: coordinate, and: destination)
+                newRoute = newResponse.route
+                let newOptions = NavigationRouteOptions(coordinates: [coordinate, destination])
+                return (newOptions, .success(newResponse.response))
+            }
+        }
+        
+        let rerouteFinished = expectation(description: "Reroute finished")
+        rerouteFinished.assertForOverFulfill = false
+        
+        routerDelegateSpy.onDidRerouteAlong = { result in
+            XCTAssertEqual(result.route, newRoute!, "New route should be the custom one.")
+            
+            rerouteFinished.fulfill()
+        }
+        
+        let speedMultiplier: TimeInterval = 100
+        locationManager.speedMultiplier = speedMultiplier
+        locationManager.startUpdatingLocation()
+        waitForExpectations(timeout: TimeInterval(replyLocations.count) / speedMultiplier + 1, handler: nil)
+    }
 }
 
 extension RouteControllerTests: RouterDataSource {

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -169,7 +169,7 @@ class RouteControllerTests: TestCase {
         let directions = DirectionsSpy()
 
         let navOptions = NavigationRouteOptions(coordinates: routeCoordinates)
-        navOptions.avoidManeuversInOriginRadius = 100
+        navOptions.initialManeuverAvoidanceRadius = 100
         
         let routeController = RouteController(alongRouteAtIndex: 0,
                                               in: routeResponse,
@@ -192,8 +192,8 @@ class RouteControllerTests: TestCase {
         calculateRouteCalled.assertForOverFulfill = false
         
         directions.onCalculateRoute = { [unowned directions] in
-            XCTAssertTrue((directions.lastCalculateOptions as? RouteOptions)?.avoidManeuversInOriginRadius == 500)
-            
+            XCTAssertTrue((directions.lastCalculateOptions as? RouteOptions)?.initialManeuverAvoidanceRadius == 500)
+
             calculateRouteCalled.fulfill()
         }
 

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -184,7 +184,7 @@ class RouteControllerTests: TestCase {
         locationManager.startDate = Date()
         locationManager.delegate = routeController
 
-        routerDelegateSpy.onManeuverOffsetWhenRerouting = {
+        routerDelegateSpy.onManeuverBufferWhenRerouting = {
             return .radius(500)
         }
         

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -153,6 +153,55 @@ class RouteControllerTests: TestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func testRerouteDangerousManeuverOverride() {
+        let origin = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let destination = CLLocationCoordinate2D(latitude: 0.001, longitude: 0.001)
+
+        let routeResponse = Fixture.route(between: origin, and: destination).response
+        let routeCoordinates = Fixture.generateCoordinates(between: origin, and: destination, count: 10)
+
+        let overshootingDestination = CLLocationCoordinate2D(latitude: 0.002, longitude: 0.002)
+        let replyLocations = Fixture.generateCoordinates(between: origin, and: overshootingDestination, count: 11).map {
+            CLLocation(coordinate: $0)
+        }.shiftedToPresent()
+
+        let directions = DirectionsSpy()
+
+        let navOptions = NavigationRouteOptions(coordinates: routeCoordinates)
+        navOptions.avoidManeuversInOriginRadius = 100
+        
+        let routeController = RouteController(alongRouteAtIndex: 0,
+                                              in: routeResponse,
+                                              options: navOptions,
+                                              directions: directions,
+                                              dataSource: self)
+
+        let routerDelegateSpy = RouterDelegateSpy()
+        routeController.delegate = routerDelegateSpy
+
+        let locationManager = ReplayLocationManager(locations: replyLocations)
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+
+        routerDelegateSpy.onManeuverOffsetWhenRerouting = {
+            return .radius(500)
+        }
+        
+        let calculateRouteCalled = expectation(description: "Calculate route called")
+        calculateRouteCalled.assertForOverFulfill = false
+        
+        directions.onCalculateRoute = { [unowned directions] in
+            XCTAssertTrue((directions.lastCalculateOptions as? RouteOptions)?.avoidManeuversInOriginRadius == 500)
+            
+            calculateRouteCalled.fulfill()
+        }
+
+        let speedMultiplier: TimeInterval = 100
+        locationManager.speedMultiplier = speedMultiplier
+        locationManager.startUpdatingLocation()
+        waitForExpectations(timeout: TimeInterval(replyLocations.count) / speedMultiplier + 1, handler: nil)
+    }
 }
 
 extension RouteControllerTests: RouterDataSource {

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -89,6 +89,7 @@ class NavigationViewControllerTests: TestCase {
                 XCTFail("Navigation Service is nil"); return nil
             }
             let router = navigationService.router
+            router.reroutesProactively = false
             guard let firstCoord = router.routeProgress.nearbyShape.coordinates.first else {
                 XCTFail("First Coordinate is nil"); return nil
             }


### PR DESCRIPTION
Added `RouterDelegate/NavigationServiceDelegate/NavigationViewControllerDelegate` method to allow overriding  `RouteOptions.avoidManeuversInOriginRadius` for rerouting. This setting is useful for adjusting rerouting logic according to current user's velocity to not force him into unexpected turns.