### PR TITLE
Replace deprecated `Navigator.resetRideSession()` with `Navigator.reset()` methods.

### DIFF
--- a/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
@@ -77,25 +77,31 @@ class PassiveLocationManagerTests: TestCase {
     }
     
     func testManualLocations() {
-        let locationManager = PassiveLocationManager()
-        Navigator.shared.navigator.resetRideSession()
+        let navigatorResetExpectation = expectation(description: "Navigator should be reset successfully.")
+        Navigator.shared.navigator.reset {
+            navigatorResetExpectation.fulfill()
+        }
+        wait(for: [navigatorResetExpectation], timeout: 1.0)
+        
         let locationUpdateExpectation = expectation(description: "Location manager takes some time to start mapping locations to a road graph")
         locationUpdateExpectation.expectedFulfillmentCount = 1
         
         let road = Road(from: CLLocationCoordinate2D(latitude: 47.207966, longitude: 9.527012), to: CLLocationCoordinate2D(latitude: 47.209518, longitude: 9.522167))
         let delegate = Delegate(road: road, locationUpdateExpectation: locationUpdateExpectation)
         let date = Date()
+        let locationManager = PassiveLocationManager()
         locationManager.updateLocation(CLLocation(latitude: 47.208674, longitude: 9.524650, timestamp: date.addingTimeInterval(-5)))
         locationManager.delegate = delegate
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
-            Navigator.shared.navigator.resetRideSession()
-            locationManager.updateLocation(CLLocation(latitude: 47.208943, longitude: 9.524707, timestamp: date.addingTimeInterval(-4)))
-            locationManager.updateLocation(CLLocation(latitude: 47.209082, longitude: 9.524319, timestamp: date.addingTimeInterval(-3)))
-            locationManager.updateLocation(CLLocation(latitude: 47.209229, longitude: 9.523838, timestamp: date.addingTimeInterval(-2)))
-            locationManager.updateLocation(CLLocation(latitude: 47.209612, longitude: 9.522629, timestamp: date.addingTimeInterval(-1)))
-            locationManager.updateLocation(CLLocation(latitude: 47.209842, longitude: 9.522377, timestamp: date.addingTimeInterval(0)))
+            Navigator.shared.navigator.reset {
+                locationManager.updateLocation(CLLocation(latitude: 47.208943, longitude: 9.524707, timestamp: date.addingTimeInterval(-4)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209082, longitude: 9.524319, timestamp: date.addingTimeInterval(-3)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209229, longitude: 9.523838, timestamp: date.addingTimeInterval(-2)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209612, longitude: 9.522629, timestamp: date.addingTimeInterval(-1)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209842, longitude: 9.522377, timestamp: date.addingTimeInterval(0)))
 
-            locationUpdateExpectation.fulfill()
+                locationUpdateExpectation.fulfill()
+            }
         }
         wait(for: [locationUpdateExpectation], timeout: 5)
     }

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -232,7 +232,11 @@ class CarPlayManagerSpec: QuickSpec {
                                                  tileStoreConfiguration: .default)
             let mockedHandler = BillingHandler.__createMockedHandler(with: BillingServiceMock())
             BillingHandler.__replaceSharedInstance(with: mockedHandler)
-            Navigator.shared.navigator.resetRideSession()
+            let navigatorResetExpectation = self.expectation(description: "Navigator should be reset successfully.")
+            Navigator.shared.navigator.reset {
+                navigatorResetExpectation.fulfill()
+            }
+            self.wait(for: [navigatorResetExpectation], timeout: 1.0)
             Navigator._recreateNavigator()
             
             CarPlayMapViewController.swizzleMethods()

--- a/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
+++ b/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
@@ -72,7 +72,7 @@ class SpeechSynthesizersControllerTests: TestCase {
         super.tearDown()
         synthesizers = []
         delegateErrorBlock = nil
-        Navigator.shared.navigator.resetRideSession()
+        Navigator.shared.navigator.reset { }
     }
 
     func testNoFallback() {


### PR DESCRIPTION
PR replaces deprecated `Navigator.resetRideSession()` with newly added `Navigator.reset()` methods.