### PR TITLE
Support to show and hide traffic data from V2 beta version tile set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Map
 
-* Added `MapView.showsTileSet(withIdentifiers:layerIdentifier:)` and `MapView.setShowsTileSet(_:withIdentifiers:layerIdentifier:)`to public to support developers show and hide custom TileSet IDs for the map view. ([#3700](https://github.com/mapbox/mapbox-navigation-ios/pull/3700))
+* Added `MapView.showsTileSet(with:layerIdentifier:)` and `MapView.setShowsTileSet(_:with:layerIdentifier:)` to provide the ability to show and hide custom tile set identifiers on the map view. ([#3700](https://github.com/mapbox/mapbox-navigation-ios/pull/3700))
 
 ### Offline routing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Fixed cases in which the user location indicator floated around when the user was stopped at an intersection in an urban canyon. ([#3705](https://github.com/mapbox/mapbox-navigation-ios/pull/3705))
 * Fixed poor location snapping while the user is inside a tunnel. ([#3705](https://github.com/mapbox/mapbox-navigation-ios/pull/3705))
 
+### Map
+
+* Added `MapView.showsTileSet(withIdentifiers:layerIdentifier:)` and `MapView.setShowsTileSet(_:withIdentifiers:layerIdentifier:)`to public to support developers show and hide custom TileSet IDs for the map view. ([#3700](https://github.com/mapbox/mapbox-navigation-ios/pull/3700))
+
 ### Offline routing
 
 * If routing tiles in local storage are corrupted, the tiles are now redownloaded. ([#3705](https://github.com/mapbox/mapbox-navigation-ios/pull/3705))

--- a/Sources/MapboxNavigation/MapView.swift
+++ b/Sources/MapboxNavigation/MapView.swift
@@ -26,7 +26,7 @@ extension MapView {
      - parameter sourceIdentifier: Identifier of the source, which will be searched for in current style of the `MapView`.
      - returns: Set of tile set identifiers.
      */
-    func tileSetIdentifiersSet(_ sourceIdentifier: String) -> Set<String> {
+    func tileSetIdentifiers(_ sourceIdentifier: String) -> Set<String> {
         if let properties = try? mapboxMap.style.sourceProperties(for: sourceIdentifier),
            let url = properties["url"] as? String,
            let configurationURL = URL(string: url),
@@ -49,7 +49,7 @@ extension MapView {
      */
     func tileSetIdentifiers(_ sourceIdentifier: String, sourceType: String) -> [String] {
         if sourceType == "vector" {
-            return Array(tileSetIdentifiersSet(sourceIdentifier))
+            return Array(tileSetIdentifiers(sourceIdentifier))
         }
         
         return []
@@ -65,7 +65,7 @@ extension MapView {
         return Set(mapboxMap.style.allSourceIdentifiers.filter {
             $0.type.rawValue == "vector"
         }.filter {
-            !tileSetIdentifiersSet($0.id).isDisjoint(with: tileSetIdentifiers)
+            !self.tileSetIdentifiers($0.id).isDisjoint(with: tileSetIdentifiers)
         }.map {
             $0.id
         })
@@ -77,7 +77,7 @@ extension MapView {
      - parameter tileSetIdentifiers: Identifiers of the tile sets in the form `user.tileset`.
      - parameter layerIdentifier: Identifier of the layer in the tile set; in other words, a source layer identifier. Not to be confused with a style layer.
      */
-    public func showsTileSet(withIdentifiers tileSetIdentifiers: Set<String>, layerIdentifier: String) -> Bool {
+    public func showsTileSet(with tileSetIdentifiers: Set<String>, layerIdentifier: String) -> Bool {
         let sourceIdentifiers = self.sourceIdentifiers(tileSetIdentifiers)
         var foundTileSets = false
         
@@ -106,7 +106,7 @@ extension MapView {
      - parameter tileSetIdentifiers: Identifiers of the tile sets in the form `user.tileset`.
      - parameter layerIdentifier: Identifier of the layer in the tile set; in other words, a source layer identifier. Not to be confused with a style layer.
      */
-    public func setShowsTileSet(_ isVisible: Bool, withIdentifiers tileSetIdentifiers: Set<String>, layerIdentifier: String) {
+    public func setShowsTileSet(_ isVisible: Bool, with tileSetIdentifiers: Set<String>, layerIdentifier: String) {
         let sourceIdentifiers = self.sourceIdentifiers(tileSetIdentifiers)
         
         for mapViewLayerIdentifier in mapboxMap.style.allLayerIdentifiers.map({ $0.id }) {
@@ -129,10 +129,10 @@ extension MapView {
      */
     public var showsTraffic: Bool {
         get {
-            return showsTileSet(withIdentifiers: trafficTileSetIdentifiers, layerIdentifier: "traffic")
+            return showsTileSet(with: trafficTileSetIdentifiers, layerIdentifier: "traffic")
         }
         set {
-            setShowsTileSet(newValue, withIdentifiers: trafficTileSetIdentifiers, layerIdentifier: "traffic")
+            setShowsTileSet(newValue, with: trafficTileSetIdentifiers, layerIdentifier: "traffic")
         }
     }
     
@@ -141,10 +141,10 @@ extension MapView {
      */
     public var showsIncidents: Bool {
         get {
-            return showsTileSet(withIdentifiers: incidentsTileSetIdentifiers, layerIdentifier: "closures")
+            return showsTileSet(with: incidentsTileSetIdentifiers, layerIdentifier: "closures")
         }
         set {
-            setShowsTileSet(newValue, withIdentifiers: incidentsTileSetIdentifiers, layerIdentifier: "closures")
+            setShowsTileSet(newValue, with: incidentsTileSetIdentifiers, layerIdentifier: "closures")
         }
     }
     
@@ -220,7 +220,7 @@ extension MapView {
         guard !ResourceOptionsManager.hasChinaBaseURL,
               let mapboxStreetsSource = streetsSources().first else { return }
         
-        let streetsSourceTilesetIdentifiers = tileSetIdentifiersSet(mapboxStreetsSource.id)
+        let streetsSourceTilesetIdentifiers = tileSetIdentifiers(mapboxStreetsSource.id)
         let roadLabelSourceLayerIdentifier = streetsSourceTilesetIdentifiers.compactMap { VectorSource.roadLabelLayerIdentifiersByTileSetIdentifier[$0]
         }.first
         

--- a/Sources/MapboxNavigation/MapView.swift
+++ b/Sources/MapboxNavigation/MapView.swift
@@ -72,13 +72,14 @@ extension MapView {
     }
     
     /**
-     Returns a Boolean value indicating whether data from the given tile set layers is currently visible in the map view’s style.
+     Returns a Boolean value indicating whether data from the given tile set layers is currently all visible in the map view’s style.
      
      - parameter tileSetIdentifiers: Identifiers of the tile sets in the form `user.tileset`.
      - parameter layerIdentifier: Identifier of the layer in the tile set; in other words, a source layer identifier. Not to be confused with a style layer.
      */
     public func showsTileSet(withIdentifiers tileSetIdentifiers: Set<String>, layerIdentifier: String) -> Bool {
         let sourceIdentifiers = self.sourceIdentifiers(tileSetIdentifiers)
+        var foundTileSets = false
         
         for mapViewLayerIdentifier in mapboxMap.style.allLayerIdentifiers.map({ $0.id }) {
             guard let sourceIdentifier = mapboxMap.style.layerProperty(for: mapViewLayerIdentifier,
@@ -87,13 +88,15 @@ extension MapView {
                                                                             property: "source-layer").value as? String else { return false }
             
             if sourceIdentifiers.contains(sourceIdentifier) && sourceLayerIdentifier == layerIdentifier {
+                foundTileSets = true
                 let visibility = mapboxMap.style.layerProperty(for: mapViewLayerIdentifier, property: "visibility").value as? String
-                
-                return visibility == "visible"
+                if visibility != "visible" {
+                    return false
+                }
             }
         }
         
-        return false
+        return foundTileSets
     }
     
     /**

--- a/Tests/MapboxNavigationTests/MapViewTests.swift
+++ b/Tests/MapboxNavigationTests/MapViewTests.swift
@@ -50,12 +50,12 @@ class MapViewTests: TestCase {
         
         wait(for: [mapLoadingErrorExpectation], timeout: 1.0)
         
-        let tileSetIdentifiers = mapView.tileSetIdentifiers("composite")
+        let tileSetIdentifiers = mapView.tileSetIdentifiersSet("composite")
         
-        let expectedTileSetIdentifiers = [
+        let expectedTileSetIdentifiers = Set([
             "mapbox.mapbox-streets-v8",
             "mapbox.mapbox-terrain-v2"
-        ]
+        ])
         
         XCTAssertEqual(tileSetIdentifiers.count,
                        expectedTileSetIdentifiers.count,
@@ -71,7 +71,7 @@ class MapViewTests: TestCase {
         
         // Verify whether `MapView.sourceIdentifiers(_:)` returns only source identifiers for
         // Mapbox tile set identifiers.
-        let mapboxSourceIdentifiers = mapView.sourceIdentifiers("mapbox.mapbox-terrain-v2")
+        let mapboxSourceIdentifiers = mapView.sourceIdentifiers(Set(["mapbox.mapbox-terrain-v2"]))
         XCTAssertEqual(mapboxSourceIdentifiers.count,
                        1,
                        "There should be only one source identifier.")

--- a/Tests/MapboxNavigationTests/MapViewTests.swift
+++ b/Tests/MapboxNavigationTests/MapViewTests.swift
@@ -50,7 +50,7 @@ class MapViewTests: TestCase {
         
         wait(for: [mapLoadingErrorExpectation], timeout: 1.0)
         
-        let tileSetIdentifiers = mapView.tileSetIdentifiersSet("composite")
+        let tileSetIdentifiers = mapView.tileSetIdentifiers("composite")
         
         let expectedTileSetIdentifiers = Set([
             "mapbox.mapbox-streets-v8",


### PR DESCRIPTION
### Description
This pr is to allow the mapView to show and hide traffic data from traffic v2 tile set.

### Implementation
Right now the `MapView.showsTileSet(withIdentifiers:layerIdentifier:)` and `MapView.setShowsTileSet(_:withIdentifiers:layerIdentifier:)` are both public to allow developers to show and hide custom  TileSet IDs for the map.
