### PR TITLE
Fix issues related to `routeLineTracksTraversal` usage and custom delegate methods for route line modification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 ### CarPlay
 
 * Fixed an issue where CarPlay application was crashing during template dismissal on iOS 14 and higher. ([#3794](https://github.com/mapbox/mapbox-navigation-ios/pull/3794))
+* Added the ability to style each route line differently on CarPlay during route preview and active navigation using such delegate methods ([#3744](https://github.com/mapbox/mapbox-navigation-ios/pull/3744)):
+  * `CarPlayManagerDelegate.carPlayManager(_:routeLineLayerWithIdentifier:sourceIdentifier:for:)` to style the route.
+  * `CarPlayManagerDelegate.carPlayManager(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:for:)` to style the casing of the route.
 
 ### Other changes
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -4,6 +4,7 @@ import CarPlay
 import MapboxGeocoder
 import MapboxCoreNavigation
 import MapboxDirections
+import MapboxMaps
 
 let CarPlayWaypointKey: String = "MBCarPlayWaypoint"
 
@@ -234,6 +235,32 @@ extension AppDelegate: CarPlayManagerDelegate {
         case .previewing, .navigating, .panningInBrowsingMode, .panningInNavigationMode:
             return nil
         }
+    }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        routeLineLayerWithIdentifier identifier: String,
+                        sourceIdentifier: String) -> LineLayer? {
+        var lineLayer = LineLayer(id: identifier)
+        lineLayer.source = sourceIdentifier
+        lineLayer.lineColor = .constant(StyleColor(.red))
+        lineLayer.lineWidth = .constant(15.0)
+        lineLayer.lineJoin = .constant(.round)
+        lineLayer.lineCap = .constant(.round)
+        
+        return lineLayer
+    }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        routeCasingLineLayerWithIdentifier identifier: String,
+                        sourceIdentifier: String) -> LineLayer? {
+        var lineLayer = LineLayer(id: identifier)
+        lineLayer.source = sourceIdentifier
+        lineLayer.lineColor = .constant(StyleColor(.cyan))
+        lineLayer.lineWidth = .constant(30.0)
+        lineLayer.lineJoin = .constant(.round)
+        lineLayer.lineCap = .constant(.round)
+        
+        return lineLayer
     }
 }
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -241,11 +241,17 @@ extension AppDelegate: CarPlayManagerDelegate {
                         routeLineLayerWithIdentifier identifier: String,
                         sourceIdentifier: String,
                         for parentViewController: UIViewController) -> LineLayer? {
+        let lineColor = UIColor.lightGray
+        
         if parentViewController is CarPlayMapViewController {
             var lineLayer = LineLayer(id: identifier)
             lineLayer.source = sourceIdentifier
-            lineLayer.lineColor = .constant(StyleColor(.yellow))
-            lineLayer.lineWidth = .constant(15.0)
+            lineLayer.lineColor = .constant(StyleColor(lineColor))
+            lineLayer.lineWidth = .expression(Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                RouteLineWidthByZoomLevel
+            })
             lineLayer.lineJoin = .constant(.round)
             lineLayer.lineCap = .constant(.round)
             
@@ -253,8 +259,12 @@ extension AppDelegate: CarPlayManagerDelegate {
         } else if parentViewController is CarPlayNavigationViewController {
             var lineLayer = LineLayer(id: identifier)
             lineLayer.source = sourceIdentifier
-            lineLayer.lineColor = .constant(StyleColor(.red))
-            lineLayer.lineWidth = .constant(20.0)
+            lineLayer.lineColor = .constant(StyleColor(lineColor))
+            lineLayer.lineWidth = .expression(Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                RouteLineWidthByZoomLevel
+            })
             lineLayer.lineJoin = .constant(.miter)
             lineLayer.lineCap = .constant(.square)
             
@@ -268,11 +278,17 @@ extension AppDelegate: CarPlayManagerDelegate {
                         routeCasingLineLayerWithIdentifier identifier: String,
                         sourceIdentifier: String,
                         for parentViewController: UIViewController) -> LineLayer? {
+        let lineColor = UIColor.darkGray
+        
         if parentViewController is CarPlayMapViewController {
             var lineLayer = LineLayer(id: identifier)
             lineLayer.source = sourceIdentifier
-            lineLayer.lineColor = .constant(StyleColor(.blue))
-            lineLayer.lineWidth = .constant(30.0)
+            lineLayer.lineColor = .constant(StyleColor(lineColor))
+            lineLayer.lineWidth = .expression(Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                RouteLineWidthByZoomLevel.multiplied(by: 1.5)
+            })
             lineLayer.lineJoin = .constant(.round)
             lineLayer.lineCap = .constant(.round)
             
@@ -280,8 +296,12 @@ extension AppDelegate: CarPlayManagerDelegate {
         } else if parentViewController is CarPlayNavigationViewController {
             var lineLayer = LineLayer(id: identifier)
             lineLayer.source = sourceIdentifier
-            lineLayer.lineColor = .constant(StyleColor(.green))
-            lineLayer.lineWidth = .constant(30.0)
+            lineLayer.lineColor = .constant(StyleColor(lineColor))
+            lineLayer.lineWidth = .expression(Exp(.interpolate) {
+                Exp(.linear)
+                Exp(.zoom)
+                RouteLineWidthByZoomLevel.multiplied(by: 1.5)
+            })
             lineLayer.lineJoin = .constant(.miter)
             lineLayer.lineCap = .constant(.square)
             

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -239,28 +239,56 @@ extension AppDelegate: CarPlayManagerDelegate {
     
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeLineLayerWithIdentifier identifier: String,
-                        sourceIdentifier: String) -> LineLayer? {
-        var lineLayer = LineLayer(id: identifier)
-        lineLayer.source = sourceIdentifier
-        lineLayer.lineColor = .constant(StyleColor(.red))
-        lineLayer.lineWidth = .constant(15.0)
-        lineLayer.lineJoin = .constant(.round)
-        lineLayer.lineCap = .constant(.round)
-        
-        return lineLayer
+                        sourceIdentifier: String,
+                        for parentViewController: UIViewController) -> LineLayer? {
+        if parentViewController is CarPlayMapViewController {
+            var lineLayer = LineLayer(id: identifier)
+            lineLayer.source = sourceIdentifier
+            lineLayer.lineColor = .constant(StyleColor(.yellow))
+            lineLayer.lineWidth = .constant(15.0)
+            lineLayer.lineJoin = .constant(.round)
+            lineLayer.lineCap = .constant(.round)
+            
+            return lineLayer
+        } else if parentViewController is CarPlayNavigationViewController {
+            var lineLayer = LineLayer(id: identifier)
+            lineLayer.source = sourceIdentifier
+            lineLayer.lineColor = .constant(StyleColor(.red))
+            lineLayer.lineWidth = .constant(20.0)
+            lineLayer.lineJoin = .constant(.miter)
+            lineLayer.lineCap = .constant(.square)
+            
+            return lineLayer
+        }
+
+        return nil
     }
     
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeCasingLineLayerWithIdentifier identifier: String,
-                        sourceIdentifier: String) -> LineLayer? {
-        var lineLayer = LineLayer(id: identifier)
-        lineLayer.source = sourceIdentifier
-        lineLayer.lineColor = .constant(StyleColor(.cyan))
-        lineLayer.lineWidth = .constant(30.0)
-        lineLayer.lineJoin = .constant(.round)
-        lineLayer.lineCap = .constant(.round)
-        
-        return lineLayer
+                        sourceIdentifier: String,
+                        for parentViewController: UIViewController) -> LineLayer? {
+        if parentViewController is CarPlayMapViewController {
+            var lineLayer = LineLayer(id: identifier)
+            lineLayer.source = sourceIdentifier
+            lineLayer.lineColor = .constant(StyleColor(.blue))
+            lineLayer.lineWidth = .constant(30.0)
+            lineLayer.lineJoin = .constant(.round)
+            lineLayer.lineCap = .constant(.round)
+            
+            return lineLayer
+        } else if parentViewController is CarPlayNavigationViewController {
+            var lineLayer = LineLayer(id: identifier)
+            lineLayer.source = sourceIdentifier
+            lineLayer.lineColor = .constant(StyleColor(.green))
+            lineLayer.lineWidth = .constant(30.0)
+            lineLayer.lineJoin = .constant(.miter)
+            lineLayer.lineCap = .constant(.square)
+            
+            return lineLayer
+        }
+
+        return nil
     }
 }
 

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -275,7 +275,7 @@ open class RouteProgress: Codable {
         guard coordinatesLeftOnStepCount >= 0 else { return .unknown }
 
         guard legIndex < congestionTravelTimesSegmentsByStep.count,
-            currentLegProgress.stepIndex < congestionTravelTimesSegmentsByStep[legIndex].count else { return .unknown }
+              currentLegProgress.stepIndex < congestionTravelTimesSegmentsByStep[legIndex].count else { return .unknown }
 
         let congestionTimesForStep = congestionTravelTimesSegmentsByStep[legIndex][currentLegProgress.stepIndex]
         guard coordinatesLeftOnStepCount <= congestionTimesForStep.count else { return .unknown }

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -1007,7 +1007,8 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
                                                 sourceIdentifier: String) -> LineLayer? {
         return delegate?.carPlayManager(self,
                                         routeLineLayerWithIdentifier: identifier,
-                                        sourceIdentifier: sourceIdentifier)
+                                        sourceIdentifier: sourceIdentifier,
+                                        for: carPlayNavigationViewController)
     }
     
     public func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
