### PR TITLE
Add `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:byCanceling:)`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 ### CarPlay
 
 * Added `CarPlayUserInfo` type alias for storing CarPlay-related user information. This type will be used by `CPRouteChoice` or `CPListItem` while presenting trip with multiple route choices or when selecting list item from search results, respectively. ([#3709](https://github.com/mapbox/mapbox-navigation-ios/pull/3709))
-* Deprecated `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:)` in favor of `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:byCanceling:)`. ([#3731](https://github.com/mapbox/mapbox-navigation-ios/pull/3731))
+* Added the `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:byCanceling:)` method, which is similar to the existing `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:)` method but indicates whether the user canceled the navigation session. ([#3731](https://github.com/mapbox/mapbox-navigation-ios/pull/3731))
 
 ### Offline routing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### CarPlay
 
 * Added `CarPlayUserInfo` type alias for storing CarPlay-related user information. This type will be used by `CPRouteChoice` or `CPListItem` while presenting trip with multiple route choices or when selecting list item from search results, respectively. ([#3709](https://github.com/mapbox/mapbox-navigation-ios/pull/3709))
+* Deprecated `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:)` in favor of `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:byCanceling:)`. ([#3731](https://github.com/mapbox/mapbox-navigation-ios/pull/3731))
 
 ### Offline routing
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -100,7 +100,8 @@ extension AppDelegate: CarPlayManagerDelegate {
         navigationViewController.waypointStyle = .extrudedBuilding
     }
     
-    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager,
+                                        byCanceling canceled: Bool) {
         // Dismiss NavigationViewController if it's present in the navigation stack
         currentAppRootViewController?.dismissActiveNavigationViewController()
     }

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -733,7 +733,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         if let passiveLocationProvider = navigationMapView.mapView.location.locationProvider as? PassiveLocationProvider {
             passiveLocationProvider.locationManager.resumeTripSession()
         }
-        
+        delegate?.carPlayManagerDidEndNavigation(self)
         delegate?.carPlayManagerDidEndNavigation(self, byCanceling: false)
     }
     
@@ -980,7 +980,7 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
         }
         
         self.carPlayNavigationViewController = nil
-        
+        delegate?.carPlayManagerDidEndNavigation(self)
         delegate?.carPlayManagerDidEndNavigation(self, byCanceling: canceled)
     }
     

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -733,7 +733,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         if let passiveLocationProvider = navigationMapView.mapView.location.locationProvider as? PassiveLocationProvider {
             passiveLocationProvider.locationManager.resumeTripSession()
         }
-        delegate?.carPlayManagerDidEndNavigation(self)
+        
         delegate?.carPlayManagerDidEndNavigation(self, byCanceling: false)
     }
     
@@ -980,7 +980,7 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
         }
         
         self.carPlayNavigationViewController = nil
-        delegate?.carPlayManagerDidEndNavigation(self)
+        
         delegate?.carPlayManagerDidEndNavigation(self, byCanceling: canceled)
     }
     

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -734,6 +734,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
             passiveLocationProvider.locationManager.resumeTripSession()
         }
         delegate?.carPlayManagerDidEndNavigation(self)
+        delegate?.carPlayManagerDidEndNavigation(self, byCanceling: false)
     }
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate, didEndPanGestureWithVelocity velocity: CGPoint) {
@@ -980,6 +981,7 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
         
         self.carPlayNavigationViewController = nil
         delegate?.carPlayManagerDidEndNavigation(self)
+        delegate?.carPlayManagerDidEndNavigation(self, byCanceling: canceled)
     }
     
     public func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -388,8 +388,11 @@ public extension CarPlayManagerDelegate {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
-        // No-op, deprecated method.
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
     
     /**

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -167,13 +167,16 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      */
     func carPlayManagerWillEndNavigation(_ carPlayManager: CarPlayManager, byCanceling canceled: Bool)
     
-    /**
-     Called when navigation ends so that the containing app can update accordingly.
-     This delegate method will be called after dismissing `CarPlayNavigationViewController`.
-     
-     - parameter carPlayManager: The CarPlay manager instance.
-     */
     @available(*, deprecated, renamed: "carPlayManagerDidEndNavigation(_:byCanceling:)")
+    /**
+     :nodoc:
+     
+     `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:)` is no longer called due to
+     warnings, which are emitted after deprecating it. It's also not possible to make this delegate
+     method obsolete because of `Protocol members can only be marked unavailable in an @objc protocol`
+     error.
+     Use `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:byCanceling:)` instead.
+     */
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager)
     
     /**

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -173,7 +173,18 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      
      - parameter carPlayManager: The CarPlay manager instance.
      */
