### PR TITLE
Allow maneuver arrow styling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * MapboxCoreNavigation now depends on [MapboxDirections v2.1.0](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.1.0). ([#3630](https://github.com/mapbox/mapbox-navigation-ios/pull/3630))
 * MapboxCoreNavigation now depends on [MapboxNavigationNative v81._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/81.0.0). ([#3614](https://github.com/mapbox/mapbox-navigation-ios/pull/3614))
 
+### Route overlay
+
+* Fixed an issue where changing color of `NavigationMapView.maneuverArrowColor` and `NavigationMapView.maneuverArrowStrokeColor` did not work. ([#3633](https://github.com/mapbox/mapbox-navigation-ios/pull/3633))
+
 ## v2.1.0
 
 ### Pricing

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -235,7 +235,14 @@ open class NavigationMapView: UIView {
               let triangleImage = Bundle.mapboxNavigation.image(named: "triangle")?.withRenderingMode(.alwaysTemplate) else { return }
         
         do {
-            try mapView.mapboxMap.style.addImage(triangleImage, id: NavigationMapView.ImageIdentifier.arrowImage, stretchX: [], stretchY: [])
+            if mapView.mapboxMap.style.image(withId: NavigationMapView.ImageIdentifier.arrowImage) == nil {
+                try mapView.mapboxMap.style.addImage(triangleImage,
+                                                     id: NavigationMapView.ImageIdentifier.arrowImage,
+                                                     sdf: true,
+                                                     stretchX: [],
+                                                     stretchY: [])
+            }
+            
             let step = route.legs[legIndex].steps[stepIndex]
             let maneuverCoordinate = step.maneuverLocation
             guard step.maneuverType != .arrive else { return }
@@ -381,6 +388,14 @@ open class NavigationMapView: UIView {
             NavigationMapView.SourceIdentifier.arrowSymbolSource
         ]
         mapView.mapboxMap.style.removeSources(sources)
+        
+        do {
+            if mapView.mapboxMap.style.image(withId: NavigationMapView.ImageIdentifier.arrowImage) != nil {
+                try mapView.mapboxMap.style.removeImage(withId: NavigationMapView.ImageIdentifier.arrowImage)
+            }
+        } catch {
+            NSLog("Failed to remove image \(NavigationMapView.ImageIdentifier.arrowImage) from style with error: \(error.localizedDescription).")
+        }
     }
     
     /**


### PR DESCRIPTION
Closing #3633.

PR updates code, which adds image, which is used for drawing maneuver arrow with `sdf` property set to `true`, as it's required for changing color.