### PR TITLE
Stop the location update in the background during active navigation using default course view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Added the `ReplayLocationManager.replayCompletionHandler` property that allows you to loop location. ([#3528](https://github.com/mapbox/mapbox-navigation-ios/pull/3528), [3550](https://github.com/mapbox/mapbox-navigation-ios/pull/3550))
 * Changed the behavior of `ReplayLocationManager` so that it doesn't loop locations by default. ([#3550](https://github.com/mapbox/mapbox-navigation-ios/pull/3550))
 * Fixed an issue where `ReplayLocationManager` didn't update location timestamps when a new loop started. ([#3550](https://github.com/mapbox/mapbox-navigation-ios/pull/3550))
+* Fixed the background location update issue during active navigation when using default `.courseView` for `NavigationMapView.userLocationStyle`. ([#3533](https://github.com/mapbox/mapbox-navigation-ios/pull/3533))
 
 ### Banners and guidance instructions
 

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -375,6 +375,7 @@ open class CarPlayNavigationViewController: UIViewController {
         navigationService.start()
         carPlayManager.delegate?.carPlayManager(carPlayManager, didBeginNavigationWith: navigationService)
         currentLegIndexMapped = navigationService.router.routeProgress.legIndex
+        navigationMapView?.inActiveNavigation = true
         navigationMapView?.simulatesLocation = navigationService.locationManager.simulatesLocation
         
         updateTripEstimateStyle(traitCollection.userInterfaceStyle)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -573,6 +573,11 @@ open class NavigationMapView: UIView {
             setupUserLocation()
         }
     }
+    var inActiveNavigation: Bool = false {
+        didSet {
+            setupUserLocation()
+        }
+    }
     
     /**
      Most recent user location, which is used to place `UserCourseView`.
@@ -604,7 +609,7 @@ open class NavigationMapView: UIView {
         } else {
             switch userLocationStyle {
             case .courseView(let courseView):
-                mapView.location.options.puckType = .puck2D(emptyPuckConfiguration)
+                mapView.location.options.puckType = inActiveNavigation ? nil : .puck2D(emptyPuckConfiguration)
                 
                 courseView.tag = NavigationMapView.userCourseViewTag
                 mapView.addSubview(courseView)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1404,7 +1404,7 @@ open class NavigationMapView: UIView {
                     self.travelAlongRouteLine(to: location.coordinate)
                 }
             default:
-                if self.simulatesLocation && self.inActiveNavigation, let locationProvider = self.mapView.location.locationProvider {
+                if self.simulatesLocation, self.inActiveNavigation, let locationProvider = self.mapView.location.locationProvider {
                     self.mapView.location.locationProvider(locationProvider, didUpdateLocations: [location])
                 }
             }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1404,7 +1404,7 @@ open class NavigationMapView: UIView {
                     self.travelAlongRouteLine(to: location.coordinate)
                 }
             default:
-                if self.simulatesLocation, let locationProvider = self.mapView.location.locationProvider {
+                if self.simulatesLocation && self.inActiveNavigation, let locationProvider = self.mapView.location.locationProvider {
                     self.mapView.location.locationProvider(locationProvider, didUpdateLocations: [location])
                 }
             }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -236,6 +236,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
                               routeProgress: navigationService.routeProgress)
         }
 
+        navigationMapView?.inActiveNavigation = true
         navigationMapView?.simulatesLocation = navigationService.locationManager.simulatesLocation
     }
     


### PR DESCRIPTION
### Description

This pr is to stop the location update in the background of the `mapView` during the active navigation when users using the default course view for the user location indicator layer.

Right now we have 2 types of user indicator layers, the map puck and the `.courseView`. During the active navigation, if we choose the map puck, we rely on the location update from `mapView` to update the location of user location indicator and the vanishing route line, so they could keep in sync.

But when we use the default `.courseView`, the user indicator layer and the vanishing route line are both listen to the router. If there're location updates in the background of the `mapView` during the active navigation, it could trigger the navigator to gives different location and `routeProgress`, which lead to a jumping location of user location indicator and the flickering of vanishing route line effect due to the `fractionTraveled` is calculated based on the location.

And because the map side decides to open or shut down location update based on the `puckType` , we right now have an empty `puck2D` to make sure we are able to receive location when using a standalone `navigationMapView`. But in active navigation when we choose the default `.courseView` we should stop the location update in the background like before to avoid the drifting location information.

https://github.com/mapbox/mapbox-maps-ios/blob/75f38ef5c15a7ff97bd41f4243ad343befcd3e6a/Sources/MapboxMaps/Location/LocationManager.swift#L183-L205