### PR TITLE
Fix tap gesture to stop camera transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Other Changes
 
 * Extracted `MapboxNavigationNative_Private` usage into a type alias to fix a compilation in Xcode 12.4. ([#3662](https://github.com/mapbox/mapbox-navigation-ios/pull/3662))
+* Fixed a bug where tapping `NavigationMapView` while it transitions the camera to or from `following/overview` states would leave it in `transitioning` state, and thus blocking switching to either mode. ([#3685](https://github.com/mapbox/mapbox-navigation-ios/pull/3685))
 
 ## v2.1.0
 

--- a/Sources/MapboxNavigation/NavigationCamera.swift
+++ b/Sources/MapboxNavigation/NavigationCamera.swift
@@ -34,6 +34,7 @@ public class NavigationCamera: NSObject, ViewportDataSourceDelegate {
     
     func setupGestureRecognizers() {
         makeGestureRecognizersDisableCameraFollowing()
+        makeTapGestureRecognizerStopAnimatedTransitions()
     }
     
     // MARK: Reacting to ViewportDataSourceDelegate Updates
@@ -194,11 +195,19 @@ public class NavigationCamera: NSObject, ViewportDataSourceDelegate {
      and stops all pending transitions.
      */
     @objc public func stop() {
-        if state == .idle { return }
-        
+        stopTransition(ignoring: .idle)
+    }
+    
+    @objc func stopNonFollowingTransition() {
+        stopTransition(ignoring: .following)
+    }
+    
+    private func stopTransition(ignoring state: NavigationCameraState) {
+        if self.state == state { return }
+
         cameraStateTransition.cancelPendingTransition()
-        
-        state = .idle
+
+        self.state = .idle
     }
     
     /**
@@ -211,6 +220,14 @@ public class NavigationCamera: NSObject, ViewportDataSourceDelegate {
             || gestureRecognizer is UIRotationGestureRecognizer
             || gestureRecognizer is UIPinchGestureRecognizer {
             gestureRecognizer.addTarget(self, action: #selector(stop))
+        }
+    }
+    
+    func makeTapGestureRecognizerStopAnimatedTransitions() {
+        for gestureRecognizer in mapView?.gestureRecognizers ?? []
+        where gestureRecognizer is UITapGestureRecognizer
+        {
+            gestureRecognizer.addTarget(self, action: #selector(stopNonFollowingTransition))
         }
     }
     


### PR DESCRIPTION
Fixes and issue, where tapping `NavigationMapView` while it transitions the camera to or from `following/overview` states would leave it in `transitioning` state, and thus blocking switching to either mode.