### PR TITLE
Implement FixLocation.provider field based on CLLocationSourceInformation

### DIFF
--- a/Sources/MapboxCoreNavigation/FixLocation.swift
+++ b/Sources/MapboxCoreNavigation/FixLocation.swift
@@ -2,13 +2,26 @@ import CoreLocation
 import Foundation
 import MapboxNavigationNative
 
-extension FixLocation {
 
+extension FixLocation {
     convenience init(_ location: CLLocation, isMock: Bool = false) {
         var bearingAccuracy: NSNumber? = nil
         if #available(iOS 13.4, *) {
             bearingAccuracy = location.courseAccuracy >= 0 ? location.courseAccuracy as NSNumber : nil
         }
+
+        var provider: String? = nil
+        #if compiler(>=5.5)
+        if #available(iOS 15.0, *) {
+            if let sourceInformation = location.sourceInformation {
+                // in some scenarios we store this information to history files, so to save space there, we use "short" names and 1/0 instead of true/false
+                let isSimulated = sourceInformation.isSimulatedBySoftware ? 1 : 0
+                let isProducedByAccessory = sourceInformation.isProducedByAccessory ? 1 : 0
+                
+                provider = "sim:\(isSimulated),acc:\(isProducedByAccessory)"
+            }
+        }
+        #endif
         
         self.init(coordinate: location.coordinate,
                   monotonicTimestampNanoseconds: Int64(location.timestamp.nanosecondsSince1970),
@@ -17,7 +30,7 @@ extension FixLocation {
                   bearing: location.course >= 0 ? location.course as NSNumber : nil,
                   altitude: location.altitude as NSNumber,
                   accuracyHorizontal: location.horizontalAccuracy >= 0 ? location.horizontalAccuracy as NSNumber : nil,
-                  provider: nil,
+                  provider: provider,
                   bearingAccuracy: bearingAccuracy,
                   speedAccuracy: location.speedAccuracy >= 0 ? location.speedAccuracy as NSNumber : nil,
                   verticalAccuracy: location.verticalAccuracy >= 0 ? location.verticalAccuracy as NSNumber : nil,

--- a/Tests/MapboxCoreNavigationTests/CLLocationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/CLLocationTests.swift
@@ -92,7 +92,25 @@ class CLLocationTests: TestCase {
                                   speedAccuracy: speedAccuracy,
                                   timestamp: timestamp)
         }
-        
+        #if compiler(>=5.5)
+        if #available(iOS 15.0, *) {
+            let sourceInfo = CLLocationSourceInformation(
+                softwareSimulationState: true,
+                andExternalAccessoryState: false
+            )
+            location = CLLocation(coordinate: coordinate,
+                                  altitude: altitude,
+                                  horizontalAccuracy: horizontalAccuracy,
+                                  verticalAccuracy: verticalAccuracy,
+                                  course: bearing,
+                                  courseAccuracy: bearingAccuracy,
+                                  speed: speed,
+                                  speedAccuracy: speedAccuracy,
+                                  timestamp: timestamp,
+                                  sourceInfo: sourceInfo)
+        }
+        #endif
+
         let fixLocation = FixLocation(location)
         
         XCTAssertEqual(fixLocation.coordinate.latitude, coordinate.latitude)
@@ -108,6 +126,11 @@ class CLLocationTests: TestCase {
             XCTAssertEqual(fixLocation.bearingAccuracy?.doubleValue, bearingAccuracy)
             XCTAssertEqual(fixLocation.speedAccuracy?.doubleValue, speedAccuracy)
         }
+        #if compiler(>=5.5)
+        if #available(iOS 15.0, *) {
+            XCTAssertEqual(fixLocation.provider, "sim:1,acc:0")
+        }
+        #endif
     }
 }
 


### PR DESCRIPTION
## Description

Here we add encoding of [`CLLocation.sourceInformation`](https://developer.apple.com/documentation/corelocation/cllocation/3861803-sourceinformation) which was introduced in iOS 15 to `FixLocation.provider` field and allows to better understand nature of the signal. It would provide us additional information which can be useful during debug.