### PR TITLE
Remove redundant UIViewController.willMove(toParent:)

### DIFF
--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -601,7 +601,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
     
     func embed(_ child: UIViewController, in container: UIView, constrainedBy constraints: ((NavigationViewController, UIViewController) -> [NSLayoutConstraint])?) {
-        child.willMove(toParent: self)
         addChild(child)
         container.addSubview(child.view)
         if let childConstraints: [NSLayoutConstraint] = constraints?(self, child) {

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -73,7 +73,6 @@ extension NavigationMapView {
         }
         
         private func embed(_ child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])?) {
-            child.willMove(toParent: navigationViewData.containerViewController)
             navigationViewData.containerViewController.addChild(child)
             container.addSubview(child.view)
             if let childConstraints: [NSLayoutConstraint] = constraints?(navigationViewData.containerViewController, child) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -429,7 +429,6 @@ extension TopBannerViewController: NavigationComponent {
     }
     
     private func embed(_ child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])? = nil) {
-        child.willMove(toParent: self)
         addChild(child)
         container.addSubview(child.view)
         if let childConstraints: [NSLayoutConstraint] = constraints?(self, child) {

--- a/Tests/MapboxNavigationTests/XCTestCase.swift
+++ b/Tests/MapboxNavigationTests/XCTestCase.swift
@@ -43,7 +43,6 @@ extension XCTestCase {
     }
 
     func embed(parent:UIViewController, child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])?) {
-        child.willMove(toParent: parent)
         parent.addChild(child)
         container.addSubview(child.view)
         if let childConstraints: [NSLayoutConstraint] = constraints?(parent, child) {


### PR DESCRIPTION
This method is called automatically by UIViewController.addChild