### PR TITLE
Fix mapView ornaments position

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aCx-td-5El">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aCx-td-5El">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,14 +14,18 @@
             <objects>
                 <viewController storyboardIdentifier="mainMap" id="BYZ-38-t0r" customClass="ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ecA-xF-EKz">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="816"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
                             <view alpha="0.69999999999999996" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tfo-Ic-OqD">
-                                <rect key="frame" x="16" y="578" width="343" height="30"/>
+                                <rect key="frame" x="16" y="771" width="382" height="30"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Long press to select a destination" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dEY-t6-Ect">
-                                        <rect key="frame" x="8" y="0.0" width="327" height="30"/>
+                                        <rect key="frame" x="8" y="0.0" width="366" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
@@ -35,37 +40,33 @@
                                     <constraint firstAttribute="trailing" secondItem="dEY-t6-Ect" secondAttribute="trailing" constant="8" id="xw9-0e-meb"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="52U-cY-V4s" userLabel="Bottom Background View">
-                                <rect key="frame" x="0.0" y="623" width="375" height="44"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tgD-cs-dAn">
-                                <rect key="frame" x="0.0" y="623" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="816" width="414" height="80"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iiq-Gf-SKY">
-                                        <rect key="frame" x="8" y="0.0" width="130" height="44"/>
-                                        <state key="normal" title="Simulate Locations"/>
-                                        <connections>
-                                            <action selector="simulateButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="76o-Mq-vnj"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nMe-Tl-a1N">
-                                        <rect key="frame" x="256" y="0.0" width="111" height="44"/>
+                                        <rect key="frame" x="280" y="8" width="111" height="30"/>
                                         <state key="normal" title="Start Navigation"/>
                                         <connections>
                                             <action selector="startButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xoh-ho-hPb"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iiq-Gf-SKY">
+                                        <rect key="frame" x="23" y="8" width="130" height="30"/>
+                                        <state key="normal" title="Simulate Locations"/>
+                                        <connections>
+                                            <action selector="simulateButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="76o-Mq-vnj"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="iiq-Gf-SKY" secondAttribute="bottom" id="7p5-1W-AI2"/>
-                                    <constraint firstAttribute="height" constant="44" id="NAn-eL-wzR"/>
-                                    <constraint firstItem="iiq-Gf-SKY" firstAttribute="top" secondItem="tgD-cs-dAn" secondAttribute="top" id="SNC-nT-W9c"/>
-                                    <constraint firstItem="iiq-Gf-SKY" firstAttribute="leading" secondItem="tgD-cs-dAn" secondAttribute="leading" constant="8" id="VMr-sP-IRW"/>
-                                    <constraint firstItem="nMe-Tl-a1N" firstAttribute="top" secondItem="tgD-cs-dAn" secondAttribute="top" id="h6j-5n-dYg"/>
-                                    <constraint firstAttribute="bottom" secondItem="nMe-Tl-a1N" secondAttribute="bottom" id="lTg-Mf-WlN"/>
-                                    <constraint firstAttribute="trailing" secondItem="nMe-Tl-a1N" secondAttribute="trailing" constant="8" id="yyl-3H-w1W"/>
+                                    <constraint firstItem="iiq-Gf-SKY" firstAttribute="top" secondItem="tgD-cs-dAn" secondAttribute="topMargin" id="GWI-9J-I7h"/>
+                                    <constraint firstItem="nMe-Tl-a1N" firstAttribute="top" secondItem="tgD-cs-dAn" secondAttribute="topMargin" id="MxG-xH-5bn"/>
+                                    <constraint firstAttribute="trailingMargin" secondItem="nMe-Tl-a1N" secondAttribute="trailing" constant="15" id="QH1-W9-l8T"/>
+                                    <constraint firstAttribute="bottomMargin" secondItem="nMe-Tl-a1N" secondAttribute="bottom" id="Yk8-xr-NZg"/>
+                                    <constraint firstItem="iiq-Gf-SKY" firstAttribute="leading" secondItem="tgD-cs-dAn" secondAttribute="leadingMargin" constant="15" id="goJ-Ni-9ao"/>
+                                    <constraint firstAttribute="bottomMargin" secondItem="iiq-Gf-SKY" secondAttribute="bottom" id="khX-e3-2yv"/>
+                                    <constraint firstItem="nMe-Tl-a1N" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iiq-Gf-SKY" secondAttribute="trailing" constant="20" id="w1y-S4-7Ff"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -73,14 +74,14 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstItem="52U-cY-V4s" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailing" id="9K1-Lm-Kxd"/>
-                            <constraint firstItem="52U-cY-V4s" firstAttribute="bottom" secondItem="8bC-Xf-vdC" secondAttribute="bottom" id="DpJ-Ay-3wD"/>
-                            <constraint firstItem="52U-cY-V4s" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="Feq-fR-8fo"/>
+                            <constraint firstItem="ecA-xF-EKz" firstAttribute="leading" secondItem="eNZ-Hz-1oT" secondAttribute="leading" id="CSR-dP-F4t"/>
                             <constraint firstItem="eNZ-Hz-1oT" firstAttribute="trailing" secondItem="tgD-cs-dAn" secondAttribute="trailing" id="Fgp-Hc-0OK"/>
