### PR TITLE
Customizing SpeechSynthesizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fixed an issue where the route line appeared to begin away from the user’s current location after the route was refreshed. ([#3781](https://github.com/mapbox/mapbox-navigation-ios/pull/3781))
 * Fixed a memory leak after ending a turn-by-turn navigation session. ([#3782](https://github.com/mapbox/mapbox-navigation-ios/pull/3782))
+* Added the `MapboxSpeechSynthesizer(remoteSpeechSynthesizer:)` initializer for creating a `MapboxSpeechSynthesizer` object that uses a custom `SpeechSynthesizer` instance. ([#3747](https://github.com/mapbox/mapbox-navigation-ios/pull/3747))
 
 ## v2.3.0
 

--- a/Sources/MapboxNavigation/MapboxSpeechSynthesizer.swift
+++ b/Sources/MapboxNavigation/MapboxSpeechSynthesizer.swift
@@ -54,10 +54,13 @@ open class MapboxSpeechSynthesizer: NSObject, SpeechSynthesizing {
     
     // MARK: Instructions vocalization
     
+    /// Checks if speech synthesizer is now pronouncing an instruction.
     public var isSpeaking: Bool {
         return audioPlayer?.isPlaying ?? false
     }
     
+    
+    /// Creates new `MapboxSpeechSynthesizer` with standard `SpeechSynthesizer` for converting text to audio.
     public init(accessToken: String? = nil, host: String? = nil) {
         self.cache = DataCache()
         
@@ -67,6 +70,12 @@ open class MapboxSpeechSynthesizer: NSObject, SpeechSynthesizing {
         }
         
         self.remoteSpeechSynthesizer = SpeechSynthesizer(accessToken: accessToken, host: hostString)
+    }
+    
+    /// Creates new `MapboxSpeechSynthesizer` with provided `SpeechSynthesizer` instance for converting text to audio.
+    public init(remoteSpeechSynthesizer: SpeechSynthesizer) {
+        self.cache = DataCache()
+        self.remoteSpeechSynthesizer = remoteSpeechSynthesizer
     }
     
     deinit {

--- a/Sources/MapboxNavigation/MapboxSpeechSynthesizer.swift
+++ b/Sources/MapboxNavigation/MapboxSpeechSynthesizer.swift
@@ -61,6 +61,9 @@ open class MapboxSpeechSynthesizer: NSObject, SpeechSynthesizing {
     
     
     /// Creates new `MapboxSpeechSynthesizer` with standard `SpeechSynthesizer` for converting text to audio.
+    ///
+    /// - parameter accessToken: A Mapbox [access token](https://www.mapbox.com/help/define-access-token/) used to authorize Mapbox Voice API requests. If an access token is not specified when initializing the speech synthesizer object, it should be specified in the `MBXAccessToken` key in the main application bundle’s Info.plist.
+    /// - parameter host: An optional hostname to the server API. The Mapbox Voice API endpoint is used by default.
     public init(accessToken: String? = nil, host: String? = nil) {
         self.cache = DataCache()
         
@@ -73,6 +76,8 @@ open class MapboxSpeechSynthesizer: NSObject, SpeechSynthesizing {
     }
     
     /// Creates new `MapboxSpeechSynthesizer` with provided `SpeechSynthesizer` instance for converting text to audio.
+    ///
+    /// - parameter remoteSpeechSynthesizer: Custom `SpeechSynthesizer` used to provide voice data.
     public init(remoteSpeechSynthesizer: SpeechSynthesizer) {
         self.cache = DataCache()
         self.remoteSpeechSynthesizer = remoteSpeechSynthesizer


### PR DESCRIPTION
This PR adds ability to provide custom subclasses of `SpeechSynthesizer` to be used in `MapboxSpeechSynthesizer`.