### PR TITLE
Building highlighting overlaps POI icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 * Extracted `MapboxNavigationNative_Private` usage into a type alias to fix a compilation in Xcode 12.4. ([#3662](https://github.com/mapbox/mapbox-navigation-ios/pull/3662))
 * Fixed a bug where tapping `NavigationMapView` while it transitions the camera to or from `following/overview` states would leave it in `transitioning` state, and thus blocking switching to either mode. ([#3685](https://github.com/mapbox/mapbox-navigation-ios/pull/3685))
+* Fixed an issue where building extrusion highlighting was covering oter items located on the map like POI and destination/arrival icons. ([#3692](https://github.com/mapbox/mapbox-navigation-ios/pull/3692))
 
 ## v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 * Extracted `MapboxNavigationNative_Private` usage into a type alias to fix a compilation in Xcode 12.4. ([#3662](https://github.com/mapbox/mapbox-navigation-ios/pull/3662))
 * Fixed a bug where tapping `NavigationMapView` while it transitions the camera to or from `following/overview` states would leave it in `transitioning` state, and thus blocking switching to either mode. ([#3685](https://github.com/mapbox/mapbox-navigation-ios/pull/3685))
-* Fixed an issue where building extrusion highlighting was covering oter items located on the map like POI and destination/arrival icons. ([#3692](https://github.com/mapbox/mapbox-navigation-ios/pull/3692))
+* Fixed an issue where building extrusion highlighting was covering other items located on the map like POI and destination/arrival icons. ([#3692](https://github.com/mapbox/mapbox-navigation-ios/pull/3692))
 
 ## v2.1.0
 

--- a/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
@@ -21,6 +21,7 @@ extension NavigationMapView {
         let identifiers = mapView.mapboxMap.style.allLayerIdentifiers
             .compactMap({ $0.id })
             .filter({ $0.contains("building") })
+        let layerPosition = identifiers.last.map { LayerPosition.above($0) }
         
         coordinates.forEach {
             group.enter()
@@ -46,7 +47,7 @@ extension NavigationMapView {
         }
 
         group.notify(queue: DispatchQueue.main) {
-            self.addBuildingsLayer(with: foundBuildingIds, in3D: extrudesBuildings)
+            self.addBuildingsLayer(with: foundBuildingIds, in3D: extrudesBuildings, layerPosition: layerPosition)
             completion?(foundBuildingIds.count == coordinates.count)
         }
     }
@@ -66,7 +67,7 @@ extension NavigationMapView {
         }
     }
 
-    private func addBuildingsLayer(with identifiers: Set<Int64>, in3D: Bool = false, extrudeAll: Bool = false) {
+    private func addBuildingsLayer(with identifiers: Set<Int64>, in3D: Bool = false, extrudeAll: Bool = false, layerPosition: LayerPosition? = nil) {
         let identifier = NavigationMapView.LayerIdentifier.buildingExtrusionLayer
         
         do {
@@ -120,7 +121,7 @@ extension NavigationMapView {
             highlightedBuildingsLayer.fillExtrusionColor = .constant(.init(buildingHighlightColor))
             highlightedBuildingsLayer.fillExtrusionHeightTransition = StyleTransition(duration: 0.8, delay: 0)
             highlightedBuildingsLayer.fillExtrusionOpacityTransition = StyleTransition(duration: 0.8, delay: 0)
-            try mapView.mapboxMap.style.addLayer(highlightedBuildingsLayer)
+            try mapView.mapboxMap.style.addLayer(highlightedBuildingsLayer, layerPosition: layerPosition)
         } catch {
             NSLog("Failed to perform operation on \(identifier) with error: \(error.localizedDescription).")
         }


### PR DESCRIPTION
This PR fixes a bug where building highlighting extrusion was hiding POIs and destination marker.
Issue is resolved by specifying layer order of extrusion graphic to be just above the original building layer.

Compare before and after:
![image](https://user-images.githubusercontent.com/23082783/150306348-66022ce5-04a0-4266-9f5f-2ea630a6ae05.png)

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-01-20 at 11 50 41](https://user-images.githubusercontent.com/23082783/150306233-c5445390-1e94-4359-aa20-c7a75e120961.png)