-                            <constraint firstItem="eNZ-Hz-1oT" firstAttribute="bottom" secondItem="tgD-cs-dAn" secondAttribute="bottom" id="dZs-zT-gb0"/>
+                            <constraint firstItem="eNZ-Hz-1oT" firstAttribute="trailing" secondItem="ecA-xF-EKz" secondAttribute="trailing" id="WUQ-12-EKD"/>
+                            <constraint firstItem="ecA-xF-EKz" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="abx-Td-Lwo"/>
+                            <constraint firstAttribute="bottom" secondItem="tgD-cs-dAn" secondAttribute="bottom" id="dZs-zT-gb0"/>
                             <constraint firstItem="Tfo-Ic-OqD" firstAttribute="leading" secondItem="eNZ-Hz-1oT" secondAttribute="leading" constant="16" id="eEd-cM-pFc"/>
                             <constraint firstItem="tgD-cs-dAn" firstAttribute="leading" secondItem="eNZ-Hz-1oT" secondAttribute="leading" id="fio-xr-zWS"/>
-                            <constraint firstItem="52U-cY-V4s" firstAttribute="top" secondItem="Tfo-Ic-OqD" secondAttribute="bottom" constant="15" id="rRl-cZ-UWe"/>
+                            <constraint firstItem="tgD-cs-dAn" firstAttribute="top" secondItem="ecA-xF-EKz" secondAttribute="bottom" id="g9d-92-Ua7"/>
                             <constraint firstItem="tgD-cs-dAn" firstAttribute="top" secondItem="Tfo-Ic-OqD" secondAttribute="bottom" constant="15" id="sdu-md-ykj"/>
                             <constraint firstItem="eNZ-Hz-1oT" firstAttribute="trailing" secondItem="Tfo-Ic-OqD" secondAttribute="trailing" constant="16" id="veQ-GA-9Zk"/>
                         </constraints>
@@ -88,7 +89,7 @@
                     <navigationItem key="navigationItem" title="Mapbox Navigation" id="zxr-0T-HBr">
                         <barButtonItem key="leftBarButtonItem" id="XbQ-fY-lUb">
                             <button key="customView" hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="6ux-mK-LQF">
-                                <rect key="frame" x="16" y="7" width="83" height="30"/>
+                                <rect key="frame" x="20" y="7" width="83" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Clear map"/>
                                 <connections>
@@ -100,6 +101,7 @@
                     <connections>
                         <outlet property="clearMap" destination="6ux-mK-LQF" id="9M7-CK-q1M"/>
                         <outlet property="longPressHintView" destination="Tfo-Ic-OqD" id="gYu-YW-6FX"/>
+                        <outlet property="mapHostView" destination="ecA-xF-EKz" id="qiB-HW-7up"/>
                         <outlet property="simulationButton" destination="iiq-Gf-SKY" id="DHR-zB-Mwv"/>
                         <outlet property="startButton" destination="nMe-Tl-a1N" id="tCJ-tk-vph"/>
                     </connections>
@@ -107,14 +109,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
                 <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="Tey-e2-Fxu"/>
             </objects>
-            <point key="canvasLocation" x="8.8000000000000007" y="34.632683658170919"/>
+            <point key="canvasLocation" x="8.8000000000000007" y="33.990147783251231"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="Ctm-Jp-i2T">
             <objects>
                 <navigationController id="aCx-td-5El" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="RVz-Wl-lF8">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -130,22 +132,22 @@
             <objects>
                 <viewController storyboardIdentifier="custom" id="j9p-fX-jo4" customClass="CustomViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gqy-oH-EyZ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bFk-po-evo" customClass="NavigationMapView" customModule="MapboxNavigation">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xEg-9E-ca4" userLabel="Recenter">
