### PR TITLE
Reroute Controller integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Routing
 
-* Integrated MaboxNavigtionNative rerouting mechanism. `Router.routingProvider` has now became optional and is used as customization for reroutng mechanism. Default `nil` value corresponds to SDK's default rerouting mechanism to be used. If you don't want custom reroute requests, update your `NavigationService` and `Router` instances instantiation to use the default `nil` value. ([#3754](https://github.com/mapbox/mapbox-navigation-ios/pull/3754))
+* Integrated MaboxNavigtionNative rerouting mechanism. `Router.routingProvider` is replaced with optional `customRoutingProvider` which is used as customization for reroutng mechanism. Default `nil` value corresponds to SDK's default rerouting mechanism to be used. If you don't want custom reroute requests, update your `NavigationService` and `Router` instances instantiation to use the default `nil` value. ([#3754](https://github.com/mapbox/mapbox-navigation-ios/pull/3754))
 * Exposed configurations for rerouting aspects like controlling usage of online vs. offline data for route building using desired `RoutingProviderSource` in `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:)` method, and `Router.initialManeuverAvoidanceRadius` to configure radius before first dangerous maneuver. ([#3754](https://github.com/mapbox/mapbox-navigation-ios/pull/3754))
 
 ### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 
 * Added the `CarPlayManagerDelegate.carPlayManager(_:shouldUpdateNotificationFor:with:in:)` and `CarPlayManagerDelegate.carPlayManager(_:shouldShowNotificationFor:in:)` to provide the ability to control notifications presentation while CarPlay application is in the background. ([#3828](https://github.com/mapbox/mapbox-navigation-ios/pull/3828))
 
+### Routing
+
+* Integrated MaboxNavigtionNative rerouting mechanism. `Router.routingProvider` has now became optional and is used as customization for reroutng mechanism. Default `nil` value corresponds to SDK's default rerouting mechanism to be used. If you don't want custom reroute requests, update your `NavigationService` and `Router` instances instantiation to use the default `nil` value. ([#3754](https://github.com/mapbox/mapbox-navigation-ios/pull/3754))
+* Exposed configurations for rerouting aspects like controlling usage of online vs. offline data for route building using desired `RoutingProviderSource` in `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:)` method, and `Router.initialManeuverAvoidanceRadius` to configure radius before first dangerous maneuver. ([#3754](https://github.com/mapbox/mapbox-navigation-ios/pull/3754))
+
 ### Other changes
 
 * Added the `NavigationViewControllerDelegate.navigationViewController(_:, didSubmitArrivalFeedback:)` method which is called to notify that the user submitted the end of route feedback. Implementation of this method receives an `EndOfRouteFeedback` object with user's rating and comment. ([#3842](https://github.com/mapbox/mapbox-navigation-ios/pull/3842))

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -84,7 +84,7 @@ extension AppDelegate: CarPlayManagerDelegate {
         return MapboxNavigationService(routeResponse: routeResponse,
                                        routeIndex: routeIndex,
                                        routeOptions: routeOptions,
-                                       routingProvider: MapboxRoutingProvider(.hybrid),
+                                       routingProvider: nil,
                                        credentials: NavigationSettings.shared.directions.credentials,
                                        simulating: desiredSimulationMode)
     }

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -84,7 +84,7 @@ extension AppDelegate: CarPlayManagerDelegate {
         return MapboxNavigationService(routeResponse: routeResponse,
                                        routeIndex: routeIndex,
                                        routeOptions: routeOptions,
-                                       routingProvider: nil,
+                                       customRoutingProvider: nil,
                                        credentials: NavigationSettings.shared.directions.credentials,
                                        simulating: desiredSimulationMode)
     }

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     @available(iOS 12.0, *)
-    lazy var carPlayManager: CarPlayManager = CarPlayManager(routingProvider: MapboxRoutingProvider(.hybrid))
+    lazy var carPlayManager: CarPlayManager = CarPlayManager(customRoutingProvider: MapboxRoutingProvider(.hybrid))
     
     @available(iOS 12.0, *)
     lazy var carPlaySearchController: CarPlaySearchController = CarPlaySearchController()

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -48,7 +48,7 @@ class CustomViewController: UIViewController {
         navigationService = MapboxNavigationService(routeResponse: indexedUserRouteResponse!.routeResponse,
                                                     routeIndex: indexedUserRouteResponse!.routeIndex,
                                                     routeOptions: userRouteOptions!,
-                                                    routingProvider: MapboxRoutingProvider(.hybrid),
+                                                    routingProvider: nil,
                                                     credentials: NavigationSettings.shared.directions.credentials,
                                                     locationSource: locationManager,
                                                     simulating: simulateLocation ? .always : .inTunnels)

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -48,7 +48,7 @@ class CustomViewController: UIViewController {
         navigationService = MapboxNavigationService(routeResponse: indexedUserRouteResponse!.routeResponse,
                                                     routeIndex: indexedUserRouteResponse!.routeIndex,
                                                     routeOptions: userRouteOptions!,
-                                                    routingProvider: nil,
+                                                    customRoutingProvider: nil,
                                                     credentials: NavigationSettings.shared.directions.credentials,
                                                     locationSource: locationManager,
                                                     simulating: simulateLocation ? .always : .inTunnels)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -601,7 +601,7 @@ class ViewController: UIViewController {
         return MapboxNavigationService(routeResponse: response,
                                        routeIndex: routeIndex,
                                        routeOptions: options,
-                                       routingProvider: MapboxRoutingProvider(.hybrid),
+                                       routingProvider: nil,
                                        credentials: NavigationSettings.shared.directions.credentials,
                                        simulating: mode)
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -601,7 +601,7 @@ class ViewController: UIViewController {
         return MapboxNavigationService(routeResponse: response,
                                        routeIndex: routeIndex,
                                        routeOptions: options,
-                                       routingProvider: nil,
+                                       customRoutingProvider: nil,
                                        credentials: NavigationSettings.shared.directions.credentials,
                                        simulating: mode)
     }

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		2B01E4B7274671550002A5F7 /* RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B4274671540002A5F7 /* RoutingProvider.swift */; };
 		2B01E4B8274671550002A5F7 /* Directions+RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */; };
 		2B07444124B4832400615E87 /* TokenTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B07444024B4832400615E87 /* TokenTestViewController.swift */; };
+		2B28E22127EB48C60029E4C1 /* RerouteControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22027EB48C60029E4C1 /* RerouteControllerDelegate.swift */; };
 		2B3ED38C2609FA7900861A84 /* ArrivalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3ED38B2609FA7900861A84 /* ArrivalController.swift */; };
 		2B3ED3962609FB2300861A84 /* CameraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3ED3952609FB2300861A84 /* CameraController.swift */; };
 		2B3ED3B4260A162900861A84 /* NavigationViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3ED3B3260A162900861A84 /* NavigationViewData.swift */; };
@@ -68,6 +69,7 @@
 		2BE7013D25359C7B00F46E4E /* RouteAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE7013C25359C7B00F46E4E /* RouteAlert.swift */; };
 		2BE7016925371E3400F46E4E /* Incident.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE7016825371E3400F46E4E /* Incident.swift */; };
 		2BE70189253734A000F46E4E /* TollCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE7012C2535946300F46E4E /* TollCollection.swift */; };
+		2BEA240A27D205B500EE05D9 /* RerouteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEA240827D205B500EE05D9 /* RerouteController.swift */; };
 		2BEF16472775C8FD0085E3C6 /* MapMatchingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEF16462775C8FD0085E3C6 /* MapMatchingResult.swift */; };
 		2BF398C1274BDEA8000C9A72 /* Directions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF398C0274BDEA8000C9A72 /* Directions.swift */; };
 		2BF398C3274FE99A000C9A72 /* HandlerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF398C2274FE99A000C9A72 /* HandlerFactory.swift */; };
@@ -591,6 +593,7 @@
 		2B01E4B4274671540002A5F7 /* RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutingProvider.swift; sourceTree = "<group>"; };
 		2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Directions+RoutingProvider.swift"; sourceTree = "<group>"; };
 		2B07444024B4832400615E87 /* TokenTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenTestViewController.swift; sourceTree = "<group>"; };
+		2B28E22027EB48C60029E4C1 /* RerouteControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RerouteControllerDelegate.swift; sourceTree = "<group>"; };
 		2B3ED38B2609FA7900861A84 /* ArrivalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrivalController.swift; sourceTree = "<group>"; };
 		2B3ED3952609FB2300861A84 /* CameraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraController.swift; sourceTree = "<group>"; };
 		2B3ED3B3260A162900861A84 /* NavigationViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewData.swift; sourceTree = "<group>"; };
@@ -621,6 +624,7 @@
 		2BE701342535948100F46E4E /* RestStop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestStop.swift; sourceTree = "<group>"; };
 		2BE7013C25359C7B00F46E4E /* RouteAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteAlert.swift; sourceTree = "<group>"; };
 		2BE7016825371E3400F46E4E /* Incident.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Incident.swift; sourceTree = "<group>"; };
+		2BEA240827D205B500EE05D9 /* RerouteController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RerouteController.swift; sourceTree = "<group>"; };
 		2BEF16462775C8FD0085E3C6 /* MapMatchingResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapMatchingResult.swift; sourceTree = "<group>"; };
 		2BF398C0274BDEA8000C9A72 /* Directions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Directions.swift; sourceTree = "<group>"; };
 		2BF398C2274FE99A000C9A72 /* HandlerFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HandlerFactory.swift; sourceTree = "<group>"; };
@@ -1998,8 +2002,8 @@
 				3582A24F20EEC46B0029C5DE /* Router.swift */,
 				353E69031EF0C4E5007B2AE5 /* SimulatedLocationManager.swift */,
 				35C98730212E02B500808B82 /* RouteController.swift */,
-				2B5A4ABF2807124800170A2B /* RerouteController.swift */,
-				2B5A4AC02807124800170A2B /* RerouteControllerDelegate.swift */,
+				2BEA240827D205B500EE05D9 /* RerouteController.swift */,
+				2B28E22027EB48C60029E4C1 /* RerouteControllerDelegate.swift */,
 				5A39B9272498F9890026DFD1 /* PassiveLocationManager.swift */,
 				8A3A218F25EEC00200EDA999 /* CoreNavigationNavigator.swift */,
 				E2805A5726CB994500165DB9 /* NSLock+MapboxInternal.swift */,
@@ -2922,7 +2926,7 @@
 				3A163AE3249901D000D66A0D /* FixLocation.swift in Sources */,
 				2E50E0D2264E468B009D3848 /* RoadObjectMatcherError.swift in Sources */,
 				8D2AA745211CDD4000EB7F72 /* NavigationService.swift in Sources */,
-				2B5A4AC12807124900170A2B /* RerouteController.swift in Sources */,
+				2BEA240A27D205B500EE05D9 /* RerouteController.swift in Sources */,
 				2B01E4B8274671550002A5F7 /* Directions+RoutingProvider.swift in Sources */,
 				2B7ACA9C25E3F84700B0ACFD /* PredictiveCacheOptions.swift in Sources */,
 				35A5413B1EFC052700E49846 /* RouteOptions.swift in Sources */,
@@ -2944,7 +2948,7 @@
 				2BBED93B267A3AB900F90032 /* BillingHandler.swift in Sources */,
 				2BE701352535948100F46E4E /* RestStop.swift in Sources */,
 				2B01E4B6274671550002A5F7 /* MapboxRoutingProvider.swift in Sources */,
-				2B5A4AC22807124900170A2B /* RerouteControllerDelegate.swift in Sources */,
+				2B28E22127EB48C60029E4C1 /* RerouteControllerDelegate.swift in Sources */,
 				8D4CF9C621349FFB009C3FEE /* NavigationServiceDelegate.swift in Sources */,
 				2BF398C3274FE99A000C9A72 /* HandlerFactory.swift in Sources */,
 				118D883626F8CA0700B2ED7B /* ActiveNavigationFeedbackType.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -122,7 +122,7 @@ class Navigator {
                                             tilesVersion: Self.tilesVersion,
                                             historyDirectoryURL: Self.historyDirectoryURL,
                                             datasetProfileIdentifier: Self.datasetProfileIdentifier,
-                                            navigatorRouterType: NavigationSettings.shared.routingProviderSource.nativeSource)
+                                            routingProviderSource: NavigationSettings.shared.routingProviderSource.nativeSource)
         tileStore = factory.tileStore
         historyRecorder = factory.historyRecorder
         cacheHandle = factory.cacheHandle
@@ -151,7 +151,7 @@ class Navigator {
                                             historyDirectoryURL: Self.historyDirectoryURL,
                                             targetVersion: version.map { _ in Self.tilesVersion },
                                             datasetProfileIdentifier: Self.datasetProfileIdentifier,
-                                            navigatorRouterType: NavigationSettings.shared.routingProviderSource.nativeSource)
+                                            routingProviderSource: NavigationSettings.shared.routingProviderSource.nativeSource)
         tileStore = factory.tileStore
         historyRecorder = factory.historyRecorder
         cacheHandle = factory.cacheHandle

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -24,10 +24,18 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     public lazy var directions: Directions = routingProvider as? Directions ?? Directions.shared
     
     /**
-     Routing provider used to create the route.
+     Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     
+     If set to `nil` - default Mapbox implementation will be used.
      */
-    public var routingProvider: RoutingProvider
+    public var routingProvider: RoutingProvider?
 
+    private lazy var defaultRoutingProvider: RoutingProvider = MapboxRoutingProvider(NavigationSettings.shared.routingProviderSource)
+    
+    var resolvedRoutingProvider:  RoutingProvider {
+        routingProvider ?? defaultRoutingProvider
+    }
+    
     public var route: Route {
         routeProgress.route
     }
@@ -99,6 +107,8 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     var isRerouting = false
     
     var lastRerouteLocation: CLLocation?
+    
+    public var initialManeuverAvoidanceRadius: TimeInterval = RerouteController.DefaultManeuverAvoidanceRadius
     
     public var refreshesRoute: Bool = true
     
@@ -217,7 +227,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     required public init(alongRouteAtIndex routeIndex: Int,
                          in routeResponse: RouteResponse,
                          options: RouteOptions,
-                         routingProvider: RoutingProvider = Directions.shared,
+                         routingProvider: RoutingProvider? = Directions.shared,
                          dataSource source: RouterDataSource) {
         self.routingProvider = routingProvider
         self.indexedRouteResponse = .init(routeResponse: routeResponse, routeIndex: routeIndex)

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -212,7 +212,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         return false
     }
     
-    @available(*, deprecated, renamed: "init(alongRouteAtIndex:routeIndex:in:options:routingProvider:dataSource:)")
+    @available(*, deprecated, renamed: "init(alongRouteAtIndex:routeIndex:in:options:customRoutingProvider:dataSource:)")
     public convenience init(alongRouteAtIndex routeIndex: Int,
                             in routeResponse: RouteResponse,
                             options: RouteOptions,
@@ -225,6 +225,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                   dataSource: source)
     }
     
