### PR TITLE
Fix the congestion color missing issue of route line when refresh.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fixed the background location update issue during active navigation when using default `.courseView` for `NavigationMapView.userLocationStyle`. ([#3533](https://github.com/mapbox/mapbox-navigation-ios/pull/3533))
 * Fixed an issue where `UserPuckCourseView` is trimmed when using custom frame for `UserLocationStyle.courseView(_:)`. ([#3601](https://github.com/mapbox/mapbox-navigation-ios/pull/3601))
 * Fixed an issue where route line blinks when style is changed during active navigation. ([#3613](https://github.com/mapbox/mapbox-navigation-ios/pull/3613))
+* Fixed an issue where route line missing traffic colors after refresh or rerouting. ([#3622](https://github.com/mapbox/mapbox-navigation-ios/pull/3622))
 
 ### Banners and guidance instructions
 

--- a/Sources/MapboxNavigation/Array.swift
+++ b/Sources/MapboxNavigation/Array.swift
@@ -89,7 +89,7 @@ extension Array where Iterator.Element == CLLocationCoordinate2D {
             }
             
             if segments.last?.1 == overriddenCongestionLevel {
-                segments[segments.count - 1].0 += coordinates
+                segments[segments.count - 1].0 += [firstSegment.1]
             } else {
                 segments.append((coordinates, overriddenCongestionLevel))
             }

--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -53,7 +53,7 @@ extension Route {
             let legFeatures: [Feature]
             let currentLegAttribute = (legIndex != nil) ? index == legIndex : true
 
-            if let congestionLevels = leg.resolvedCongestionLevels, congestionLevels.count < coordinates.count {
+            if let congestionLevels = leg.resolvedCongestionLevels, congestionLevels.count < coordinates.count + 2 {
                 // The last coordinate of the preceding step, is shared with the first coordinate of the next step, we don't need both.
                 let legCoordinates: [CLLocationCoordinate2D] = leg.steps.enumerated().reduce([]) { allCoordinates, current in
                     let index = current.offset

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -47,7 +47,7 @@ class NavigationMapViewTests: TestCase {
         ])
         
         XCTAssertEqual(congestionSegments.count, 1)
-        XCTAssertEqual(congestionSegments[0].0.count, 10)
+        XCTAssertEqual(congestionSegments[0].0.count, 6)
         XCTAssertEqual(congestionSegments[0].1, .low)
     }
     
@@ -64,9 +64,9 @@ class NavigationMapViewTests: TestCase {
         // Any time the current congestion level is different than the previous segment, we have to create a new congestion segment.
         XCTAssertEqual(congestionSegmentsSevere.count, 3)
         
-        XCTAssertEqual(congestionSegmentsSevere[0].0.count, 4)
+        XCTAssertEqual(congestionSegmentsSevere[0].0.count, 3)
         XCTAssertEqual(congestionSegmentsSevere[1].0.count, 2)
-        XCTAssertEqual(congestionSegmentsSevere[2].0.count, 4)
+        XCTAssertEqual(congestionSegmentsSevere[2].0.count, 3)
         
         XCTAssertEqual(congestionSegmentsSevere[0].1, .low)
         XCTAssertEqual(congestionSegmentsSevere[1].1, .severe)


### PR DESCRIPTION
### Description
This or is to fix #3542 by changing the coordinates count issue brought by https://github.com/mapbox/mapbox-directions-swift/pull/587 in generating congesting features of route line.

### Implementation
https://github.com/mapbox/mapbox-directions-swift/pull/587 added one more coordinate in the final step of each route leg, it would lead to the `resolvedCongestionLevels` count larger than the coordinates count as in https://github.com/mapbox/mapbox-navigation-ios/issues/3542#issuecomment-972380046 . This pr is to fix this issue by changing the count constraint and to allow the congestion feature generation.

Much of the work is from #3603 

### Screenshots or Gifs
The refresh rate is set to 5, and we could see that the route line doesn't lost its traffic color after refresh as following.
The route line blinks is #3621 .

![refresh](https://user-images.githubusercontent.com/48976398/143946467-e954fca3-4788-4dbd-b649-c9df433746a7.gif)
