### PR TITLE
Expose waypoint and route detection methods publicly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Fixed the route layers disappearance in preview mode and in passive navigation when map style changes. ([#3734](https://github.com/mapbox/mapbox-navigation-ios/pull/3734))
 * Fixed an issue where highlighted buildings were removed from the map during style change. ([#3736](https://github.com/mapbox/mapbox-navigation-ios/pull/3736))
 * Renamed the `NavigationMapView.highlightBuildings(at:in3D:completion:)` method to `NavigationMapView.highlightBuildings(at:in3D:extrudeAll:completion:)` to provide the ability to extrude not only buildings at specific coordinates, but all other buildings as well. ([#3736](https://github.com/mapbox/mapbox-navigation-ios/pull/3736))
-* Added the `NavigationMapView.mapViewTapGestureRecognizer`, `NavigationMapView.waypoints(on:closeTo:)` and `NavigationMapView.routes(closeTo:)` to be able to detect waypoints and routes on the map view. ([#3746](https://github.com/mapbox/mapbox-navigation-ios/pull/3746))
+* Added the `NavigationMapView.mapViewTapGestureRecognizer` property and the `NavigationMapView.legSeparatingWaypoints(on:closeTo:)` and `NavigationMapView.routes(closeTo:)` methods for configuring how the map view responds to tap gestures when previewing a route. ([#3746](https://github.com/mapbox/mapbox-navigation-ios/pull/3746))
 
 ### CarPlay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fixed the route layers disappearance in preview mode and in passive navigation when map style changes. ([#3734](https://github.com/mapbox/mapbox-navigation-ios/pull/3734))
 * Fixed an issue where highlighted buildings were removed from the map during style change. ([#3736](https://github.com/mapbox/mapbox-navigation-ios/pull/3736))
 * Renamed the `NavigationMapView.highlightBuildings(at:in3D:completion:)` method to `NavigationMapView.highlightBuildings(at:in3D:extrudeAll:completion:)` to provide the ability to extrude not only buildings at specific coordinates, but all other buildings as well. ([#3736](https://github.com/mapbox/mapbox-navigation-ios/pull/3736))
+* Added the `NavigationMapView.mapViewTapGestureRecognizer`, `NavigationMapView.waypoints(on:closeTo:)` and `NavigationMapView.routes(closeTo:)` to be able to detect waypoints and routes on the map view. ([#3746](https://github.com/mapbox/mapbox-navigation-ios/pull/3746))
 
 ### CarPlay
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -90,7 +90,8 @@ open class NavigationMapView: UIView {
     // MARK: Customizing and Displaying the Route Line(s)
     
     /**
-     Maximum distance the user can tap for a selection to be valid when selecting an alternate route.
+     Maximum distance (in screen points) the user can tap for a selection to be valid when selecting
+     an alternate route.
      */
     public var tapGestureDistanceThreshold: CGFloat = 50
     
@@ -1644,7 +1645,7 @@ open class NavigationMapView: UIView {
     @objc func didReceiveTap(sender: UITapGestureRecognizer) {
         guard let routes = routes, let tapPoint = sender.point else { return }
         
-        let waypointTest = waypoints(on: routes, closeTo: tapPoint)
+        let waypointTest = legSeparatingWaypoints(on: routes, closeTo: tapPoint)
         if let selected = waypointTest?.first {
             delegate?.navigationMapView(self, didSelect: selected)
             return
@@ -1670,7 +1671,7 @@ open class NavigationMapView: UIView {
      - returns: List of the waypoints, which were found. If no routes have more than one leg, `nil`
      will be returned.
      */
-    public func waypoints(on routes: [Route], closeTo point: CGPoint) -> [Waypoint]? {
+    public func legSeparatingWaypoints(on routes: [Route], closeTo point: CGPoint) -> [Waypoint]? {
         // In case if route does not contain more than one leg - do nothing.
         let multipointRoutes = routes.filter({ $0.legs.count > 1 })
         guard multipointRoutes.count > 0 else { return nil }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -94,6 +94,12 @@ open class NavigationMapView: UIView {
      */
     public var tapGestureDistanceThreshold: CGFloat = 50
     
+    /**
+     Gesture recognizer, that is used to detect taps on waypoints and routes that are currently
+     present on the map. Enabled by default.
+     */
+    public private(set) var mapViewTapGestureRecognizer: UITapGestureRecognizer!
+    
     @objc dynamic public var routeCasingColor: UIColor = .defaultRouteCasing
     @objc dynamic public var routeAlternateColor: UIColor = .defaultAlternateLine
     @objc dynamic public var routeAlternateCasingColor: UIColor = .defaultAlternateLineCasing
@@ -1627,7 +1633,7 @@ open class NavigationMapView: UIView {
     
     func setupGestureRecognizers() {
         // Gesture recognizer, which is used to detect taps on route line and waypoint.
-        let mapViewTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didReceiveTap(sender:)))
+        mapViewTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didReceiveTap(sender:)))
         mapViewTapGestureRecognizer.delegate = self
         mapView.addGestureRecognizer(mapViewTapGestureRecognizer)
     }
@@ -1654,15 +1660,27 @@ open class NavigationMapView: UIView {
         }
     }
     
-    private func waypoints(on routes: [Route], closeTo point: CGPoint) -> [Waypoint]? {
-        let tapCoordinate = mapView.mapboxMap.coordinate(for: point)
-        let multipointRoutes = routes.filter { $0.legs.count > 1}
+    /**
+     Returns a list of waypoints, that are located on the routes with more than one leg and are
+     close to a certain point and are within threshold distance defined in
+     `NavigationMapView.tapGestureDistanceThreshold`.
+     
+     - parameter routes: List of the routes.
+     - parameter point: Point on the screen.
+     - returns: List of the waypoints, which were found. If no routes have more than one leg, `nil`
+     will be returned.
+     */
+    public func waypoints(on routes: [Route], closeTo point: CGPoint) -> [Waypoint]? {
+        // In case if route does not contain more than one leg - do nothing.
+        let multipointRoutes = routes.filter({ $0.legs.count > 1 })
         guard multipointRoutes.count > 0 else { return nil }
+        
         let waypoints = multipointRoutes.compactMap { route in
-            route.legs.dropLast().compactMap { $0.destination }
-        }.flatMap {$0}
+            route.legs.dropLast().compactMap({ $0.destination })
+        }.flatMap({ $0 })
         
         // Sort the array in order of closest to tap.
+        let tapCoordinate = mapView.mapboxMap.coordinate(for: point)
         let closest = waypoints.sorted { (left, right) -> Bool in
             let leftDistance = left.coordinate.projectedDistance(to: tapCoordinate)
             let rightDistance = right.coordinate.projectedDistance(to: tapCoordinate)
@@ -1679,13 +1697,20 @@ open class NavigationMapView: UIView {
         return candidates
     }
     
-    private func routes(closeTo point: CGPoint) -> [Route]? {
-        let tapCoordinate = mapView.mapboxMap.coordinate(for: point)
-        
+    /**
+     Returns a list of the routes, that are close to a certain point and are within threshold distance
+     defined in `NavigationMapView.tapGestureDistanceThreshold`.
+     
+     - parameter point: Point on the screen.
+     - returns: List of the routes, which were found. If there are no routes on the map view `nil`
+     will be returned.
+     */
+    public func routes(closeTo point: CGPoint) -> [Route]? {
         // Filter routes with at least 2 coordinates.
         guard let routes = routes?.filter({ $0.shape?.coordinates.count ?? 0 > 1 }) else { return nil }
         
         // Sort routes by closest distance to tap gesture.
+        let tapCoordinate = mapView.mapboxMap.coordinate(for: point)
         let closest = routes.sorted { (left, right) -> Bool in
             // Existence has been assured through use of filter.
             let leftLine = left.shape!


### PR DESCRIPTION
This PR:
- Adds the ability to disable `NavigationMapView` tap gesture recognizer. 
- Makes `NavigationMapView.waypoints(on:closeTo:)` and `NavigationMapView.routes(closeTo:)` public to be able to detect waypoints and routes on the map view.