### PR TITLE
[Issue-3707] Support Offline Navigation Rerouting

### DIFF
--- a/Sources/MapboxCoreNavigation/Directions+RoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/Directions+RoutingProvider.swift
@@ -8,30 +8,30 @@ extension URLSessionDataTask: NavigationProviderRequest {
 }
 
 extension Directions: RoutingProvider {
-    
+
     @discardableResult public func calculateRoutes(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) -> NavigationProviderRequest? {
-        return calculate(options, completionHandler: completionHandler)
+        return calculateWithCache(options, completionHandler: completionHandler)
     }
-    
+
     @discardableResult public func calculateRoutes(options: MatchOptions, completionHandler: @escaping MatchCompletionHandler) -> NavigationProviderRequest? {
-        return calculate(options, completionHandler: completionHandler)
+        return calculateWithCache(options, completionHandler: completionHandler)
     }
-    
+
     @discardableResult public func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, completionHandler: @escaping RouteCompletionHandler) -> NavigationProviderRequest? {
         guard case let .route(routeOptions) = indexedRouteResponse.routeResponse.options else {
             preconditionFailure("Invalid route data passed for refreshing. Expected `RouteResponse` containing `.route` `ResponseOptions` but got `.match`.")
         }
-        
+
         let session = (options: routeOptions as DirectionsOptions,
                        credentials: self.credentials)
-        
+
         guard let responseIdentifier = indexedRouteResponse.routeResponse.identifier else {
             DispatchQueue.main.async {
                 completionHandler(session, .failure(.noData))
             }
             return nil
         }
-        
+
         return refreshRoute(responseIdentifier: responseIdentifier,
                             routeIndex: indexedRouteResponse.routeIndex,
                             fromLegAtIndex: Int(fromLegAtIndex),
@@ -73,7 +73,7 @@ extension Route {
         let encoder = JSONEncoder()
         encoder.userInfo[.options] = options
         let encoded = try encoder.encode(self)
-        
+
         let decoder = JSONDecoder()
         decoder.userInfo[.options] = options
         return try decoder.decode(Self.self, from: encoded)


### PR DESCRIPTION
## Issue:

Fixes https://github.com/mapbox/mapbox-navigation-ios/issues/3707

## Problem:

If offline/flakey network, a user is unable to reroute during navigation.

## Why:

Even if app/sdk has offline tilesets loaded, this data isn't leveraged for reroute given the default use of `Directions.shared.calculate(::)`. vs method that takes offline tiles into consideration.

## Change:

- Swap Directions method implementation call to leverage offline data

## Alternatives

- Provide own RoutingController in our app. This seemed like overkill given the existing functionality.
- Injectable options? Allows for injection of options, but I"m not sure how useful that is just yet? Would defer to the team in case there are better approaches to support?