@@ -1015,7 +1016,8 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
                                                 sourceIdentifier: String) -> LineLayer? {
         return delegate?.carPlayManager(self,
                                         routeCasingLineLayerWithIdentifier: identifier,
-                                        sourceIdentifier: sourceIdentifier)
+                                        sourceIdentifier: sourceIdentifier,
+                                        for: carPlayNavigationViewController)
     }
 }
 
@@ -1031,6 +1033,24 @@ extension CarPlayManager: CarPlayMapViewControllerDelegate {
                                  didAdd: finalDestinationAnnotation,
                                  to: carPlayMapViewController,
                                  pointAnnotationManager: pointAnnotationManager)
+    }
+    
+    public func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
+                                         routeLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer? {
+        delegate?.carPlayManager(self,
+                                 routeLineLayerWithIdentifier: identifier,
+                                 sourceIdentifier: sourceIdentifier,
+                                 for: carPlayMapViewController)
+    }
+    
+    public func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
+                                         routeCasingLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer? {
+        delegate?.carPlayManager(self,
+                                 routeCasingLineLayerWithIdentifier: identifier,
+                                 sourceIdentifier: sourceIdentifier,
+                                 for: carPlayMapViewController)
     }
 }
 

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -1001,6 +1001,22 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
                                  to: carPlayNavigationViewController,
                                  pointAnnotationManager: pointAnnotationManager)
     }
