### PR TITLE
Extract MapboxNavigationNative_Private usage into type alias

### DIFF
--- a/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
@@ -3,6 +3,9 @@ import MapboxDirections
 import MapboxNavigationNative
 @_implementationOnly import MapboxNavigationNative_Private
 
+/// RouterInterface from MapboxNavigationNative
+typealias RouterInterfaceNative = MapboxNavigationNative_Private.RouterInterface
+
 /**
  Provides alternative access to routing API.
  
@@ -114,7 +117,7 @@ public class MapboxRoutingProvider: RoutingProvider {
     public private(set) var activeRequests: [RequestId : Request] = [:]
     
     private let requestsLock = NSLock()
-    private let router: MapboxNavigationNative_Private.RouterInterface
+    private let router: RouterInterfaceNative
     
     private func complete(requestId: RequestId, with result: @escaping () -> Void) {
         DispatchQueue.main.async { [self] in


### PR DESCRIPTION
For whatever reason, Swift 5.3 (Xcode 12.4) requires us to use a type alias if we refer to a module as a namespace and the module had been imported as `@_implementationOnly` and CocoaPods is doing its magic behind the scenes. This small change fixes building with CocoaPods in Xcode 12.4 and unblocks v2.1.1.

Cherry-pick to the release-v2.1 branch after merging.

/cc @mapbox/navigation-ios