-                                <rect key="frame" x="8" y="577" width="62" height="30"/>
+                                <rect key="frame" x="8" y="806" width="62" height="30"/>
                                 <state key="normal" title="Recenter"/>
                                 <connections>
                                     <action selector="recenterMap:" destination="j9p-fX-jo4" eventType="touchUpInside" id="xjV-KY-kRg"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="68P-Cf-VxO">
-                                <rect key="frame" x="157.5" y="587" width="60" height="60"/>
+                                <rect key="frame" x="177" y="782" width="60" height="60"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="60" id="LOt-aV-LJs"/>
@@ -174,18 +176,18 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zwg-TF-wCY" userLabel="Background">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="125"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="125"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zeb-q8-C2a" customClass="InstructionsBannerView" customModule="MapboxNavigation">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="125"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="125"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="125" id="JIN-44-TWV"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ocq-gm-39c">
-                                <rect key="frame" x="297" y="145" width="68" height="30"/>
+                                <rect key="frame" x="336" y="189" width="68" height="30"/>
                                 <state key="normal" title="Feedback"/>
                                 <connections>
                                     <action selector="showFeedback:" destination="j9p-fX-jo4" eventType="touchUpInside" id="ZNw-Hv-gpO"/>
@@ -225,4 +227,12 @@
             <point key="canvasLocation" x="1028" y="34.632683658170919"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -8,7 +8,8 @@ import MapboxCoreMaps
 import MapboxNavigation
 
 class ViewController: UIViewController {
-    
+
+    @IBOutlet weak var mapHostView: UIView!
     @IBOutlet weak var longPressHintView: UIView!
     @IBOutlet weak var simulationButton: UIButton!
     @IBOutlet weak var startButton: UIButton!
@@ -41,8 +42,8 @@ class ViewController: UIViewController {
             }
             
             if let navigationMapView = navigationMapView {
+                mapHostView.addSubview(navigationMapView)
                 configure(navigationMapView)
-                view.insertSubview(navigationMapView, belowSubview: longPressHintView)
             }
         }
     }
@@ -152,7 +153,7 @@ class ViewController: UIViewController {
         super.viewWillAppear(animated)
         
         if navigationMapView == nil {
-            navigationMapView = NavigationMapView(frame: view.bounds)
+            navigationMapView = NavigationMapView(frame: .zero)
             navigationMapView.mapView.mapboxMap.onEvery(.styleLoaded) { [weak self] _ in
                 self?.navigationMapView.localizeLabels()
             }
@@ -164,12 +165,21 @@ class ViewController: UIViewController {
 
         requestNotificationCenterAuthorization()
     }
-    
+
     private func configure(_ navigationMapView: NavigationMapView) {
         setupPassiveLocationProvider()
         
-        navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        
+        navigationMapView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            navigationMapView.topAnchor.constraint(equalTo: mapHostView.topAnchor),
+            navigationMapView.leadingAnchor.constraint(equalTo: mapHostView.leadingAnchor),
+            navigationMapView.bottomAnchor.constraint(equalTo: mapHostView.bottomAnchor),
+            navigationMapView.trailingAnchor.constraint(equalTo: mapHostView.trailingAnchor),
+        ])
+
+        let mapOrnamentsMargin: CGFloat = 55
+        navigationMapView.mapView.ornaments.options.logo.margins.y = mapOrnamentsMargin
+        navigationMapView.mapView.ornaments.options.attributionButton.margins.y = mapOrnamentsMargin
         navigationMapView.delegate = self
         navigationMapView.userLocationStyle = .puck2D()
         navigationMapView.mapView.mapboxMap.loadStyleURI(.navigationDay)


### PR DESCRIPTION
- NavigationMapView now placed in a special host view so that the
position can be layouted in the storyboard.
- Use Autolayout for positioning of the map.
- Set relevant MapView ornament parameters so that they are not
overlapped.

![Simulator Screen Shot - iPhone 13 - 2021-10-18 at 16 08 32](https://user-images.githubusercontent.com/413986/137737953-c6524d05-0400-4e99-a855-3260452249e4.png)