+    
+    public func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
+                                                routeLineLayerWithIdentifier identifier: String,
+                                                sourceIdentifier: String) -> LineLayer? {
+        return delegate?.carPlayManager(self,
+                                        routeLineLayerWithIdentifier: identifier,
+                                        sourceIdentifier: sourceIdentifier)
+    }
+    
+    public func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
+                                                routeCasingLineLayerWithIdentifier identifier: String,
+                                                sourceIdentifier: String) -> LineLayer? {
+        return delegate?.carPlayManager(self,
+                                        routeCasingLineLayerWithIdentifier: identifier,
+                                        sourceIdentifier: sourceIdentifier)
+    }
 }
 
 // MARK: CarPlayMapViewControllerDelegate Methods

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -285,6 +285,14 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         templateDidDisappear template: CPTemplate,
                         animated: Bool)
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        routeLineLayerWithIdentifier identifier: String,
+                        sourceIdentifier: String) -> LineLayer?
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        routeCasingLineLayerWithIdentifier identifier: String,
+                        sourceIdentifier: String) -> LineLayer?
 }
 
 @available(iOS 12.0, *)
@@ -472,5 +480,25 @@ public extension CarPlayManagerDelegate {
                         templateDidDisappear template: CPTemplate,
                         animated: Bool) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        routeLineLayerWithIdentifier identifier: String,
+                        sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+        return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        routeCasingLineLayerWithIdentifier identifier: String,
+                        sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+        return nil
     }
 }

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -295,6 +295,10 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - parameter parentViewController: The view controller that contains the map view, which is an
      instance of either `CarPlayMapViewController` or `CarPlayNavigationViewController`.
+     - returns: A `LineLayer` that is applied to the route line.
+     
+     - seealso: `NavigationMapViewDelegate.navigationMapView(_:routeLineLayerWithIdentifier:sourceIdentifier:)`,
+     `NavigationViewControllerDelegate.navigationViewController.carPlayManager(_:routeLineLayerWithIdentifier:sourceIdentifier:)`.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeLineLayerWithIdentifier identifier: String,
@@ -311,6 +315,10 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - parameter parentViewController: The view controller that contains the map view, which is an
      instance of either `CarPlayMapViewController` or `CarPlayNavigationViewController`.
+     - returns: A `LineLayer` that is applied as a casing around the route line.
+     
+     - seealso: `NavigationMapViewDelegate.navigationMapView(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:)`,
+     `NavigationViewControllerDelegate.navigationViewController.carPlayManager(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:)`.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeCasingLineLayerWithIdentifier identifier: String,

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -286,13 +286,36 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
                         templateDidDisappear template: CPTemplate,
                         animated: Bool)
     
+    /**
+     Asks the receiver to return a `LineLayer` for the route line, given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
+     - parameter parentViewController: The view controller that contains the map view, which is an
+     instance of either `CarPlayMapViewController` or `CarPlayNavigationViewController`.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeLineLayerWithIdentifier identifier: String,
-                        sourceIdentifier: String) -> LineLayer?
+                        sourceIdentifier: String,
+                        for parentViewController: UIViewController) -> LineLayer?
     
+    /**
+     Asks the receiver to return a `LineLayer` for the casing layer that surrounds route line,
+     given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
+     - parameter parentViewController: The view controller that contains the map view, which is an
+     instance of either `CarPlayMapViewController` or `CarPlayNavigationViewController`.
+     */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeCasingLineLayerWithIdentifier identifier: String,
-                        sourceIdentifier: String) -> LineLayer?
+                        sourceIdentifier: String,
+                        for parentViewController: UIViewController) -> LineLayer?
 }
 
 @available(iOS 12.0, *)
