### PR TITLE
Deprecate custom usesMetric in favor of iOS defined usesMetricSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 * Fixed an issue where the entire route line was colored as `NavigationMapView.routeCasingColor` instead of `NavigationMapView.trafficUnknownColor` when traffic congestion data was missing. ([#3577](https://github.com/mapbox/mapbox-navigation-ios/pull/3577))
 * Fixed an issue where `RouteStepProgress.currentIntersection` was always returning invalid value, which in turn caused inability to correctly detect whether specific location along the route is in tunnel, or not. ([#3559](https://github.com/mapbox/mapbox-navigation-ios/pull/3559))
 
+### Other changes
+
+* Renamed the `Locale.usesMetric` property to `Locale.measuresDistancesInMetricUnits`. `Locale.usesMetric` is still available but deprecated. ([#3547](https://github.com/mapbox/mapbox-navigation-ios/pull/3547))
+
 ## v2.0.1
 
 * Added the `Notification.Name.didArriveAtWaypoint` constant for notifications posted when the user arrives at a waypoint. ([#3514](https://github.com/mapbox/mapbox-navigation-ios/pull/3514))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Banners and guidance instructions
 
-* Fixed the crash when scrolling the guidance cards while the orientaion changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
+* Fixed the crash when scrolling the guidance cards while the orientation changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
 
 ### Map
 
@@ -47,7 +47,7 @@
 * Added the `CarPlayManager.currentActivity` property to determine how a `CPTemplate` is being used. ([#3521](https://github.com/mapbox/mapbox-navigation-ios/pull/3521))
 * Fixed an issue where setting `StyleManager.styles` to an array of only one style did not immediately apply the style. ([#3508](https://github.com/mapbox/mapbox-navigation-ios/pull/3508))
 * Fixed an issue in CarPlay’s previewing activity where only the selected route was visible on the map, while other alternative routes were hidden. Now all the routes are visible simultaneously. ([#3511](https://github.com/mapbox/mapbox-navigation-ios/pull/3511))
-* Fixed an issue where the route line flashed when the user arrived at the destination if `NavigationViewcontroller.routeLineTracksTraversal` was enabled. ([#3516](https://github.com/mapbox/mapbox-navigation-ios/pull/3516))
+* Fixed an issue where the route line flashed when the user arrived at the destination if `NavigationViewController.routeLineTracksTraversal` was enabled. ([#3516](https://github.com/mapbox/mapbox-navigation-ios/pull/3516))
 
 ### Banners and guidance instructions
 

--- a/Sources/MapboxCoreNavigation/Locale.swift
+++ b/Sources/MapboxCoreNavigation/Locale.swift
@@ -24,15 +24,17 @@ extension Locale {
      */
     public static var nationalizedCurrent = Locale(identifier: preferredLocalLanguageCountryCode)
     
+    @available(*, deprecated, message: "Use Locale.current.measuresDistancesInMetricUnits instead")
     public static var usesMetric: Bool {
-        let locale = self.current as NSLocale
-        guard let measurementSystem = locale.object(forKey: .measurementSystem) as? String else {
-            return false
-        }
-        return measurementSystem == "Metric"
+        Locale.current.measuresDistancesInMetricUnits
     }
-    
+
+    @available(*, deprecated, renamed: "measuresDistancesInMetricUnits")
     public var usesMetric: Bool {
+        measuresDistancesInMetricUnits
+    }
+
+    public var measuresDistancesInMetricUnits: Bool {
         let locale = self as NSLocale
         guard let measurementSystem = locale.object(forKey: .measurementSystem) as? String else {
             return false

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -308,7 +308,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         
         let routerType = routerType ?? DefaultRouter.self
         _router = routerType.init(alongRouteAtIndex: routeIndex, in: routeResponse, options: routeOptions, directions: self.directions, dataSource: self)
-        NavigationSettings.shared.distanceUnit = routeOptions.locale.usesMetric ? .kilometer : .mile
+        NavigationSettings.shared.distanceUnit = routeOptions.locale.measuresDistancesInMetricUnits ? .kilometer : .mile
         
         let eventType = eventsManagerType ?? NavigationEventsManager.self
         _eventsManager = eventType.init(activeNavigationDataSource: self,

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -125,7 +125,7 @@ public class NavigationSettings {
      - note: Anything but `kilometer` and `mile` will fall back to the default measurement for the current locale.
         Meters and feets will be used when the presented distances are small enough. See `DistanceFormatter` for more information.
      */
-    public dynamic var distanceUnit : LengthFormatter.Unit = Locale.current.usesMetric ? .kilometer : .mile {
+    public dynamic var distanceUnit : LengthFormatter.Unit = Locale.current.measuresDistancesInMetricUnits ? .kilometer : .mile {
         didSet {
             notifyChanged(property: .distanceUnit, value: distanceUnit.rawValue)
         }
@@ -139,7 +139,7 @@ public class NavigationSettings {
             case .mile:
                 return false
             default:
-                return Locale.current.usesMetric
+                return Locale.current.measuresDistancesInMetricUnits
             }
         }
     }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -220,7 +220,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
                                        simulating: navigationOptions?.simulationMode)
         navigationService.delegate = self
         
-        NavigationSettings.shared.distanceUnit = routeOptions.locale.usesMetric ? .kilometer : .mile
+        NavigationSettings.shared.distanceUnit = routeOptions.locale.measuresDistancesInMetricUnits ? .kilometer : .mile
         
         setupControllers(navigationOptions)
         setupStyleManager(navigationOptions)


### PR DESCRIPTION
iOS has standard `usesMetricSystem` variable that [works differently](https://github.com/mapbox/mapbox-navigation-ios/pull/3547#discussion_r741311298) for UK locale
