### PR TITLE
Update directions dependency to v2.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Packaging
 
 * MapboxNavigation now requires [MapboxMaps v10._x_](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.2.0). ([#3665](https://github.com/mapbox/mapbox-navigation-ios/pull/3665))
-* MapboxCoreNavigation now requires [MapboxDirections v2.2.0-rc.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.2.0-rc.1). ([#3683](https://github.com/mapbox/mapbox-navigation-ios/pull/3683))
+* MapboxCoreNavigation now requires [MapboxDirections v2._x_](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.2.0). ([#3694](https://github.com/mapbox/mapbox-navigation-ios/pull/3694))
 * MapboxCoreNavigation now requires [MapboxNavigationNative v83._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/83.0.0). ([#3683](https://github.com/mapbox/mapbox-navigation-ios/pull/3683))
 
 ### Map

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 21.0.1
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 83.0
-github "mapbox/mapbox-directions-swift" ~> 2.2.0-rc.1
+github "mapbox/mapbox-directions-swift" ~> 2.2.0
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,7 @@ binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "83.0.0"
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v3.1.2"
-github "mapbox/mapbox-directions-swift" "v2.2.0-rc.1"
+github "mapbox/mapbox-directions-swift" "v2.2.0"
 github "mapbox/mapbox-events-ios" "v1.0.7"
 github "mapbox/turf-swift" "v2.1.0"
 github "pointfreeco/swift-snapshot-testing" "1.9.0"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxCoreNavigation"
 
   s.dependency "MapboxNavigationNative", "~> 83.0"
-  s.dependency "MapboxDirections-pre", "~> 2.2.0-rc.1"
+  s.dependency "MapboxDirections", "~> 2.2.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 
   s.swift_version = "5.0"

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "35d35453e83813765d869ccf34b5ab751fe7ba90",
-          "version": "2.2.0-rc.1"
+          "revision": "0f20e9a3d5928333eb311dc3a6f6ae363a05a8a3",
+          "version": "2.2.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "35d35453e83813765d869ccf34b5ab751fe7ba90",
-          "version": "2.2.0-rc.1"
+          "revision": "0f20e9a3d5928333eb311dc3a6f6ae363a05a8a3",
+          "version": "2.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.2.0-rc.1"),
+        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.2.0"),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
         .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "83.0.0"),
         .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.2.0"),

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
@@ -232,7 +232,7 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
-				"${BUILT_PRODUCTS_DIR}/MapboxDirections-pre/MapboxDirections.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxDirections/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMaps/MapboxMaps.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxSpeech/MapboxSpeech.framework",

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - MapboxCoreMaps (10.2.0):
     - MapboxCommon (~> 21.0)
   - MapboxCoreNavigation (2.2.0-rc.1):
-    - MapboxDirections-pre (~> 2.2.0-rc.1)
+    - MapboxDirections (~> 2.2.0)
     - MapboxMobileEvents (~> 1.0)
     - MapboxNavigationNative (~> 83.0)
-  - MapboxDirections-pre (2.2.0-rc.1):
+  - MapboxDirections (2.2.0):
     - Polyline (~> 5.0)
     - Turf (~> 2.0)
   - MapboxMaps (10.2.0):
@@ -36,7 +36,7 @@ SPEC REPOS:
   trunk:
     - MapboxCommon
     - MapboxCoreMaps
-    - MapboxDirections-pre
+    - MapboxDirections
     - MapboxMaps
     - MapboxMobileEvents
     - MapboxNavigationNative
@@ -54,8 +54,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: fdfdbd4e87a225190913f2f4b4a73ec51ed77eaa
   MapboxCoreMaps: bdd0115bfd8bf6df402468710cb23c926938b03d
-  MapboxCoreNavigation: 8f1f07a6fbe1cadf272fd4fd3ad6c1c06746ab6e
-  MapboxDirections-pre: 0067f769e264d49e8ad95fb73c46e6799ffca917
+  MapboxCoreNavigation: 36ce9c8778249be5d23f69ee3ac62e34001ccb27
+  MapboxDirections: aaa6f1ae1612692ef3b4211d20d22404ad8ef607
   MapboxMaps: 1ed477cbe573a9e740801dfc9c636ef33bbc3f54
   MapboxMobileEvents: 14d7ac3ee95b4142c4fec2205dfd48ff453e8871
   MapboxNavigation: 0a34d7a24a1a1cd702748dffe5380d4d3fc154e0


### PR DESCRIPTION
This PR is to update `MapboxDirections` for Swift dependency to `v2.2.0`