### PR TITLE
Fix issue, which was causing inability to see `SpeedLimitView` and `CarPlayCompassView` when right-to-left mode is used on CarPlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 * Added the `CarPlayActivity.panningInNavigationMode` case, which allows to track a state when user is panning a map view while actively navigating. ([#3545](https://github.com/mapbox/mapbox-navigation-ios/pull/3545))
 * Fixed an issue that caused the panning dismissal button to stop working on CarPlay. ([#3543](https://github.com/mapbox/mapbox-navigation-ios/pull/3543))
+* Fixed an issue which caused the inability to see `SpeedLimitView` and `CarPlayCompassView` when left-hand traffic mode is used on CarPlay. ([#3583](https://github.com/mapbox/mapbox-navigation-ios/pull/3583))
 
 ### Other changes
 

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -227,8 +227,8 @@ open class CarPlayMapViewController: UIViewController {
         speedLimitView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(speedLimitView)
         
-        speedLimitView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8).isActive = true
-        speedLimitView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -8).isActive = true
+        speedLimitView.topAnchor.constraint(equalTo: view.safeTopAnchor, constant: 8).isActive = true
+        speedLimitView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: -8).isActive = true
         speedLimitView.widthAnchor.constraint(equalToConstant: 30).isActive = true
         speedLimitView.heightAnchor.constraint(equalToConstant: 30).isActive = true
         

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -77,7 +77,7 @@ open class CarPlayNavigationViewController: UIViewController {
         let compassView = CarPlayCompassView()
         view.addSubview(compassView)
         compassView.topAnchor.constraint(equalTo: view.safeTopAnchor, constant: 8).isActive = true
-        compassView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -8).isActive = true
+        compassView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: -8).isActive = true
         self.compassView = compassView
         
         let speedLimitView = SpeedLimitView()
@@ -85,7 +85,7 @@ open class CarPlayNavigationViewController: UIViewController {
         view.addSubview(speedLimitView)
         
         speedLimitView.topAnchor.constraint(equalTo: compassView.bottomAnchor, constant: 8).isActive = true
-        speedLimitView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -8).isActive = true
+        speedLimitView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: -8).isActive = true
         speedLimitView.widthAnchor.constraint(equalToConstant: 30).isActive = true
         speedLimitView.heightAnchor.constraint(equalToConstant: 30).isActive = true
         


### PR DESCRIPTION
Closing #3582.