### PR TITLE
Allow the customization of TopBannerViewController.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@
 ### Banners and guidance instructions
 
 * Fixed the crash when scrolling the guidance cards while the orientation changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
+* Added the ability to customize the `TopBannerViewController` through the publicly exposed `lanesView`, `nextBannerView`, `statusView` and `junctionView`. The `TopBannerViewController.instructionsBannerView` could also be customized through `NavigationViewControllerDelegate.label(_:willPresent:as:)` during active navigation. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
 
 ### Map
 
 * Added the `NavigationViewController.usesNightStyleWhileInTunnel` and `CarPlayNavigationViewController.usesNightStyleWhileInTunnel` properties, which allow to disable dark style usage, while traversing the tunnels. ([#3559](https://github.com/mapbox/mapbox-navigation-ios/pull/3559))
+
 
 ### CarPlay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@
 
 ### Banners and guidance instructions
 
-* Fixed the crash when scrolling the guidance cards while the orientation changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
-* Added the ability to customize the `TopBannerViewController` through the publicly exposed `lanesView`, `nextBannerView`, `statusView` and `junctionView`. The `TopBannerViewController.instructionsBannerView` could also be customized through `NavigationViewControllerDelegate.label(_:willPresent:as:)` during active navigation. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
+* Fixed the crash when scrolling the guidance cards while the orientaion changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
+* Added the `TopBannerViewController.lanesView`, `TopBannerViewController.nextBannerView`, `TopBannerViewController.statusView` and `TopBannerViewController.junctionView` properties. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
+* The `InstructionsBannerViewDelegate` and `TopBannerViewControllerDelegate` protocols now conform to the `VisualInstructionDelegate` protocol. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
+* Fixed an issue where `VisualInstructionDelegate.label(_:willPresent:as:)` was never called. Your `NavigationViewControllerDelegate` class can now implement this method to customize the contents of a visual instruction during turn-by-turn navigation. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
 
 ### Map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Banners and guidance instructions
 
-* Fixed the crash when scrolling the guidance cards while the orientaion changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
+* Fixed the crash when scrolling the guidance cards while the orientation changes. ([#3544](https://github.com/mapbox/mapbox-navigation-ios/pull/3544))
 * Added the `TopBannerViewController.lanesView`, `TopBannerViewController.nextBannerView`, `TopBannerViewController.statusView` and `TopBannerViewController.junctionView` properties. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
 * The `InstructionsBannerViewDelegate` and `TopBannerViewControllerDelegate` protocols now conform to the `VisualInstructionDelegate` protocol. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
 * Fixed an issue where `VisualInstructionDelegate.label(_:willPresent:as:)` was never called. Your `NavigationViewControllerDelegate` class can now implement this method to customize the contents of a visual instruction during turn-by-turn navigation. ([#3575](https://github.com/mapbox/mapbox-navigation-ios/pull/3575))
@@ -28,7 +28,6 @@
 ### Map
 
 * Added the `NavigationViewController.usesNightStyleWhileInTunnel` and `CarPlayNavigationViewController.usesNightStyleWhileInTunnel` properties, which allow to disable dark style usage, while traversing the tunnels. ([#3559](https://github.com/mapbox/mapbox-navigation-ios/pull/3559))
-
 
 ### CarPlay
 

--- a/Sources/MapboxNavigation/InstructionsBannerView.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerView.swift
@@ -6,7 +6,7 @@ import MapboxDirections
 /**
  `InstructionsBannerViewDelegate` provides methods for reacting to user interactions in `InstructionsBannerView`.
  */
-public protocol InstructionsBannerViewDelegate: AnyObject, UnimplementedLogging {
+public protocol InstructionsBannerViewDelegate: VisualInstructionDelegate {
     /**
      Called when the user taps the `InstructionsBannerView`.
      */
@@ -68,13 +68,8 @@ open class BaseInstructionsBannerView: UIControl {
             if showStepIndicator {
                 stepListIndicatorView.isHidden = false
             }
-        }
-    }
-    
-    weak var instructionDelegate: VisualInstructionDelegate? {
-        didSet {
-            primaryLabel.instructionDelegate = instructionDelegate
-            secondaryLabel.instructionDelegate = instructionDelegate
+            primaryLabel.instructionDelegate = delegate
+            secondaryLabel.instructionDelegate = delegate
         }
     }
     
@@ -212,7 +207,7 @@ open class BaseInstructionsBannerView: UIControl {
         self.distanceLabel = distanceLabel
         
         let primaryLabel = PrimaryLabel()
-        primaryLabel.instructionDelegate = instructionDelegate
+        primaryLabel.instructionDelegate = delegate
         primaryLabel.translatesAutoresizingMaskIntoConstraints = false
         primaryLabel.allowsDefaultTighteningForTruncation = true
         primaryLabel.adjustsFontSizeToFitWidth = true
@@ -223,7 +218,7 @@ open class BaseInstructionsBannerView: UIControl {
         self.primaryLabel = primaryLabel
         
         let secondaryLabel = SecondaryLabel()
-        secondaryLabel.instructionDelegate = instructionDelegate
+        secondaryLabel.instructionDelegate = delegate
         secondaryLabel.translatesAutoresizingMaskIntoConstraints = false
         secondaryLabel.allowsDefaultTighteningForTruncation = true
         secondaryLabel.numberOfLines = 1

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -217,7 +217,7 @@ open class NavigationView: UIView {
     }
 }
 
-protocol NavigationViewDelegate: NavigationMapViewDelegate, InstructionsBannerViewDelegate, VisualInstructionDelegate {
+protocol NavigationViewDelegate: NavigationMapViewDelegate, InstructionsBannerViewDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton)
 }
 

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -1136,6 +1136,10 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
     public func topBanner(_ banner: TopBannerViewController, didDisplayStepsController: StepsViewController) {
         cameraController?.recenter(self)
     }
+    
+    public func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
+        delegate?.label(label, willPresent: instruction, as: presented)
+    }
 }
 
 // MARK: BottomBannerViewControllerDelegate methods

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 import MapboxCoreNavigation
 import MapboxDirections
 
-public protocol TopBannerViewControllerDelegate: AnyObject, UnimplementedLogging {
+public protocol TopBannerViewControllerDelegate: VisualInstructionDelegate {
     func topBanner(_ banner: TopBannerViewController, didSwipeInDirection direction: UISwipeGestureRecognizer.Direction)
     
     func topBanner(_ banner: TopBannerViewController, didSelect legIndex: Int, stepIndex: Int, cell: StepTableViewCell)
@@ -71,19 +71,10 @@ open class TopBannerViewController: UIViewController {
         return banner
     }()
     
-    lazy var lanesView: LanesView = .forAutoLayout(hidden: true)
-    lazy var nextBannerView: NextBannerView = .forAutoLayout(hidden: true)
-    lazy var statusView: StatusView = {
-        let view: StatusView = .forAutoLayout()
-        view.isHidden = true
-        return view
-    }()
-    
-    lazy var junctionView: JunctionView = {
-        let view: JunctionView = .forAutoLayout()
-        view.isHidden = true
-        return view
-    }()
+    public var lanesView: LanesView = .forAutoLayout(hidden: true)
+    public var nextBannerView: NextBannerView = .forAutoLayout(hidden: true)
+    public var statusView: StatusView = .forAutoLayout(hidden: true)
+    public var junctionView: JunctionView = .forAutoLayout(hidden: true)
     
     private let instructionsBannerHeight: CGFloat = 100.0
     
@@ -450,6 +441,10 @@ extension TopBannerViewController: InstructionsBannerViewDelegate {
     
     public func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizer.Direction) {
         delegate?.topBanner(self, didSwipeInDirection: direction)
+    }
+    
+    public func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
+        delegate?.label(label, willPresent: instruction, as: presented)
     }
 }
 

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -71,9 +71,24 @@ open class TopBannerViewController: UIViewController {
         return banner
     }()
     
+    /**
+     A view that contains one or more maneuver images indicating the lanes of road user driving on.
+     */
     public var lanesView: LanesView = .forAutoLayout(hidden: true)
+    
+    /**
+     A view that indicates the instruction for next step.
+     */
     public var nextBannerView: NextBannerView = .forAutoLayout(hidden: true)
+    
+    /**
+     A translucent bar that indicates the navigation status.
+     */
     public var statusView: StatusView = .forAutoLayout(hidden: true)
+    
+    /**
+     A view that indicates the layout of a highway junction.
+     */
     public var junctionView: JunctionView = .forAutoLayout(hidden: true)
     
     private let instructionsBannerHeight: CGFloat = 100.0

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -72,7 +72,7 @@ open class TopBannerViewController: UIViewController {
     }()
     
     /**
-     A view that contains one or more maneuver images indicating the lanes of road user driving on.
+     A view that contains one or more images indicating which lanes of road the user should take to complete the maneuver.
      */
     public var lanesView: LanesView = .forAutoLayout(hidden: true)
     

--- a/Tests/MapboxNavigationTests/InstructionsBannerViewIntegrationTests.swift
+++ b/Tests/MapboxNavigationTests/InstructionsBannerViewIntegrationTests.swift
@@ -88,7 +88,7 @@ class InstructionsBannerViewIntegrationTests: TestCase {
     
     func testCustomVisualInstructionDelegate() {
         let view = instructionsView()
-        view.instructionDelegate = reverseDelegate
+        view.delegate = reverseDelegate
         
         view.update(for: typicalInstruction)
         
@@ -97,7 +97,7 @@ class InstructionsBannerViewIntegrationTests: TestCase {
     
     func testCustomDelegateReturningNilTriggersDefaultBehavior() {
         let view = instructionsView()
-        view.instructionDelegate = silentDelegate
+        view.delegate = silentDelegate
         
         view.update(for: typicalInstruction)
         
@@ -339,7 +339,7 @@ class InstructionsBannerViewIntegrationTests: TestCase {
     }
 }
 
-private class TextReversingDelegate: VisualInstructionDelegate {
+private class TextReversingDelegate: InstructionsBannerViewDelegate {
     func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
         let forwards = Array(presented.string)
         let reverse = String(forwards.reversed())
@@ -349,7 +349,7 @@ private class TextReversingDelegate: VisualInstructionDelegate {
     }
 }
 
-private class DefaultBehaviorDelegate: VisualInstructionDelegate {
+private class DefaultBehaviorDelegate: InstructionsBannerViewDelegate {
     func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
         return nil
     }


### PR DESCRIPTION
### Description
This pr is to allow the customization of `TopBannerViewController` and fix #3567 

### Implementation
1. `TopBannerViewController`'s `lanesView` , `nextBannerView` , `statusView` , `junctionView` are exposed publicly to allow access and modification of it's contents.
2.  `NavigationViewControllerDelegate ` right now extends `TopBannerViewControllerDelegate`,both  `TopBannerViewControllerDelegate` and `InstructionsBannerViewDelegate` extend `VisualInstructionDelegate`. So right now through the `NavigationViewControllerDelegate`, developers could call `fNavigationViewControllerDelegate.label(_:willPresent:as:)` to customize the `instructionsBannerView` of the `TopBannerViewController` during navigation.

### Screenshots or Gifs
For example, in `Example`, we allow the `ViewController` extends `NavigationViewControllerDelegate` as following to customize the `instructionsBannerView` of `TopBannerViewController` by presenting a reversed instruction.

```
extension ViewController: NavigationViewControllerDelegate {
    func label(_ label: InstructionLabel, willPresent instruction: VisualInstruction, as presented: NSAttributedString) -> NSAttributedString? {
        let forwards = Array(presented.string)
        let reverse = String(forwards.reversed())
        var range = NSRange(location: 0, length: presented.string.count)
        let attributes = presented.attributes(at: 0, effectiveRange: &range)
        return NSAttributedString(string: reverse, attributes: attributes)
    }
}
```
![reversedInstruction](https://user-images.githubusercontent.com/48976398/140984791-bda0384c-c70a-40c1-9f7e-4d0ea8e48576.png)