+    @available(*, deprecated, renamed: "init(alongRouteAtIndex:routeIndex:in:options:customRoutingProvider:dataSource:)")
     required public convenience init(alongRouteAtIndex routeIndex: Int,
                                      in routeResponse: RouteResponse,
                                      options: RouteOptions,
@@ -242,9 +243,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                          options: RouteOptions,
                          customRoutingProvider: RoutingProvider?,
                          dataSource source: RouterDataSource) {
-        if let customRoutingProvider = customRoutingProvider {
-            self.customRoutingProvider = customRoutingProvider
-        }
+        self.customRoutingProvider = customRoutingProvider
         self.indexedRouteResponse = .init(routeResponse: routeResponse, routeIndex: routeIndex)
         self.routeProgress = RouteProgress(route: routeResponse.routes![routeIndex], options: options)
         self.dataSource = source

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -241,7 +241,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     required public init(alongRouteAtIndex routeIndex: Int,
                          in routeResponse: RouteResponse,
                          options: RouteOptions,
-                         customRoutingProvider: RoutingProvider?,
+                         customRoutingProvider: RoutingProvider? = nil,
                          dataSource source: RouterDataSource) {
         self.customRoutingProvider = customRoutingProvider
         self.indexedRouteResponse = .init(routeResponse: routeResponse, routeIndex: routeIndex)

--- a/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
@@ -124,7 +124,7 @@ public class MapboxRoutingProvider: RoutingProvider {
                                             tilesVersion: Navigator.tilesVersion,
                                             historyDirectoryURL: Navigator.historyDirectoryURL,
                                             datasetProfileIdentifier: datasetProfileIdentifier ?? Navigator.datasetProfileIdentifier,
-                                            navigatorRouterType: source.nativeSource)
+                                            routingProviderSource: source.nativeSource)
         return RouterFactory.build(for: source.nativeSource,
                                       cache: factory.cacheHandle,
                                       config: factory.configHandle,

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -21,7 +21,7 @@ class NativeHandlersFactory {
     let targetVersion: String?
     let configFactoryType: ConfigFactory.Type
     let datasetProfileIdentifier: ProfileIdentifier
-    let navigatorRouterType: MapboxNavigationNative.RouterType?
+    let routingProviderSource: MapboxNavigationNative.RouterType?
     
     init(tileStorePath: String,
          credentials: Credentials,
@@ -30,7 +30,7 @@ class NativeHandlersFactory {
          targetVersion: String? = nil,
          configFactoryType: ConfigFactory.Type = ConfigFactory.self,
          datasetProfileIdentifier: ProfileIdentifier = ProfileIdentifier.automobile,
-         navigatorRouterType: MapboxNavigationNative.RouterType? = nil) {
+         routingProviderSource: MapboxNavigationNative.RouterType? = nil) {
         self.tileStorePath = tileStorePath
         self.credentials = credentials
         self.tilesVersion = tilesVersion
@@ -38,7 +38,7 @@ class NativeHandlersFactory {
         self.targetVersion = targetVersion
         self.configFactoryType = configFactoryType
         self.datasetProfileIdentifier = datasetProfileIdentifier
-        self.navigatorRouterType = navigatorRouterType
+        self.routingProviderSource = routingProviderSource
     }
     
     // MARK: - Native Handlers
@@ -55,7 +55,7 @@ class NativeHandlersFactory {
         onMainQueueSync { // Make sure that Navigator pick ups Main Thread RunLoop.
             LogConfiguration.getInstance().setFilterLevelFor(LoggingLevel.info)
             
-            let router = navigatorRouterType.map {
+            let router = routingProviderSource.map {
                 MapboxNavigationNative.RouterFactory.build(for: $0,
                                                            cache: cacheHandle,
                                                            config: configHandle,

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -27,7 +27,7 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
     /**
      `RoutingProvider`, used to create a route during refreshing or rerouting.
      */
-    @available(*, deprecated, renamed: "customRoutingProvider")
+    @available(*, deprecated, message: "Use `customRoutingProvider` instead. Nullable value now corresponds to SDK default behavior.")
     var routingProvider: RoutingProvider { get }
     
     /**
@@ -292,7 +292,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:routingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
+    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -304,31 +304,14 @@ public class MapboxNavigationService: NSObject, NavigationService {
         self.init(routeResponse: routeResponse,
                   routeIndex: routeIndex,
                   routeOptions: routeOptions,
-                  routingProvider: directions ?? Directions.shared,
+                  customRoutingProvider: directions ?? Directions.shared,
                   credentials: directions?.credentials ?? NavigationSettings.shared.directions.credentials,
                   locationSource: locationSource,
                   eventsManagerType: eventsManagerType,
                   simulating: simulationMode,
                   routerType: routerType)
     }
-    
-    /**
-     Intializes a new `NavigationService`. Useful convienence initalizer for OBJ-C users, for when you just want to set up a service without customizing anything.
-     
-     - parameter routeResponse: `RouteResponse` object, containing selection of routes to follow.
-     - parameter routeIndex: The index of the route within the original `RouteResponse` object.
-     - parameter routeOptions: The route options used to get the route.
-     */
-    convenience init(routeResponse: RouteResponse, routeIndex: Int, routeOptions options: RouteOptions) {
-        self.init(routeResponse: routeResponse,
-                  routeIndex: routeIndex,
-                  routeOptions: options,
-                  customRoutingProvider: NavigationSettings.shared.directions,
-                  credentials: NavigationSettings.shared.directions.credentials,
-                  locationSource: nil,
-                  eventsManagerType: nil)
-    }
-    
+        
     /**
      Intializes a new `NavigationService`.
      
@@ -343,15 +326,15 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter routerType: An optional router type to use for traversing the route.
      */
     @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
-    required public convenience init(routeResponse: RouteResponse,
-                                     routeIndex: Int,
-                                     routeOptions: RouteOptions,
-                                     routingProvider: RoutingProvider,
-                                     credentials: Credentials,
-                                     locationSource: NavigationLocationManager? = nil,
-                                     eventsManagerType: NavigationEventsManager.Type? = nil,
-                                     simulating simulationMode: SimulationMode? = nil,
-                                     routerType: Router.Type? = nil) {
+    public convenience init(routeResponse: RouteResponse,
+                            routeIndex: Int,
+                            routeOptions: RouteOptions,
+                            routingProvider: RoutingProvider,
+                            credentials: Credentials,
+                            locationSource: NavigationLocationManager? = nil,
+                            eventsManagerType: NavigationEventsManager.Type? = nil,
+                            simulating simulationMode: SimulationMode? = nil,
+                            routerType: Router.Type? = nil) {
         self.init(routeResponse: routeResponse,
                   routeIndex: routeIndex,
                   routeOptions: routeOptions,

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -21,13 +21,19 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
     /**
      A reference to a MapboxDirections service. Used for rerouting.
      */
-    @available(*, deprecated, message: "Use `routingProvider` instead. If navigation service was not initialized using `Directions` object - this property is unused and ignored.")
+    @available(*, deprecated, message: "Use `customRoutingProvider` instead. If navigation service was not initialized using `Directions` object - this property is unused and ignored.")
     var directions: Directions { get }
     
     /**
      `RoutingProvider`, used to create a route during refreshing or rerouting.
      */
-    var routingProvider: RoutingProvider? { get }
+    @available(*, deprecated, renamed: "customRoutingProvider")
+    var routingProvider: RoutingProvider { get }
+    
+    /**
+     Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     */
+    var customRoutingProvider: RoutingProvider? { get }
     
     /**
      Credentials data, used to authorize server requests.
@@ -317,7 +323,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         self.init(routeResponse: routeResponse,
                   routeIndex: routeIndex,
                   routeOptions: options,
-                  routingProvider: NavigationSettings.shared.directions,
+                  customRoutingProvider: NavigationSettings.shared.directions,
                   credentials: NavigationSettings.shared.directions.credentials,
                   locationSource: nil,
                   eventsManagerType: nil)
@@ -329,7 +335,40 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter routeResponse: `RouteResponse` object, containing selection of routes to follow.
      - parameter routeIndex: The index of the route within the original `RouteResponse` object.
      - parameter routeOptions: The route options used to get the route.
-     - parameter routingProvider: Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     - parameter routingProvider: `RoutingProvider`, used to create a route during refreshing or rerouting.
+     - parameter credentials: Credentials to authorize additional data requests throughout the route.
+     - parameter locationSource: An optional override for the default `NaviationLocationManager`.
+     - parameter eventsManagerType: An optional events manager type to use while tracking the route.
+     - parameter simulationMode: The simulation mode desired.
+     - parameter routerType: An optional router type to use for traversing the route.
+     */
+    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
+    required public convenience init(routeResponse: RouteResponse,
+                                     routeIndex: Int,
+                                     routeOptions: RouteOptions,
+                                     routingProvider: RoutingProvider,
+                                     credentials: Credentials,
+                                     locationSource: NavigationLocationManager? = nil,
+                                     eventsManagerType: NavigationEventsManager.Type? = nil,
+                                     simulating simulationMode: SimulationMode? = nil,
+                                     routerType: Router.Type? = nil) {
+        self.init(routeResponse: routeResponse,
+                  routeIndex: routeIndex,
+                  routeOptions: routeOptions,
+                  customRoutingProvider: routingProvider,
+                  credentials: credentials,
+                  locationSource: locationSource,
+                  eventsManagerType: eventsManagerType,
+                  simulating: simulationMode,
+                  routerType: routerType)
+    }
+    /**
+     Intializes a new `NavigationService`.
+     
+     - parameter routeResponse: `RouteResponse` object, containing selection of routes to follow.
+     - parameter routeIndex: The index of the route within the original `RouteResponse` object.
+     - parameter routeOptions: The route options used to get the route.
+     - parameter customRoutingProvider: Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
      - parameter credentials: Credentials to authorize additional data requests throughout the route.
      - parameter locationSource: An optional override for the default `NaviationLocationManager`.
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
@@ -339,7 +378,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     required public init(routeResponse: RouteResponse,
                          routeIndex: Int,
                          routeOptions: RouteOptions,
-                         routingProvider: RoutingProvider?,
+                         customRoutingProvider: RoutingProvider?,
                          credentials: Credentials,
                          locationSource: NavigationLocationManager? = nil,
                          eventsManagerType: NavigationEventsManager.Type? = nil,
@@ -362,7 +401,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         _router = routerType.init(alongRouteAtIndex: routeIndex,
                                   in: routeResponse,
                                   options: routeOptions,
-                                  routingProvider: routingProvider,
+                                  customRoutingProvider: customRoutingProvider,
                                   dataSource: self)
         NavigationSettings.shared.distanceUnit = .init(routeOptions.distanceMeasurementSystem)
 
@@ -432,11 +471,19 @@ public class MapboxNavigationService: NSObject, NavigationService {
     
     /**
      Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     */
+    @available(*, deprecated, message: "Use `customRoutingProvider` instead. This property will be equal to `customRoutingProvider` if that is provided or a `MapboxRoutingProvider` instance otherwise.")
+    public var routingProvider: RoutingProvider {
+        router.routingProvider
+    }
+    
+    /**
+     Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
      
      If set to `nil` - default Mapbox implementation will be used.
      */
-    public var routingProvider: RoutingProvider? {
-        router.routingProvider
+    public var customRoutingProvider: RoutingProvider? {
+        router.customRoutingProvider
     }
     
     /**

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -25,9 +25,9 @@ public protocol NavigationService: CLLocationManagerDelegate, RouterDataSource, 
     var directions: Directions { get }
     
     /**
-     `RoutingProvider`, used to create route.
+     `RoutingProvider`, used to create a route during refreshing or rerouting.
      */
-    var routingProvider: RoutingProvider { get }
+    var routingProvider: RoutingProvider? { get }
     
     /**
      Credentials data, used to authorize server requests.
@@ -329,7 +329,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter routeResponse: `RouteResponse` object, containing selection of routes to follow.
      - parameter routeIndex: The index of the route within the original `RouteResponse` object.
      - parameter routeOptions: The route options used to get the route.
-     - parameter routingProvider: `RoutingProvider`, used to create route.
+     - parameter routingProvider: Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
      - parameter credentials: Credentials to authorize additional data requests throughout the route.
      - parameter locationSource: An optional override for the default `NaviationLocationManager`.
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
@@ -339,14 +339,13 @@ public class MapboxNavigationService: NSObject, NavigationService {
     required public init(routeResponse: RouteResponse,
                          routeIndex: Int,
                          routeOptions: RouteOptions,
-                         routingProvider: RoutingProvider,
+                         routingProvider: RoutingProvider?,
                          credentials: Credentials,
                          locationSource: NavigationLocationManager? = nil,
                          eventsManagerType: NavigationEventsManager.Type? = nil,
                          simulating simulationMode: SimulationMode? = nil,
                          routerType: Router.Type? = nil) {
         nativeLocationSource = locationSource ?? NavigationLocationManager()
-        self.routingProvider = routingProvider
         self.credentials = credentials
         self.simulationMode = simulationMode ?? .inTunnels
         super.init()
@@ -432,9 +431,13 @@ public class MapboxNavigationService: NSObject, NavigationService {
     public lazy var directions: Directions = self.routingProvider as? Directions ?? NavigationSettings.shared.directions
     
     /**
-     `RoutingProvider`, used to create route.
+     Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     
+     If set to `nil` - default Mapbox implementation will be used.
      */
-    public var routingProvider: RoutingProvider
+    public var routingProvider: RoutingProvider? {
+        router.routingProvider
+    }
     
     /**
      Credentials data, used to authorize server requests.

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -361,7 +361,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     required public init(routeResponse: RouteResponse,
                          routeIndex: Int,
                          routeOptions: RouteOptions,
-                         customRoutingProvider: RoutingProvider?,
+                         customRoutingProvider: RoutingProvider? = nil,
                          credentials: Credentials,
                          locationSource: NavigationLocationManager? = nil,
                          eventsManagerType: NavigationEventsManager.Type? = nil,

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MapboxDirections
 
+/// Defines source of routing engine (online or offline) to be used for requests.
 public typealias RoutingProviderSource = MapboxRoutingProvider.Source
 
 /**
@@ -101,7 +102,7 @@ public class NavigationSettings {
      fall back to the `NavigationSettings.directions` by default.
        - tileStoreConfiguration: Options for configuring how map and navigation tiles are stored on the device. See
      `TileStoreConfiguration` for more details.
-     - routingProviderSource: Configures the type of routing to be used by various SDK objects when providing route calculations.
+     - routingProviderSource: Configures the type of routing to be used by various SDK objects when providing route calculations. Use this value to configure usage of onlive vs. offline data for routing.
      */
     public func initialize(directions: Directions,
                            tileStoreConfiguration: TileStoreConfiguration,

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -8,7 +8,7 @@ import MapboxDirections
  This class handles correct setup for custom or default `RerouteControllerInterface`, monitoring native reroute events and configuring the process.
  */
 class RerouteController {
-    
+
     // MARK: Configuration
     
     static let DefaultManeuverAvoidanceRadius: TimeInterval = 8.0

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -2,13 +2,24 @@ import Foundation
 import MapboxDirections
 @_implementationOnly import MapboxNavigationNative_Private
 
+/**
+ Adapter for `MapboxNavigationNative.RerouteControllerInterface` usage inside `Navigator`.
+ 
+ This class handles correct setup for custom or default`RerouteControllerInterface`, monitoring native reroute events and configuring the process.
+ */
 class RerouteController {
-
+    
     // MARK: Configuration
     
     static let DefaultManeuverAvoidanceRadius: TimeInterval = 8.0
 
-    var reroutesProactively: Bool = true
+    var reroutesProactively: Bool = true {
+        didSet {
+            if !reroutesProactively {
+                reroutingRequest?.cancel()
+            }
+        }
+    }
 
     var initialManeuverAvoidanceRadius: TimeInterval {
         get {
@@ -19,6 +30,14 @@ class RerouteController {
         }
     }
 
+    var customRoutingProvider: RoutingProvider? = nil {
+        didSet {
+            self.navigator?.setRerouteControllerForController(
+                customRoutingProvider.map { _ in self } ?? defaultRerouteController
+            )
+        }
+    }
+    
     private var config: NavigatorConfig
 
     // MARK: Reporting Data
@@ -37,12 +56,18 @@ class RerouteController {
     
     private let defaultRerouteController: RerouteControllerInterface
     private let rerouteDetector: RerouteDetectorInterface
-
+    
+    private var reroutingRequest: NavigationProviderRequest?
+    private var recentRouteResponse: (response: RouteResponse, options: RouteOptions)?
+    private var isCancelled = false
+    
     private weak var navigator: MapboxNavigationNative.Navigator?
 
     func resetToDefaultSettings() {
         reroutesProactively = true
+        isCancelled = false
         config.avoidManeuverSeconds = NSNumber(value: Self.DefaultManeuverAvoidanceRadius)
+        customRoutingProvider = nil
     }
 
     required init(_ navigator: MapboxNavigationNative.Navigator, config: NavigatorConfig) {
@@ -55,6 +80,7 @@ class RerouteController {
 
     deinit {
         self.navigator?.removeRerouteObserver(for: self)
+        self.navigator?.setRerouteControllerForController(defaultRerouteController)
     }
 }
 
@@ -64,20 +90,55 @@ extension RerouteController: RerouteObserver {
     }
 
     func onRerouteDetected(forRouteRequest routeRequest: String) {
-        // TODO: fill with Native RerouteController integration
-        defaultRerouteController.cancel()
+        isCancelled = false
+        recentRouteResponse = nil
+        guard reroutesProactively else { return }
+        delegate?.rerouteControllerDidDetectReroute(self)
     }
 
     func onRerouteReceived(forRouteResponse routeResponse: String, routeRequest: String, origin: RouterOrigin) {
-        // TODO: fill with Native RerouteController integration
+        guard reroutesProactively else { return }
+        
+        guard let decodedRequest = Self.decode(routeRequest: routeRequest) else {
+            delegate?.rerouteControllerDidFailToReroute(self, with: DirectionsError.invalidResponse(nil))
+            return
+        }
+        
+        if let recentRouteResponse = recentRouteResponse,
+           decodedRequest.routeOptions == recentRouteResponse.options {
+            delegate?.rerouteControllerDidRecieveReroute(self,
+                                                         response: recentRouteResponse.response,
+                                                         options: recentRouteResponse.options)
+        } else {
+            guard let decodedResponse = Self.decode(routeResponse: routeResponse,
+                                                    routeOptions: decodedRequest.routeOptions,
+                                                    credentials: decodedRequest.credentials) else {
+                delegate?.rerouteControllerDidFailToReroute(self, with: DirectionsError.invalidResponse(nil))
+                return
+            }
+            
+            delegate?.rerouteControllerDidRecieveReroute(self,
+                                                         response: decodedResponse,
+                                                         options: decodedRequest.routeOptions)
+        }
     }
 
     func onRerouteCancelled() {
-        // TODO: fill with Native RerouteController integration
+        recentRouteResponse = nil
+        guard reroutesProactively else { return }
+        
+        delegate?.rerouteControllerDidCancelReroute(self)
     }
 
     func onRerouteFailed(forError error: RerouteError) {
-        // TODO: fill with Native RerouteController integration
+        recentRouteResponse = nil
+        guard reroutesProactively else { return }
+        
+        delegate?.rerouteControllerDidFailToReroute(self,
+                                                    with: DirectionsError.unknown(response: nil,
+                                                                                  underlying: ReroutingError(error),
+                                                                                  code: nil,
+                                                                                  message: error.message))
     }
 }
 
@@ -116,5 +177,51 @@ extension RerouteController {
 
         return try? decoder.decode(RouteResponse.self,
                                    from: data)
+    }
+}
+
+extension RerouteController: RerouteControllerInterface {
+    func reroute(forUrl url: String, callback: @escaping RerouteCallback) {
+        guard reroutesProactively && !isCancelled else {
+            callback(.init(error: RerouteError(message: "Cancelled by user.",
+                                               type: .cancelled)))
+            return
+        }
+        
+        guard let customRoutingProvider = customRoutingProvider else {
+            callback(.init(error: RerouteError(message: "Custom rerouting triggered with no proper rerouting provider.",
+                                               type: .routerError)))
+            return
+        }
+        
+        guard let routeOptions = RouteOptions(url: URL(string: url)!) else {
+            callback(.init(error: RerouteError(message: "Unable to decode route request for rerouting.",
+                                               type: .routerError)))
+            return
+        }
+        
+        reroutingRequest = customRoutingProvider.calculateRoutes(options: routeOptions) { session, result in
+            switch result {
+            case .failure(let error):
+                callback(.init(error: RerouteError(message: error.localizedDescription,
+                                                   type: .routerError)))
+            case .success(let routeResponse):
+                if let responseString = routeResponse.identifier {
+                    self.recentRouteResponse = (routeResponse, routeOptions)
+                    callback(.init(value: RerouteInfo(routeResponse: responseString,
+                                                                                    routeRequest: url,
+                                                                                    origin: .onboard)))
+                } else {
+                    callback(.init(value: RerouteError(message: "Failed to process `routeResponse`.",
+                                                                                      type: .routerError)))
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        isCancelled = true
+        defaultRerouteController.cancel()
+        reroutingRequest?.cancel()
     }
 }

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -212,8 +212,8 @@ extension RerouteController: RerouteControllerInterface {
                                                                                     routeRequest: url,
                                                                                     origin: .onboard)))
                 } else {
-                    callback(.init(value: RerouteError(message: "Failed to process `routeResponse`.",
-                                                                                      type: .routerError)))
+                    callback(.init(error: RerouteError(message: "Failed to process `routeResponse`.",
+                                                       type: .routerError)))
                 }
             }
         }

--- a/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
@@ -5,4 +5,33 @@ import MapboxNavigationNative
 
 protocol ReroutingControllerDelegate: AnyObject {
     // TODO: fill with Native RerouteController and Alternative routes integration
+    func rerouteControllerDidDetectReroute(_ rerouteController: RerouteController)
+    func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions)
+    func rerouteControllerDidCancelReroute(_ rerouteController: RerouteController)
+    func rerouteControllerDidFailToReroute(_ rerouteController: RerouteController, with error: DirectionsError)
+}
+
+/**
+ Error type, describing rerouting process malfunction.
+ */
+public enum ReroutingError: Error {
+    /// Could not correctly process the reroute.
+    case routeError
+    /// Could not compose correct request for rerouting.
+    case wrongRequest
+    /// Reroute was cancelled by user.
+    case cancelled
+
+    init( _ nativeError: RerouteError) {
+        switch (nativeError.type) {
+        case .routerError:
+            self = .routeError
+        case .wrongRequest:
+            self = .wrongRequest
+        case .cancelled:
+            self = .cancelled
+        @unknown default:
+            fatalError("Unknown MapboxNavigationNative.RerouteError value.")
+        }
+    }
 }

--- a/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
@@ -22,7 +22,7 @@ public enum ReroutingError: Error {
     /// Reroute was cancelled by user.
     case cancelled
 
-    init( _ nativeError: RerouteError) {
+    init(_ nativeError: RerouteError) {
         switch (nativeError.type) {
         case .routerError:
             self = .routeError

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -63,7 +63,7 @@ open class RouteController: NSObject {
      `RoutingProvider`, used to create a route during refreshing or rerouting.
      */
     @available(*, deprecated, message: "Use `customRoutingProvider` instead. This property will be equal to `customRoutingProvider` if that is provided or a `MapboxRoutingProvider` instance otherwise.")
-    public lazy var routingProvider: RoutingProvider = customRoutingProvider ?? defaultRoutingProvider
+    public lazy var routingProvider: RoutingProvider = resolvedRoutingProvider
     
     /**
      Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
@@ -75,7 +75,7 @@ open class RouteController: NSObject {
     // TODO: remove when NN implements RouteRefreshing and Continuos Alternatives
     private lazy var defaultRoutingProvider: RoutingProvider = MapboxRoutingProvider(NavigationSettings.shared.routingProviderSource)
 
-    var resolvedRoutingProvider:  RoutingProvider {
+    var resolvedRoutingProvider: RoutingProvider {
         customRoutingProvider ?? defaultRoutingProvider
     }
     
@@ -543,7 +543,7 @@ open class RouteController: NSObject {
         NotificationCenter.default.post(name: .didArriveAtWaypoint, object: self, userInfo: info)
     }
     
-    private func announcReroutingError(with error: Error) {
+    private func announceReroutingError(with error: Error) {
         delegate?.router(self, didFailToRerouteWith: error)
         NotificationCenter.default.post(name: .routeControllerDidFailToReroute, object: self, userInfo: [
             NotificationUserInfoKey.routingErrorKey: error,
@@ -563,7 +563,7 @@ open class RouteController: NSObject {
     
     // MARK: Handling Lifecycle
     
-    @available(*, deprecated, renamed: "init(alongRouteAtIndex:in:options:routingProvider:dataSource:)")
+    @available(*, deprecated, renamed: "init(alongRouteAtIndex:in:options:customRoutingProvider:dataSource:)")
     public convenience init(alongRouteAtIndex routeIndex: Int, in routeResponse: RouteResponse, options: RouteOptions, directions: Directions = NavigationSettings.shared.directions, dataSource source: RouterDataSource) {
         self.init(alongRouteAtIndex: routeIndex,
                   in: routeResponse,
@@ -572,6 +572,7 @@ open class RouteController: NSObject {
                   dataSource: source)
     }
     
+    @available(*, deprecated, renamed: "init(alongRouteAtIndex:in:options:customRoutingProvider:dataSource:)")
     required public convenience init(alongRouteAtIndex routeIndex: Int,
                                      in routeResponse: RouteResponse,
                                      options: RouteOptions,
@@ -756,7 +757,7 @@ extension RouteController: Router {
                     self?.isRerouting = false
                 }
             case let .failure(error):
-                self.announcReroutingError(with: error)
+                self.announceReroutingError(with: error)
                 self.isRerouting = false
             }
         }
@@ -864,7 +865,7 @@ extension RouteController: ReroutingControllerDelegate {
     }
     
     func rerouteControllerDidFailToReroute(_ rerouteController: RerouteController, with error: DirectionsError) {
-        announcReroutingError(with: error)
+        announceReroutingError(with: error)
         self.isRerouting = false
     }
 }

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -60,9 +60,18 @@ open class RouteController: NSObject {
     public lazy var directions: Directions = routingProvider as? Directions ?? Directions.shared
     
     /**
-     `RoutingProvider`, used to create route.
+     Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     
+     If set to `nil` - default Mapbox implementation will be used.
      */
-    public var routingProvider: RoutingProvider
+    public var routingProvider: RoutingProvider?
+    
+    // TODO: remove when NN implements RouteRefreshing and Continuos Alternatives
+    private lazy var defaultRoutingProvider: RoutingProvider = MapboxRoutingProvider(NavigationSettings.shared.routingProviderSource)
+    
+    var resolvedRoutingProvider:  RoutingProvider {
+        routingProvider ?? defaultRoutingProvider
+    }
     
     public var route: Route {
         return routeProgress.route
@@ -174,6 +183,10 @@ open class RouteController: NSObject {
     
     // MARK: Controlling and Altering the Route
     
+    var rerouteController: RerouteController {
+        sharedNavigator.rerouteController
+    }
+    
     public var reroutesProactively: Bool = true
     
     var lastProactiveRerouteDate: Date?
@@ -181,6 +194,15 @@ open class RouteController: NSObject {
     var isRerouting = false
     
     var lastRerouteLocation: CLLocation?
+    
+    public var initialManeuverAvoidanceRadius: TimeInterval {
+        get {
+            rerouteController.initialManeuverAvoidanceRadius
+        }
+        set {
+            rerouteController.initialManeuverAvoidanceRadius = newValue
+        }
+    }
     
     public var refreshesRoute: Bool = true
     
@@ -321,19 +343,14 @@ open class RouteController: NSObject {
         
         updateIndexes(status: status, progress: routeProgress)
         updateRouteLegProgress(status: status)
-        let willReroute = !userIsOnRoute(snappedLocation, status: status)
-        && (delegate?.router(self, shouldRerouteFrom: snappedLocation)
-            ?? DefaultBehavior.shouldRerouteFromLocation)
         
-        updateSpokenInstructionProgress(status: status, willReRoute: willReroute)
+        updateSpokenInstructionProgress(status: status, willReRoute: isRerouting)
         updateVisualInstructionProgress(status: status)
         updateRoadName(status: status)
         updateDistanceToIntersection(from: snappedLocation)
         
-        if willReroute {
-            reroute(from: snappedLocation, along: routeProgress)
-        }
-
+        rerouteAfterArrivalIfNeeded(snappedLocation, status: status)
+        
         if status.routeState != .complete {
             // Check for faster route proactively (if reroutesProactively is enabled)
             refreshAndCheckForFasterRoute(from: snappedLocation, routeProgress: routeProgress)
@@ -520,6 +537,13 @@ open class RouteController: NSObject {
         NotificationCenter.default.post(name: .didArriveAtWaypoint, object: self, userInfo: info)
     }
     
+    private func announcReroutingError(with error: Error) {
+        delegate?.router(self, didFailToRerouteWith: error)
+        NotificationCenter.default.post(name: .routeControllerDidFailToReroute, object: self, userInfo: [
+            NotificationUserInfoKey.routingErrorKey: error,
+        ])
+    }
+    
     func geometryEncoding(_ routeShapeFormat: RouteShapeFormat) -> ActiveGuidanceGeometryEncoding {
         switch routeShapeFormat {
         case .geoJSON:
@@ -545,7 +569,7 @@ open class RouteController: NSObject {
     required public init(alongRouteAtIndex routeIndex: Int,
                          in routeResponse: RouteResponse,
                          options: RouteOptions,
-                         routingProvider: RoutingProvider,
+                         routingProvider: RoutingProvider?,
                          dataSource source: RouterDataSource) {
         Self.instanceLock.lock()
         let twoInstances = Self.instance != nil
@@ -564,6 +588,7 @@ open class RouteController: NSObject {
         UIDevice.current.isBatteryMonitoringEnabled = true
         
         super.init()
+        rerouteController.customRoutingProvider = self.routingProvider
         BillingHandler.shared.beginBillingSession(for: .activeGuidance, uuid: sessionUUID)
 
         subscribeNotifications()
@@ -580,6 +605,7 @@ open class RouteController: NSObject {
         BillingHandler.shared.stopBillingSession(with: sessionUUID)
         unsubscribeNotifications()
         routeTask?.cancel()
+        rerouteController.resetToDefaultSettings()
         Self.instanceLock.lock()
         Self.instance = nil
         Self.instanceLock.unlock()
@@ -598,10 +624,12 @@ open class RouteController: NSObject {
                                                selector: #selector(navigationStatusDidChange),
                                                name: .navigationStatusDidChange,
                                                object: nil)
+        rerouteController.delegate = self
     }
     
     private func unsubscribeNotifications() {
         NotificationCenter.default.removeObserver(self)
+        rerouteController.delegate = nil
     }
     
     // MARK: Accessing Relevant Routing Data
@@ -633,7 +661,10 @@ extension RouteController: Router {
     }
     
     public func userIsOnRoute(_ location: CLLocation, status: NavigationStatus?) -> Bool {
-        
+        return rerouteController.userIsOnRoute()
+    }
+    
+    func rerouteAfterArrivalIfNeeded(_ location: CLLocation, status: NavigationStatus?) {
         guard let destination = routeProgress.currentLeg.destination else {
             preconditionFailure("Route legs used for navigation must have destinations")
         }
@@ -641,23 +672,23 @@ extension RouteController: Router {
         // If the user has arrived, do not continue monitor reroutes, step progress, etc
         if routeProgress.currentLegProgress.userHasArrivedAtWaypoint &&
             (delegate?.router(self, shouldPreventReroutesWhenArrivingAt: destination) ??
-                DefaultBehavior.shouldPreventReroutesWhenArrivingAtWaypoint) {
-            return true
+             DefaultBehavior.shouldPreventReroutesWhenArrivingAtWaypoint) {
+            return
         }
         
         // If we still wait for the first status from NavNative, there is no need to reroute
-        guard let status = status ?? sharedNavigator.mostRecentNavigationStatus else { return true }
+        guard let status = status ?? sharedNavigator.mostRecentNavigationStatus else { return }
 
-        /// NavNative doesn't support reroutes after arrival.
-        /// The code below is a port of logic from LegacyRouteController
-        /// This should be removed once NavNative adds support for reroutes after arrival. 
+        // NavNative doesn't support reroutes after arrival.
+        // The code below is a port of logic from LegacyRouteController
+        // This should be removed once NavNative adds support for reroutes after arrival.
         if status.routeState == .complete {
             // If the user has arrived and reroutes after arrival should be prevented, do not continue monitor
             // reroutes, step progress, etc
             if routeProgress.currentLegProgress.userHasArrivedAtWaypoint &&
                 (delegate?.router(self, shouldPreventReroutesWhenArrivingAt: destination) ??
-                    RouteController.DefaultBehavior.shouldPreventReroutesWhenArrivingAtWaypoint) {
-                return true
+                 RouteController.DefaultBehavior.shouldPreventReroutesWhenArrivingAtWaypoint) {
+                return
             }
 
             func userIsWithinRadiusOfDestination(location: CLLocation) -> Bool {
@@ -667,19 +698,18 @@ extension RouteController: Router {
                 return isCloseToFinalStep
             }
 
-            return userIsWithinRadiusOfDestination(location: location)
-        }
-        else {
-            let offRoute = status.routeState == .offRoute
-            return !offRoute
+            if !userIsWithinRadiusOfDestination(location: location) &&
+                (delegate?.router(self, shouldRerouteFrom: location)
+                 ?? DefaultBehavior.shouldRerouteFromLocation) {
+                reroute(from: location, along: routeProgress)
+            }
         }
     }
     
     public func reroute(from location: CLLocation, along progress: RouteProgress) {
-        if let lastRerouteLocation = lastRerouteLocation {
-            guard location.distance(from: lastRerouteLocation) >= RouteControllerMaximumDistanceBeforeRecalculating else {
-                return
-            }
+        guard routingProvider != nil else {
+            rerouteController.forceReroute()
+            return
         }
         
         // Avoid interrupting an ongoing reroute
@@ -687,8 +717,7 @@ extension RouteController: Router {
         isRerouting = true
 
         announceImpendingReroute(at: location)
-        self.lastRerouteLocation = location
-
+        
         calculateRoutes(from: location, along: progress) { [weak self] (session, result) in
             guard let self = self else { return }
 
@@ -705,10 +734,7 @@ extension RouteController: Router {
                     self?.isRerouting = false
                 }
             case let .failure(error):
-                self.delegate?.router(self, didFailToRerouteWith: error)
-                NotificationCenter.default.post(name: .routeControllerDidFailToReroute, object: self, userInfo: [
-                    NotificationUserInfoKey.routingErrorKey: error,
-                ])
+                self.announcReroutingError(with: error)
                 self.isRerouting = false
             }
         }
@@ -788,6 +814,39 @@ extension RouteController: Router {
 }
 
 extension RouteController: InternalRouter { }
+
+extension RouteController: ReroutingControllerDelegate {
+    func rerouteControllerDidDetectReroute(_ rerouteController: RerouteController) {
+        guard let location = location else { return }
+        
+        if delegate?.router(self, shouldRerouteFrom: location) ?? DefaultBehavior.shouldRerouteFromLocation {
+            announceImpendingReroute(at: location)
+            
+            isRerouting = true
+        } else {
+            rerouteController.cancel()
+        }
+    }
+    
+    func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions) {
+        updateRoute(with: IndexedRouteResponse(routeResponse: response,
+                                               routeIndex: 0),
+                    routeOptions: options,
+                    isProactive: false) { [weak self] _ in
+            self?.isRerouting = false
+        }
+    }
+    
+    func rerouteControllerDidCancelReroute(_ rerouteController: RerouteController) {
+        self.isRerouting = false
+    }
+    
+    func rerouteControllerDidFailToReroute(_ rerouteController: RerouteController, with error: DirectionsError) {
+        announcReroutingError(with: error)
+        self.isRerouting = false
+    }
+}
+
 
 enum RouteControllerError: Error {
     case internalError

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -77,14 +77,19 @@ public protocol Router: CLLocationManagerDelegate {
      
      - parameter routeIndex: The index of the route within the original `RouteResponse` object.
      - parameter routeResponse: `RouteResponse` object, containing selection of routes to follow.
-     - parameter routingProvider: `RoutingProvider`, used to create route.
+     - parameter routingProvider: `RoutingProvider`, used to create a route during refreshing or rerouting.
      - parameter source: The data source for the RouteController.
      */
     init(alongRouteAtIndex routeIndex: Int,
          in routeResponse: RouteResponse,
          options: RouteOptions,
-         routingProvider: RoutingProvider,
+         routingProvider: RoutingProvider?,
          dataSource source: RouterDataSource)
+    
+    /**
+     `RoutingProvider`, used to create a route during refreshing or rerouting.
+     */
+    var routingProvider: RoutingProvider? { get }
     
     /**
      Details about the user’s progress along the current route, leg, and step.
@@ -108,6 +113,13 @@ public protocol Router: CLLocationManagerDelegate {
      */
     func userIsOnRoute(_ location: CLLocation) -> Bool
     func reroute(from: CLLocation, along: RouteProgress)
+    
+    /**
+     A radius around the current user position in which the API will avoid returning any significant maneuvers when rerouting.
+     
+     Provided `TimeInterval` value will be converted to meters using current speed. Default value is `8 seconds`.
+     */
+    var initialManeuverAvoidanceRadius: TimeInterval { get set }
     
     /**
      The idealized user location. Snapped to the route line, if applicable, otherwise raw or nil.
@@ -182,7 +194,7 @@ protocol InternalRouter: AnyObject {
     
     var isRefreshing: Bool { get set }
     
-    var routingProvider: RoutingProvider { get }
+    var resolvedRoutingProvider: RoutingProvider { get }
     
     var routeProgress: RouteProgress { get }
     
@@ -228,8 +240,8 @@ extension InternalRouter where Self: Router {
             return
         }
         isRefreshing = true
-        routingProvider.refreshRoute(indexedRouteResponse: indexedRouteResponse,
-                                     fromLegAtIndex: UInt32(legIndex)) { [weak self] session, result in
+        resolvedRoutingProvider.refreshRoute(indexedRouteResponse: indexedRouteResponse,
+                                             fromLegAtIndex: UInt32(legIndex)) { [weak self] session, result in
             defer {
                 self?.isRefreshing = false
                 self?.lastRouteRefresh = nil
@@ -336,10 +348,14 @@ extension InternalRouter where Self: Router {
         routeTask?.cancel()
         let options = progress.reroutingOptions(from: origin)
         
+        if isRerouting {
+            options.initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius * origin.speed
+        }
+        
         lastRerouteLocation = origin
         
-        routeTask = routingProvider.calculateRoutes(options: options) { [weak self] (session, result) in
-            guard let self = self else { return }            
+        routeTask = resolvedRoutingProvider.calculateRoutes(options: options) { [weak self] (session, result) in
+            guard let self = self else { return }
             defer { self.routeTask = nil }
             switch result {
             case .failure(let error):

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -80,17 +80,37 @@ public protocol Router: CLLocationManagerDelegate {
      - parameter routingProvider: `RoutingProvider`, used to create a route during refreshing or rerouting.
      - parameter source: The data source for the RouteController.
      */
+    @available(*, deprecated, renamed: "init(alongRouteAtIndex:in:options:customRoutingProvider:dataSource:)")
     init(alongRouteAtIndex routeIndex: Int,
          in routeResponse: RouteResponse,
          options: RouteOptions,
-         routingProvider: RoutingProvider?,
+         routingProvider: RoutingProvider,
+         dataSource source: RouterDataSource)
+    
+    /**
+     Intializes a new `RouteController`.
+     
+     - parameter routeIndex: The index of the route within the original `RouteResponse` object.
+     - parameter routeResponse: `RouteResponse` object, containing selection of routes to follow.
+     - parameter customRoutingProvider: Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     - parameter source: The data source for the RouteController.
+     */
+    init(alongRouteAtIndex routeIndex: Int,
+         in routeResponse: RouteResponse,
+         options: RouteOptions,
+         customRoutingProvider: RoutingProvider?,
          dataSource source: RouterDataSource)
     
     /**
      `RoutingProvider`, used to create a route during refreshing or rerouting.
      */
-    var routingProvider: RoutingProvider? { get }
+    @available(*, deprecated, renamed: "customRoutingProvider")
+    var routingProvider: RoutingProvider { get }
     
+    /**
+     Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     */
+    var customRoutingProvider: RoutingProvider? { get }
     /**
      Details about the user’s progress along the current route, leg, and step.
      */

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -666,7 +666,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         MapboxNavigationService(routeResponse: routeResponse.response,
                                 routeIndex: routeResponse.routeIndex,
                                 routeOptions: routeOptions,
-                                routingProvider: nil,
+                                customRoutingProvider: nil,
                                 credentials: NavigationSettings.shared.directions.credentials,
                                 simulating: desiredSimulationMode)
         

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -65,7 +65,9 @@ public class CarPlayManager: NSObject {
     public lazy var directions: Directions = self.routingProvider as? Directions ?? NavigationSettings.shared.directions
     
     /**
-     `RoutingProvider`, used to create route.
+     Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     
+     If set to `nil` - default Mapbox implementation will be used.
      */
     public var routingProvider: RoutingProvider
     
@@ -664,7 +666,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         MapboxNavigationService(routeResponse: routeResponse.response,
                                 routeIndex: routeResponse.routeIndex,
                                 routeOptions: routeOptions,
-                                routingProvider: NavigationSettings.shared.directions,
+                                routingProvider: nil,
                                 credentials: NavigationSettings.shared.directions.credentials,
                                 simulating: desiredSimulationMode)
         

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -65,11 +65,23 @@ public class CarPlayManager: NSObject {
     public lazy var directions: Directions = self.routingProvider as? Directions ?? NavigationSettings.shared.directions
     
     /**
+     `RoutingProvider`, used to create a route during refreshing or rerouting.
+     */
+    @available(*, deprecated, message: "Use `customRoutingProvider` instead. This property will be equal to `customRoutingProvider` if that is provided or a `MapboxRoutingProvider` instance otherwise.")
+    public lazy var routingProvider: RoutingProvider = resolvedRoutingProvider
+    
+    /**
      Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
      
      If set to `nil` - default Mapbox implementation will be used.
      */
-    public var routingProvider: RoutingProvider
+    public var customRoutingProvider: RoutingProvider? = nil
+    
+    private lazy var defaultRoutingProvider: RoutingProvider = MapboxRoutingProvider(NavigationSettings.shared.routingProviderSource)
+
+    var resolvedRoutingProvider: RoutingProvider {
+        customRoutingProvider ?? defaultRoutingProvider
+    }
     
     /**
      Returns current `CarPlayActivity`, which is based on currently present `CPTemplate`. In case if
@@ -115,12 +127,12 @@ public class CarPlayManager: NSObject {
      - parameter directions: The object that calculates routes when the user interacts with the CarPlay interface. If this argument is `nil` or omitted, the shared `Directions` object is used by default.
      - parameter eventsManager: The events manager to use during turn-by-turn navigation while connected to CarPlay. If this argument is `nil` or omitted, a standard `NavigationEventsManager` object is used by default.
      */
-    @available(*, deprecated, renamed: "init(styles:routingProvider:eventsManager:carPlayNavigationViewControllerClass:)")
+    @available(*, deprecated, renamed: "init(styles:customRoutingProvider:eventsManager:carPlayNavigationViewControllerClass:)")
     public convenience init(styles: [Style]? = nil,
                             directions: Directions? = nil,
                             eventsManager: NavigationEventsManager? = nil) {
         self.init(styles: styles,
-                  routingProvider: directions ?? NavigationSettings.shared.directions,
+                  customRoutingProvider: directions ?? NavigationSettings.shared.directions,
                   eventsManager: eventsManager,
                   carPlayNavigationViewControllerClass: nil)
     }
@@ -132,21 +144,38 @@ public class CarPlayManager: NSObject {
      - parameter routingProvider: The object that calculates routes when the user interacts with the CarPlay interface.
      - parameter eventsManager: The events manager to use during turn-by-turn navigation while connected to CarPlay. If this argument is `nil` or omitted, a standard `NavigationEventsManager` object is used by default.
      */
+    @available(*, deprecated, renamed: "init(styles:customRoutingProvider:eventsManager:)")
     public convenience init(styles: [Style]? = nil,
                             routingProvider: RoutingProvider,
                             eventsManager: NavigationEventsManager? = nil) {
         self.init(styles: styles,
-                  routingProvider: routingProvider,
+                  customRoutingProvider: routingProvider,
+                  eventsManager: eventsManager,
+                  carPlayNavigationViewControllerClass: nil)
+    }
+    
+    /**
+     Initializes a new CarPlay manager that manages a connection to the CarPlay interface.
+     
+     - parameter styles: The styles to display in the CarPlay interface. If this argument is omitted, `DayStyle` and `NightStyle` are displayed by default.
+     - parameter customRoutingProvider: The object that customizes routes calculation when the user interacts with the CarPlay interface.
+     - parameter eventsManager: The events manager to use during turn-by-turn navigation while connected to CarPlay. If this argument is `nil` or omitted, a standard `NavigationEventsManager` object is used by default.
+     */
+    public convenience init(styles: [Style]? = nil,
+                            customRoutingProvider: RoutingProvider?,
+                            eventsManager: NavigationEventsManager? = nil) {
+        self.init(styles: styles,
+                  customRoutingProvider: customRoutingProvider,
                   eventsManager: eventsManager,
                   carPlayNavigationViewControllerClass: nil)
     }
     
     init(styles: [Style]? = nil,
-         routingProvider: RoutingProvider,
+         customRoutingProvider: RoutingProvider?,
          eventsManager: NavigationEventsManager? = nil,
          carPlayNavigationViewControllerClass: CarPlayNavigationViewController.Type? = nil) {
         self.styles = styles ?? [DayStyle(), NightStyle()]
-        self.routingProvider = routingProvider
+        self.customRoutingProvider = customRoutingProvider
         self.eventsManager = eventsManager ?? .init(activeNavigationDataSource: nil,
                                                     accessToken: NavigationSettings.shared.directions.credentials.accessToken)
         self.mapTemplateProvider = MapTemplateProvider()
@@ -582,7 +611,7 @@ extension CarPlayManager {
     }
     
     func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) {
-        routingProvider.calculateRoutes(options: options, completionHandler: completionHandler)
+        resolvedRoutingProvider.calculateRoutes(options: options, completionHandler: completionHandler)
     }
     
     func didCalculate(_ result: Result<RouteResponse, DirectionsError>,
@@ -666,7 +695,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         MapboxNavigationService(routeResponse: routeResponse.response,
                                 routeIndex: routeResponse.routeIndex,
                                 routeOptions: routeOptions,
-                                customRoutingProvider: nil,
+                                customRoutingProvider: customRoutingProvider,
                                 credentials: NavigationSettings.shared.directions.credentials,
                                 simulating: desiredSimulationMode)
         

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -158,11 +158,11 @@ public class CarPlayManager: NSObject {
      Initializes a new CarPlay manager that manages a connection to the CarPlay interface.
      
      - parameter styles: The styles to display in the CarPlay interface. If this argument is omitted, `DayStyle` and `NightStyle` are displayed by default.
-     - parameter customRoutingProvider: The object that customizes routes calculation when the user interacts with the CarPlay interface.
+     - parameter customRoutingProvider: The object that customizes routes calculation when the user interacts with the CarPlay interface. `nil` value corresponds to default behavior.
      - parameter eventsManager: The events manager to use during turn-by-turn navigation while connected to CarPlay. If this argument is `nil` or omitted, a standard `NavigationEventsManager` object is used by default.
      */
     public convenience init(styles: [Style]? = nil,
-                            customRoutingProvider: RoutingProvider?,
+                            customRoutingProvider: RoutingProvider? = nil,
                             eventsManager: NavigationEventsManager? = nil) {
         self.init(styles: styles,
                   customRoutingProvider: customRoutingProvider,

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -218,7 +218,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
             ?? MapboxNavigationService(routeResponse: routeResponse,
                                        routeIndex: routeIndex,
                                        routeOptions: routeOptions,
-                                       routingProvider: NavigationSettings.shared.directions,
+                                       routingProvider: nil,
                                        credentials: NavigationSettings.shared.directions.credentials,
                                        simulating: navigationOptions?.simulationMode)
         navigationService.delegate = self

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -218,7 +218,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
             ?? MapboxNavigationService(routeResponse: routeResponse,
                                        routeIndex: routeIndex,
                                        routeOptions: routeOptions,
-                                       routingProvider: nil,
+                                       customRoutingProvider: nil,
                                        credentials: NavigationSettings.shared.directions.credentials,
                                        simulating: navigationOptions?.simulationMode)
         navigationService.delegate = self

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -82,7 +82,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      Called when the user arrives at a waypoint.
 
      Return false to continue checking if reroute is needed. By default, the user will not be rerouted when arriving at a waypoint.
-
+    
      - parameter navigationViewController: The navigation view controller that has detected the need to calculate a new route.
      - parameter waypoint: The waypoint that the controller has arrived at.
      - returns: True to prevent reroutes.

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -82,7 +82,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      Called when the user arrives at a waypoint.
 
      Return false to continue checking if reroute is needed. By default, the user will not be rerouted when arriving at a waypoint.
-    
+     
      - parameter navigationViewController: The navigation view controller that has detected the need to calculate a new route.
      - parameter waypoint: The waypoint that the controller has arrived at.
      - returns: True to prevent reroutes.

--- a/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
@@ -542,7 +542,7 @@ final class BillingHandlerUnitTests: TestCase {
         let routeController = RouteController(alongRouteAtIndex: 0,
                                               in: initialRouteResponse,
                                               options: NavigationRouteOptions(coordinates: initialRouteWaypoints),
-                                              routingProvider: MapboxRoutingProvider(.offline),
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                               dataSource: dataSource)
 
         let routeUpdated = expectation(description: "Route updated")
@@ -628,7 +628,7 @@ final class BillingHandlerUnitTests: TestCase {
             let routeController = RouteController(alongRouteAtIndex: 0,
                                                   in: routeResponse,
                                                   options: routeOptions,
-                                                  routingProvider: MapboxRoutingProvider(.offline),
+                                                  customRoutingProvider: MapboxRoutingProvider(.offline),
                                                   dataSource: self)
 
             let routerDelegateSpy = RouterDelegateSpy()

--- a/Tests/MapboxCoreNavigationTests/LeakTests.swift
+++ b/Tests/MapboxCoreNavigationTests/LeakTests.swift
@@ -9,7 +9,7 @@ final class LeakTests: TestCase {
             MapboxNavigationService(routeResponse: response,
                                     routeIndex: 0,
                                     routeOptions: routeOptions,
-                                    routingProvider: MapboxRoutingProvider(.offline),
+                                    customRoutingProvider: MapboxRoutingProvider(.offline),
                                     credentials: .mocked)
         }
         XCTAssertFalse(leakTester.isLeaking())

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -42,7 +42,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation = MapboxNavigationService(routeResponse: response,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
-                                             routingProvider: MapboxRoutingProvider(.offline),
+                                             customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
                                              simulating: .never)
         let now = Date()
@@ -87,7 +87,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation = MapboxNavigationService(routeResponse: response,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
-                                             routingProvider: MapboxRoutingProvider(.offline),
+                                             customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
                                              simulating: .never)
         
@@ -137,7 +137,7 @@ class MapboxCoreNavigationTests: TestCase {
         let navigationService = MapboxNavigationService(routeResponse: response,
                                                         routeIndex: 0,
                                                         routeOptions: routeOptions,
-                                                        routingProvider: MapboxRoutingProvider(.offline),
+                                                        customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,
                                                         locationSource: locationManager,
                                                         simulating: .never)
@@ -194,7 +194,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation = MapboxNavigationService(routeResponse: response,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
-                                             routingProvider: MapboxRoutingProvider(.offline),
+                                             customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
                                              locationSource: locationManager,
                                              simulating: .never)
@@ -246,7 +246,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation = MapboxNavigationService(routeResponse: response,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
-                                             routingProvider: MapboxRoutingProvider(.offline),
+                                             customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
                                              locationSource: locationManager,
                                              simulating: .never)
@@ -287,7 +287,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation = MapboxNavigationService(routeResponse: routeResponse,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
-                                             routingProvider: MapboxRoutingProvider(.offline),
+                                             customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
                                              locationSource: locationManager,
                                              simulating: .never)
@@ -337,7 +337,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation = MapboxNavigationService(routeResponse: response,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
-                                             routingProvider: MapboxRoutingProvider(.offline),
+                                             customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
                                              locationSource: locationManager)
         navigation.router.refreshesRoute = false
@@ -459,7 +459,7 @@ class MapboxCoreNavigationTests: TestCase {
         navigation = MapboxNavigationService(routeResponse: response,
                                              routeIndex: 0,
                                              routeOptions: routeOptions,
-                                             routingProvider: MapboxRoutingProvider(.online),
+                                             customRoutingProvider: MapboxRoutingProvider(.online),
                                              credentials: Fixture.credentials,
                                              simulating: .never)
         

--- a/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -35,7 +35,7 @@ class NavigationEventsManagerTests: TestCase {
         let locationManager = NavigationLocationManager()
         let service = MapboxNavigationService(routeResponse: firstRouteResponse, routeIndex: 0,
                                               routeOptions: firstRouteOptions,
-                                              routingProvider: MapboxRoutingProvider(.offline),
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                               credentials: Fixture.credentials,
                                               locationSource: locationManager,
                                               eventsManagerType: NavigationEventsManagerSpy.self,
@@ -92,7 +92,7 @@ class NavigationEventsManagerTests: TestCase {
         let dataSource = MapboxNavigationService(routeResponse: routeResponse,
                                                  routeIndex: 0,
                                                  routeOptions: routeOptions,
-                                                 routingProvider: MapboxRoutingProvider(.offline),
+                                                 customRoutingProvider: MapboxRoutingProvider(.offline),
                                                  credentials: Fixture.credentials,
                                                  simulating: .onPoorGPS)
         let sessionState = SessionState(currentRoute: route, originalRoute: route, routeIdentifier: routeResponse.identifier)

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -27,7 +27,7 @@ class NavigationServiceTests: TestCase {
         let navigationService = MapboxNavigationService(routeResponse: initialRouteResponse,
                                                         routeIndex: 0,
                                                         routeOptions: routeOptions,
-                                                        routingProvider: MapboxRoutingProvider(.offline),
+                                                        customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,
                                                         locationSource: locationSource,
                                                         eventsManagerType: NavigationEventsManagerSpy.self,
@@ -411,7 +411,7 @@ class NavigationServiceTests: TestCase {
     func testTurnstileEventSentUponInitialization() {
         // MARK: it sends a turnstile event upon initialization
 
-        let service = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, routingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
+        let service = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
         let eventsManagerSpy = service.eventsManager as! NavigationEventsManagerSpy
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: MMEEventTypeAppUserTurnstile))
     }
@@ -420,7 +420,7 @@ class NavigationServiceTests: TestCase {
         let navigationService = MapboxNavigationService(routeResponse: initialRouteResponse,
                                                         routeIndex: 0,
                                                         routeOptions: routeOptions,
-                                                        routingProvider: MapboxRoutingProvider(.offline),
+                                                        customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,
                                                         eventsManagerType: NavigationEventsManagerSpy.self,
                                                         simulating: .always)
@@ -633,7 +633,7 @@ class NavigationServiceTests: TestCase {
     }
 
     func testCountdownTimerDefaultAndUpdate() {
-        let subject = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, routingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials)
+        let subject = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials)
 
         XCTAssert(subject.poorGPSTimer.countdownInterval == .milliseconds(2500), "Default countdown interval should be 2500 milliseconds.")
 
@@ -712,7 +712,7 @@ class NavigationServiceTests: TestCase {
         let service = MapboxNavigationService(routeResponse: routeResponse,
                                               routeIndex: 0,
                                               routeOptions: options,
-                                              routingProvider: MapboxRoutingProvider(.online),
+                                              customRoutingProvider: MapboxRoutingProvider(.online),
                                               credentials: Fixture.credentials,
                                               locationSource: locationManager)
         service.delegate = delegate

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -356,7 +356,7 @@ class NavigationServiceTests: TestCase {
             CLLocationCoordinate2D(latitude: 37.777016, longitude: -122.468832),
         ])
         let routeResponse = Fixture.routeResponse(from: "straight-line", options: options)
-        let navigationService = MapboxNavigationService(routeResponse: routeResponse, routeIndex: 0, routeOptions: options)
+        let navigationService = MapboxNavigationService(routeResponse: routeResponse, routeIndex: 0, routeOptions: options, customRoutingProvider: nil, credentials: Fixture.credentials)
         let router = navigationService.router
         let firstCoordinate = router.routeProgress.nearbyShape.coordinates.first!
         let firstLocation = CLLocation(latitude: firstCoordinate.latitude, longitude: firstCoordinate.longitude)
@@ -613,7 +613,7 @@ class NavigationServiceTests: TestCase {
 
         autoreleasepool {
             let fakeDataSource = RouteControllerDataSourceFake()
-            let routeController = RouteController(alongRouteAtIndex: 0, in: initialRouteResponse, options: routeOptions, routingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
+            let routeController = RouteController(alongRouteAtIndex: 0, in: initialRouteResponse, options: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
             subject = routeController
         }
 
@@ -625,7 +625,7 @@ class NavigationServiceTests: TestCase {
 
         autoreleasepool {
             let fakeDataSource = RouteControllerDataSourceFake()
-            _ = RouteController(alongRouteAtIndex: 0, in: initialRouteResponse, options: routeOptions, routingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
+            _ = RouteController(alongRouteAtIndex: 0, in: initialRouteResponse, options: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
             subject = fakeDataSource
         }
 

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -29,7 +29,7 @@ class RouteControllerTests: TestCase {
         let locationManager = ReplayLocationManager(locations: locations)
         replayManager = locationManager
         let equivalentRouteOptions = NavigationRouteOptions(navigationMatchOptions: options)
-        let routeController = RouteController(alongRouteAtIndex: 0, in: routeResponse, options: equivalentRouteOptions, routingProvider: MapboxRoutingProvider(.offline), dataSource: self)
+        let routeController = RouteController(alongRouteAtIndex: 0, in: routeResponse, options: equivalentRouteOptions, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: self)
         locationManager.delegate = routeController
         let routerDelegateSpy = RouterDelegateSpy()
         routeController.delegate = routerDelegateSpy
@@ -83,7 +83,7 @@ class RouteControllerTests: TestCase {
         let routeController = RouteController(alongRouteAtIndex: 0,
                                               in: routeResponse,
                                               options: navigationRouteOptions,
-                                              routingProvider: MapboxRoutingProvider(.offline),
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                               dataSource: self)
 
         let routerDelegateSpy = RouterDelegateSpy()

--- a/Tests/MapboxNavigationTests/CarPlayManagerSpec.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerSpec.swift
@@ -23,7 +23,7 @@ class CarPlayManagerSpec: QuickSpec {
             BillingHandler.__replaceSharedInstance(with: mockedHandler)
             
             CarPlayMapViewController.swizzleMethods()
-            carPlayManager = CarPlayManager(routingProvider: MapboxRoutingProvider(.offline))
+            carPlayManager = CarPlayManager(customRoutingProvider: MapboxRoutingProvider(.offline))
             delegate = TestCarPlayManagerDelegate()
             carPlayManager.delegate = delegate
             

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -19,7 +19,7 @@ class CarPlayManagerTests: TestCase {
         super.setUp()
         
         eventsManagerSpy = NavigationEventsManagerSpy()
-        carPlayManager = CarPlayManager(routingProvider: MapboxRoutingProvider(.offline),
+        carPlayManager = CarPlayManager(customRoutingProvider: MapboxRoutingProvider(.offline),
                                         eventsManager: eventsManagerSpy,
                                         carPlayNavigationViewControllerClass: CarPlayNavigationViewControllerTestable.self)
         carPlaySearchController = CarPlaySearchController()
@@ -256,7 +256,7 @@ class CarPlayManagerTests: TestCase {
         let routeOptions = RouteOptions(coordinates: [
             CLLocationCoordinate2D(latitude: 0, longitude: 0)
         ])
-        let carPlayManager = CarPlayManager(routingProvider: MapboxRoutingProvider(.offline))
+        let carPlayManager = CarPlayManager(customRoutingProvider: MapboxRoutingProvider(.offline))
         carPlayManager.delegate = carPlayManagerDelegateMock
         let testError = DirectionsError.requestTooLarge
         carPlayManager.didCalculate(.failure(testError),
@@ -277,7 +277,7 @@ class CarPlayManagerTests: TestCase {
         
         let styles = [CustomStyle()]
         let carPlayManagerWithModifiedStyles = CarPlayManager(styles: styles,
-                                                              routingProvider: MapboxRoutingProvider(.offline))
+                                                              customRoutingProvider: MapboxRoutingProvider(.offline))
         XCTAssertEqual(carPlayManagerWithModifiedStyles.styles,
                        styles,
                        "CarPlayManager should persist the initial styles given to it.")

--- a/Tests/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
@@ -38,7 +38,9 @@ class CarPlayNavigationViewControllerTests: TestCase {
         
         let navigationService = MapboxNavigationService(routeResponse: routeResponse,
                                                         routeIndex: 0,
-                                                        routeOptions: navigationRouteOptions)
+                                                        routeOptions: navigationRouteOptions,
+                                                        customRoutingProvider: nil,
+                                                        credentials: Fixture.credentials)
         
         let mapTemplateMock = MapTemplateMock()
         let navigationSession = CPNavigationSessionFake(maneuvers: [CPManeuver()])
@@ -46,7 +48,7 @@ class CarPlayNavigationViewControllerTests: TestCase {
         
         let interfaceController = FakeCPInterfaceController(context: #function)
         
-        let carPlayManager = CarPlayManager(routingProvider: MapboxRoutingProvider(.offline))
+        let carPlayManager = CarPlayManager(customRoutingProvider: MapboxRoutingProvider(.offline))
         
         let carPlayNavigationViewController = CarPlayNavigationViewController(navigationService: navigationService,
                                                                               mapTemplate: mapTemplateMock,

--- a/Tests/MapboxNavigationTests/CarPlayUtils.swift
+++ b/Tests/MapboxNavigationTests/CarPlayUtils.swift
@@ -89,7 +89,7 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
         let navigationService = MapboxNavigationService(routeResponse: routeResponse,
                                                         routeIndex: routeIndex,
                                                         routeOptions: routeOptions,
-                                                        routingProvider: MapboxRoutingProvider(.offline),
+                                                        customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,
                                                         locationSource: NavigationLocationManager(),
                                                         eventsManagerType: NavigationEventsManagerSpy.self,

--- a/Tests/MapboxNavigationTests/EndOfRouteFeedbackTests.swift
+++ b/Tests/MapboxNavigationTests/EndOfRouteFeedbackTests.swift
@@ -16,7 +16,7 @@ final class EndOfRouteFeedbackTests: TestCase {
         let service = MapboxNavigationService(routeResponse: route.response,
                                               routeIndex: 0,
                                               routeOptions: options,
-                                              routingProvider: MapboxRoutingProvider(.offline),
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                               credentials: Fixture.credentials,
                                               locationSource: nil,
                                               eventsManagerType: nil,

--- a/Tests/MapboxNavigationTests/InstructionsCardViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/InstructionsCardViewControllerTests.swift
@@ -49,7 +49,7 @@ class InstructionsCardViewControllerTests: TestCase {
             let navigationService = MapboxNavigationService(routeResponse: initialRouteResponse,
                                                             routeIndex: 0,
                                                             routeOptions: navigationRouteOptions,
-                                                            routingProvider: MapboxRoutingProvider(.offline),
+                                                            customRoutingProvider: MapboxRoutingProvider(.offline),
                                                             credentials: Fixture.credentials,
                                                             simulating: .never)
             let routeProgress = RouteProgress(route: route, options: navigationRouteOptions)

--- a/Tests/MapboxNavigationTests/LeaksTests.swift
+++ b/Tests/MapboxNavigationTests/LeaksTests.swift
@@ -21,7 +21,11 @@ final class LeaksTests: TestCase {
     }
 
     func testRouteVoiceController() {
-        let dummySvc = MapboxNavigationService(routeResponse: response, routeIndex: 0, routeOptions: initialOptions)
+        let dummySvc = MapboxNavigationService(routeResponse: response,
+                                               routeIndex: 0,
+                                               routeOptions: initialOptions,
+                                               customRoutingProvider: nil,
+                                               credentials: Fixture.credentials)
 
         let leakTester = LeakTest {
             let routeVoiceController = RouteVoiceController(navigationService: dummySvc,

--- a/Tests/MapboxNavigationTests/LeaksTests.swift
+++ b/Tests/MapboxNavigationTests/LeaksTests.swift
@@ -38,7 +38,7 @@ final class LeaksTests: TestCase {
             let service = MapboxNavigationService(routeResponse: response,
                                                   routeIndex: 0,
                                                   routeOptions: self.initialOptions,
-                                                  routingProvider: MapboxRoutingProvider(.offline),
+                                                  customRoutingProvider: MapboxRoutingProvider(.offline),
                                                   credentials: Fixture.credentials,
                                                   eventsManagerType: NavigationEventsManagerSpy.self)
             let navOptions = NavigationOptions(navigationService: service, voiceController:

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -423,7 +423,11 @@ class NavigationViewControllerTests: TestCase {
             CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
         ])
 
-        let navService = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions)
+        let navService = MapboxNavigationService(routeResponse: initialRouteResponse,
+                                                 routeIndex: 0,
+                                                 routeOptions: routeOptions,
+                                                 customRoutingProvider: nil,
+                                                 credentials: Fixture.credentials)
         let navOptions = NavigationOptions(navigationService: navService, topBanner: top, bottomBanner: bottom)
 
         let subject = NavigationViewController(for: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, navigationOptions: navOptions)
@@ -444,7 +448,11 @@ class NavigationViewControllerTests: TestCase {
             CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
         ])
 
-        let navService = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions)
+        let navService = MapboxNavigationService(routeResponse: initialRouteResponse,
+                                                 routeIndex: 0,
+                                                 routeOptions: routeOptions,
+                                                 customRoutingProvider: nil,
+                                                 credentials: Fixture.credentials)
         let navOptions = NavigationOptions(navigationService: navService, navigationMapView: injected)
 
         let subject = NavigationViewController(for: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, navigationOptions: navOptions)
@@ -462,7 +470,9 @@ class NavigationViewControllerTests: TestCase {
         
         let navigationService = MapboxNavigationService(routeResponse: initialRouteResponse,
                                                         routeIndex: 0,
-                                                        routeOptions: navigationRouteOptions)
+                                                        routeOptions: navigationRouteOptions,
+                                                        customRoutingProvider: nil,
+                                                        credentials: Fixture.credentials)
         
         let navigationOptions = NavigationOptions(navigationService: navigationService)
         

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -74,7 +74,7 @@ class NavigationViewControllerTests: TestCase {
             let fakeService = MapboxNavigationService(routeResponse: initialRouteResponse,
                                                       routeIndex: 0,
                                                       routeOptions: routeOptions,
-                                                      routingProvider: MapboxRoutingProvider(.offline),
+                                                      customRoutingProvider: MapboxRoutingProvider(.offline),
                                                       credentials: Fixture.credentials,
                                                       locationSource: NavigationLocationManagerStub(),
                                                       simulating: .never)
@@ -286,7 +286,7 @@ class NavigationViewControllerTests: TestCase {
         let service = MapboxNavigationService(routeResponse: initialRouteResponse,
                                               routeIndex: 0,
                                               routeOptions: routeOptions,
-                                              routingProvider: MapboxRoutingProvider(.offline),
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                               credentials: Fixture.credentials,
                                               simulating: .never)
         let options = NavigationOptions(styles: [TestableDayStyle()], navigationService: service)
@@ -337,7 +337,7 @@ class NavigationViewControllerTests: TestCase {
         let service = MapboxNavigationService(routeResponse: initialRouteResponse,
                                               routeIndex: 0,
                                               routeOptions: routeOptions,
-                                              routingProvider: MapboxRoutingProvider(.offline),
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                               credentials: Fixture.credentials,
                                               simulating: .never)
         let options = NavigationOptions(styles: [TestableDayStyle()], navigationService: service)

--- a/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
+++ b/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
@@ -130,7 +130,11 @@ class SpeechSynthesizersControllerTests: TestCase {
         deinitExpectation.expectedFulfillmentCount = 2
         (synthesizers[0] as! FailingSpeechSynthesizerMock).deinitExpectation = deinitExpectation
         (synthesizers[1] as! FailingSpeechSynthesizerMock).deinitExpectation = deinitExpectation
-        let dummyService = MapboxNavigationService(routeResponse: routeResponse, routeIndex: 0, routeOptions: routeOptions)
+        let dummyService = MapboxNavigationService(routeResponse: routeResponse,
+                                                   routeIndex: 0,
+                                                   routeOptions: routeOptions,
+                                                   customRoutingProvider: nil,
+                                                   credentials: Fixture.credentials)
         
         var routeController: RouteVoiceController? = RouteVoiceController(navigationService: dummyService,
                                                                           speechSynthesizer: MultiplexedSpeechSynthesizer(synthesizers))

--- a/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
+++ b/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
@@ -149,7 +149,7 @@ class SpeechSynthesizersControllerTests: TestCase {
         let dummyService = MapboxNavigationService(routeResponse: routeResponse,
                                                    routeIndex: 0,
                                                    routeOptions: routeOptions,
-                                                   routingProvider: MapboxRoutingProvider(.offline),
+                                                   customRoutingProvider: MapboxRoutingProvider(.offline),
                                                    credentials: Fixture.credentials,
                                                    simulating: .always)
         let routeController: RouteVoiceController? = RouteVoiceController(navigationService: dummyService,
@@ -168,7 +168,7 @@ class SpeechSynthesizersControllerTests: TestCase {
         let dummyService = MapboxNavigationService(routeResponse: routeResponse,
                                                    routeIndex: 0,
                                                    routeOptions: routeOptions,
-                                                   routingProvider: MapboxRoutingProvider(.offline),
+                                                   customRoutingProvider: MapboxRoutingProvider(.offline),
                                                    credentials: Fixture.credentials,
                                                    simulating: .always)
         let routeController: RouteVoiceController? = RouteVoiceController(navigationService: dummyService,

--- a/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -20,7 +20,7 @@ class StepsViewControllerTests: TestCase {
         dependencies = {
             let dataSource = RouteControllerDataSourceFake()
 
-            let routeController = RouteController(alongRouteAtIndex: 0, in: response, options: Constants.options, routingProvider: MapboxRoutingProvider(.offline), dataSource: dataSource)
+            let routeController = RouteController(alongRouteAtIndex: 0, in: response, options: Constants.options, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: dataSource)
 
             let stepsViewController = StepsViewController(routeProgress: routeController.routeProgress)
 


### PR DESCRIPTION
This PR introduces integration of NavNative's RerouteController and replacing platform implementation with it.
Logic of the change is to allow user to provide custom `RoutingProvider` which will be used as a customization for requesting reroutes. To enable rerouting feature, it is also required to provide full `routeResponse` string to be set to `Navigator` instead of the 1 selected route.