### PR TITLE
Remove RouteOptions NSCopying conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,10 +123,11 @@
 
 #### Rerouting
 
+* `RouteOptions` no longer conforms to `NSCopying`. Use `JSONEncoder` and `JSONDecoder` to get a copy of the `RouteOptions` object round-tripped through JSON. ([#3484](https://github.com/mapbox/mapbox-navigation-ios/pull/3484))
 * Added the `NavigationViewControllerDelegate.navigationViewController(_:shouldPreventReroutesWhenArrivingAt:)` method, which is called each time the user arrives at a waypoint. By default, this method returns true and prevents rerouting upon arriving. ([#3195](https://github.com/mapbox/mapbox-navigation-ios/pull/3195))
 * Renamed `RouteOptions.without(waypoint:)` to `RouteOptions.without(_:)`. ([#3192](https://github.com/mapbox/mapbox-navigation-ios/pull/3192))
 * Rerouting now uses a snapped location instead of a raw location from Core Location. ([#3361](https://github.com/mapbox/mapbox-navigation-ios/pull/3361))
-* Fixed an issue where a subclass of `NavigationRouteOptions` would turn into an ordinary `RouteOptions` when rerouting the user. ([#3192](https://github.com/mapbox/mapbox-navigation-ios/pull/3192))
+* Fixed an issue where a subclass of `NavigationRouteOptions` would turn into an ordinary `RouteOptions` when rerouting the user. ([#3192](https://github.com/mapbox/mapbox-navigation-ios/pull/3192), [#3484](https://github.com/mapbox/mapbox-navigation-ios/pull/3484))
 * Fixed an issue where the `RouteController.indexedRouteResponse` property would remain unchanged after the user is rerouted. ([#3344](https://github.com/mapbox/mapbox-navigation-ios/pull/3344]))
 * Fixed an issue where the `IndexedRouteResponse.routeIndex` of the `NavigationService.indexedRouteResponse` property would reset to zero after the user is rerouted. ([#3345](https://github.com/mapbox/mapbox-navigation-ios/pull/3345]))
 * Fixed an issue where the user would be rerouted even if `NavigationViewControllerDelegate.navigationViewController(_:shouldRerouteFrom:)` returned `false`. To implement reroute after arrival behavior, return `true` from this method and `false` from `NavigationViewControllerDelegate.navigationViewController(_:shouldPreventReroutesWhenArrivingAt:)`, then set `NavigationViewController.showsEndOfRouteFeedback` to `false`. ([#3195](https://github.com/mapbox/mapbox-navigation-ios/pull/3195))

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -34,7 +34,12 @@ open class RouteProgress: Codable {
             user.headingAccuracy = RouteProgress.reroutingAccuracy
         }
         let newWaypoints = [user] + remainingWaypointsForCalculatingRoute()
-        let newOptions = oldOptions.copy() as! RouteOptions
+        let newOptions: RouteOptions
+        do {
+            newOptions = try oldOptions.copy()
+        } catch {
+            newOptions = oldOptions
+        }
         newOptions.waypoints = newWaypoints
 
         return newOptions

--- a/Tests/MapboxCoreNavigationTests/Extensions/RouteOptionsTests.swift
+++ b/Tests/MapboxCoreNavigationTests/Extensions/RouteOptionsTests.swift
@@ -28,7 +28,8 @@ class RouteOptionsTests: XCTestCase {
             .init(latitude: 1, longitude: 1),
         ]
         let options = GolfCartRouteOptions(coordinates: coordinates, profileIdentifier: .automobile)
-        let copy = options.copy() as? GolfCartRouteOptions
+        var copy: GolfCartRouteOptions?
+        XCTAssertNoThrow(copy = try options.copy())
         XCTAssertNotNil(copy)
         XCTAssertTrue(copy?.urlQueryItems.contains(URLQueryItem(name: "passengers", value: "3")) ?? false)
     }


### PR DESCRIPTION
RouteOptions no longer conforms to NSCopying via an extension in MapboxCoreNavigation. Instead, the workaround for mapbox/mapbox-directions-swift#564 that was introduced in #3192 has been isolated into an internal, throwable method that `RouteOptions.without(_:)` and `RouteProgress.reroutingOptions(with:)` use to get a copy round-tripped through JSON. If the instance of RouteOptions (or a developer-defined subclass) fails to round-trip, these methods mutate the waypoints on the original object, as a last resort, to limit the fallout in the API.

Fixes #3478.

/cc @mapbox/navigation-ios