+    @available(*, deprecated, renamed: "carPlayManagerDidEndNavigation(_:byCanceling:)")
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager)
+    
+    /**
+     Called when navigation ends so that the containing app can update accordingly.
+     This delegate method will be called after dismissing `CarPlayNavigationViewController`.
+     
+     - parameter carPlayManager: The CarPlay manager instance.
+     - parameter canceled: A Boolean value indicating whether this method is being called because
+     the user canceled the trip, as opposed to letting it run to completion/being canceled by the system.
+     */
+    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager, byCanceling canceled: Bool)
     
     /**
      Called when the CarPlayManager detects the user arrives at the destination waypoint for a route leg.
@@ -370,14 +381,20 @@ public extension CarPlayManagerDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
-    func carPlayManagerWillEndNavigation(_ carPlayManager: CarPlayManager, byCanceling canceled: Bool) {
+    func carPlayManagerWillEndNavigation(_ carPlayManager: CarPlayManager,
+                                         byCanceling canceled: Bool) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+    }
+    
+    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+        // No-op, deprecated method.
     }
     
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
-    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager,
+                                        byCanceling canceled: Bool) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
     

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -167,16 +167,13 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      */
     func carPlayManagerWillEndNavigation(_ carPlayManager: CarPlayManager, byCanceling canceled: Bool)
     
-    @available(*, deprecated, renamed: "carPlayManagerDidEndNavigation(_:byCanceling:)")
     /**
-     :nodoc:
+     Called when navigation ends so that the containing app can update accordingly.
+     This delegate method will be called after dismissing `CarPlayNavigationViewController`.
      
-     `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:)` is no longer called due to
-     warnings, which are emitted after deprecating it. It's also not possible to make this delegate
-     method obsolete because of `Protocol members can only be marked unavailable in an @objc protocol`
-     error.
-     Use `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:byCanceling:)` instead.
+     - parameter carPlayManager: The CarPlay manager instance.
      */
+    @available(*, deprecated, renamed: "carPlayManagerDidEndNavigation(_:byCanceling:)")
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager)
     
     /**

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -171,9 +171,11 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      Called when navigation ends so that the containing app can update accordingly.
      This delegate method will be called after dismissing `CarPlayNavigationViewController`.
      
+     If you need to know whether the navigation ended because the user arrived or canceled it, use the
+     `carPlayManagerDidEndNavigation(_:byCanceling:)` method.
+     
      - parameter carPlayManager: The CarPlay manager instance.
      */
-    @available(*, deprecated, renamed: "carPlayManagerDidEndNavigation(_:byCanceling:)")
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager)
     
     /**

--- a/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
@@ -70,8 +70,8 @@ public extension CarPlayNavigationViewControllerDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
-    func carPlayNavigationViewControllerDidDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController,
-                                                   shouldPresentArrivalUIFor waypoint: Waypoint) {
+    func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
+                                         shouldPresentArrivalUIFor waypoint: Waypoint) {
         logUnimplemented(protocolType: CarPlayNavigationViewControllerDelegate.self, level: .debug)
     }
     

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -181,7 +181,9 @@ class CarPlayManagerTests: TestCase {
         class CarPlayManagerDelegateMock: CarPlayManagerDelegate {
             
             var navigationStarted = false
+            var legacyNavigationEnded = false
             var navigationEnded = false
+            var navigationEndedByCanceling = false
             
             func carPlayManager(_ carPlayManager: CarPlayManager,
                                 didPresent navigationViewController: CarPlayNavigationViewController) {
@@ -189,10 +191,17 @@ class CarPlayManagerTests: TestCase {
                 navigationStarted = true
             }
             
+            // TODO: This delegate method should be removed in next major release.
+            func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+                XCTAssertTrue(navigationStarted)
+                legacyNavigationEnded = true
+            }
+            
             func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager,
                                                 byCanceling canceled: Bool) {
                 XCTAssertTrue(navigationStarted)
                 navigationEnded = true
+                navigationEndedByCanceling = canceled
             }
         }
         
@@ -216,8 +225,14 @@ class CarPlayManagerTests: TestCase {
                       "The CarPlayManagerDelegate should have been told that navigation was initiated.")
         
         carPlayManager.carPlayNavigationViewController?.exitNavigation(byCanceling: true)
+        XCTAssertTrue(carPlayManagerDelegateMock.legacyNavigationEnded,
+                      "The CarPlayManagerDelegate should have been told that navigation ended.")
+        
         XCTAssertTrue(carPlayManagerDelegateMock.navigationEnded,
                       "The CarPlayManagerDelegate should have been told that navigation ended.")
+        
+        XCTAssertTrue(carPlayManagerDelegateMock.navigationEndedByCanceling,
+                      "The CarPlayManagerDelegate should have been told that navigation ended by canceling.")
         
         CarPlayMapViewController.unswizzleMethods()
     }

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -189,7 +189,8 @@ class CarPlayManagerTests: TestCase {
                 navigationStarted = true
             }
             
-            func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+            func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager,
+                                                byCanceling canceled: Bool) {
                 XCTAssertTrue(navigationStarted)
                 navigationEnded = true
             }

--- a/Tests/MapboxNavigationTests/CarPlayUtils.swift
+++ b/Tests/MapboxNavigationTests/CarPlayUtils.swift
@@ -102,7 +102,8 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
         currentService = service
     }
     
-    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
+    func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager,
+                                        byCanceling canceled: Bool) {
         currentService = nil
     }
     


### PR DESCRIPTION
PR deprecates `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:)` and adds `CarPlayManagerDelegate.carPlayManagerDidEndNavigation(_:byCanceling:)` as a replacement.

Closing #3727.

/cc @ChristianSteffens 