### PR TITLE
Use a snapped location instead of a raw location during off-route detection process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,7 +230,7 @@
 * `RouteOptions` no longer conforms to `NSCopying`. Use `JSONEncoder` and `JSONDecoder` to get a copy of the `RouteOptions` object round-tripped through JSON. ([#3484](https://github.com/mapbox/mapbox-navigation-ios/pull/3484))
 * Added the `NavigationViewControllerDelegate.navigationViewController(_:shouldPreventReroutesWhenArrivingAt:)` method, which is called each time the user arrives at a waypoint. By default, this method returns true and prevents rerouting upon arriving. ([#3195](https://github.com/mapbox/mapbox-navigation-ios/pull/3195))
 * Renamed `RouteOptions.without(waypoint:)` to `RouteOptions.without(_:)`. ([#3192](https://github.com/mapbox/mapbox-navigation-ios/pull/3192))
-* Rerouting now uses a snapped location instead of a raw location from Core Location. ([#3361](https://github.com/mapbox/mapbox-navigation-ios/pull/3361))
+* Rerouting now uses a snapped location instead of a raw location from Core Location. ([#3361](https://github.com/mapbox/mapbox-navigation-ios/pull/3361), [#3644](https://github.com/mapbox/mapbox-navigation-ios/pull/3644))
 * Fixed an issue where a subclass of `NavigationRouteOptions` would turn into an ordinary `RouteOptions` when rerouting the user. ([#3192](https://github.com/mapbox/mapbox-navigation-ios/pull/3192), [#3484](https://github.com/mapbox/mapbox-navigation-ios/pull/3484))
 * Fixed an issue where the `RouteController.indexedRouteResponse` property would remain unchanged after the user is rerouted. ([#3344](https://github.com/mapbox/mapbox-navigation-ios/pull/3344]))
 * Fixed an issue where the `IndexedRouteResponse.routeIndex` of the `NavigationService.indexedRouteResponse` property would reset to zero after the user is rerouted. ([#3345](https://github.com/mapbox/mapbox-navigation-ios/pull/3345]))

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -311,19 +311,26 @@ open class RouteController: NSObject {
     }
 
     private func update(to status: NavigationStatus) {
-        guard let location = rawLocation else { return }
+        guard let rawLocation = rawLocation else { return }
+        
+        let snappedLocation = CLLocation(status.location)
+        
         // Notify observers if the step’s remaining distance has changed.
-        update(progress: routeProgress, with: CLLocation(status.location), rawLocation: location, upcomingRouteAlerts: status.upcomingRouteAlerts)
+        update(progress: routeProgress,
+               with: snappedLocation,
+               rawLocation: rawLocation,
+               upcomingRouteAlerts: status.upcomingRouteAlerts)
         
         updateIndexes(status: status, progress: routeProgress)
         updateRouteLegProgress(status: status)
-        let willReroute = !userIsOnRoute(location, status: status) && delegate?.router(self, shouldRerouteFrom: location)
-            ?? DefaultBehavior.shouldRerouteFromLocation
+        let willReroute = !userIsOnRoute(snappedLocation, status: status)
+        && delegate?.router(self, shouldRerouteFrom: snappedLocation)
+        ?? DefaultBehavior.shouldRerouteFromLocation
         
         updateSpokenInstructionProgress(status: status, willReRoute: willReroute)
         updateVisualInstructionProgress(status: status)
         updateRoadName(status: status)
-        updateDistanceToIntersection(from: CLLocation(status.location))
+        updateDistanceToIntersection(from: snappedLocation)
         
         if willReroute {
             reroute(from: CLLocation(status.location), along: routeProgress)
@@ -331,7 +338,7 @@ open class RouteController: NSObject {
 
         if status.routeState != .complete {
             // Check for faster route proactively (if reroutesProactively is enabled)
-            refreshAndCheckForFasterRoute(from: location, routeProgress: routeProgress)
+            refreshAndCheckForFasterRoute(from: snappedLocation, routeProgress: routeProgress)
         }
     }
     

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -324,8 +324,8 @@ open class RouteController: NSObject {
         updateIndexes(status: status, progress: routeProgress)
         updateRouteLegProgress(status: status)
         let willReroute = !userIsOnRoute(snappedLocation, status: status)
-        && delegate?.router(self, shouldRerouteFrom: snappedLocation)
-        ?? DefaultBehavior.shouldRerouteFromLocation
+        && (delegate?.router(self, shouldRerouteFrom: snappedLocation)
+            ?? DefaultBehavior.shouldRerouteFromLocation)
         
         updateSpokenInstructionProgress(status: status, willReRoute: willReroute)
         updateVisualInstructionProgress(status: status)
@@ -333,7 +333,7 @@ open class RouteController: NSObject {
         updateDistanceToIntersection(from: snappedLocation)
         
         if willReroute {
-            reroute(from: CLLocation(status.location), along: routeProgress)
+            reroute(from: snappedLocation, along: routeProgress)
         }
 
         if status.routeState != .complete {


### PR DESCRIPTION
Change off-route detection logic to use snapped location instead of raw location.

/cc @azarovalex 