### PR TITLE
Navigator deinitialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 * Fixed an issue where changes made to `NavigationViewController.showsReportFeedback`, `NavigationViewController.showsSpeedLimits`, `NavigationViewController.detailedFeedbackEnabled`, `NavigationViewController.floatingButtonsPosition` and `NavigationViewController.floatingButtons` before `NavigationViewController` presentation were not saved. ([#3718](https://github.com/mapbox/mapbox-navigation-ios/pull/3718))
 * Fixed an issue where `SpeechSynthesizing.managesAudioSession` was ignored by `RouteVoiceController`. ([#3572](https://github.com/mapbox/mapbox-navigation-ios/pull/3572))
-* Updated Navigation engine lifecycle, to allow freeing core navigator when there is no active free drive or active guidance sessions. ([#3724](https://github.com/mapbox/mapbox-navigation-ios/pull/3724))
+* Location tracking and routing resources are now freed if no `RouteController` or `PassiveLocationManager` instance is actively being used. ([#3724](https://github.com/mapbox/mapbox-navigation-ios/pull/3724))
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 * Fixed an issue where changes made to `NavigationViewController.showsReportFeedback`, `NavigationViewController.showsSpeedLimits`, `NavigationViewController.detailedFeedbackEnabled`, `NavigationViewController.floatingButtonsPosition` and `NavigationViewController.floatingButtons` before `NavigationViewController` presentation were not saved. ([#3718](https://github.com/mapbox/mapbox-navigation-ios/pull/3718))
 * Fixed an issue where `SpeechSynthesizing.managesAudioSession` was ignored by `RouteVoiceController`. ([#3572](https://github.com/mapbox/mapbox-navigation-ios/pull/3572))
+* Updated Navigation engine lifecycle, to allow freeing core navigator when there is no active free drive or active guidance sessions. ([#3724](https://github.com/mapbox/mapbox-navigation-ios/pull/3724))
 
 ## v2.2.0
 

--- a/Sources/MapboxCoreNavigation/BillingHandler.swift
+++ b/Sources/MapboxCoreNavigation/BillingHandler.swift
@@ -455,11 +455,14 @@ final class BillingHandler {
         lock.lock()
         let hasRunningSession = _sessions.values.contains { !$0.isPaused }
         lock.unlock()
-        if hasRunningSession {
-            navigator.resume()
-        }
-        else {
-            navigator.pause()
+        assert(Navigator.isSharedInstanceCreated, "Billing attempted to update `Navigator` while it is deallocated.")
+        if Navigator.isSharedInstanceCreated {
+            if hasRunningSession {
+                navigator.resume()
+            }
+            else {
+                navigator.pause()
+            }
         }
     }
 }

--- a/Sources/MapboxCoreNavigation/HistoryRecording.swift
+++ b/Sources/MapboxCoreNavigation/HistoryRecording.swift
@@ -62,7 +62,9 @@ public extension HistoryRecording {
     }
 
     static func startRecordingHistory() {
-        Navigator.shared.historyRecorder?.startRecording()
+        if Navigator.isSharedInstanceCreated {
+            Navigator.shared.historyRecorder?.startRecording()
+        }
     }
 
     static func pushHistoryEvent(type: String, jsonData: Data?) throws {
@@ -74,11 +76,14 @@ public extension HistoryRecording {
             }
             jsonString = value
         }
-        Navigator.shared.historyRecorder?.pushHistory(forEventType: type, eventJson: jsonString ?? "")
+        if Navigator.isSharedInstanceCreated {
+            Navigator.shared.historyRecorder?.pushHistory(forEventType: type, eventJson: jsonString ?? "")
+        }
     }
 
     static func stopRecordingHistory(writingFileWith completionHandler: @escaping HistoryFileWritingCompletionHandler) {
-        guard let historyRecorder = Navigator.shared.historyRecorder else {
+        guard Navigator.isSharedInstanceCreated,
+              let historyRecorder = Navigator.shared.historyRecorder else {
             completionHandler(nil)
             return
         }

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -57,18 +57,20 @@ open class PassiveLocationManager: NSObject {
     
     private var _eventsManager: NavigationEventsManager?
     
+    private let sharedNavigator = Navigator.shared
+    
     /**
      The underlying navigator that performs map matching.
      */
     var navigator: MapboxNavigationNative.Navigator {
-        return Navigator.shared.navigator
+        return sharedNavigator.navigator
     }
     
     /**
      A `TileStore` instance used by navigator
      */
     open var navigatorTileStore: TileStore {
-        return Navigator.shared.tileStore
+        return sharedNavigator.tileStore
     }
     
     /**
@@ -119,7 +121,7 @@ open class PassiveLocationManager: NSObject {
         }
         
         for location in locations {
-            Navigator.shared.updateLocation(location) { success in
+            sharedNavigator.updateLocation(location) { success in
                 let result: Result<CLLocation, Error>
                 if success {
                     result = .success(location)
@@ -172,14 +174,14 @@ open class PassiveLocationManager: NSObject {
      - note: The Mapbox Electronic Horizon feature of the Mapbox Navigation SDK is in public beta and is subject to changes, including its pricing. Use of the feature is subject to the beta product restrictions in the Mapbox Terms of Service. Mapbox reserves the right to eliminate any free tier or free evaluation offers at any time and require customers to place an order to purchase the Mapbox Electronic Horizon feature, regardless of the level of use of the feature.
      */
     public func startUpdatingElectronicHorizon(with options: ElectronicHorizonOptions? = nil) {
-        Navigator.shared.startUpdatingElectronicHorizon(with: options)
+        sharedNavigator.startUpdatingElectronicHorizon(with: options)
     }
 
     /**
      Stops electronic horizon updates.
      */
     public func stopUpdatingElectronicHorizon() {
-        Navigator.shared.stopUpdatingElectronicHorizon()
+        sharedNavigator.stopUpdatingElectronicHorizon()
     }
 
     @objc private func navigationStatusDidChange(_ notification: NSNotification) {
@@ -304,17 +306,17 @@ open class PassiveLocationManager: NSObject {
     
     /// The road graph that is updated as the passive location manager tracks the user’s location.
     public var roadGraph: RoadGraph {
-        return Navigator.shared.roadGraph
+        return sharedNavigator.roadGraph
     }
     
     /// The road object store that is updated as the passive location manager tracks the user’s location.
     public var roadObjectStore: RoadObjectStore {
-        return Navigator.shared.roadObjectStore
+        return sharedNavigator.roadObjectStore
     }
 
     /// The road object matcher that allows to match user-defined road objects.
     public var roadObjectMatcher: RoadObjectMatcher {
-        return Navigator.shared.roadObjectMatcher
+        return sharedNavigator.roadObjectMatcher
     }
 }
 

--- a/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
+++ b/Sources/MapboxCoreNavigation/PredictiveCacheManager.swift
@@ -91,17 +91,18 @@ public class PredictiveCacheManager {
                                                  dataset: String = "mapbox",
                                                  maxConcurrentRequests: UInt32 = 2) -> PredictiveCacheController? {
         let predictiveLocationTrackerOptions = PredictiveLocationTrackerOptions(options)
+        let navigator = Navigator.shared
         if let tileStore = tileStore {
             let cacheOptions = PredictiveCacheControllerOptions(version: version,
                                                                 dataset: dataset,
                                                                 dataDomain: .maps,
                                                                 concurrency: maxConcurrentRequests,
                                                                 maxAverageDownloadBytesPerSecond: 0)
-            return Navigator.shared.navigator.createPredictiveCacheController(for: tileStore,
-                                                                              cacheOptions: cacheOptions,
-                                                                              locationTrackerOptions: predictiveLocationTrackerOptions)
+            return navigator.navigator.createPredictiveCacheController(for: tileStore,
+                                                                cacheOptions: cacheOptions,
+                                                                locationTrackerOptions: predictiveLocationTrackerOptions)
         } else {
-            return Navigator.shared.navigator.createPredictiveCacheController(for: predictiveLocationTrackerOptions)
+            return navigator.navigator.createPredictiveCacheController(for: predictiveLocationTrackerOptions)
         }
     }
 }

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -39,7 +39,7 @@ open class RouteController: NSObject {
      A `TileStore` instance used by navigator
      */
     open var navigatorTileStore: TileStore {
-        return Navigator.shared.tileStore
+        return sharedNavigator.tileStore
     }
     
     /**
@@ -105,7 +105,7 @@ open class RouteController: NSObject {
      */
     var snappedLocation: CLLocation? {
         guard lastLocationUpdateDate != nil,
-              let status = Navigator.shared.mostRecentNavigationStatus else {
+              let status = sharedNavigator.mostRecentNavigationStatus else {
             return nil
         }
         
@@ -156,14 +156,14 @@ open class RouteController: NSObject {
      - note: The Mapbox Electronic Horizon feature of the Mapbox Navigation SDK is in public beta and is subject to changes, including its pricing. Use of the feature is subject to the beta product restrictions in the Mapbox Terms of Service. Mapbox reserves the right to eliminate any free tier or free evaluation offers at any time and require customers to place an order to purchase the Mapbox Electronic Horizon feature, regardless of the level of use of the feature.
      */
     public func startUpdatingElectronicHorizon(with options: ElectronicHorizonOptions? = nil) {
-        Navigator.shared.startUpdatingElectronicHorizon(with: options)
+        sharedNavigator.startUpdatingElectronicHorizon(with: options)
     }
 
     /**
      Stops electronic horizon updates.
      */
     public func stopUpdatingElectronicHorizon() {
-        Navigator.shared.stopUpdatingElectronicHorizon()
+        sharedNavigator.stopUpdatingElectronicHorizon()
     }
 
     func changeRouteProgress(_ routeProgress: RouteProgress,
@@ -202,8 +202,10 @@ open class RouteController: NSObject {
     
     // MARK: Navigating
     
+    private let sharedNavigator = Navigator.shared
+    
     var navigator: MapboxNavigationNative.Navigator {
-        return Navigator.shared.navigator
+        return sharedNavigator.navigator
     }
     
     var userSnapToStepDistanceFromManeuver: CLLocationDistance?
@@ -220,7 +222,7 @@ open class RouteController: NSObject {
         rawLocation = location
         
         locations.forEach {
-            Navigator.shared.updateLocation($0) { _ in
+            sharedNavigator.updateLocation($0) { _ in
                 // No-op
             }
         }
@@ -253,7 +255,7 @@ open class RouteController: NSObject {
                             legIndex: UInt32(progress.legIndex),
                             routesRequest: routeRequest)
 
-        Navigator.shared.setRoutes(routes) { result in
+        sharedNavigator.setRoutes(routes) { result in
             completion?(result)
         }
     }
@@ -587,17 +589,17 @@ open class RouteController: NSObject {
     
     /// The road graph that is updated as the route controller tracks the user’s location.
     public var roadGraph: RoadGraph {
-        return Navigator.shared.roadGraph
+        return sharedNavigator.roadGraph
     }
 
     /// The road object store that is updated as the route controller tracks the user’s location.
     public var roadObjectStore: RoadObjectStore {
-        return Navigator.shared.roadObjectStore
+        return sharedNavigator.roadObjectStore
     }
 
     /// The road object matcher that allows to match user-defined road objects.
     public var roadObjectMatcher: RoadObjectMatcher {
-        return Navigator.shared.roadObjectMatcher
+        return sharedNavigator.roadObjectMatcher
     }
 }
 
@@ -625,7 +627,7 @@ extension RouteController: Router {
         }
         
         // If we still wait for the first status from NavNative, there is no need to reroute
-        guard let status = status ?? Navigator.shared.mostRecentNavigationStatus else { return true }
+        guard let status = status ?? sharedNavigator.mostRecentNavigationStatus else { return true }
 
         /// NavNative doesn't support reroutes after arrival.
         /// The code below is a port of logic from LegacyRouteController
@@ -724,7 +726,7 @@ extension RouteController: Router {
     }
 
     private func removeRoutes(completion: ((Error?) -> Void)?) {
-        Navigator.shared.setRoutes(nil) { result in
+        sharedNavigator.setRoutes(nil) { result in
             switch result {
             case .success:
                 completion?(nil)

--- a/Sources/TestHelper/TestCase.swift
+++ b/Sources/TestHelper/TestCase.swift
@@ -28,8 +28,6 @@ open class TestCase: XCTestCase {
         super.tearDown()
         // Reset navigator
         NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: .default)
-        Navigator.shared.restartNavigator(forcing: nil)
-        Navigator.shared.mostRecentNavigationStatus = nil
     }
 
     /// Prepares tests for execution. Should be called once before any test runs.

--- a/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
@@ -11,6 +11,7 @@ final class BillingHandlerUnitTests: TestCase {
     private var handler: BillingHandler!
     private let freeRideToken = UUID().uuidString
     private let activeGuidanceToken = UUID().uuidString
+    private var navigator: MapboxCoreNavigation.Navigator? = nil
 
     override func setUp() {
         super.setUp()
@@ -22,12 +23,14 @@ final class BillingHandlerUnitTests: TestCase {
             case .freeDrive: return freeRideToken
             }
         }
+        navigator = Navigator.shared
     }
 
     override func tearDown() {
         super.tearDown()
         billingService = nil
         handler = nil
+        navigator = nil
     }
 
     func testSessionStop() {

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
@@ -77,12 +77,6 @@ class PassiveLocationManagerTests: TestCase {
     }
     
     func testManualLocations() {
-        let navigatorResetExpectation = expectation(description: "Navigator should be reset successfully.")
-        Navigator.shared.navigator.reset {
-            navigatorResetExpectation.fulfill()
-        }
-        wait(for: [navigatorResetExpectation], timeout: 1.0)
-        
         let locationUpdateExpectation = expectation(description: "Location manager takes some time to start mapping locations to a road graph")
         locationUpdateExpectation.expectedFulfillmentCount = 1
         
@@ -108,7 +102,6 @@ class PassiveLocationManagerTests: TestCase {
     
     func testNoHistoryRecording() {
         PassiveLocationManager.historyDirectoryURL = nil
-        Navigator._recreateNavigator()
         PassiveLocationManager.startRecordingHistory()
                 
         let historyCallbackExpectation = XCTestExpectation(description: "History callback should be called")
@@ -123,7 +116,7 @@ class PassiveLocationManagerTests: TestCase {
         let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("test")
         
         PassiveLocationManager.historyDirectoryURL = supportDir
-        Navigator._recreateNavigator()
+        let navigator = Navigator.shared
         PassiveLocationManager.startRecordingHistory()
                 
         let historyCallbackExpectation = XCTestExpectation(description: "History callback should be called")

--- a/Tests/MapboxCoreNavigationTests/TilesetDescriptorFactoryTests.swift
+++ b/Tests/MapboxCoreNavigationTests/TilesetDescriptorFactoryTests.swift
@@ -15,7 +15,7 @@ final class TilesetDescriptorFactoryTests: TestCase {
     func testLatestDescriptorsAreFromGlobalNavigatorCacheHandle() {
         NavigationSettings.shared.initialize(directions: .mocked,
                                              tileStoreConfiguration: .custom(FileManager.default.temporaryDirectory))
-        MapboxCoreNavigation.Navigator._recreateNavigator()
+        let navigator = Navigator.shared
 
         let tilesetReceived = expectation(description: "Tileset received")
         TilesetDescriptorFactory.getLatest(completionQueue: .global()) { latestTilesetDescriptor in

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -232,12 +232,6 @@ class CarPlayManagerSpec: QuickSpec {
                                                  tileStoreConfiguration: .default)
             let mockedHandler = BillingHandler.__createMockedHandler(with: BillingServiceMock())
             BillingHandler.__replaceSharedInstance(with: mockedHandler)
-            let navigatorResetExpectation = self.expectation(description: "Navigator should be reset successfully.")
-            Navigator.shared.navigator.reset {
-                navigatorResetExpectation.fulfill()
-            }
-            self.wait(for: [navigatorResetExpectation], timeout: 1.0)
-            Navigator._recreateNavigator()
             
             CarPlayMapViewController.swizzleMethods()
             manager = CarPlayManager(styles: nil, routingProvider: MapboxRoutingProvider(.offline), eventsManager: nil)

--- a/Tests/MapboxNavigationTests/SKUTests.swift
+++ b/Tests/MapboxNavigationTests/SKUTests.swift
@@ -7,6 +7,18 @@ import MapboxNavigation
 import MapboxCommon_Private
 
 class SKUTests: TestCase {
+    private var navigator: MapboxCoreNavigation.Navigator? = nil
+
+    override func setUp() {
+        super.setUp()
+        navigator = Navigator.shared
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        navigator = nil
+    }
+    
     func testDirectionsSKU() {
         let expected: String = UUID().uuidString
         billingServiceMock.onGetSKUTokenIfValid = { _ in

--- a/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
+++ b/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
@@ -72,7 +72,6 @@ class SpeechSynthesizersControllerTests: TestCase {
         super.tearDown()
         synthesizers = []
         delegateErrorBlock = nil
-        Navigator.shared.navigator.reset { }
     }
 
     func testNoFallback() {


### PR DESCRIPTION
This PR changes Navigator behavior to be deallocated when it is not needed anymore. This allows clearer state resetting when re-running navigation and clears up some used resources when navigation is not needed anymore.
Reworked CoreNavigationNavigator to be weak referenced, updated it's consumers to maintain a strong reference to Navigator while in use. Reworked native navigator observers to avoid retain cycle.