### PR TITLE
Update directions dependency to 2.1.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" ~> 20.1.1
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 80.0
-github "mapbox/mapbox-directions-swift" ~> 2.1.0-rc.1
+github "mapbox/mapbox-directions-swift" ~> 2.1.0
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,7 @@ binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "80.0.2"
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v3.1.2"
-github "mapbox/mapbox-directions-swift" "v2.1.0-rc.1"
+github "mapbox/mapbox-directions-swift" "v2.1.0"
 github "mapbox/mapbox-events-ios" "v1.0.6"
 github "mapbox/turf-swift" "v2.0.0"
 github "pointfreeco/swift-snapshot-testing" "1.9.0"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxCoreNavigation"
 
   s.dependency "MapboxNavigationNative", "~> 80.0"
-  s.dependency "MapboxDirections-pre", ">= 2.1.0-rc.1", "< 3.0.0"
+  s.dependency "MapboxDirections", "~> 2.1"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 
   s.swift_version = "5.0"

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "02767cb1c752f6e0c781037dc75792a16b11b1d0",
-          "version": "2.1.0-rc.1"
+          "revision": "3371531c62e8abe5acecbdde403bd84e8d2b077e",
+          "version": "2.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.1.0-rc.1"),
+        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.1.0"),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
         .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "80.0.0"),
         .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.1.1"),

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
@@ -232,7 +232,7 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
-				"${BUILT_PRODUCTS_DIR}/MapboxDirections-pre/MapboxDirections.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxDirections/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMaps/MapboxMaps.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxSpeech/MapboxSpeech.framework",

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - MapboxCoreMaps (10.1.1):
     - MapboxCommon (~> 20.1)
   - MapboxCoreNavigation (2.1.0):
-    - MapboxDirections-pre (< 3.0.0, >= 2.1.0-rc.1)
+    - MapboxDirections (~> 2.1)
     - MapboxMobileEvents (~> 1.0)
     - MapboxNavigationNative (~> 80.0)
-  - MapboxDirections-pre (2.1.0-rc.1):
+  - MapboxDirections (2.1.0):
     - Polyline (~> 5.0)
     - Turf (~> 2.0)
   - MapboxMaps (10.1.1):
@@ -36,7 +36,7 @@ SPEC REPOS:
   trunk:
     - MapboxCommon
     - MapboxCoreMaps
-    - MapboxDirections-pre
+    - MapboxDirections
     - MapboxMaps
     - MapboxMobileEvents
     - MapboxNavigationNative
@@ -54,8 +54,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 206a7ff42bcf95776ba2c4b492abcbd520375303
   MapboxCoreMaps: ee3d7f31efbbafe81ce33907b6a96066e111a244
-  MapboxCoreNavigation: aab1b6f25ba136861983944251a9040846dcabac
-  MapboxDirections-pre: 3a4102435de37f3b23022efa9afaaf9ef77307bf
+  MapboxCoreNavigation: 47effe1fd3048f46ebcff041b4311f9b6f0d8d8a
+  MapboxDirections: f9787126bb46a3c9164978761ccdafccdbad1220
   MapboxMaps: 9a73c3ce2583d8925ae119038e916761243b5411
   MapboxMobileEvents: 14d7ac3ee95b4142c4fec2205dfd48ff453e8871
   MapboxNavigation: 77aabeee10bff6a54ccfbe5885b02d8ea0ec6d18


### PR DESCRIPTION
Update direction dependency to the latest version
https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.1.0