### PR TITLE
Skip CI for docs commit

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -19,5 +19,5 @@ git checkout publisher-production
 BRANCH="docs-${VERSION}" # push directly to publisher-production when verified on a release tag
 git checkout "${BRANCH}" || git checkout -b "${BRANCH}"
 git add "${VERSION}"
-git commit -m "v${VERSION}"
+git commit -m "v${VERSION} [skip ci]"
 git push origin "${BRANCH}"


### PR DESCRIPTION
This allows skipping the Circle CI builds as they are not configured for the `publisher-production` branch.