### PR TITLE
Add preventive checks to make sure that before running camera animations coordinate is valid.

### DIFF
--- a/Sources/MapboxNavigation/NavigationCameraStateTransition.swift
+++ b/Sources/MapboxNavigation/NavigationCameraStateTransition.swift
@@ -85,6 +85,7 @@ public class NavigationCameraStateTransition: CameraStateTransition {
     public func update(to cameraOptions: CameraOptions, state: NavigationCameraState) {
         guard let mapView = mapView,
               let center = cameraOptions.center,
+              CLLocationCoordinate2DIsValid(center),
               let zoom = cameraOptions.zoom,
               let bearing = (state == .overview) ? 0.0 : cameraOptions.bearing,
               let pitch = cameraOptions.pitch,
@@ -303,6 +304,7 @@ public class NavigationCameraStateTransition: CameraStateTransition {
     func transition(_ transitionParameters: TransitionParameters, completion: @escaping (() -> Void)) {
         guard let mapView = mapView,
               let center = transitionParameters.cameraOptions.center,
+              CLLocationCoordinate2DIsValid(center),
               let zoom = transitionParameters.cameraOptions.zoom,
               let bearing = transitionParameters.cameraOptions.bearing,
               let pitch = transitionParameters.cameraOptions.pitch,

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -673,6 +673,39 @@ class NavigationCameraTests: TestCase {
                        "OverviewCameraOptions instances should be equal.")
     }
     
+    func testInvalidCameraOptions() {
+        let navigationMapView = NavigationMapView(frame: .zero)
+        
+        let navigationCameraStateTransition = NavigationCameraStateTransition(navigationMapView.mapView)
+        
+        let invalidCoordinates = [
+            CLLocationCoordinate2D(latitude: CLLocationDegrees.nan,
+                                   longitude: CLLocationDegrees.nan),
+            CLLocationCoordinate2D(latitude: Double.greatestFiniteMagnitude,
+                                   longitude: Double.greatestFiniteMagnitude),
+            CLLocationCoordinate2D(latitude: Double.leastNormalMagnitude,
+                                   longitude: Double.greatestFiniteMagnitude)
+        ]
+        
+        invalidCoordinates.forEach { invalidCoordinate in
+            let cameraOptions = CameraOptions(center: invalidCoordinate,
+                                              padding: .zero,
+                                              anchor: .zero,
+                                              zoom: 15.0,
+                                              bearing: 0.0,
+                                              pitch: 45.0)
+            
+            XCTAssertNoThrow(navigationCameraStateTransition.update(to: cameraOptions, state: .overview),
+                             "Update animation should not be performed for invalid coordinate.")
+            
+            XCTAssertNoThrow(navigationCameraStateTransition.transitionToOverview(cameraOptions, completion: {}),
+                             "Transition animation should not be performed for invalid coordinate.")
+            
+            XCTAssertNoThrow(navigationCameraStateTransition.transitionToFollowing(cameraOptions, completion: {}),
+                             "Transition animation should not be performed for invalid coordinate.")
+        }
+    }
+    
     // MARK: - Helper methods
     
     func route(from file: String) -> Route? {


### PR DESCRIPTION
PR adds preventive checks to make sure that before running camera animations coordinate is valid.