### PR TITLE
Fix crash displaying unrecognized lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## main
+
+* Fixed a crash when approaching an intersection in which one of the lanes is a merge lane. ([#3699](https://github.com/mapbox/mapbox-navigation-ios/pull/3699))
+
 ## v2.2.0
 
 ### Packaging

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -153,7 +153,7 @@ extension LanesStyleKit {
             TurnClassification(laneIndication: $0, dominantSide: dominantSide, drivingSide: drivingSide)
         }
         guard let method = styleKitMethod(turnClassifications: turnClassifications, favoredTurnClassification: favoredTurnClassification) ??
-                favoredTurnClassification.map({ styleKitMethod(turnClassifications: [$0], favoredTurnClassification: $0) }) ??
+                favoredTurnClassification.flatMap({ styleKitMethod(turnClassifications: [$0], favoredTurnClassification: $0) }) ??
                 styleKitMethod(turnClassifications: [.straightAhead], favoredTurnClassification: nil) else {
             preconditionFailure("No StyleKit method for straight ahead.")
         }

--- a/Tests/MapboxNavigationTests/LaneViewTests.swift
+++ b/Tests/MapboxNavigationTests/LaneViewTests.swift
@@ -148,6 +148,11 @@ class LaneViewTests: TestCase {
         XCTAssertEqual(LanesStyleKit.styleKitMethod(turnClassifications: [.sharpTurn], favoredTurnClassification: .sharpTurn)?.isOn, true)
         XCTAssertEqual(LanesStyleKit.styleKitMethod(turnClassifications: [.uTurn], favoredTurnClassification: nil)?.isOff, true)
         XCTAssertEqual(LanesStyleKit.styleKitMethod(turnClassifications: [.uTurn], favoredTurnClassification: .uTurn)?.isOn, true)
+        
+        // Unrecognized turn indications show up as empty lanes in the Directions API response.
+        // https://github.com/mapbox/mapbox-navigation-ios/issues/3596
+        XCTAssertNil(LanesStyleKit.styleKitMethod(turnClassifications: [], favoredTurnClassification: nil))
+        XCTAssertNil(LanesStyleKit.styleKitMethod(turnClassifications: [], favoredTurnClassification: .straightAhead))
     }
     
     func testStyleKitMethodDoubleUseAllowingStraightAhead() {
@@ -324,5 +329,10 @@ class LaneViewTests: TestCase {
         
         XCTAssertTrue(LanesStyleKit.styleKitMethod(lane: [.sharpLeft, .sharpRight], maneuverDirection: nil, drivingSide: .right).isSymmetric, "Unsupported configuration should fall back to straight ahead")
         XCTAssertTrue(LanesStyleKit.styleKitMethod(lane: [.sharpLeft, .sharpRight], maneuverDirection: nil, drivingSide: .right).isOff, "Unsupported configuration should fall back to straight ahead")
+        
+        // Unrecognized turn indications show up as empty lanes in the Directions API response.
+        // https://github.com/mapbox/mapbox-navigation-ios/issues/3596
+        XCTAssertTrue(LanesStyleKit.styleKitMethod(lane: [], maneuverDirection: .left, drivingSide: .right).isSymmetric)
+        XCTAssertTrue(LanesStyleKit.styleKitMethod(lane: [], maneuverDirection: .left, drivingSide: .right).isOff)
     }
 }


### PR DESCRIPTION
When displaying an unrecognized turn lane indication combination, such as a U-turn-and-opposite-turn combination, we fall back to just the active indication. When that active indication is unrecognized, such as for a merge lane, there’s supposed to be a last-resort fallback to a dimmed out straight-ahead icon. However, this fallback was being short-circuited by a stray optional from the previous fallback, prematurely triggering the precondition failure. This specific case was covered by a test at a low level for the method that worked correctly but not at a higher level for the method that short-circuited it.

Fixes #3596.

/cc @mapbox/navigation-ios