### PR TITLE
Add more precise docs post-processing

### DIFF
--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -25,10 +25,6 @@ THEME=${JAZZY_THEME:-$DEFAULT_THEME}
 
 BASE_URL="https://docs.mapbox.com/ios"
 
-# Link to directions documentation
-DIRECTIONS_VERSION=$(grep 'mapbox-directions-swift' Cartfile.resolved | grep -oE '"v.+?"' | grep -oE '[^"v]+')
-DIRECTIONS_SYMBOLS="AttributeOptions|CoordinateBounds|Directions|DirectionsCredentials|DirectionsOptions|DirectionsPriority|DirectionsProfileIdentifier|DirectionsResult|Intersection|Lane|LaneIndication|MapMatchingResponse|Match|MatchOptions|RoadClasses|Route|RouteLeg|RouteOptions|RouteResponse|RouteStep|SpokenInstruction|Tracepoint|VisualInstruction|VisualInstruction.Component|VisualInstruction.Component.ImageRepresentation|VisualInstruction.Component.TextRepresentation|VisualInstructionBanner|Waypoint"
-
 rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}
 
@@ -71,10 +67,8 @@ fi
     
 rm docs.output
 
-REPLACE_REGEXP='s/MapboxNavigation\s+(Docs|Reference)/Mapbox Navigation SDK for iOS $1/, '
-REPLACE_REGEXP+="s/<span class=\"kt\">(${DIRECTIONS_SYMBOLS})<\/span>/<span class=\"kt\"><a href=\"${BASE_URL//\//\\/}\/directions\/api\/${DIRECTIONS_VERSION}\/Classes\/\$1.html\">\$1<\/a><\/span>/, "
-
-find ${OUTPUT} -name *.html -exec \
-    perl -pi -e "$REPLACE_REGEXP" {} \;
+# Link to directions documentation
+DIRECTIONS_VERSION=$(python3 -c "import json; print(list(filter(lambda x:x['package']=='MapboxDirections', json.loads(open('Package.resolved').read())['object']['pins']))[0]['state']['version'])")
+python3 scripts/postprocess-docs.py -b "${BASE_URL}/directions/api/${DIRECTIONS_VERSION}" -d "${OUTPUT}"
 
 echo $SHORT_VERSION > $OUTPUT/latest_version

--- a/scripts/postprocess-docs.py
+++ b/scripts/postprocess-docs.py
@@ -15,14 +15,8 @@ for opt, arg in opts:
      docs_root = arg
      
 # receive, parse and remove index file
-index_file = "search.json"
-urllib.request.urlretrieve('{base_url}/search.json'.format(base_url=base_url), index_file)
-
-with open(index_file) as index:
-  index_data = json.load(index)
-  
-if os.path.exists(index_file):
-  os.remove(index_file)
+with urllib.request.urlopen('{base_url}/search.json'.format(base_url=base_url)) as url:
+  index_data = json.load(url)
 
 # fill the [symbol: url] dictionary
 symbols = dict()
@@ -44,4 +38,4 @@ for root, dirs, files in os.walk(docs_root):
       # Mapbox Navigation specific
       line = re.sub(r'MapboxNavigation\s+(Docs|Reference)', lambda x: 'Mapbox Navigation SDK for iOS {section}'.format(section=x.group(1)), line.rstrip('\n'))
       
-      print(line)
+      sys.stdout.write(line)

--- a/scripts/postprocess-docs.py
+++ b/scripts/postprocess-docs.py
@@ -1,0 +1,47 @@
+import json, os, re, fileinput, getopt, sys, urllib.request
+
+base_url=''
+docs_root=''
+
+try:
+  opts, args = getopt.getopt(sys.argv[1:], "b:d:")
+except getopt.GetoptError:
+  print('post-document.py -b <base_url> -d <docs_root>')
+  sys.exit(2)
+for opt, arg in opts:
+  if opt in ("-b", "--baseurl"):
+     base_url = arg
+  elif opt in ("-d", "--docsroot"):
+     docs_root = arg
+     
+# receive, parse and remove index file
+index_file = "search.json"
+urllib.request.urlretrieve('{base_url}/search.json'.format(base_url=base_url), index_file)
+
+with open(index_file) as index:
+  index_data = json.load(index)
+  
+if os.path.exists(index_file):
+  os.remove(index_file)
+
+# fill the [symbol: url] dictionary
+symbols = dict()
+
+for path in filter(lambda p: (p.startswith('Classes') or p.startswith('Structs') or p.startswith('Enums')) and p.endswith('.html'), index_data):
+  # path is expected to be in the format Classes/VisualInstruction/Component/ImageRepresentation/Format.html
+  # VisualInstruction.Component.ImageRepresentation.Format -> https://example.com/Classes/VisualInstruction/Component/ImageRepresentation/Format.html
+  symbols[".".join(path.split('.')[0].split('/')[1:])] = '{base}/{path}'.format(base=base_url, path=path)
+  
+# substitute symbols in all html files with links
+for root, dirs, files in os.walk(docs_root):
+  for file in [f for f in files if f.endswith('.html')]:
+    file_path = os.path.join(root, file)
+    
+    for line in fileinput.FileInput(file_path, inplace=True):
+      line = re.sub(r"<span class=\"kt\">({keys})</span>".format(keys='|'.join(symbols.keys())), lambda x: '<span class=\"kt\"><a href=\"{link}\">{symbol}</a></span>'.format(link=symbols.get(x.group(1)), symbol=x.group(1)), line.rstrip('\n'))
+      line = re.sub(r"<code>({keys})</code>".format(keys='|'.join(symbols.keys())), lambda x: '<code><a href=\"{link}\">{symbol}</a></code>'.format(link=symbols.get(x.group(1)), symbol=x.group(1)), line.rstrip('\n'))
+      
+      # Mapbox Navigation specific
+      line = re.sub(r'MapboxNavigation\s+(Docs|Reference)', lambda x: 'Mapbox Navigation SDK for iOS {section}'.format(section=x.group(1)), line.rstrip('\n'))
+      
+      print(line)


### PR DESCRIPTION
Changes similar to https://github.com/mapbox/mapbox-directions-swift/pull/631, which brings dynamic symbol retrieval.
This fixes lots of broken links and adds new ones for recently added symbols.

The script is almost the same as in https://github.com/mapbox/mapbox-directions-swift/pull/631, only changing a custom string substitute.