### PR TITLE
Allow the mapView receives simulated location update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Added the `RouterDelegate.router(_:initialManeuverBufferWhenReroutingFrom:)` method and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to configure rerouting buffering. ([#3454](https://github.com/mapbox/mapbox-navigation-ios/pull/3454))
 * Added `RouterDelegate.router(_:requestBehaviorForReroutingWith:)` and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to provide customization for rerouting mechanism by providing a user-defined route as a reroute. ([#3472](https://github.com/mapbox/mapbox-navigation-ios/pull/3472))
-* Fixed an issue where customized `.puck2D` and `.puck3D` of `NavigationMapView.userLocationStyle` being stale during simulated active navigation. ([#3674](https://github.com/mapbox/mapbox-navigation-ios/pull/3674))
+* Fixed an issue where customized `.puck2D` and `.puck3D` of `NavigationMapView.userLocationStyle` is not shown during simulated active navigation. ([#3674](https://github.com/mapbox/mapbox-navigation-ios/pull/3674))
 * Added the `NavigationLocationProvider.didUpdateLocations(locations:)` to send locations update to `MapView` and notify its `LocationConsumer`. ([#3674](https://github.com/mapbox/mapbox-navigation-ios/pull/3674))
 
 ### Other Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 * Added the `RouterDelegate.router(_:initialManeuverBufferWhenReroutingFrom:)` method and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to configure rerouting buffering. ([#3454](https://github.com/mapbox/mapbox-navigation-ios/pull/3454))
 * Added `RouterDelegate.router(_:requestBehaviorForReroutingWith:)` and related `NavigationServiceDelegate` and `NavigationViewControllerDelegate` methods to provide customization for rerouting mechanism by providing a user-defined route as a reroute. ([#3472](https://github.com/mapbox/mapbox-navigation-ios/pull/3472))
+* Fixed an issue where customized `.puck2D` and `.puck3D` of `NavigationMapView.userLocationStyle` being stale during simulated active navigation. ([#3674](https://github.com/mapbox/mapbox-navigation-ios/pull/3674))
+* Added the `NavigationLocationProvider.didUpdateLocations(locations:)` to send locations update to `MapView` and notify its `LocationConsumer`. ([#3674](https://github.com/mapbox/mapbox-navigation-ios/pull/3674))
 
 ### Other Changes
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		B456A8D22620C9C700FD86D8 /* MMEEventsManager+Spy.m in Sources */ = {isa = PBXBuildFile; fileRef = B456A8B72620C9C000FD86D8 /* MMEEventsManager+Spy.m */; };
 		B456A8EC2620D26B00FD86D8 /* LeakTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456A8EB2620D26A00FD86D8 /* LeakTest.swift */; };
 		B456A9062620D73700FD86D8 /* CLHeadingPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = B456A9052620D73700FD86D8 /* CLHeadingPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B473E901278651DD00D9E821 /* NavigationLocationProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B473E900278651DD00D9E821 /* NavigationLocationProviderTests.swift */; };
 		B47C1B05261FD0C00078546C /* TestHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = B47C1AFF261FD0A30078546C /* TestHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B47C1B1E261FD3290078546C /* CoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C1AE3261FD0A30078546C /* CoreLocation.swift */; };
 		B47C1B47261FD3A90078546C /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C1ACF261FD0A30078546C /* Date.swift */; };
@@ -829,6 +830,7 @@
 		B456A8B82620C9C000FD86D8 /* MMEEventsManager+Spy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "MMEEventsManager+Spy.h"; path = "include/MMEEventsManager+Spy.h"; sourceTree = "<group>"; };
 		B456A8EB2620D26A00FD86D8 /* LeakTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeakTest.swift; sourceTree = "<group>"; };
 		B456A9052620D73700FD86D8 /* CLHeadingPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CLHeadingPrivate.h; path = include/CLHeadingPrivate.h; sourceTree = "<group>"; };
+		B473E900278651DD00D9E821 /* NavigationLocationProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationProviderTests.swift; sourceTree = "<group>"; };
 		B47C1AAA261FCDF30078546C /* CTestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTestHelper.h; sourceTree = "<group>"; };
 		B47C1ACF261FD0A30078546C /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		B47C1AD0261FD0A30078546C /* NavigationEventsManagerTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationEventsManagerTestDoubles.swift; sourceTree = "<group>"; };
@@ -1478,6 +1480,7 @@
 				AED2156E208F7FEA009AA673 /* NavigationViewControllerTests.swift */,
 				169A9709216440820082A6A0 /* NavigationViewControllerTestDoubles.swift */,
 				B40B1C60270380EC0065F57D /* VanishingRouteLineTests.swift */,
+				B473E900278651DD00D9E821 /* NavigationLocationProviderTests.swift */,
 			);
 			name = Navigation;
 			sourceTree = "<group>";
@@ -2629,6 +2632,7 @@
 				AE00A73A209A2C38006A3DC7 /* StepsViewControllerTests.swift in Sources */,
 				8DEDBCA9222F442900DA2618 /* CarPlayNavigationViewControllerTests.swift in Sources */,
 				8A6C468226C2FA2E00452EBE /* NavigationGeocodedPlacemarkTests.swift in Sources */,
+				B473E901278651DD00D9E821 /* NavigationLocationProviderTests.swift in Sources */,
 				35B1AEBC20AD9B3C00C8544E /* LeaksSpec.swift in Sources */,
 				16A509D5202A87B20011D788 /* ImageDownloaderTests.swift in Sources */,
 				8AB316C926BCA56D00C3AC76 /* UIViewController.swift in Sources */,

--- a/Sources/MapboxNavigation/NavigationLocationProvider.swift
+++ b/Sources/MapboxNavigation/NavigationLocationProvider.swift
@@ -116,6 +116,13 @@ open class NavigationLocationProvider: NSObject, LocationProvider, CLLocationMan
     }
     
     /**
+     Sends the locations update through the delegate to the `MapView` after overriding the `locationProvider` of `MapView`.
+     */
+    public func didUpdateLocations(locations: [CLLocation]) {
+        delegate?.locationProvider(self, didUpdateLocations: locations)
+    }
+    
+    /**
      Returns the current accuracy authorization that the user has granted
      */
     public var accuracyAuthorization: CLAccuracyAuthorization {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1548,8 +1548,8 @@ open class NavigationMapView: UIView {
                     self.travelAlongRouteLine(to: location.coordinate)
                 }
             default:
-                if self.simulatesLocation, self.inActiveNavigation, let locationProvider = self.mapView.location.locationProvider {
-                    self.mapView.location.locationProvider(locationProvider, didUpdateLocations: [location])
+                if self.simulatesLocation, self.inActiveNavigation, let locationProvider = self.mapView.location.locationProvider as? NavigationLocationProvider {
+                    locationProvider.didUpdateLocations(locations: [location])
                 }
             }
         }

--- a/Tests/MapboxNavigationTests/NavigationLocationProviderTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationLocationProviderTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import MapboxMaps
+@testable import MapboxNavigation
+import TestHelper
+
+class NavigationLocationProviderTests: TestCase {
+    var navigationMapView: NavigationMapView!
+    
+    override func setUp() {
+        super.setUp()
+        navigationMapView = NavigationMapView(frame: .zero)
+    }
+    
+    override func tearDown() {
+        navigationMapView = nil
+        super.tearDown()
+    }
+    
+    func testOverriddenLocationProviderUpdateLocations() {
+        let navigationLocationManagerStub = NavigationLocationManagerStub()
+        let navigationLocationProviderStub = NavigationLocationProvider(locationManager: navigationLocationManagerStub)
+        let location = CLLocation(latitude: 0, longitude: 0)
+        
+        navigationMapView.mapView.location.overrideLocationProvider(with: navigationLocationProviderStub)
+        navigationLocationProviderStub.didUpdateLocations(locations: [location])
+        
+        XCTAssert(navigationMapView.mapView?.location.locationProvider is NavigationLocationProvider, "Failed to override mapView location provider.")
+        XCTAssertEqual(navigationMapView.mapView.location.latestLocation?.coordinate, location.coordinate, "Failed to update mapView location.")
+    }
+}


### PR DESCRIPTION
### Description
This pr is to fix #3673 to allow the `NavigationMapView.MapView` could receive the simulated location updates from our `NavigationLocationProvider`.

### Implementation
Because of the `MapboxMaps` upgrade and the refactoring in the `LocationManager` of `MapView`, right now the `MapView.location.locationProvider(_: didUpdateLocations:)` having issues with the locations update and notification to its consumers. Now we add the `NavigationLocationProvider.didUpdateLocations(locations:)` method to notify the `MapView` about the locations update, and the location consumers of the `MapView` such as the map puck could be noticed and updated with the locations.

#### Screenshots or Gifs
![mapPuck](https://user-images.githubusercontent.com/48976398/148291725-178582b8-f978-402a-ace5-936271b90580.gif)