@@ -487,7 +510,8 @@ public extension CarPlayManagerDelegate {
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeLineLayerWithIdentifier identifier: String,
-                        sourceIdentifier: String) -> LineLayer? {
+                        sourceIdentifier: String,
+                        for parentViewController: UIViewController) -> LineLayer? {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
         return nil
     }
@@ -497,7 +521,8 @@ public extension CarPlayManagerDelegate {
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         routeCasingLineLayerWithIdentifier identifier: String,
-                        sourceIdentifier: String) -> LineLayer? {
+                        sourceIdentifier: String,
+                        for parentViewController: UIViewController) -> LineLayer? {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
         return nil
     }

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -396,5 +396,21 @@ extension CarPlayMapViewController: NavigationMapViewDelegate {
                                            didAdd: finalDestinationAnnotation,
                                            pointAnnotationManager: pointAnnotationManager)
     }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView,
+                                  routeLineLayerWithIdentifier identifier: String,
+                                  sourceIdentifier: String) -> LineLayer? {
+        delegate?.carPlayMapViewController(self,
+                                           routeLineLayerWithIdentifier: identifier,
+                                           sourceIdentifier: sourceIdentifier)
+    }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView,
+                                  routeCasingLineLayerWithIdentifier identifier: String,
+                                  sourceIdentifier: String) -> LineLayer? {
+        delegate?.carPlayMapViewController(self,
+                                           routeCasingLineLayerWithIdentifier: identifier,
+                                           sourceIdentifier: sourceIdentifier)
+    }
 }
 #endif

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -15,7 +15,9 @@ open class CarPlayMapViewController: UIViewController {
     // MARK: UI Elements Configuration
     
     /**
-     The view controller’s delegate.
+     The view controller’s delegate, that is used by the `CarPlayManager`.
+     
+     Do not overwrite this property and use `CarPlayManagerDelegate` methods directly.
      */
     public weak var delegate: CarPlayMapViewControllerDelegate?
     

--- a/Sources/MapboxNavigation/CarPlayMapViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewControllerDelegate.swift
@@ -39,7 +39,7 @@ public protocol CarPlayMapViewControllerDelegate: AnyObject, UnimplementedLoggin
      - parameter carPlayMapViewController: The `CarPlayMapViewController` object.
      - parameter identifier: The `LineLayer` identifier.
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
-     - returns: A `LineLayer` that is applied to the route line.
+     - returns: A `LineLayer` that is applied as a casing around the route line.
      */
     func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
                                   routeCasingLineLayerWithIdentifier identifier: String,

--- a/Sources/MapboxNavigation/CarPlayMapViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewControllerDelegate.swift
@@ -17,6 +17,33 @@ public protocol CarPlayMapViewControllerDelegate: AnyObject, UnimplementedLoggin
     func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
                                   didAdd finalDestinationAnnotation: PointAnnotation,
                                   pointAnnotationManager: PointAnnotationManager)
+    
+    /**
+     Asks the receiver to return a `LineLayer` for the route line, given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter carPlayMapViewController: The `CarPlayMapViewController` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
+     - returns: A `LineLayer` that is applied to the route line.
+     */
+    func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
+                                  routeLineLayerWithIdentifier identifier: String,
+                                  sourceIdentifier: String) -> LineLayer?
+    
+    /**
+     Asks the receiver to return a `LineLayer` for the casing layer that surrounds route line,
+     given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter carPlayMapViewController: The `CarPlayMapViewController` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
+     - returns: A `LineLayer` that is applied to the route line.
+     */
+    func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
+                                  routeCasingLineLayerWithIdentifier identifier: String,
+                                  sourceIdentifier: String) -> LineLayer?
 }
 
 @available(iOS 12.0, *)
@@ -28,6 +55,26 @@ public extension CarPlayMapViewControllerDelegate {
     func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
                                   didAdd finalDestinationAnnotation: PointAnnotation,
                                   pointAnnotationManager: PointAnnotationManager) {
-        logUnimplemented(protocolType: CarPlayMapViewController.self, level: .debug)
+        logUnimplemented(protocolType: CarPlayMapViewControllerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayMapViewController(_ carPlayMapViewController: CarPlayNavigationViewController,
+                                         routeLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: CarPlayMapViewControllerDelegate.self, level: .debug)
+        return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayMapViewController(_ carPlayMapViewController: CarPlayNavigationViewController,
+                                         routeCasingLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: CarPlayMapViewControllerDelegate.self, level: .debug)
+        return nil
     }
 }

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -884,6 +884,22 @@ extension CarPlayNavigationViewController: NavigationMapViewDelegate {
                                                   didAdd: finalDestinationAnnotation,
                                                   pointAnnotationManager: pointAnnotationManager)
     }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView,
