### PR TITLE
Route linke blinking on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+* Fixed route line blinking when route is refreshed. ([#3647](https://github.com/mapbox/mapbox-navigation-ios/pull/3647))
 * Fixed a crash when approaching an intersection in which one of the lanes is a merge lane. ([#3699](https://github.com/mapbox/mapbox-navigation-ios/pull/3699))
 
 ## v2.2.0

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "3dabe41278e9b88e3eb2851dd3967493d21f08af",
-          "version": "21.0.1"
+          "revision": "ff38feb00183210d0e8807a205f9de2be97a5a38",
+          "version": "21.0.0-rc.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "a9955a309b7d17ce743bb9ea2eaf259540a2f64a",
-          "version": "10.2.0"
+          "revision": "9fe2c2e9c39c463973be407f3ba4d9a11c95f9c9",
+          "version": "10.2.0-rc.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "0f20e9a3d5928333eb311dc3a6f6ae363a05a8a3",
-          "version": "2.2.0"
+          "revision": "99d9d936ffe096a5d3e5d019a9eefe22e243c6e5",
+          "version": null
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "f8f4bb51777d2062b171018ac738c87d1ec94c7a",
-          "version": "10.2.0"
+          "revision": "7d9359bf08be6712b53621631f0cd4b899f0c4a9",
+          "version": "10.2.0-rc.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "147df82d8ca8b5438defb3a78b59320419b884df",
-          "version": "83.0.0"
+          "revision": "8665568a07a09086aaa704e4edf2af8644e14ab3",
+          "version": "81.0.0"
         }
       },
       {

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "ff38feb00183210d0e8807a205f9de2be97a5a38",
-          "version": "21.0.0-rc.2"
+          "revision": "3dabe41278e9b88e3eb2851dd3967493d21f08af",
+          "version": "21.0.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "9fe2c2e9c39c463973be407f3ba4d9a11c95f9c9",
-          "version": "10.2.0-rc.1"
+          "revision": "a9955a309b7d17ce743bb9ea2eaf259540a2f64a",
+          "version": "10.2.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "99d9d936ffe096a5d3e5d019a9eefe22e243c6e5",
-          "version": null
+          "revision": "0f20e9a3d5928333eb311dc3a6f6ae363a05a8a3",
+          "version": "2.2.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "7d9359bf08be6712b53621631f0cd4b899f0c4a9",
-          "version": "10.2.0-rc.1"
+          "revision": "f8f4bb51777d2062b171018ac738c87d1ec94c7a",
+          "version": "10.2.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "8665568a07a09086aaa704e4edf2af8644e14ab3",
-          "version": "81.0.0"
+          "revision": "bda9362b9f2900f035836d751f185c9d1c1413c7",
+          "version": "83.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .revision( "99d9d936ffe096a5d3e5d019a9eefe22e243c6e5")),
+        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.2.0"),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "81.0.0"),
-        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", .exact("10.2.0-rc.1")),
+        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "83.0.0"),
+        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.2.0"),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", from: "3.1.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.2.0"),
+        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .revision( "99d9d936ffe096a5d3e5d019a9eefe22e243c6e5")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "83.0.0"),
-        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.2.0"),
+        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "81.0.0"),
+        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", .exact("10.2.0-rc.1")),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", from: "3.1.2"),

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -139,28 +139,15 @@ open class RouteProgress: Codable {
     public var route: Route
     
     /**
-     Updates the current route with a refreshed one.
+     Updates the current route with attributes from the given skeletal route.
      */
-    func refreshRoute(with refreshedRoute: Route, at location: CLLocation) {
-        route = refreshedRoute
-        refreshLegProgress(at: location)
-    }
-    
-    private func refreshLegProgress(at location: CLLocation) {
+    public func refreshRoute(with refreshedRoute: RouteRefreshing, at location: CLLocation) {
+        route.refreshLegAttributes(from: refreshedRoute)
         currentLegProgress = RouteLegProgress(leg: route.legs[legIndex],
                                               stepIndex: currentLegProgress.stepIndex,
                                               spokenInstructionIndex: currentLegProgress.currentStepProgress.spokenInstructionIndex)
         calculateLegsCongestion()
         updateDistanceTraveled(with: location)
-    }
-    
-    /**
-     Updates the current route with attributes from the given skeletal route.
-     */
-    @available(*, deprecated, message: "Route refreshing logic should be handled by the SDK. There is no need to refresh the route object manually.")
-    public func refreshRoute(with refreshedRoute: RefreshedRoute, at location: CLLocation) {
-        route.refreshLegAttributes(from: refreshedRoute)
-        refreshLegProgress(at: location)
     }
     
     /**

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -141,7 +141,7 @@ open class RouteProgress: Codable {
     /**
      Updates the current route with attributes from the given skeletal route.
      */
-    public func refreshRoute(with refreshedRoute: RouteRefreshing, at location: CLLocation) {
+    public func refreshRoute(with refreshedRoute: RouteRefreshSource, at location: CLLocation) {
         route.refreshLegAttributes(from: refreshedRoute)
         currentLegProgress = RouteLegProgress(leg: route.legs[legIndex],
                                               stepIndex: currentLegProgress.stepIndex,


### PR DESCRIPTION
Resolves #3621 
Temporarily set Directions to track [custom commit](https://github.com/mapbox/mapbox-directions-swift/pull/634) to test new Directions API before it's release.

PR reverts route refreshing methods on `RouteProgress` to utilize new refreshing protocol.