### PR TITLE
Support instant Restricted Areas Route Line update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * Added `NavigationMapView.showsRestrictedAreasOnRoute` property which allows displaying on UI parts of a route which lie on restricted roads. This overlay is customisable through `NavigationMapView.routeRestrictedAreaColor`, `NavigationMapViewDelegate.navigationMapView(_:, restrictedAreasShapeFor:)` and `NavigationMapView.navigationMapView(_:, routeRestrictedAreasLineLayerWithIdentifier:, sourceIdentifier:)` methods. ([#3603](https://github.com/mapbox/mapbox-navigation-ios/pull/3603))
 * Fixed an issue where changing color of `NavigationMapView.maneuverArrowColor` and `NavigationMapView.maneuverArrowStrokeColor` did not work. ([#3633](https://github.com/mapbox/mapbox-navigation-ios/pull/3633))
-* Added the ability to support the instant route line change of `NavigationMapView.showsRestrictedAreasOnRoute` during active navigation. ([#3654](https://github.com/mapbox/mapbox-navigation-ios/pull/3654))
+* Fixed an issue where the route line blinks when `NavigationMapView.showsRestrictedAreasOnRoute` turns on during active navigation with `routeLineTracksTraversal` enabled. ([#3654](https://github.com/mapbox/mapbox-navigation-ios/pull/3654))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Added `NavigationMapView.showsRestrictedAreasOnRoute` property which allows displaying on UI parts of a route which lie on restricted roads. This overlay is customisable through `NavigationMapView.routeRestrictedAreaColor`, `NavigationMapViewDelegate.navigationMapView(_:, restrictedAreasShapeFor:)` and `NavigationMapView.navigationMapView(_:, routeRestrictedAreasLineLayerWithIdentifier:, sourceIdentifier:)` methods. ([#3603](https://github.com/mapbox/mapbox-navigation-ios/pull/3603))
 * Fixed an issue where changing color of `NavigationMapView.maneuverArrowColor` and `NavigationMapView.maneuverArrowStrokeColor` did not work. ([#3633](https://github.com/mapbox/mapbox-navigation-ios/pull/3633))
+* Added the ability to support the instant route line change of `NavigationMapView.showsRestrictedAreasOnRoute` during active navigation. ([#3654](https://github.com/mapbox/mapbox-navigation-ios/pull/3654))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * Added `NavigationMapView.showsRestrictedAreasOnRoute` property which allows displaying on UI parts of a route which lie on restricted roads. This overlay is customisable through `NavigationMapView.routeRestrictedAreaColor`, `NavigationMapViewDelegate.navigationMapView(_:, restrictedAreasShapeFor:)` and `NavigationMapView.navigationMapView(_:, routeRestrictedAreasLineLayerWithIdentifier:, sourceIdentifier:)` methods. ([#3603](https://github.com/mapbox/mapbox-navigation-ios/pull/3603))
 * Fixed an issue where changing color of `NavigationMapView.maneuverArrowColor` and `NavigationMapView.maneuverArrowStrokeColor` did not work. ([#3633](https://github.com/mapbox/mapbox-navigation-ios/pull/3633))
-* Fixed an issue where the route line blinks when `NavigationMapView.showsRestrictedAreasOnRoute` turns on during active navigation with `routeLineTracksTraversal` enabled. ([#3654](https://github.com/mapbox/mapbox-navigation-ios/pull/3654))
+* Fixed an issue where the route line blinks when `NavigationMapView.showsRestrictedAreasOnRoute` is turned on during active navigation, and when `NavigationMapView.routeLineTracksTraversal` is set to `true`. ([#3654](https://github.com/mapbox/mapbox-navigation-ios/pull/3654))
 
 ### Location tracking
 

--- a/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
+++ b/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
@@ -357,7 +357,7 @@ class VanishingRouteLineTests: TestCase {
               }
         XCTAssert(indexOfMainRouteLayer < indexOfArrowStrokeLayer, "Arrow stroke layer should be above main route layer")
         
-        // When the `NavigationMapView.showsRestrictedAreasOnRoute` turns on during active navigation with `routeLineTracksTraversal` enabled,
+        // When the `NavigationMapView.showsRestrictedAreasOnRoute` is turned on during active navigation with `routeLineTracksTraversal` enabled,
         // the previous vanishing effect should be kept, and the new restricted areas layer should be added
         // above the main route line layer but below the arrow stroke layer.
         navigationMapView.showsRestrictedAreasOnRoute = true
@@ -379,7 +379,7 @@ class VanishingRouteLineTests: TestCase {
             XCTFail(error.localizedDescription)
         }
         
-        // When the `NavigationMapView.showsRestrictedAreasOnRoute` turns off during active navigation with `routeLineTracksTraversal` enabled,
+        // When the `NavigationMapView.showsRestrictedAreasOnRoute` is turned off during active navigation with `routeLineTracksTraversal` enabled,
         // the previous vanishing effect should be kept, but the restricted areas layer and its source should be removed.
         navigationMapView.showsRestrictedAreasOnRoute = false
         do {

--- a/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
+++ b/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
@@ -359,7 +359,7 @@ class VanishingRouteLineTests: TestCase {
         
         // When the `NavigationMapView.showsRestrictedAreasOnRoute` turns on during active navigation with `routeLineTracksTraversal` enabled,
         // the previous vanishing effect should be kept, and the new restricted areas layer should be added
-        // avove the main route line layer but below the arrow stroke layer.
+        // above the main route line layer but below the arrow stroke layer.
         navigationMapView.showsRestrictedAreasOnRoute = true
         do {
             let layer = try navigationMapView.mapView.mapboxMap.style.layer(withId: layerIdentifier) as! LineLayer


### PR DESCRIPTION
### Description
This pr is to fix #3636 and support the instant change of `NavigationMapView.showsRestrictedAreasOnRoute` during active navigation.

### Implementation
When the `NavigationMapView.showsRestrictedAreasOnRoute` turns on during active navigation with `routeLineTracksTraversal` enabled, the `currentRestrictedAreasStops` will be updated, the new restricted areas layer will be added above the main route line layer and below the arrow stroke layer.

When the `NavigationMapView.showsRestrictedAreasOnRoute` turns off during active navigation with `routeLineTracksTraversal` enabled, the `currentRestrictedAreasStops` will be removed, the restricted areas layer and its source would also be removed.

When `NavigationMapView.showsRestrictedAreasOnRoute` value changes during active navigation with `routeLineTracksTraversal` disabled, or during the previewing mode, the whole route line layers will be re-generated.

### Screenshots or Gifs
1. Add the following code below the https://github.com/mapbox/mapbox-navigation-ios/blob/81559e7da04456231df3e6eb16a10e75e7b79b48/Sources/MapboxNavigation/CameraController.swift#L72
to switch the `navigationMapView.showsRestrictedAreasOnRoute` value during active navigation through resume button.
```
navigationMapView.showsRestrictedAreasOnRoute = !navigationMapView.showsRestrictedAreasOnRoute
```
2. In `Example` run `basic` mode, click resume button to see the difference.
3. Also try to replace the `showsRestrictedAreasOnRoute` with `crossfadesCongestionSegments`, and `navigationViewController.routeLineTracksTraversal` to test the instant change.

![switch](https://user-images.githubusercontent.com/48976398/146097999-c5a10450-425d-4acc-9b60-49727e8b36fa.gif)

