### PR TITLE
Update default attributes per profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
 * Fixed an issue where `UIApplication.shared.isIdleTimerDisabled` was not properly set in some cases. ([#3245](https://github.com/mapbox/mapbox-navigation-ios/pull/3245))
 * Fixed an issue where `LegacyRouteController` could not correctly handle arrival to the intermediate waypoint of a multi leg route. ([#3483](https://github.com/mapbox/mapbox-navigation-ios/pull/3483))
 * Added the `Notification.Name.navigationServiceSimulationDidChange` to detect when the navigation service changes the simulating status, including `MapboxNavigationService.NotificationUserInfoKey.simulationStateKey` and `MapboxNavigationService.NotificationUserInfoKey.simulatedSpeedMultiplierKey`. ([#3393](https://github.com/mapbox/mapbox-navigation-ios/pull/3393)).
+* By default, `NavigationRouteOptions` requests `AttributeOptions.maximumSpeedLimit` attributes along the route with the `DirectionsProfileIdentifier.walking` profile as with other profiles. ([#3496](https://github.com/mapbox/mapbox-navigation-ios/pull/3496))
 
 ## v1.4.1
 

--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -23,10 +23,12 @@ open class NavigationRouteOptions: RouteOptions, OptimizedForNavigation {
             return $0
         }, profileIdentifier: profileIdentifier)
         includesAlternativeRoutes = true
-        if profileIdentifier == .walking {
-            attributeOptions = [.numericCongestionLevel, .expectedTravelTime]
+        attributeOptions = [.expectedTravelTime, .maximumSpeedLimit]
+        if profileIdentifier == .cycling {
+            // https://github.com/mapbox/mapbox-navigation-ios/issues/3495
+            attributeOptions.update(with: .congestionLevel)
         } else {
-            attributeOptions = [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit]
+            attributeOptions.update(with: .numericCongestionLevel)
         }
         includesExitRoundaboutManeuver = true
         if profileIdentifier == .automobileAvoidingTraffic {

--- a/Tests/MapboxCoreNavigationTests/OptionsTests.swift
+++ b/Tests/MapboxCoreNavigationTests/OptionsTests.swift
@@ -25,4 +25,20 @@ class OptionsTests: TestCase {
         XCTAssertTrue(options.includesVisualInstructions)
         XCTAssertTrue(options.includesSpokenInstructions)
     }
+    
+    func testDefaultAttributeOptions() {
+        XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates).attributeOptions,
+                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+        XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .automobile).attributeOptions,
+                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+        XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .automobileAvoidingTraffic).attributeOptions,
+                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+        // https://github.com/mapbox/mapbox-navigation-ios/issues/3495
+        XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .cycling).attributeOptions,
+                       [.congestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+        XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .walking).attributeOptions,
+                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+        XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .init(rawValue: "mapbox/unicycling")).attributeOptions,
+                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+    }
 }


### PR DESCRIPTION
Reverted to non-numeric congestion levels for cycling profile while the profile is powered by OSRM. Request speed limits for the walking profile too, because it no longer triggers an error. (Speed limits along walkways are rare, but if the route happens to traverse the roadway itself, then it might be interesting to know how fast motor vehicles can whiz by the user.)

Fixes #3495. Cherry-pick to release-v2.0 after merging.

/cc @mapbox/navigation-ios