### PR TITLE
Clean working directory before switching branches

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -14,7 +14,7 @@ if ! [[ "${VERSION}" =~ ^([0-9]+\.){2}[0-9]+(-.+)?$ ]]; then
   exit 1
 fi
 
-
+git checkout -- .
 git checkout publisher-production
 git add "${VERSION}"
 git commit -m "v${VERSION} [skip ci]"


### PR DESCRIPTION
The script fails to publish docs because previous actions could pollute the working directory. In my case, it was `Package.resolved` from `Navigation-SPM.xcodeproj` that was updated during docs generation.