### PR TITLE
Fix style change caused route line update delay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fixed an issue where `ReplayLocationManager` didn't update location timestamps when a new loop started. ([#3550](https://github.com/mapbox/mapbox-navigation-ios/pull/3550))
 * Fixed the background location update issue during active navigation when using default `.courseView` for `NavigationMapView.userLocationStyle`. ([#3533](https://github.com/mapbox/mapbox-navigation-ios/pull/3533))
 * Fixed an issue where `UserPuckCourseView` is trimmed when using custom frame for `UserLocationStyle.courseView(_:)`. ([#3601](https://github.com/mapbox/mapbox-navigation-ios/pull/3601))
+* Fixed an issue where route line blinks when users drive through tunnel. ([#3613](https://github.com/mapbox/mapbox-navigation-ios/pull/3613))
 
 ### Banners and guidance instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Fixed an issue where `ReplayLocationManager` didn't update location timestamps when a new loop started. ([#3550](https://github.com/mapbox/mapbox-navigation-ios/pull/3550))
 * Fixed the background location update issue during active navigation when using default `.courseView` for `NavigationMapView.userLocationStyle`. ([#3533](https://github.com/mapbox/mapbox-navigation-ios/pull/3533))
 * Fixed an issue where `UserPuckCourseView` is trimmed when using custom frame for `UserLocationStyle.courseView(_:)`. ([#3601](https://github.com/mapbox/mapbox-navigation-ios/pull/3601))
-* Fixed an issue where route line blinks when users drive through tunnel. ([#3613](https://github.com/mapbox/mapbox-navigation-ios/pull/3613))
+* Fixed an issue where route line blinks when style is changed during active navigation. ([#3613](https://github.com/mapbox/mapbox-navigation-ios/pull/3613))
 
 ### Banners and guidance instructions
 

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -640,7 +640,7 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
     }
     
     @objc func refresh(_ notification: NSNotification) {
-        updateRouteLine(routeProgress: navigationService.routeProgress, coordinate: navigationService.router.location?.coordinate)
+        navigationMapView?.updateRouteLine(routeProgress: navigationService.routeProgress, coordinate: navigationService.router.location?.coordinate)
     }
     
     @objc func simulationStateDidChange(_ notification: NSNotification) {
@@ -684,19 +684,8 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         let nextStep = progress.currentLegProgress.stepIndex + 1
         
         navigationMapView?.addArrow(route: progress.route, legIndex: legIndex, stepIndex: nextStep)
-        updateRouteLine(routeProgress: progress, coordinate: navigationService.router.location?.coordinate)
+        navigationMapView?.updateRouteLine(routeProgress: progress, coordinate: navigationService.router.location?.coordinate)
         navigationMapView?.showWaypoints(on: progress.route, legIndex: legIndex)
-    }
-    
-    func updateRouteLine(routeProgress: RouteProgress, coordinate: CLLocationCoordinate2D?) {
-        navigationMapView?.show([routeProgress.route], legIndex: routeProgress.legIndex)
-        if routeLineTracksTraversal {
-            if routeProgress.routeIsComplete {
-                navigationMapView?.removeRoutes()
-            }
-            navigationMapView?.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
-            navigationMapView?.travelAlongRouteLine(to: coordinate)
-        }
     }
     
     func updateManeuvers(_ routeProgress: RouteProgress) {

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -640,15 +640,7 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
     }
     
     @objc func refresh(_ notification: NSNotification) {
-        let progress = navigationService.routeProgress
-        let legIndex = progress.legIndex
-        let coordinate = navigationService.router.location?.coordinate
-        
-        navigationMapView?.show([progress.route], legIndex: legIndex)
-        if routeLineTracksTraversal {
-            navigationMapView?.updateUpcomingRoutePointIndex(routeProgress: progress)
-            navigationMapView?.travelAlongRouteLine(to: coordinate)
-        }
+        updateRouteLine(routeProgress: navigationService.routeProgress, coordinate: navigationService.router.location?.coordinate)
     }
     
     @objc func simulationStateDidChange(_ notification: NSNotification) {
@@ -692,8 +684,19 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         let nextStep = progress.currentLegProgress.stepIndex + 1
         
         navigationMapView?.addArrow(route: progress.route, legIndex: legIndex, stepIndex: nextStep)
-        navigationMapView?.show([progress.route], legIndex: legIndex)
+        updateRouteLine(routeProgress: progress, coordinate: navigationService.router.location?.coordinate)
         navigationMapView?.showWaypoints(on: progress.route, legIndex: legIndex)
+    }
+    
+    func updateRouteLine(routeProgress: RouteProgress, coordinate: CLLocationCoordinate2D?) {
+        navigationMapView?.show([routeProgress.route], legIndex: routeProgress.legIndex)
+        if routeLineTracksTraversal {
+            if routeProgress.routeIsComplete {
+                navigationMapView?.removeRoutes()
+            }
+            navigationMapView?.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
+            navigationMapView?.travelAlongRouteLine(to: coordinate)
+        }
     }
     
     func updateManeuvers(_ routeProgress: RouteProgress) {

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -47,6 +47,24 @@ extension NavigationMapView {
     }
     
     /**
+     Update the existing primary route line during active navigation.
+     
+     - parameter routeProgress: The current `RouteProgress`.
+     - parameter coordinate: The current user location coordinate.
+     */
+    func updateRouteLine(routeProgress: RouteProgress, coordinate: CLLocationCoordinate2D?) {
+        show([routeProgress.route], legIndex: routeProgress.legIndex)
+        guard routeLineTracksTraversal else { return }
+        
+        if routeProgress.routeIsComplete {
+            removeRoutes()
+        } else {
+            updateUpcomingRoutePointIndex(routeProgress: routeProgress)
+            travelAlongRouteLine(to: coordinate)
+        }
+    }
+    
+    /**
      Find and cache the index of the upcoming [RouteLineDistancesIndex].
      */
     public func updateUpcomingRoutePointIndex(routeProgress: RouteProgress) {

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -39,7 +39,7 @@ extension NavigationMapView {
             guard navigationViewData.containerViewController.isViewLoaded else { return }
             
             guard !navigationMapView.showsRoute else { return }
-            updateRouteLine(routeProgress: router.routeProgress, coordinate: router.location?.coordinate)
+            navigationMapView.updateRouteLine(routeProgress: router.routeProgress, coordinate: router.location?.coordinate)
             navigationMapView.showWaypoints(on: router.route, legIndex: router.routeProgress.legIndex)
             
             let currentLegProgress = router.routeProgress.currentLegProgress
@@ -70,7 +70,7 @@ extension NavigationMapView {
             navigationMapView.removeWaypoints()
             
             navigationMapView.addArrow(route: route, legIndex: legIndex, stepIndex: stepIndex + 1)
-            updateRouteLine(routeProgress: router.routeProgress, coordinate: location?.coordinate)
+            navigationMapView.updateRouteLine(routeProgress: router.routeProgress, coordinate: location?.coordinate)
             navigationMapView.showWaypoints(on: route)
             
             if annotatesSpokenInstructions {
@@ -148,19 +148,8 @@ extension NavigationMapView {
             }
         }
         
-        private func updateRouteLine(routeProgress: RouteProgress, coordinate: CLLocationCoordinate2D?) {
-            navigationMapView.show([routeProgress.route], legIndex: routeProgress.legIndex)
-            if routeLineTracksTraversal {
-                if routeProgress.routeIsComplete {
-                    navigationMapView.removeRoutes()
-                }
-                navigationMapView.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
-                navigationMapView.travelAlongRouteLine(to: coordinate)
-            }
-        }
-        
         func navigationService(_ service: NavigationService, didRefresh routeProgress: RouteProgress) {
-            updateRouteLine(routeProgress: routeProgress, coordinate: router.location?.coordinate)
+            navigationMapView.updateRouteLine(routeProgress: routeProgress, coordinate: router.location?.coordinate)
         }
     }
 }

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -39,7 +39,7 @@ extension NavigationMapView {
             guard navigationViewData.containerViewController.isViewLoaded else { return }
             
             guard !navigationMapView.showsRoute else { return }
-            navigationMapView.show([router.route], legIndex: router.routeProgress.legIndex)
+            updateRouteLine(routeProgress: router.routeProgress, coordinate: router.location?.coordinate)
             navigationMapView.showWaypoints(on: router.route, legIndex: router.routeProgress.legIndex)
             
             let currentLegProgress = router.routeProgress.currentLegProgress
@@ -70,16 +70,11 @@ extension NavigationMapView {
             navigationMapView.removeWaypoints()
             
             navigationMapView.addArrow(route: route, legIndex: legIndex, stepIndex: stepIndex + 1)
-            navigationMapView.show([route], legIndex: legIndex)
+            updateRouteLine(routeProgress: router.routeProgress, coordinate: location?.coordinate)
             navigationMapView.showWaypoints(on: route)
             
             if annotatesSpokenInstructions {
                 navigationMapView.showVoiceInstructionsOnMap(route: route)
-            }
-            
-            if routeLineTracksTraversal {
-                navigationMapView.updateUpcomingRoutePointIndex(routeProgress: router.routeProgress)
-                navigationMapView.travelAlongRouteLine(to: location?.coordinate)
             }
         }
         
@@ -153,12 +148,19 @@ extension NavigationMapView {
             }
         }
         
-        func navigationService(_ service: NavigationService, didRefresh routeProgress: RouteProgress) {
+        private func updateRouteLine(routeProgress: RouteProgress, coordinate: CLLocationCoordinate2D?) {
             navigationMapView.show([routeProgress.route], legIndex: routeProgress.legIndex)
             if routeLineTracksTraversal {
+                if routeProgress.routeIsComplete {
+                    navigationMapView.removeRoutes()
+                }
                 navigationMapView.updateUpcomingRoutePointIndex(routeProgress: routeProgress)
-                navigationMapView.travelAlongRouteLine(to: router.location?.coordinate)
+                navigationMapView.travelAlongRouteLine(to: coordinate)
             }
+        }
+        
+        func navigationService(_ service: NavigationService, didRefresh routeProgress: RouteProgress) {
+            updateRouteLine(routeProgress: routeProgress, coordinate: router.location?.coordinate)
         }
     }
 }


### PR DESCRIPTION
### Description
This pr is to fix #3612 by packing the route line update methods into the `func updateRouteLine(routeProgress:coordinate:)` through `CarPlayNavigationViewController` and `RouteLineController`, to reduce code duplication and avoid the route line update delay.

### Implementation
Previously when style changes or when reroute event happens in CarPlay, the `CarPlayNavigationViewController` only shows the route line without updating the upcoming route point index, which cause a 1 second delay and the route line blinking. This pr is to pack the route line update methods into `CarPlayNavigationViewController.updateRouteLine(routeProgress:coordinate:)` and `RouteLineController.updateRouteLinee(routeProgress:coordinate:)`. So when the style changes, rerouting and refresh event happens, `mobile` and `CarPlay` will it directly to update the route line without delay. 

### Screenshots or Gifs
Choose the location as following to start the route with driving through tunnels:
```
latitude: 37.789812
longitude: -122.470759
```
![styleChange](https://user-images.githubusercontent.com/48976398/142950508-7d19b9bc-699d-4a4c-aedc-bc857ebd2944.gif)

