### PR TITLE
Add documentation for `InstructionsBannerViewDelegate`.

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		B47C1B86261FD3E00078546C /* NavigationPlotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C1B01261FD0A30078546C /* NavigationPlotter.swift */; };
 		B47C1B8F261FD3E70078546C /* NavigationServiceTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C1AE2261FD0A30078546C /* NavigationServiceTestDoubles.swift */; };
 		B4843887270F8E1600E161E6 /* SimulationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4843886270F8E1600E161E6 /* SimulationType.swift */; };
+		B493FB1D2767EDDB002AF455 /* InstructionsBannerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B493FB1C2767EDDB002AF455 /* InstructionsBannerViewDelegate.swift */; };
 		B4A78D19261FD47700FDF212 /* route-with-banner-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = B47C1AE5261FD0A30078546C /* route-with-banner-instructions.json */; };
 		B4A78D1A261FD47700FDF212 /* route-with-missing-road-classes.json in Resources */ = {isa = PBXBuildFile; fileRef = B47C1AE6261FD0A30078546C /* route-with-missing-road-classes.json */; };
 		B4A78D1B261FD47700FDF212 /* route-with-instructions.json in Resources */ = {isa = PBXBuildFile; fileRef = B47C1AE7261FD0A30078546C /* route-with-instructions.json */; };
@@ -864,6 +865,7 @@
 		B47C1B02261FD0A30078546C /* DirectionsSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsSpy.swift; sourceTree = "<group>"; };
 		B47C1B03261FD0A30078546C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B4843886270F8E1600E161E6 /* SimulationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationType.swift; sourceTree = "<group>"; };
+		B493FB1C2767EDDB002AF455 /* InstructionsBannerViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionsBannerViewDelegate.swift; sourceTree = "<group>"; };
 		B4BB0AD42704D1D7006F502D /* short_route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = short_route.json; sourceTree = "<group>"; };
 		B4BB0AD62704D1E6006F502D /* multileg_route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = multileg_route.json; sourceTree = "<group>"; };
 		B4D4291826260D5900EE92A8 /* MBXInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MBXInfo.plist; sourceTree = "<group>"; };
@@ -1563,6 +1565,7 @@
 				8A04DFBB275EBC1B00D87959 /* TopBannerViewControllerDelegate.swift */,
 				353610CD1FAB6A8F00FB1746 /* BottomBannerViewController.swift */,
 				355ED36F1FAB724F00BCE1B8 /* BottomBannerViewLayout.swift */,
+				B493FB1C2767EDDB002AF455 /* InstructionsBannerViewDelegate.swift */,
 			);
 			name = Banners;
 			sourceTree = "<group>";
@@ -2438,6 +2441,7 @@
 				353280A11FA72871005175F3 /* InstructionLabel.swift in Sources */,
 				351BEBFF1E5BCC63006FE110 /* ManeuversStyleKit.swift in Sources */,
 				C54C655220336F2600D338E0 /* Constants.swift in Sources */,
+				B493FB1D2767EDDB002AF455 /* InstructionsBannerViewDelegate.swift in Sources */,
 				353610CE1FAB6A8F00FB1746 /* BottomBannerViewController.swift in Sources */,
 				8A50A3CD26EC0A3100894A8E /* DialogViewController.swift in Sources */,
 				AEC3AC9A2106703100A26F34 /* HighwayShield.swift in Sources */,

--- a/Sources/MapboxNavigation/InstructionsBannerView.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerView.swift
@@ -4,58 +4,75 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 /**
- `InstructionsBannerViewDelegate` provides methods for reacting to user interactions in `InstructionsBannerView`.
- */
-public protocol InstructionsBannerViewDelegate: VisualInstructionDelegate {
-    /**
-     Called when the user taps the `InstructionsBannerView`.
-     */
-    func didTapInstructionsBanner(_ sender: BaseInstructionsBannerView)
-    
-    /**
-     Called when the user swipes either left, right, or down on the `InstructionsBannerView`
-     */
-    func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizer.Direction)
-}
-
-public extension InstructionsBannerViewDelegate {
-    /**
-     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
-     */
-    func didTapInstructionsBanner(_ sender: BaseInstructionsBannerView) {
-        logUnimplemented(protocolType: InstructionsBannerViewDelegate.self, level: .debug)
-    }
-    
-    /**
-     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
-     */
-    func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizer.Direction) {
-        logUnimplemented(protocolType: InstructionsBannerViewDelegate.self, level: .debug)
-    }
-}
-
-/// :nodoc:
+ A banner view that contains the current step instruction and responds to tap and swipe gestures.
+ 
+ This class responds and gets updated as the user progresses along a route according to the `NavigationComponent` and `BaseInstructionsBannerView` protocol.
+*/
 @IBDesignable
 open class InstructionsBannerView: BaseInstructionsBannerView, NavigationComponent {
+    
+    /**
+     Updates the instructions banner info as the user progresses along a route.
+     
+     - parameter service: The `NavigationService` instance that passes the instruction.
+     - parameter instruction: The `VisualInstructionBanner` instance to be presented.
+     - parameter routeProgress: The`RouteProgress` instance that the instruction banner view is updating.
+     */
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
         update(for: instruction)
     }
 }
 
