### PR TITLE
Fix rendering issue with route preview stretchable route duration callouts

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1149,8 +1149,11 @@ open class NavigationMapView: UIView {
         // Right-hand pin
         if let image = Bundle.mapboxNavigation.image(named: "RouteInfoAnnotationRightHanded") {
             // define the "stretchable" areas in the image that will be fitted to the text label
+            // These numbers are the pixel offsets into the PDF image asset
             let stretchX = [ImageStretches(first: Float(33), second: Float(52))]
             let stretchY = [ImageStretches(first: Float(32), second: Float(35))]
+            // define the "content" area of the image which is the portion that the maps sdk will use
+            // to place the text label within
             let imageContent = ImageContent(left: 34, top: 32, right: 56, bottom: 50)
             
             let regularAnnotationImage = image.tint(routeDurationAnnotationColor)
@@ -1171,8 +1174,11 @@ open class NavigationMapView: UIView {
         // Left-hand pin
         if let image = Bundle.mapboxNavigation.image(named: "RouteInfoAnnotationLeftHanded") {
             // define the "stretchable" areas in the image that will be fitted to the text label
+            // These numbers are the pixel offsets into the PDF image asset
             let stretchX = [ImageStretches(first: Float(47), second: Float(48))]
             let stretchY = [ImageStretches(first: Float(28), second: Float(32))]
+            // define the "content" area of the image which is the portion that the maps sdk will use
+            // to place the text label within
             let imageContent = ImageContent(left: 47, top: 28, right: 52, bottom: 40)
             
             let regularAnnotationImage = image.tint(routeDurationAnnotationColor)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -746,7 +746,7 @@ open class NavigationMapView: UIView {
             RouteDurationAnnotationTailPosition.leading,
             RouteDurationAnnotationTailPosition.trailing
         ].randomElement() else { return }
-        
+
         var features = [Turf.Feature]()
         
         // Run through our heuristic algorithm looking for a good coordinate along each route line
@@ -1149,9 +1149,9 @@ open class NavigationMapView: UIView {
         // Right-hand pin
         if let image = Bundle.mapboxNavigation.image(named: "RouteInfoAnnotationRightHanded") {
             // define the "stretchable" areas in the image that will be fitted to the text label
-            let stretchX = [ImageStretches(first: Float(24), second: Float(40))]
-            let stretchY = [ImageStretches(first: Float(25), second: Float(35))]
-            let imageContent = ImageContent(left: 24, top: 25, right: 40, bottom: 35)
+            let stretchX = [ImageStretches(first: Float(33), second: Float(52))]
+            let stretchY = [ImageStretches(first: Float(32), second: Float(35))]
+            let imageContent = ImageContent(left: 34, top: 32, right: 56, bottom: 50)
             
             let regularAnnotationImage = image.tint(routeDurationAnnotationColor)
             try style.addImage(regularAnnotationImage,
@@ -1171,9 +1171,9 @@ open class NavigationMapView: UIView {
         // Left-hand pin
         if let image = Bundle.mapboxNavigation.image(named: "RouteInfoAnnotationLeftHanded") {
             // define the "stretchable" areas in the image that will be fitted to the text label
-            let stretchX = [ImageStretches(first: Float(34), second: Float(50))]
-            let stretchY = [ImageStretches(first: Float(25), second: Float(35))]
-            let imageContent = ImageContent(left: 34, top: 25, right: 50, bottom: 35)
+            let stretchX = [ImageStretches(first: Float(47), second: Float(48))]
+            let stretchY = [ImageStretches(first: Float(28), second: Float(32))]
+            let imageContent = ImageContent(left: 47, top: 28, right: 52, bottom: 40)
             
             let regularAnnotationImage = image.tint(routeDurationAnnotationColor)
             try style.addImage(regularAnnotationImage,


### PR DESCRIPTION
Maps v10 changed the API for how stretchable image assets are defined for map symbol style layers. This caused some rendering issues with the offsets that worked in Maps v6.3.

The fix is to update the offsets used to declare the stretchable regions and content area of the route duration annotation callouts.

Screenshots of the before and after:

![Annotations Error](https://user-images.githubusercontent.com/10037825/141883480-1bd13470-fe81-4bba-b644-a0ae3bee0eb5.png)


![Annotations Working](https://user-images.githubusercontent.com/10037825/141883505-4ea5936a-3a81-4721-9e9f-749e8fb9de81.png)

