### PR TITLE
Fix excessive padding on CarPlay during active navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Fixed an issue which caused the inability to see `SpeedLimitView` and `CarPlayCompassView` when left-hand traffic mode is used on CarPlay. ([#3583](https://github.com/mapbox/mapbox-navigation-ios/pull/3583))
 * Added the `CarPlayMapViewController.wayNameView` and `CarPlayNavigationViewController.wayNameView` properties to show the current road name on CarPlay. `CarPlayNavigationViewController.compassView`, `CarPlayNavigationViewController.speedLimitView` and `CarPlayMapViewController.speedLimitView` are kept as strong references, thus available throughout the lifetime of a parent object. ([#3534](https://github.com/mapbox/mapbox-navigation-ios/pull/3534))
 * Fixed an issue when `NavigationMapView.crossfadesCongestionSegments` enabled but congestion color transition is still sharp in CarPlay. ([#3466](https://github.com/mapbox/mapbox-navigation-ios/pull/3466))
+* Fixed an issue when incorrect padding was used for `SpeedLimitView` and `CarPlayCompassView` for right-hand traffic mode on CarPlay. ([#3605](https://github.com/mapbox/mapbox-navigation-ios/pull/3605))
 
 ### Other changes
 

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -200,7 +200,7 @@ open class CarPlayMapViewController: UIViewController {
         super.init(coder: decoder)
     }
     
-    override public func encode(with aCoder: NSCoder) {
+    public override func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
         
         aCoder.encode(styles, forKey: "styles")
@@ -300,12 +300,12 @@ open class CarPlayMapViewController: UIViewController {
     
     // MARK: UIViewController Lifecycle Methods
     
-    override public func loadView() {
+    public override func loadView() {
         setupNavigationMapView()
         setupPassiveLocationProvider()
     }
     
-    override public func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         
         setupStyleManager()
@@ -314,7 +314,7 @@ open class CarPlayMapViewController: UIViewController {
         navigationMapView.navigationCamera.follow()
     }
     
-    override public func viewSafeAreaInsetsDidChange() {
+    public override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         
         // Trigger update of view constraints to correctly position views like `SpeedLimitView`.
@@ -334,7 +334,7 @@ open class CarPlayMapViewController: UIViewController {
         }
     }
     
-    open override func updateViewConstraints() {
+    public override func updateViewConstraints() {
         if view.safeAreaInsets.right > 38.0 {
             safeTrailingSpeedLimitViewConstraint.isActive = true
             trailingSpeedLimitViewConstraint.isActive = false

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -170,6 +170,9 @@ open class CarPlayMapViewController: UIViewController {
         return closeButton
     }
     
+    private var safeTrailingSpeedLimitViewConstraint: NSLayoutConstraint!
+    private var trailingSpeedLimitViewConstraint: NSLayoutConstraint!
+    
     // MARK: Initialization Methods
     
     /**
@@ -234,7 +237,10 @@ open class CarPlayMapViewController: UIViewController {
         view.addSubview(speedLimitView)
         
         speedLimitView.topAnchor.constraint(equalTo: view.safeTopAnchor, constant: 8).isActive = true
-        speedLimitView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: -8).isActive = true
+        safeTrailingSpeedLimitViewConstraint = speedLimitView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor,
+                                                                                        constant: -8)
+        trailingSpeedLimitViewConstraint = speedLimitView.trailingAnchor.constraint(equalTo: view.trailingAnchor,
+                                                                                    constant: -8)
         speedLimitView.widthAnchor.constraint(equalToConstant: 30).isActive = true
         speedLimitView.heightAnchor.constraint(equalToConstant: 30).isActive = true
         
@@ -311,6 +317,9 @@ open class CarPlayMapViewController: UIViewController {
     override public func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         
+        // Trigger update of view constraints to correctly position views like `SpeedLimitView`.
+        view.setNeedsUpdateConstraints()
+        
         guard let activeRoute = navigationMapView.routes?.first else {
             navigationMapView.navigationCamera.follow()
             return
@@ -323,6 +332,18 @@ open class CarPlayMapViewController: UIViewController {
             
             navigationMapView.fitCamera(to: [activeRoute])
         }
+    }
+    
+    open override func updateViewConstraints() {
+        if view.safeAreaInsets.right > 38.0 {
+            safeTrailingSpeedLimitViewConstraint.isActive = true
+            trailingSpeedLimitViewConstraint.isActive = false
+        } else {
+            safeTrailingSpeedLimitViewConstraint.isActive = false
+            trailingSpeedLimitViewConstraint.isActive = true
+        }
+        
+        super.updateViewConstraints()
     }
 }
 

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -408,7 +408,15 @@ open class CarPlayNavigationViewController: UIViewController {
         }
     }
     
-    open override func updateViewConstraints() {
+    public override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        
+        // Trigger update of view constraints to correctly position views like `SpeedLimitView` and
+        // `CarPlayCompassView`.
+        view.setNeedsUpdateConstraints()
+    }
+    
+    public override func updateViewConstraints() {
         // Since there is no ability to detect current driving side mode of the CarPlay head-unit,
         // two separate `NSLayoutConstraint` objects are used to prevent `SpeedLimitView` and
         // `CarPlayCompassView` disappearance:
@@ -416,6 +424,7 @@ open class CarPlayNavigationViewController: UIViewController {
         // estimate panels will be on the right.
         // - second one is used when driving on the left side of the road, in this case guidance and trip
         // estimate panels will be on the left.
+        // Similar check is performed in `CarPlayMapViewController`.
         if view.safeAreaInsets.right > 38.0 {
             safeTrailingCompassViewConstraint.isActive = true
             trailingCompassViewConstraint.isActive = false

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -357,7 +357,7 @@ open class CarPlayNavigationViewController: UIViewController {
      
      - postcondition: Call `startNavigationSession(for:)` after initializing this object to begin navigation.
      */
-    required public init(navigationService: NavigationService,
+    public required init(navigationService: NavigationService,
                          mapTemplate: CPMapTemplate,
                          interfaceController: CPInterfaceController,
                          manager: CarPlayManager,
@@ -376,7 +376,7 @@ open class CarPlayNavigationViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override public func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         
         setupNavigationMapView()
@@ -394,7 +394,7 @@ open class CarPlayNavigationViewController: UIViewController {
         updateTripEstimateStyle(traitCollection.userInterfaceStyle)
     }
     
-    override public func viewWillDisappear(_ animated: Bool) {
+    public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         suspendNotifications()
     }


### PR DESCRIPTION
Closing #3604.

Since there is no ability to detect whether CarPlay head-unit is in either left of right driving side mode (at least I was not able to find it, feel free to provide any suggestions if you have any) I had to use `safeAreaInsets` value as a criteria.