+                                  routeLineLayerWithIdentifier identifier: String,
+                                  sourceIdentifier: String) -> LineLayer? {
+        return delegate?.carPlayNavigationViewController(self,
+                                                         routeLineLayerWithIdentifier: identifier,
+                                                         sourceIdentifier: sourceIdentifier)
+    }
+    
+    public func navigationMapView(_ navigationMapView: NavigationMapView,
+                                  routeCasingLineLayerWithIdentifier identifier: String,
+                                  sourceIdentifier: String) -> LineLayer? {
+        return delegate?.carPlayNavigationViewController(self,
+                                                         routeCasingLineLayerWithIdentifier: identifier,
+                                                         sourceIdentifier: sourceIdentifier)
+    }
 }
 
 #endif

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -309,7 +309,9 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
     // MARK: Navigating the Route
     
     /**
-     The view controller’s delegate.
+     The view controller’s delegate, that is used by the `CarPlayManager`.
+     
+     Do not overwrite this property and use `CarPlayManagerDelegate` methods directly.
      */
     public weak var delegate: CarPlayNavigationViewControllerDelegate?
     

--- a/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
@@ -46,6 +46,14 @@ public protocol CarPlayNavigationViewControllerDelegate: AnyObject, Unimplemente
     func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
                                          didAdd finalDestinationAnnotation: PointAnnotation,
                                          pointAnnotationManager: PointAnnotationManager)
+
+    func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
+                                         routeLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer?
+    
+    func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
+                                         routeCasingLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer?
 }
 
 @available(iOS 12.0, *)
@@ -82,5 +90,25 @@ public extension CarPlayNavigationViewControllerDelegate {
                                          didAdd finalDestinationAnnotation: PointAnnotation,
                                          pointAnnotationManager: PointAnnotationManager) {
         logUnimplemented(protocolType: CarPlayNavigationViewControllerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
+                                         routeLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: CarPlayNavigationViewControllerDelegate.self, level: .debug)
+        return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
+                                         routeCasingLineLayerWithIdentifier identifier: String,
+                                         sourceIdentifier: String) -> LineLayer? {
+        logUnimplemented(protocolType: CarPlayNavigationViewControllerDelegate.self, level: .debug)
+        return nil
     }
 }

--- a/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
@@ -68,7 +68,7 @@ public protocol CarPlayNavigationViewControllerDelegate: AnyObject, Unimplemente
      - parameter carPlayNavigationViewController: The `CarPlayNavigationViewController` object.
      - parameter identifier: The `LineLayer` identifier.
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
-     - returns: A `LineLayer` that is applied to the route line.
+     - returns: A `LineLayer` that is applied as a casing around the route line.
      */
     func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
                                          routeCasingLineLayerWithIdentifier identifier: String,

--- a/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
@@ -47,10 +47,29 @@ public protocol CarPlayNavigationViewControllerDelegate: AnyObject, Unimplemente
                                          didAdd finalDestinationAnnotation: PointAnnotation,
                                          pointAnnotationManager: PointAnnotationManager)
 
+    /**
+     Asks the receiver to return a `LineLayer` for the route line, given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter carPlayNavigationViewController: The `CarPlayNavigationViewController` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
+     - returns: A `LineLayer` that is applied to the route line.
+     */
     func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
                                          routeLineLayerWithIdentifier identifier: String,
                                          sourceIdentifier: String) -> LineLayer?
     
+    /**
+     Asks the receiver to return a `LineLayer` for the casing layer that surrounds route line,
+     given a layer identifier and a source identifier.
+     This method is invoked when the map view loads and any time routes are added.
+     
+     - parameter carPlayNavigationViewController: The `CarPlayNavigationViewController` object.
+     - parameter identifier: The `LineLayer` identifier.
+     - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
+     - returns: A `LineLayer` that is applied to the route line.
+     */
     func carPlayNavigationViewController(_ carPlayNavigationViewController: CarPlayNavigationViewController,
                                          routeCasingLineLayerWithIdentifier identifier: String,
                                          sourceIdentifier: String) -> LineLayer?

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -262,7 +262,6 @@ extension NavigationMapView {
             case .constant(let constant):
                 overriddenLineLayerColor = UIColor(constant)
             case .expression(_):
-                // TODO: Handle case when route line color is provided as an expression.
                 break
             }
         }
