### PR TITLE
Use `trafficUnknownColor` for route line when no congestion level found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 ### Other changes
 
 * Fixed a retain cycle in CarPlay implementation of a navigation map view that prevented `NavigationMapView` instances from being deallocated after CarPlay is stopped. ([#3552](https://github.com/mapbox/mapbox-navigation-ios/pull/3552))
-* Fixed a regression when no congestion level information found, the current active route leg shows `NavigationMapView.routeCasingColor` instead of `NavigationMapView.trafficUnknownColor`. ([#3577](https://github.com/mapbox/mapbox-navigation-ios/pull/3577))
+* Fixed an issue where the entire route line was colored as `NavigationMapView.routeCasingColor` instead of `NavigationMapView.trafficUnknownColor` when traffic congestion data was missing. ([#3577](https://github.com/mapbox/mapbox-navigation-ios/pull/3577))
 
 ## v2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Other changes
 
 * Fixed a retain cycle in CarPlay implementation of a navigation map view that prevented `NavigationMapView` instances from being deallocated after CarPlay is stopped. ([#3552](https://github.com/mapbox/mapbox-navigation-ios/pull/3552))
+* Fixed a regression when no congestion level information found, the current active route leg shows `NavigationMapView.routeCasingColor` instead of `NavigationMapView.trafficUnknownColor`. ([#3577](https://github.com/mapbox/mapbox-navigation-ios/pull/3577))
 
 ## v2.0.1
 

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -243,10 +243,13 @@ extension NavigationMapView {
 
             for (index, feature) in congestionFeatures.enumerated() {
                 var associatedFeatureColor = routeCasingColor
-                if case let .string(congestionLevel) = feature.properties?[CongestionAttribute],
-                   case let .boolean(isCurrentLeg) = feature.properties?[CurrentLegAttribute],
+                if case let .boolean(isCurrentLeg) = feature.properties?[CurrentLegAttribute],
                    isCurrentLeg {
-                    associatedFeatureColor = congestionColor(for: congestionLevel, isMain: isMain)
+                    if case let .string(congestionLevel) = feature.properties?[CongestionAttribute] {
+                        associatedFeatureColor = congestionColor(for: congestionLevel, isMain: isMain)
+                    } else {
+                        associatedFeatureColor = congestionColor(isMain: isMain)
+                    }
                 }
 
                 guard case let .lineString(lineString) = feature.geometry,
@@ -332,7 +335,7 @@ extension NavigationMapView {
     /**
      Given a congestion level, return its associated color.
      */
-    func congestionColor(for congestionLevel: String?, isMain: Bool) -> UIColor {
+    func congestionColor(for congestionLevel: String? = nil, isMain: Bool) -> UIColor {
         switch congestionLevel {
         case "low":
             return isMain ? trafficLowColor : alternativeTrafficLowColor

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -248,7 +248,7 @@ extension NavigationMapView {
                     if case let .string(congestionLevel) = feature.properties?[CongestionAttribute] {
                         associatedFeatureColor = congestionColor(for: congestionLevel, isMain: isMain)
                     } else {
-                        associatedFeatureColor = congestionColor(isMain: isMain)
+                        associatedFeatureColor = congestionColor(for: nil, isMain: isMain)
                     }
                 }
 
@@ -335,7 +335,7 @@ extension NavigationMapView {
     /**
      Given a congestion level, return its associated color.
      */
-    func congestionColor(for congestionLevel: String? = nil, isMain: Bool) -> UIColor {
+    func congestionColor(for congestionLevel: String?, isMain: Bool) -> UIColor {
         switch congestionLevel {
         case "low":
             return isMain ? trafficLowColor : alternativeTrafficLowColor


### PR DESCRIPTION
### Description
According to #3542 , the regression cause that when there's no congestion level found in the `RouteLeg`, the route leg would display a default darker blue of `routeCasingColor ` instead of `trafficUnknownColor`. This pr is to fix this issue.

### Implementation
When there's no congestion level found, default show the `trafficUnknownColor` or `alternativeTrafficUnknownColor` on the current leg.

### Screenshots or Gifs
In `Example`, By setting the ` routeLeg.segmentNumericCongestionLevels` and `routeLeg.segmentCongestionLevels` as `nil` before we generate congestion features in `Route.congestionFeatures(legIndex:roadClassesWithOverriddenCongestionLevels:)`, we could get the situation when no congestion level found in the current route. 

Then we have the following before the fix, which would show the darker blue as the `routeCasingColor` on the current active leg during active navigation.
![beforeFix](https://user-images.githubusercontent.com/48976398/141013844-cecdebfe-f94f-49b2-807e-01ac7ee112c2.png)

With the fix, we would assign the `trafficUnknownColor` for current active leg during navigation:
![fix](https://user-images.githubusercontent.com/48976398/141013912-2277fbd7-ed07-4377-88f5-f8035b6ec2f0.png)


