### PR TITLE
[bugfix] Fix Direction.calculateOffline using hybrid router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 * Fixed a crash when approaching an intersection in which one of the lanes is a merge lane. ([#3699](https://github.com/mapbox/mapbox-navigation-ios/pull/3699))
+* Fixed an error behavior where `Directions.calculateOffline` would still try to build a route online. ([#3702](https://github.com/mapbox/mapbox-navigation-ios/pull/3702))
 
 ## v2.2.0
 

--- a/Sources/MapboxCoreNavigation/Directions.swift
+++ b/Sources/MapboxCoreNavigation/Directions.swift
@@ -44,7 +44,7 @@ extension Directions {
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
      */
     open func calculateOffline(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) {
-        MapboxRoutingProvider().calculateRoutes(options: options,
-                                                completionHandler: completionHandler)
+        MapboxRoutingProvider(.offline).calculateRoutes(options: options,
+                                                        completionHandler: completionHandler)
     }
 }


### PR DESCRIPTION
This PR fixes `Directions.calculateOffline` method to use strictly offline routing provider.