### PR TITLE
Fix issue, which was causing panning dismissal button to stop working on CarPlay.

### DIFF
--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -399,15 +399,16 @@ extension CarPlayManager: CPApplicationDelegate {
         guard let carPlayMapViewController = carPlayMapViewController else {
             return nil
         }
-        var mapButtons = [
+        
+        let panMapButton = carPlayMapViewController.panningInterfaceDisplayButton(for: mapTemplate)
+        carPlayMapViewController.panMapButton = panMapButton
+        
+        let mapButtons = [
             carPlayMapViewController.recenterButton,
+            panMapButton,
             carPlayMapViewController.zoomInButton,
             carPlayMapViewController.zoomOutButton
         ]
-        let panMapButton = carPlayMapViewController.panMapButton ??
-            carPlayMapViewController.panningInterfaceDisplayButton(for: mapTemplate)
-        carPlayMapViewController.panMapButton = panMapButton
-        mapButtons.insert(panMapButton, at: 1)
         
         return mapButtons
     }
@@ -760,8 +761,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
                                                      for: currentActivity) {
             mapTemplate.mapButtons = mapButtons
         } else {
-            let closeButton = carPlayMapViewController.dismissPanningButton ??
-                carPlayMapViewController.panningInterfaceDismissalButton(for: mapTemplate)
+            let closeButton = carPlayMapViewController.panningInterfaceDismissalButton(for: mapTemplate)
             carPlayMapViewController.dismissPanningButton = closeButton
             mapTemplate.mapButtons = [closeButton]
         }

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -151,7 +151,9 @@ open class CarPlayMapViewController: UIViewController {
      */
     @discardableResult public func panningInterfaceDismissalButton(for mapTemplate: CPMapTemplate) -> CPMapButton {
         let defaultButtons = mapTemplate.mapButtons
-        let closeButton = CPMapButton { _ in
+        let closeButton = CPMapButton { [weak mapTemplate] _ in
+            guard let mapTemplate = mapTemplate else { return }
+            
             mapTemplate.mapButtons = defaultButtons
             mapTemplate.dismissPanningInterface(animated: true)
         }


### PR DESCRIPTION
PR fixes an issue, which was causing close panning button to stop working after several active-guidance navigation sessions. Root cause of this was that `closeButton` was always using the same `CPMapTemplate` even after several dismissals and presentations.

Closing #3539.