### PR TITLE
Fix issues in zoom calculations for cases when maneuver is further away from the current location.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
 * Fixed an issue when incorrect padding was used for `SpeedLimitView` and `CarPlayCompassView` for right-hand traffic mode on CarPlay. ([#3605](https://github.com/mapbox/mapbox-navigation-ios/pull/3605))
 * Added the ability to extrude or highlight building on CarPlay by setting the `CarPlayNavigationViewController.waypointStyle` property. ([#3564](https://github.com/mapbox/mapbox-navigation-ios/pull/3564))
 
+### Camera
+
+* Fixed an issue where on routes with large distances between current location and next manuever camera zoom level was too low. To control navigation camera zoom level use `IntersectionDensity.averageDistanceMultiplier` coefficient. ([#3616](https://github.com/mapbox/mapbox-navigation-ios/pull/3616))
+
 ### Other changes
 
 * Fixed a retain cycle in CarPlay implementation of a navigation map view that prevented `NavigationMapView` instances from being deallocated after CarPlay is stopped. ([#3552](https://github.com/mapbox/mapbox-navigation-ios/pull/3552))


### PR DESCRIPTION
Here are a few visual examples:

`IntersectionDensity.averageDistanceMultiplier = 100.0` (original behavior, before applying fix and regardless of value, which was set)

<img width="235" alt="Screen Shot 2021-11-24 at 11 51 23 AM" src="https://user-images.githubusercontent.com/1496498/143323966-3b689a58-6dd6-4f7b-880a-b747b73b4a2a.png">

`IntersectionDensity.averageDistanceMultiplier = 20.0`

![Screen Shot 2021-11-24 at 2 54 51 PM](https://user-images.githubusercontent.com/1496498/143324037-987d4c61-2c03-4f0d-a308-37554beb8662.png)

`IntersectionDensity.averageDistanceMultiplier = 7.0` (default value)

![Screen Shot 2021-11-24 at 3 11 29 PM](https://user-images.githubusercontent.com/1496498/143324108-949a87c9-b300-45b4-a509-2b090d6d1c59.png)


