### PR TITLE
Restore and fix disabled tests

### DIFF
--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -175,6 +175,10 @@ class Navigator {
         }
     }
 
+    func updateLocation(_ location: CLLocation, completion: @escaping (Bool) -> Void) {
+        navigator.updateLocation(for: FixLocation(location), callback: completion)
+    }
+
     func pause() {
         navigator.pause()
     }

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -119,7 +119,7 @@ open class PassiveLocationManager: NSObject {
         }
         
         for location in locations {
-            navigator.updateLocation(for: FixLocation(location)) { success in
+            Navigator.shared.updateLocation(location) { success in
                 let result: Result<CLLocation, Error>
                 if success {
                     result = .success(location)

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -220,7 +220,7 @@ open class RouteController: NSObject {
         rawLocation = location
         
         locations.forEach {
-            navigator.updateLocation(for: FixLocation($0)) { _ in
+            Navigator.shared.updateLocation($0) { _ in
                 // No-op
             }
         }

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -338,7 +338,8 @@ extension InternalRouter where Self: Router {
         
         lastRerouteLocation = origin
         
-        routeTask = routingProvider.calculateRoutes(options: options) {(session, result) in
+        routeTask = routingProvider.calculateRoutes(options: options) { [weak self] (session, result) in
+            guard let self = self else { return }            
             defer { self.routeTask = nil }
             switch result {
             case .failure(let error):

--- a/Sources/TestHelper/TestCase.swift
+++ b/Sources/TestHelper/TestCase.swift
@@ -28,8 +28,8 @@ open class TestCase: XCTestCase {
         super.tearDown()
         // Reset navigator
         NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: .default)
-        Navigator.shared.navigator.resetRideSession()
-        Navigator._recreateNavigator()
+        Navigator.shared.restartNavigator(forcing: nil)
+        Navigator.shared.mostRecentNavigationStatus = nil
     }
 
     /// Prepares tests for execution. Should be called once before any test runs.

--- a/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
@@ -590,23 +590,25 @@ final class BillingHandlerUnitTests: TestCase {
         ])
     }
 
-    func disabled_testTripPerWaypoint() {
-        var routeOptions: NavigationRouteOptions {
-            let coordinates = [
-                CLLocationCoordinate2D(latitude: 37.751748, longitude: -122.387589),
-                CLLocationCoordinate2D(latitude: 37.752397, longitude: -122.387631),
-                CLLocationCoordinate2D(latitude: 37.753186, longitude: -122.387721),
-                CLLocationCoordinate2D(latitude: 37.75405, longitude: -122.38781),
-                CLLocationCoordinate2D(latitude: 37.754817, longitude: -122.387859),
-                CLLocationCoordinate2D(latitude: 37.755594, longitude: -122.38793),
-                CLLocationCoordinate2D(latitude: 37.756574, longitude: -122.388057),
-                CLLocationCoordinate2D(latitude: 37.757531, longitude: -122.388198),
-                CLLocationCoordinate2D(latitude: 37.758628, longitude: -122.388322),
-                CLLocationCoordinate2D(latitude: 37.759682, longitude: -122.388401),
-                CLLocationCoordinate2D(latitude: 37.760872, longitude: -122.388511),
-            ]
+    func testTripPerWaypoint() {
+        let waypointCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.751748, longitude: -122.387589),
+            CLLocationCoordinate2D(latitude: 37.752397, longitude: -122.387631),
+            CLLocationCoordinate2D(latitude: 37.753186, longitude: -122.387721),
+            CLLocationCoordinate2D(latitude: 37.75405, longitude: -122.38781),
+            CLLocationCoordinate2D(latitude: 37.754817, longitude: -122.387859),
+            CLLocationCoordinate2D(latitude: 37.755594, longitude: -122.38793),
+            CLLocationCoordinate2D(latitude: 37.756574, longitude: -122.388057),
+            CLLocationCoordinate2D(latitude: 37.757531, longitude: -122.388198),
+            CLLocationCoordinate2D(latitude: 37.758628, longitude: -122.388322),
+            CLLocationCoordinate2D(latitude: 37.759682, longitude: -122.388401),
+            CLLocationCoordinate2D(latitude: 37.760872, longitude: -122.388511),
+        ]
 
-            let waypoints = coordinates.map({ Waypoint(coordinate: $0) })
+        let waypoints = waypointCoordinates.map({ Waypoint(coordinate: $0) })
+
+        var routeOptions: NavigationRouteOptions {
+
 
             return NavigationRouteOptions(waypoints: waypoints)
         }
@@ -614,10 +616,10 @@ final class BillingHandlerUnitTests: TestCase {
         let route = Fixture.route(from: "route-with-10-legs", options: routeOptions)
         
         autoreleasepool {
-            let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+            let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent()
             let routeResponse = RouteResponse(httpResponse: nil,
                                               routes: [route],
-                                              options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
+                                              options: .route(.init(coordinates: waypointCoordinates)),
                                               credentials: .mocked)
 
             let routeController = RouteController(alongRouteAtIndex: 0,

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -38,7 +38,7 @@ class MapboxCoreNavigationTests: TestCase {
         UserDefaults.resetStandardUserDefaults()
     }
     
-    func disabled_testNavigationNotificationsInfoDict() {
+    func testNavigationNotificationsInfoDict() {
         navigation = MapboxNavigationService(routeResponse: response,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
@@ -121,7 +121,7 @@ class MapboxCoreNavigationTests: TestCase {
         }
     }
     
-    func disabled_testNewStep() {
+    func testNewStep() {
         let steps = route.legs[0].steps
         // Create list of coordinates, which includes all coordinates in the first step and
         // first coordinate in the second step.
@@ -328,7 +328,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation.stop()
     }
     
-    func disabled_testOrderOfExecution() {
+    func testOrderOfExecution() {
         let trace = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
         let locationManager = ReplayLocationManager(locations: trace)
         locationManager.speedMultiplier = 100

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -349,7 +349,7 @@ class NavigationServiceTests: TestCase {
         XCTAssertLessThan(distance, distanceThreshold)
     }
 
-    func disabled_testLocationCourseShouldNotChange() {
+    func testLocationCourseShouldNotChange() {
         // This route is a simple straight line: http://geojson.io/#id=gist:anonymous/64cfb27881afba26e3969d06bacc707c&map=17/37.77717/-122.46484
         let options = NavigationRouteOptions(coordinates: [
             CLLocationCoordinate2D(latitude: 37.77735, longitude: -122.461465),
@@ -520,7 +520,7 @@ class NavigationServiceTests: TestCase {
         XCTAssertEqual(eventsManagerSpy.flushedEventCount(with: expectedEventName), 1)
     }
 
-    func disabled_testGeneratingAnArrivalEvent() {
+    func testGeneratingAnArrivalEvent() {
         let trace = Fixture.generateTrace(for: route).shiftedToPresent()
         let locationManager = ReplayLocationManager(locations: trace)
         dependencies = createDependencies(locationSource: locationManager)
@@ -549,7 +549,7 @@ class NavigationServiceTests: TestCase {
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: expectedEventName))
     }
 
-    func disabled_testNoReroutesAfterArriving() {
+    func testNoReroutesAfterArriving() {
         let now = Date()
         let trace = Fixture.generateTrace(for: route).shiftedToPresent()
         let locationManager = ReplayLocationManager(locations: trace)
@@ -641,7 +641,7 @@ class NavigationServiceTests: TestCase {
         XCTAssert(subject.poorGPSTimer.countdownInterval == .milliseconds(5000), "Timer should now have a countdown interval of 5000 millseconds.")
     }
 
-    func disabled_testMultiLegRoute() {
+    func testMultiLegRoute() {
         let route = Fixture.route(from: "multileg-route", options: routeOptions)
         let trace = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
         let locationManager = ReplayLocationManager(locations: trace)


### PR DESCRIPTION
Fixes disabled before tests:
- Better Navigator reset method
- Hard retain in new reroute code
- An attempted fix to 'tripPerWaypoint' test