### PR TITLE
Cocoapods CI Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -691,17 +691,17 @@ workflows:
           codecoverage: false
           context: Slack Orb
       - pod-job:
-          name: "Xcode_12.0_iOS_14.0_CP_install"
+          name: "Xcode_12.5_iOS_14.5_CP_install"
           update: false
-          xcode: "12.0.0"
-          iOS: "14.0"
+          xcode: "12.5.0"
+          iOS: "14.5"
           archive: true
           context: Slack Orb
       - pod-job:
-          name: "Xcode_12.0_iOS_14.0_CP_update"
+          name: "Xcode_12.5_iOS_14.5_CP_update"
           update: true
-          xcode: "12.0.0"
-          iOS: "14.0"
+          xcode: "12.5.0"
+          iOS: "14.5"
           lint: true
           context: Slack Orb
       - xcode-12-examples:


### PR DESCRIPTION
Bumped Xcode version for CocoaPods CI jobs as it used a deprecated one.