### PR TITLE
Make sure NavNative Navigator created with the main thread runloop

### DIFF
--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -269,6 +269,8 @@ extension Navigator: ElectronicHorizonObserver {
 
 extension Navigator: NavigatorObserver {
     func onStatus(for origin: NavigationStatusOrigin, status: NavigationStatus) {
+        assert(Thread.isMainThread)
+
         let userInfo: [Navigator.NotificationUserInfoKey: Any] = [
             .originKey: origin,
             .statusKey: status,

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -42,9 +42,11 @@ class NativeHandlersFactory {
     }()
     
     lazy var navigator: MapboxNavigationNative.Navigator = {
-        MapboxNavigationNative.Navigator(config: configHandle,
-                                         cache: cacheHandle,
-                                         historyRecorder: historyRecorder)
+        onMainQueueSync { // Make sure that Navigator pick ups Main Thread RunLoop.
+            MapboxNavigationNative.Navigator(config: configHandle,
+                                             cache: cacheHandle,
+                                             historyRecorder: historyRecorder)
+        }
     }()
     
     lazy var cacheHandle: CacheHandle = {

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -266,11 +266,11 @@ open class RouteController: NSObject {
     }
     
     @objc private func navigationStatusDidChange(_ notification: NSNotification) {
+        assert(Thread.isMainThread)
+
         guard let userInfo = notification.userInfo,
               let status = userInfo[Navigator.NotificationUserInfoKey.statusKey] as? NavigationStatus else { return }
-        onMainQueueSync {
-            self.update(to: status)
-        }
+        update(to: status)
     }
 
     private func update(to status: NavigationStatus) {


### PR DESCRIPTION
At the moment, Nav SDK does most of the work on the main thread and we
need to make sure that callbacks are either called on the main thread or
scheduled to the main thread.

Fixes #3467