@@ -285,7 +284,6 @@ extension NavigationMapView {
             case .constant(let constant):
                 overriddenLineLayerCasingColor = UIColor(constant)
             case .expression(_):
-                // TODO: Handle case when route line color is provided as an expression.
                 break
             }
         }

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -430,7 +430,13 @@ extension NavigationMapView {
                                      fractionTraveled: Double,
                                      isMain: Bool = true,
                                      isSoft: Bool = false) -> [Double: UIColor] {
-        let overriddenLineLayerCasingColor = lineLayerCasingColorIfPresent(from: route)
+        // If `congestionFeatures` is set to nil - check if overridden route line casing is used.
+        let overriddenLineLayerCasingColor: UIColor?
+        if let _ = congestionFeatures {
+            overriddenLineLayerCasingColor = lineLayerColorIfPresent(from: route)
+        } else {
+            overriddenLineLayerCasingColor = lineLayerCasingColorIfPresent(from: route)
+        }
         
         let lineSettings = LineGradientSettings(fractionTraveled: fractionTraveled,
                                                 isSoft: isSoft,

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -425,7 +425,7 @@ extension NavigationMapView {
         return gradientStops
     }
     
-    func routeLineCongestionGradient(_ route: Route,
+    func routeLineCongestionGradient(_ route: Route? = nil,
                                      congestionFeatures: [Turf.Feature]? = nil,
                                      fractionTraveled: Double,
                                      isMain: Bool = true,

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -431,20 +431,20 @@ extension NavigationMapView {
                                      isMain: Bool = true,
                                      isSoft: Bool = false) -> [Double: UIColor] {
         // If `congestionFeatures` is set to nil - check if overridden route line casing is used.
-        let overriddenLineLayerCasingColor: UIColor?
+        let overriddenLineLayerColor: UIColor?
         if let _ = congestionFeatures {
-            overriddenLineLayerCasingColor = lineLayerColorIfPresent(from: route)
+            overriddenLineLayerColor = lineLayerColorIfPresent(from: route)
         } else {
-            overriddenLineLayerCasingColor = lineLayerCasingColorIfPresent(from: route)
+            overriddenLineLayerColor = lineLayerCasingColorIfPresent(from: route)
         }
         
         let lineSettings = LineGradientSettings(fractionTraveled: fractionTraveled,
                                                 isSoft: isSoft,
-                                                startingColor: overriddenLineLayerCasingColor ?? (isMain ? .trafficUnknown : .alternativeTrafficUnknown),
-                                                baseColor: overriddenLineLayerCasingColor ?? routeCasingColor,
+                                                startingColor: overriddenLineLayerColor ?? (isMain ? .trafficUnknown : .alternativeTrafficUnknown),
+                                                baseColor: overriddenLineLayerColor ?? routeCasingColor,
                                                 featureColor: {
-            if let overriddenLineLayerCasingColor = overriddenLineLayerCasingColor {
-                return overriddenLineLayerCasingColor
+            if let overriddenLineLayerColor = overriddenLineLayerColor {
+                return overriddenLineLayerColor
             } else {
                 if case let .boolean(isCurrentLeg) = $0.properties?[CurrentLegAttribute],
                    isCurrentLeg {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -457,7 +457,8 @@ open class NavigationMapView: UIView {
         if let legIndex = currentLegIndex {
             let congestionFeatures = route.congestionFeatures(legIndex: legIndex,
                                                               roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
-            currentLineGradientStops = routeLineCongestionGradient(congestionFeatures,
+            currentLineGradientStops = routeLineCongestionGradient(route,
+                                                                   congestionFeatures: congestionFeatures,
                                                                    fractionTraveled: fractionTraveled,
                                                                    isSoft: crossfadesCongestionSegments)
             pendingCoordinateForRouteLine = route.shape?.coordinates.first ?? mostRecentUserCourseViewLocation?.coordinate
@@ -467,7 +468,7 @@ open class NavigationMapView: UIView {
     func updateRestrictedAreasGradientStops(along route: Route?) {
         if showsRestrictedAreasOnRoute, let route = route {
             currentRestrictedAreasStops = routeLineRestrictionsGradient(route.restrictedRoadsFeatures(),
-                                                                    fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
+                                                                        fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
         } else {
             currentRestrictedAreasStops.removeAll()
         }
@@ -536,7 +537,7 @@ open class NavigationMapView: UIView {
                                                                                              lineBaseColor: routeRestrictedAreaColor))
             } else {
                 let routeLineStops = routeLineRestrictionsGradient(restrictedRoadsFeatures,
-                                                               fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
+                                                                   fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
                 lineLayer?.lineGradient = .expression(Expression.routeLineGradientExpression(routeLineStops,
                                                                                              lineBaseColor: routeRestrictedAreaColor))
             }
@@ -606,7 +607,8 @@ open class NavigationMapView: UIView {
                                                                                                   isSoft: crossfadesCongestionSegments)))
                 } else {
                     let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
-                    let gradientStops = routeLineCongestionGradient(congestionFeatures,
+                    let gradientStops = routeLineCongestionGradient(route,
+                                                                    congestionFeatures: congestionFeatures,
                                                                     fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0,
                                                                     isSoft: crossfadesCongestionSegments)
                     
@@ -616,7 +618,8 @@ open class NavigationMapView: UIView {
                 }
             } else {
                 if showsCongestionForAlternativeRoutes {
-                    let gradientStops = routeLineCongestionGradient(route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels),
+                    let gradientStops = routeLineCongestionGradient(route,
+                                                                    congestionFeatures: route.congestionFeatures(roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels),
                                                                     fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0,
                                                                     isMain: false,
                                                                     isSoft: crossfadesCongestionSegments)
@@ -686,7 +689,8 @@ open class NavigationMapView: UIView {
             lineLayer?.lineCap = .constant(.round)
             
             if isMainRoute {
-                let gradientStops = routeLineCongestionGradient(fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
+                let gradientStops = routeLineCongestionGradient(route,
+                                                                fractionTraveled: routeLineTracksTraversal ? fractionTraveled : 0.0)
                 lineLayer?.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops, lineBaseColor: routeCasingColor)))
             } else {
                 lineLayer?.lineColor = .constant(.init(routeAlternateCasingColor))

--- a/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewDelegate.swift
@@ -20,6 +20,9 @@ public protocol NavigationMapViewDelegate: AnyObject, UnimplementedLogging {
      - parameter identifier: The `LineLayer` identifier.
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied to the route line.
+     
+     - seealso: `CarPlayManagerDelegate.carPlayManager(_:routeLineLayerWithIdentifier:sourceIdentifier:for:)`,
+     `NavigationViewControllerDelegate.navigationViewController(_:routeLineLayerWithIdentifier:sourceIdentifier:)`.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
     
@@ -31,6 +34,9 @@ public protocol NavigationMapViewDelegate: AnyObject, UnimplementedLogging {
      - parameter identifier: The `LineLayer` identifier.
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied as a casing around the route line.
+     
+     - seealso: `CarPlayManagerDelegate.carPlayManager(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:for:)`,
+     `NavigationViewControllerDelegate.navigationViewController(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:)`.
      */
     func navigationMapView(_ navigationMapView: NavigationMapView, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
     

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -144,6 +144,9 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      - parameter identifier: The `LineLayer` identifier.
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied to the route line.
+     
+     - seealso: `NavigationMapViewDelegate.navigationMapView(_:routeLineLayerWithIdentifier:sourceIdentifier:)`,
+     `CarPlayManagerDelegate.carPlayManager(_:routeLineLayerWithIdentifier:sourceIdentifier:for:)`.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
     
@@ -156,6 +159,9 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      - parameter identifier: The `LineLayer` identifier.
      - parameter sourceIdentifier: Identifier of the source, which contains the route data that this method would style.
      - returns: A `LineLayer` that is applied as a casing around the route line.
+     
+     - seealso: `NavigationMapViewDelegate.navigationMapView(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:)`,
+     `CarPlayManagerDelegate.carPlayManager(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:for:)`.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, routeCasingLineLayerWithIdentifier identifier: String, sourceIdentifier: String) -> LineLayer?
     

--- a/Sources/MapboxNavigation/UIColor.swift
+++ b/Sources/MapboxNavigation/UIColor.swift
@@ -74,6 +74,8 @@ extension UIColor {
     /**
      Convenience initializer, which allows to convert `StyleColor` to `UIColor`. This initializer
      is primarily used while retrieving color information from `LineLayer`.
+     
+     - parameter styleColor: Color, defined by the Mapbox Style Specification.
      */
     convenience init(_ styleColor: StyleColor) {
         self.init(red: CGFloat(styleColor.red / 255.0),

--- a/Sources/MapboxNavigation/UIColor.swift
+++ b/Sources/MapboxNavigation/UIColor.swift
@@ -1,4 +1,5 @@
 import UIKit
+import MapboxMaps
 
 extension UIColor {
 
@@ -68,5 +69,16 @@ extension UIColor {
             self.setFill()
             rendererContext.fill(CGRect(origin: .zero, size: size))
         }
+    }
+    
+    /**
+     Convenience initializer, which allows to convert `StyleColor` to `UIColor`. This initializer
+     is primarily used while retrieving color information from `LineLayer`.
+     */
+    convenience init(_ styleColor: StyleColor) {
+        self.init(red: CGFloat(styleColor.red / 255.0),
+                  green: CGFloat(styleColor.green / 255.0),
+                  blue: CGFloat(styleColor.blue / 255.0),
+                  alpha: CGFloat(styleColor.alpha))
     }
 }

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -377,22 +377,31 @@ class NavigationMapViewTests: TestCase {
             CongestionAttribute: .string(String(describing: congestionSegment.1)),
             CurrentLegAttribute: true
         ]
-        let congestionFeatures:[Turf.Feature] = [feature]
+        let congestionFeatures = [feature]
         
         var fractionTraveled = 0.0
-        var routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures, fractionTraveled: fractionTraveled, isMain: true, isSoft: false)
+        var routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestionFeatures,
+                                                                              fractionTraveled: fractionTraveled,
+                                                                              isMain: true,
+                                                                              isSoft: false)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.trafficLowColor)
         
         fractionTraveled = 0.3
         var fractionTraveledNextDown = Double(CGFloat(fractionTraveled).nextDown)
-        routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures, fractionTraveled: fractionTraveled, isMain: true, isSoft: false)
+        routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestionFeatures,
+                                                                          fractionTraveled: fractionTraveled,
+                                                                          isMain: true,
+                                                                          isSoft: false)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[fractionTraveled], navigationMapView.trafficLowColor)
         XCTAssertEqual(routeLineGradient[fractionTraveledNextDown], navigationMapView.traversedRouteColor)
         
         fractionTraveled = 0.999999999
         fractionTraveledNextDown = Double(CGFloat(fractionTraveled).nextDown)
-        routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures, fractionTraveled: fractionTraveled, isMain: true, isSoft: true)
+        routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestionFeatures,
+                                                                          fractionTraveled: fractionTraveled,
+                                                                          isMain: true,
+                                                                          isSoft: true)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[fractionTraveled], navigationMapView.trafficLowColor)
         XCTAssertEqual(routeLineGradient[fractionTraveledNextDown], navigationMapView.traversedRouteColor)
@@ -402,7 +411,10 @@ class NavigationMapViewTests: TestCase {
         let route = loadRoute(from: "route-with-road-classes-single-congestion")
         var congestions = route.congestionFeatures()
         var fractionTraveled = 0.0
-        var lineGradient = navigationMapView.routeLineCongestionGradient(congestions, fractionTraveled: fractionTraveled, isMain: true, isSoft: true)
+        var lineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestions,
+                                                                         fractionTraveled: fractionTraveled,
+                                                                         isMain: true,
+                                                                         isSoft: true)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.trafficUnknownColor)
         
         lineGradient = [
@@ -415,14 +427,19 @@ class NavigationMapViewTests: TestCase {
         ]
         fractionTraveled = 0.3
         let nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient, baseColor: navigationMapView.trafficUnknownColor)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled,
+                                                                      gradientStops: lineGradient,
+                                                                      baseColor: navigationMapView.trafficUnknownColor)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficSevereColor)
         XCTAssertEqual(lineGradient[0.305], navigationMapView.trafficModerateColor)
         
         congestions = [Turf.Feature]()
-        lineGradient = navigationMapView.routeLineCongestionGradient(congestions, fractionTraveled: fractionTraveled, isMain: true, isSoft: true)
+        lineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestions,
+                                                                     fractionTraveled: fractionTraveled,
+                                                                     isMain: true,
+                                                                     isSoft: true)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)
@@ -432,12 +449,16 @@ class NavigationMapViewTests: TestCase {
     func testUpdateRouteLineGradient() {
         let route = loadRoute(from: "route-with-road-classes-single-congestion")
         let congestions = route.congestionFeatures()
-        var lineGradient = navigationMapView.routeLineCongestionGradient(congestions, fractionTraveled: 0.0, isMain: true)
+        var lineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestions,
+                                                                         fractionTraveled: 0.0,
+                                                                         isMain: true)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.trafficUnknownColor)
         
         var fractionTraveled = 0.5
         var nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient, baseColor: navigationMapView.trafficUnknownColor)
+        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled,
+                                                                      gradientStops: lineGradient,
+                                                                      baseColor: navigationMapView.trafficUnknownColor)
 
         XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)

--- a/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
+++ b/Tests/MapboxNavigationTests/VanishingRouteLineTests.swift
@@ -304,7 +304,9 @@ class VanishingRouteLineTests: TestCase {
         // When there's no congestion information found or parsed from route features,
         // the route line is expcted to apply `trafficUnknownColor` for the main route.
         let congestionFeatures = route.congestionFeatures(legIndex: 0)
-        let currentLineGradientStops = navigationMapView.routeLineCongestionGradient(congestionFeatures, fractionTraveled: 0.0)
+        let currentLineGradientStops = navigationMapView.routeLineCongestionGradient(route,
+                                                                                     congestionFeatures: congestionFeatures,
+                                                                                     fractionTraveled: 0.0)
         XCTAssertEqual(currentLineGradientStops[0.0], navigationMapView.trafficUnknownColor, "Failed to use trafficUnknownColor for route line when no congestion level found.")
     }
     func testFindDistanceToNearestPointOnCurrentLine() {


### PR DESCRIPTION
Closing #2967.

In scope of this PR:
- Bug, which was causing inability to modify main route line and its casing when `routeLineTracksTraversal` is enabled on iOS and CarPlay was fixed.
- Delegate methods, which provide the ability to modify route line layer and its casing on CarPlay were added.

/cc @ChristianSteffens