-/// :nodoc:
+/**
+ A banner view that contains the current step instruction along a route and responds to tap and swipe gestures, as the base of `InstructionsCardView` and `InstructionsBannerView`.
+*/
 open class BaseInstructionsBannerView: UIControl {
+    
+    /**
+     A view that contains a simple image indicating a type of maneuver.
+     */
     public weak var maneuverView: ManeuverView!
+    
+    /**
+     A primary instruction label indicates the current step.
+     */
     public weak var primaryLabel: PrimaryLabel!
+    
+    /**
+     A secondary instruction label below the `primaryLabel` to provide detail information of current step.
+     */
     public weak var secondaryLabel: SecondaryLabel!
+    
+    /**
+     A styled lable indicates the remaining distance along the current step.
+     */
     public weak var distanceLabel: DistanceLabel!
+    
+    /**
+     A vertical view divides between `maneuverView` and `distanceLabel` to `primaryLabel` and `secondaryLabel`.
+     */
     public weak var dividerView: UIView!
     weak var _separatorView: UIView!
+    
+    /**
+     A invisible helper view for visualizing the result of the constraints.
+     */
     public weak var separatorView: SeparatorView!
+    
+    /**
+     A drag view indicates whether there're more steps in the remaining route.
+     */
     public weak var stepListIndicatorView: StepListIndicatorView!
     
+    /**
+     A `Boolean` value controls whether the banner view reponds to swipe gestures. Defaults to `false`.
+     */
     @IBInspectable
     public var swipeable: Bool = false
     
+    /**
+     A `Boolean` value controls whether the banner view shows the `stepListIndicatorView`. Defaults to `true`.
+     */
     @IBInspectable
     public var showStepIndicator: Bool = true {
         didSet {
@@ -63,6 +80,9 @@ open class BaseInstructionsBannerView: UIControl {
         }
     }
     
+    /**
+     The instruction banner view's delegate that conforms to `InstructionsBannerViewDelegate`.
+     */
     public weak var delegate: InstructionsBannerViewDelegate? {
         didSet {
             if showStepIndicator {
@@ -78,6 +98,9 @@ open class BaseInstructionsBannerView: UIControl {
     
     let distanceFormatter = DistanceFormatter()
     
+    /**
+     The remaining distance of current step in meters.
+     */
     public var distance: CLLocationDistance? {
         didSet {
             distanceLabel.attributedDistanceString = nil

--- a/Sources/MapboxNavigation/InstructionsBannerView.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerView.swift
@@ -29,7 +29,7 @@ open class InstructionsBannerView: BaseInstructionsBannerView, NavigationCompone
 open class BaseInstructionsBannerView: UIControl {
     
     /**
-     A view that contains a simple image indicating a type of maneuver.
+     A view that contains an image indicating a type of maneuver.
      */
     public weak var maneuverView: ManeuverView!
     
@@ -39,28 +39,30 @@ open class BaseInstructionsBannerView: UIControl {
     public weak var primaryLabel: PrimaryLabel!
     
     /**
-     A secondary instruction label below the `primaryLabel` to provide detail information of current step.
+     A secondary instruction label below the `PrimaryLabel`, which provides detailed information about the current step..
      */
     public weak var secondaryLabel: SecondaryLabel!
     
     /**
-     A styled lable indicates the remaining distance along the current step.
+     A styled label indicates the remaining distance along the current step.
      */
     public weak var distanceLabel: DistanceLabel!
     
     /**
-     A vertical view divides between `maneuverView` and `distanceLabel` to `primaryLabel` and `secondaryLabel`.
+     A vertical view divides between `ManeuverView` and `DistanceLabel` to `PrimaryLabel` and `SecondaryLabel`.
      */
     public weak var dividerView: UIView!
     weak var _separatorView: UIView!
     
     /**
-     A invisible helper view for visualizing the result of the constraints.
+     An invisible helper view for visualizing the result of the constraints.
      */
     public weak var separatorView: SeparatorView!
     
     /**
-     A drag view indicates whether there're more steps in the remaining route.
+     A view, which indicates that there're more steps in the current route.
+     
+     If shown, `InstructionsBannerView` can be swiped to the bottom to see all of these remaining steps.
      */
     public weak var stepListIndicatorView: StepListIndicatorView!
     
@@ -71,7 +73,7 @@ open class BaseInstructionsBannerView: UIControl {
     public var swipeable: Bool = false
     
     /**
-     A `Boolean` value controls whether the banner view shows the `stepListIndicatorView`. Defaults to `true`.
+     A `Boolean` value controls whether the banner view shows the `StepListIndicatorView`. Defaults to `true`.
      */
     @IBInspectable
     public var showStepIndicator: Bool = true {
@@ -175,6 +177,8 @@ open class BaseInstructionsBannerView: UIControl {
     
     /**
      Updates the instructions banner info with a given `VisualInstructionBanner`.
+     
+     - parameter instruction: The `VisualInstructionBanner` instance to be presented.
      */
     public func update(for instruction: VisualInstructionBanner?) {
         let secondaryInstruction = instruction?.secondaryInstruction
@@ -204,6 +208,8 @@ open class BaseInstructionsBannerView: UIControl {
     
     /**
      Updates the instructions banner distance info for a given `RouteStepProgress`.
+     
+     - parameter currentStepProgress: The current `RouteStepProgress` instance that the instruction banner view is updating.
      */
     public func updateDistance(for currentStepProgress: RouteStepProgress) {
         let distanceRemaining = currentStepProgress.distanceRemaining

--- a/Sources/MapboxNavigation/InstructionsBannerView.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerView.swift
@@ -49,7 +49,7 @@ open class BaseInstructionsBannerView: UIControl {
     public weak var distanceLabel: DistanceLabel!
     
     /**
-     A vertical view divides between `ManeuverView` and `DistanceLabel` to `PrimaryLabel` and `SecondaryLabel`.
+     A vertical view, which is used as a divider between `ManeuverView`/`DistanceLabel` views to the left and `PrimaryLabel`/`SecondaryLabel` views to the right.
      */
     public weak var dividerView: UIView!
     weak var _separatorView: UIView!

--- a/Sources/MapboxNavigation/InstructionsBannerViewDelegate.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerViewDelegate.swift
@@ -1,0 +1,37 @@
+import UIKit
+
+/**
+ `InstructionsBannerViewDelegate` provides methods for reacting to user interactions in `InstructionsBannerView`.
+ */
+public protocol InstructionsBannerViewDelegate: VisualInstructionDelegate {
+    /**
+     Called when the user taps the `InstructionsBannerView`.
+     
+     - parameter sender: The `BaseInstructionsBannerView` instance.
+     */
+    func didTapInstructionsBanner(_ sender: BaseInstructionsBannerView)
+    
+    /**
+     Called when the user swipes either left, right, or down on the `InstructionsBannerView`.
+     
+     - parameter sender: The `BaseInstructionsBannerView` instance.
+     - parameter direction: Direction, in which swiping was performed: (either `.left`, `.right`, `.top` or `.bottom`).
+     */
+    func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizer.Direction)
+}
+
+public extension InstructionsBannerViewDelegate {
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func didTapInstructionsBanner(_ sender: BaseInstructionsBannerView) {
+        logUnimplemented(protocolType: InstructionsBannerViewDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func didSwipeInstructionsBanner(_ sender: BaseInstructionsBannerView, swipeDirection direction: UISwipeGestureRecognizer.Direction) {
+        logUnimplemented(protocolType: InstructionsBannerViewDelegate.self, level: .debug)
+    }
+}

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -160,7 +160,7 @@ extension NavigationMapView {
         
         if index > 0 && offRouteDistanceCheckEnabled {
             let distanceToLine = findDistanceToNearestPointOnCurrentLine(coordinate: coordinate, granularDistances: granularDistances, upcomingIndex: index + 1)
-            if distanceToLine > OffRouteDistanceUpdateThreshold {
+            if distanceToLine > offRouteDistanceUpdateThreshold {
                 return
             }
         }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1342,7 +1342,7 @@ open class NavigationMapView: UIView {
     /**
      The maximum distance threshold of vanishing route line update. When the user's location to the route line is larger than the threshold, the user is off the route and the route line won't be updated.
      */
-    var OffRouteDistanceUpdateThreshold: CLLocationDistance = 15.0
+    var offRouteDistanceUpdateThreshold: CLLocationDistance = 15.0
     
     /**
      `MapView`, which is added on top of `NavigationMapView` and allows to render navigation related components.

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -94,7 +94,9 @@ custom_categories:
       - InstructionsCardViewController
       - InstructionsCardContainerView
       - InstructionsCardContainerViewDelegate
+      - InstructionsBannerView
       - InstructionsBannerViewDelegate
+      - BaseInstructionsBannerView
       - ManeuverView
       - JunctionView
       - GenericRouteShield


### PR DESCRIPTION
This pr is to add documentation for `InstructionsBannerView`, `BaseInstructionsBannerView` and the publicly exposed properties.`InstructionsBannerViewDelegate` is moved to a separate file as well.