### PR TITLE
Fix the scrolling guidance cards during orientation change crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Banners and guidance instructions
 
-* Fixed the crash when scrolling the guidance cards while the orienttaion change during active navigation. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
+* Fixed the crash when scrolling the guidance cards while the orientaion changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
 
 ## v2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Fixed an issue where `ReplayLocationManager` would crash if initialized with just one location. ([#3528](https://github.com/mapbox/mapbox-navigation-ios/pull/3528))
 * Added the `ReplayLocationManager.onReplayLoopCompleted` property that allows you to stop the location manager from looping back to the beginning of the route. ([#3528](https://github.com/mapbox/mapbox-navigation-ios/pull/3528))
 
+### Banners and guidance instructions
+
+* Fixed the crash when scrolling the guidance cards while the orienttaion change during active navigation. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
+
 ## v2.0.1
 
 * Added the `Notification.Name.didArriveAtWaypoint` constant for notifications posted when the user arrives at a waypoint. ([#3514](https://github.com/mapbox/mapbox-navigation-ios/pull/3514))

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -246,6 +246,7 @@ open class InstructionsCardViewController: UIViewController {
     
     @objc func orientationDidChange(_ notification: Notification) {
         instructionsCardLayout.invalidateLayout()
+        guard let itemCount = steps?.count, itemCount >= 0 && indexBeforeSwipe.row < itemCount else { return }
         handlePagingforScrollToItem(indexPath: indexBeforeSwipe)
     }
 }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -181,11 +181,11 @@ open class InstructionsCardViewController: UIViewController {
     }
     
     func snapToIndexPath(_ indexPath: IndexPath) {
-        guard let itemCount = steps?.count, itemCount >= 0 && indexPath.row < itemCount else { return }
         handlePagingforScrollToItem(indexPath: indexPath)
     }
     
     func handlePagingforScrollToItem(indexPath: IndexPath) {
+        guard let itemCount = steps?.count, indexPath.row < itemCount else { return }
         if #available(iOS 14.0, *) {
             instructionsCardLayout.collectionView?.isPagingEnabled = false
             instructionsCardLayout.collectionView?.scrollToItem(at: indexPath, at: direction, animated: true)
@@ -246,7 +246,6 @@ open class InstructionsCardViewController: UIViewController {
     
     @objc func orientationDidChange(_ notification: Notification) {
         instructionsCardLayout.invalidateLayout()
-        guard let itemCount = steps?.count, itemCount >= 0 && indexBeforeSwipe.row < itemCount else { return }
         handlePagingforScrollToItem(indexPath: indexBeforeSwipe)
     }
 }


### PR DESCRIPTION
### Description
This pr is to fix #3502 

### Implementation
By adding the items count check before the` InstructionsCardViewController.handlePagingforScrollToItem(indexPath:)` would prevent the crash, which is happening of scrolling the guidance card hard during the orientation change animation.

For example, there're some cases that when the orientation change and the swiping the guidance cards hard, the remanning steps is decreasing, it would lead to the `steps.count` as `7`, while the `indexBeforeSwipe.row` as `7`, it would lead to the crash.  The items count check would prevent this rare edge case.