### PR TITLE
Hide the remaining steps when user is on final step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Renamed the `NextBannerView.update(for:)`, `NextBannerView.show()` and `NextBannerView.hide()` methods to `NextBannerView.update(for:animated:duration:completion:)`, `NextBannerView.show(animated:duration:completion:)`, `NextBannerView.hide(animated:duration:completion:)`, respectively. ([#3704](https://github.com/mapbox/mapbox-navigation-ios/pull/3704))
 * Renamed the `LanesView.update(for:)`, `LanesView.show()` and `LanesView.hide()` methods to `LanesView.update(for:animated:duration:completion:)`, `LanesView.show(animated:duration:completion:)`, `LanesView.hide(animated:duration:completion:)`, respectively. ([#3704](https://github.com/mapbox/mapbox-navigation-ios/pull/3704))
 * Added the `InstructionsCardContainerView.separatorColor` and `InstructionsCardContainerView.highlightedSeparatorColor` to be able to change instruction card's separator colors. ([#3704](https://github.com/mapbox/mapbox-navigation-ios/pull/3704))
+* Fixed an issue where the top banner instruction shows empty remaining steps in pull-down table when user is on final step. ([#3729](https://github.com/mapbox/mapbox-navigation-ios/pull/3729))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/InstructionsBannerView.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerView.swift
@@ -145,9 +145,7 @@ open class BaseInstructionsBannerView: UIControl {
     }
     
     @objc func swipedInstructionBannerLeft(_ sender: Any) {
-        if !swipeable {
-            return
-        }
+        guard swipeable && showStepIndicator else { return }
 
         if let gestureRecognizer = sender as? UISwipeGestureRecognizer,
            gestureRecognizer.state == .ended {
@@ -158,9 +156,7 @@ open class BaseInstructionsBannerView: UIControl {
     }
     
     @objc func swipedInstructionBannerRight(_ sender: Any) {
-        if !swipeable {
-            return
-        }
+        guard swipeable && showStepIndicator else { return }
         
         if let gestureRecognizer = sender as? UISwipeGestureRecognizer,
            gestureRecognizer.state == .ended {
@@ -171,21 +167,18 @@ open class BaseInstructionsBannerView: UIControl {
     }
     
     @objc func swipedInstructionBannerDown(_ sender: Any) {
+        guard showStepIndicator else { return }
         if let gestureRecognizer = sender as? UISwipeGestureRecognizer,
            gestureRecognizer.state == .ended {
-            if showStepIndicator {
-                stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
-            }
-            
+            stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
             delegate?.didSwipeInstructionsBanner(self, swipeDirection: .down)
         }
     }
         
     @objc func tappedInstructionsBanner(_ sender: Any) {
+        guard showStepIndicator else { return }
         if let delegate = delegate {
-            if showStepIndicator {
-                stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
-            }
+            stepListIndicatorView.isHidden = !stepListIndicatorView.isHidden
             delegate.didTapInstructionsBanner(self)
         }
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -350,11 +350,8 @@ extension TopBannerViewController: NavigationComponent {
         
         if progress.remainingSteps.count < 2 {
             instructionsBannerView.showStepIndicator = false
-            
-            if let steps = stepsViewController {
-                isDisplayingSteps = false
-                steps.dismiss()
-                stepsViewController = nil
+            if isDisplayingSteps {
+                dismissStepsTable()
             }
         } else {
             instructionsBannerView.showStepIndicator = true

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -349,10 +349,13 @@ extension TopBannerViewController: NavigationComponent {
         instructionsBannerView.updateDistance(for: progress.currentLegProgress.currentStepProgress)
         
         if progress.remainingSteps.count < 2 {
-            instructionsBannerView.showStepIndicator = false
+            if isDisplayingPreviewInstructions {
+                stopPreviewing(showingSecondaryChildren: false)
+            }
             if isDisplayingSteps {
                 dismissStepsTable()
             }
+            instructionsBannerView.showStepIndicator = false
         } else {
             instructionsBannerView.showStepIndicator = true
         }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -347,6 +347,18 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
         routeProgress = progress
         instructionsBannerView.updateDistance(for: progress.currentLegProgress.currentStepProgress)
+        
+        if progress.remainingSteps.count < 2 {
+            instructionsBannerView.showStepIndicator = false
+            
+            if let steps = stepsViewController {
+                isDisplayingSteps = false
+                steps.dismiss()
+                stepsViewController = nil
+            }
+        } else {
+            instructionsBannerView.showStepIndicator = true
+        }
     }
     
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
@@ -428,7 +440,9 @@ extension TopBannerViewController: StepsViewControllerDelegate {
     
     public func didDismissStepsViewController(_ viewController: StepsViewController) {
         dismissStepsTable()
-        instructionsBannerView.showStepIndicator = true
+        if let stepCount = routeProgress?.remainingSteps.count, stepCount > 1 {
+            instructionsBannerView.showStepIndicator = true
+        }
     }
 }
 


### PR DESCRIPTION
### Description
This Pr is to fix #2015 to hide the remaining steps when user is on final step.

### Implementation
When user arrives on final step, `TopBannerViewController` would dismiss the `stepsViewController` and change the `instructionsBannerView.showStepIndicator` to `false`. And the step indicator of the instruction banner would be hidden, the swiping and tapping gestures wouldn't work.

And if the mobile is in the previewing mode, the previewing process would stop. If the mobile is displaying the remaining steps in pull-down menu, the pull-down table would be dismissed.

### Screenshots or Gifs
When in final step, the indicator view would be hidden, swiping and taping gestures wouldn't trigger the remaining steps displaying.
![finalStep](https://user-images.githubusercontent.com/48976398/153076891-daf2702c-12e5-4532-b06e-a7ea98041c6d.png)

