### PR TITLE
Fixes crash in EndOfRouteViewController when keyWindow is nil

### DIFF
--- a/Sources/MapboxNavigation/EndOfRouteViewController.swift
+++ b/Sources/MapboxNavigation/EndOfRouteViewController.swift
@@ -132,8 +132,7 @@ class EndOfRouteViewController: UIViewController {
     }
     
     private func height(for height: ContainerHeight) -> CGFloat {
-        let window = UIApplication.shared.keyWindow
-        let bottomMargin = window!.safeArea.bottom
+        let bottomMargin = view.safeAreaInsets.bottom
         return height.rawValue + bottomMargin
     }
     


### PR DESCRIPTION
Instead of using the global key window, use the iOS 11 feature to get
save area insets.


