### PR TITLE
Fix distance measurement system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 ### Other changes
 
 * Renamed the `Locale.usesMetric` property to `Locale.measuresDistancesInMetricUnits`. `Locale.usesMetric` is still available but deprecated. ([#3547](https://github.com/mapbox/mapbox-navigation-ios/pull/3547))
-* Fixed an issue where setting `DirectionsOptions.distanceMeasurementSystem` did not affect the units displayed in the user interface. ([#3541](https://github.com/mapbox/mapbox-navigation-ios/pull/3541))
+* Fixed an issue where the user interface did not necessarily display distances in the same units as the route by default. `NavigationRouteOptions` and `NavigationMatchOptions` now set `DirectionsOptions.distanceMeasurementSystem` to a default value matching the `NavigationSettings.distanceUnit` property. ([#3541](https://github.com/mapbox/mapbox-navigation-ios/pull/3541))
 
 ## v2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 ### Other changes
 
 * Renamed the `Locale.usesMetric` property to `Locale.measuresDistancesInMetricUnits`. `Locale.usesMetric` is still available but deprecated. ([#3547](https://github.com/mapbox/mapbox-navigation-ios/pull/3547))
+* Fixed an issue where setting `DirectionsOptions.distanceMeasurementSystem` did not affect the units displayed in the user interface. ([#3541](https://github.com/mapbox/mapbox-navigation-ios/pull/3541))
 
 ## v2.0.1
 

--- a/Sources/MapboxCoreNavigation/DistanceFormatter.swift
+++ b/Sources/MapboxCoreNavigation/DistanceFormatter.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+import MapboxDirections
 
 struct RoundingTable {
     struct Threshold {
@@ -73,7 +74,7 @@ extension Measurement where UnitType == UnitLength {
      */
     public func localized(into locale: Locale = .nationalizedCurrent) -> Measurement<UnitLength> {
         let threshold: RoundingTable
-        if NavigationSettings.shared.usesMetric {
+        if MeasurementSystem(NavigationSettings.shared.distanceUnit) == .metric {
             threshold = .metric
         } else if locale.languageCode == "en" && locale.regionCode == "GB" {
             threshold = .uk

--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -139,7 +139,7 @@ extension OptimizedForNavigation {
         routeShapeResolution = .full
         includesSpokenInstructions = true
         locale = Locale.nationalizedCurrent
-        distanceMeasurementSystem = Locale.current.usesMetricSystem ? .metric : .imperial
+        distanceMeasurementSystem = .init(NavigationSettings.shared.distanceUnit)
         includesVisualInstructions = true
     }
 }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -308,8 +308,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
         
         let routerType = routerType ?? DefaultRouter.self
         _router = routerType.init(alongRouteAtIndex: routeIndex, in: routeResponse, options: routeOptions, directions: self.directions, dataSource: self)
-        NavigationSettings.shared.distanceUnit = routeOptions.locale.measuresDistancesInMetricUnits ? .kilometer : .mile
-        
+        NavigationSettings.shared.distanceUnit = .init(routeOptions.distanceMeasurementSystem)
+
         let eventType = eventsManagerType ?? NavigationEventsManager.self
         _eventsManager = eventType.init(activeNavigationDataSource: self,
                                         accessToken: self.directions.credentials.accessToken)

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -122,25 +122,11 @@ public class NavigationSettings {
     
     /**
      Specifies the preferred distance measurement unit.
-     - note: Anything but `kilometer` and `mile` will fall back to the default measurement for the current locale.
-        Meters and feets will be used when the presented distances are small enough. See `DistanceFormatter` for more information.
+     - Meters and feet will be used when the presented distances are small enough. See `DistanceFormatter` for more information.
      */
     public dynamic var distanceUnit : LengthFormatter.Unit = Locale.current.measuresDistancesInMetricUnits ? .kilometer : .mile {
         didSet {
             notifyChanged(property: .distanceUnit, value: distanceUnit.rawValue)
-        }
-    }
-    
-    var usesMetric: Bool {
-        get {
-            switch distanceUnit {
-            case .kilometer:
-                return true
-            case .mile:
-                return false
-            default:
-                return Locale.current.measuresDistancesInMetricUnits
-            }
         }
     }
     

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -122,7 +122,7 @@ public class NavigationSettings {
     
     /**
      Specifies the preferred distance measurement unit.
-     - Meters and feet will be used when the presented distances are small enough. See `DistanceFormatter` for more information.
+     Meters and feet will be used when the presented distances are small enough. See `DistanceFormatter` for more information.
      */
     public dynamic var distanceUnit : LengthFormatter.Unit = Locale.current.measuresDistancesInMetricUnits ? .kilometer : .mile {
         didSet {

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -187,3 +187,18 @@ extension String {
         return "MB" + self
     }
 }
+
+extension MeasurementSystem {
+    /// :nodoc: Converts `LengthFormatter.Unit` into `MapboxDirections.MeasurementSystem`.
+    public init(_ lengthUnit: LengthFormatter.Unit) {
+        let metricUnits: [LengthFormatter.Unit] = [.kilometer, .centimeter, .meter, .millimeter]
+        self = metricUnits.contains(lengthUnit) ? .metric : .imperial
+    }
+}
+
+extension LengthFormatter.Unit {
+    /// :nodoc: Converts `MapboxDirections.MeasurementSystem` into `LengthFormatter.Unit`.
+    public init(_ measurementSystem: MeasurementSystem) {
+        self = measurementSystem == .metric ? .kilometer : .mile
+    }
+}

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -220,8 +220,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
                                        simulating: navigationOptions?.simulationMode)
         navigationService.delegate = self
         
-        NavigationSettings.shared.distanceUnit = .init(routeOptions.distanceMeasurementSystem)
-
         setupControllers(navigationOptions)
         setupStyleManager(navigationOptions)
         

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -220,8 +220,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
                                        simulating: navigationOptions?.simulationMode)
         navigationService.delegate = self
         
-        NavigationSettings.shared.distanceUnit = routeOptions.locale.measuresDistancesInMetricUnits ? .kilometer : .mile
-        
+        NavigationSettings.shared.distanceUnit = .init(routeOptions.distanceMeasurementSystem)
+
         setupControllers(navigationOptions)
         setupStyleManager(navigationOptions)
         

--- a/Tests/MapboxCoreNavigationTests/MeasurementSystemTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MeasurementSystemTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import TestHelper
+import MapboxCoreNavigation
+import MapboxDirections
+import XCTest
+
+final class MeasurementSystemTests: TestCase {
+    func testConversionFromLengthUnit() {
+        let expectedConversions: [LengthFormatter.Unit: MeasurementSystem] = [
+            .kilometer: .metric,
+            .centimeter: .metric,
+            .meter: .metric,
+            .millimeter: .metric,
+            .foot: .imperial,
+            .inch: .imperial,
+            .mile: .imperial,
+            .yard: .imperial,
+        ]
+
+        var actualConversions: [LengthFormatter.Unit: MeasurementSystem] = [:]
+        for lengthUnit in expectedConversions.keys {
+            actualConversions[lengthUnit] = .init(lengthUnit)
+        }
+
+        XCTAssertEqual(actualConversions, expectedConversions)
+    }
+
+    func testConversionToLengthUnit() {
+        let expectedConversions: [MeasurementSystem: LengthFormatter.Unit] = [
+            .metric: .kilometer,
+            .imperial: .mile,
+        ]
+
+        var actualConversions: [MeasurementSystem: LengthFormatter.Unit] = [:]
+        for measurementSystem in expectedConversions.keys {
+            actualConversions[measurementSystem] = .init(measurementSystem)
+        }
+
+        XCTAssertEqual(actualConversions, expectedConversions)
+    }
+}


### PR DESCRIPTION
# deea28cf6b6889f3794f94056207bfcad48296b5

Fixes #2578

Prefers distance measurement system from RouteOptions instead of just current locale. It allows having US locale and metric system distance. 

NavigationRouteOptions now reads global NavigationSettings for preferred distance measurement system. This fixes CarPlay implementation for route previews. 

# a6ee65d9f30f211e4b83cb90f275026187791e37

Deletes misleading property from NavigationSettings.