### PR TITLE
Allow the leg separator view in StepsViewController updated with style.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Added the `InstructionsCardContainerView.separatorColor` and `InstructionsCardContainerView.highlightedSeparatorColor` to be able to change instruction card's separator colors. ([#3704](https://github.com/mapbox/mapbox-navigation-ios/pull/3704))
 * Fixed an issue where the top banner instruction shows empty remaining steps in pull-down table when user is on final step. ([#3729](https://github.com/mapbox/mapbox-navigation-ios/pull/3729))
 * Fixed an issue where the end of route view has a gap between the screen bottom in landscape mode. ([#3769](https://github.com/mapbox/mapbox-navigation-ios/pull/3769))
+* Fixed an issue where the leg separator in drop down `StepsViewController` shows day style during active navigation in night style. ([#3760](https://github.com/mapbox/mapbox-navigation-ios/pull/3760))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -308,9 +308,11 @@ open class DayStyle: Style {
         WayNameView.appearance().backgroundColor = UIColor.defaultRouteLayer.withAlphaComponent(0.85)
         WayNameView.appearance().borderColor = UIColor.defaultRouteCasing.withAlphaComponent(0.8)
         WayNameView.appearance().borderWidth = 1.0
-        StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.431372549, green: 0.431372549, blue: 0.431372549, alpha: 1)
-        StepsTableHeaderView.appearance().normalBackgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-        StepsTableHeaderView.appearance().normalFont = UIFont.systemFont(ofSize: 18, weight: .medium).adjustedFont
+        
+        if #available(iOS 15.0, *) {} else {
+            StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
+        }
+        StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -275,7 +275,8 @@ open class DayStyle: Style {
         StepInstructionsView.appearance().backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
         StepListIndicatorView.appearance().gradientColors = [#colorLiteral(red: 0.431372549, green: 0.431372549, blue: 0.431372549, alpha: 1), #colorLiteral(red: 0.6274509804, green: 0.6274509804, blue: 0.6274509804, alpha: 1), #colorLiteral(red: 0.431372549, green: 0.431372549, blue: 0.431372549, alpha: 1)]
         StepTableViewCell.appearance().backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
-        StepsBackgroundView.appearance().backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
+        UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
+        StepsBackgroundView.appearance().backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         StylableLabel.appearance(whenContainedInInstancesOf: [CarPlayCompassView.self]).normalFont = UIFont.systemFont(ofSize: 12, weight: .medium).adjustedFont
         StylableLabel.appearance(whenContainedInInstancesOf: [CarPlayCompassView.self]).normalTextColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
         TimeRemainingLabel.appearance(for: regularAndRegularSizeClassTraitCollection).normalFont = UIFont.systemFont(ofSize: 28, weight: .medium).adjustedFont
@@ -308,11 +309,11 @@ open class DayStyle: Style {
         WayNameView.appearance().backgroundColor = UIColor.defaultRouteLayer.withAlphaComponent(0.85)
         WayNameView.appearance().borderColor = UIColor.defaultRouteCasing.withAlphaComponent(0.8)
         WayNameView.appearance().borderWidth = 1.0
-        
-        if #available(iOS 15.0, *) {} else {
-            StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
-        }
+        StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
         StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
+        if #available(iOS 15.0, *) {
+            UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).sectionHeaderTopPadding = 0.0
+        }
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -311,9 +311,12 @@ open class DayStyle: Style {
         WayNameView.appearance().borderWidth = 1.0
         StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
         StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
+        
+        #if swift(>=5.5)
         if #available(iOS 15.0, *) {
             UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).sectionHeaderTopPadding = 0.0
         }
+        #endif
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -308,6 +308,9 @@ open class DayStyle: Style {
         WayNameView.appearance().backgroundColor = UIColor.defaultRouteLayer.withAlphaComponent(0.85)
         WayNameView.appearance().borderColor = UIColor.defaultRouteCasing.withAlphaComponent(0.8)
         WayNameView.appearance().borderWidth = 1.0
+        StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.431372549, green: 0.431372549, blue: 0.431372549, alpha: 1)
+        StepsTableHeaderView.appearance().normalBackgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        StepsTableHeaderView.appearance().normalFont = UIFont.systemFont(ofSize: 18, weight: .medium).adjustedFont
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -108,5 +108,8 @@ open class NightStyle: DayStyle {
         TimeRemainingLabel.appearance().trafficUnknownColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         TopBannerView.appearance().backgroundColor = backgroundColor
         WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
+        
+        StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.9996390939, green: 1, blue: 0.9997561574, alpha: 1)
+        StepsTableHeaderView.appearance().normalBackgroundColor = backgroundColor
     }
 }

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -102,16 +102,14 @@ open class NightStyle: DayStyle {
         SpeedLimitView.appearance().signBackColor = #colorLiteral(red: 0.7991961837, green: 0.8232284188, blue: 0.8481693864, alpha: 1)
         StepInstructionsView.appearance().backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
         StepTableViewCell.appearance().backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
-        StepsBackgroundView.appearance().backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
+        UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
+        StepsBackgroundView.appearance().backgroundColor = backgroundColor
         StylableLabel.appearance(whenContainedInInstancesOf: [CarPlayCompassView.self]).normalTextColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         TimeRemainingLabel.appearance().normalTextColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         TimeRemainingLabel.appearance().trafficUnknownColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         TopBannerView.appearance().backgroundColor = backgroundColor
         WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
-        
-        if #available(iOS 15.0, *) {} else {
-            StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
-        }
+        StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
         StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.9996390939, green: 1, blue: 0.9997561574, alpha: 1)
     }
 }

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -109,7 +109,9 @@ open class NightStyle: DayStyle {
         TopBannerView.appearance().backgroundColor = backgroundColor
         WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
         
+        if #available(iOS 15.0, *) {} else {
+            StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
+        }
         StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.9996390939, green: 1, blue: 0.9997561574, alpha: 1)
-        StepsTableHeaderView.appearance().normalBackgroundColor = backgroundColor
     }
 }

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -9,8 +9,8 @@ open class StepsBackgroundView: UIView { }
 /// :nodoc:
 public class StepsViewController: UIViewController {
     weak var tableView: UITableView!
-    weak var backgroundView: UIView!
-    weak var bottomView: UIView!
+    weak var backgroundView: StepsBackgroundView!
+    weak var bottomView: StepsBackgroundView!
     weak var separatorBottomView: SeparatorView!
     weak var dismissButton: DismissButton!
     public weak var delegate: StepsViewControllerDelegate?
@@ -109,7 +109,6 @@ public class StepsViewController: UIViewController {
 
         let tableView = UITableView(frame: view.bounds, style: .plain)
         tableView.separatorColor = .clear
-        tableView.backgroundColor = .clear
         tableView.backgroundView = nil
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
@@ -125,9 +124,8 @@ public class StepsViewController: UIViewController {
         view.addSubview(dismissButton)
         self.dismissButton = dismissButton
 
-        let bottomView = UIView()
+        let bottomView = StepsBackgroundView()
         bottomView.translatesAutoresizingMaskIntoConstraints = false
-        bottomView.backgroundColor = DismissButton.appearance().backgroundColor
         view.addSubview(bottomView)
         self.bottomView = bottomView
 

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -264,8 +264,17 @@ extension StepsViewController: UITableViewDataSource {
     }
     
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section != 0 else { return nil }
         let view = StepsTableHeaderView()
-        view.text = titleForHeader(in: section)
+        view.textLabel?.text = titleForHeader(in: section)
         return view
+    }
+}
+
+class StepsTableHeaderView: UITableViewHeaderFooterView {
+    @objc dynamic var normalTextColor: UIColor = .black {
+        didSet {
+            self.textLabel?.textColor = normalTextColor
+        }
     }
 }

--- a/Sources/MapboxNavigation/StepsViewController.swift
+++ b/Sources/MapboxNavigation/StepsViewController.swift
@@ -239,7 +239,7 @@ extension StepsViewController: UITableViewDataSource {
         cell.separatorView.isHidden = isLastRowInSection
     }
 
-    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    func titleForHeader(in section: Int) -> String? {
         if section == 0 {
             return nil
         }
@@ -257,5 +257,15 @@ extension StepsViewController: UITableViewDataSource {
         } else {
             return leg.name
         }
+    }
+    
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return (section == 0) ? 0.0 : tableView.sectionHeaderHeight
+    }
+    
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let view = StepsTableHeaderView()
+        view.text = titleForHeader(in: section)
+        return view
     }
 }

--- a/Sources/MapboxNavigation/Style.swift
+++ b/Sources/MapboxNavigation/Style.swift
@@ -255,43 +255,6 @@ open class StylableLabel: UILabel {
 }
 
 /// :nodoc:
-@objc(MBStepsTableHeaderView)
-open class StepsTableHeaderView: UITableViewHeaderFooterView {
-    @objc dynamic open var normalTextColor: UIColor = .black {
-        didSet { update() }
-    }
-    
-    @objc dynamic open var normalBackgroundColor: UIColor = .white {
-        didSet { update() }
-    }
-    
-    @objc dynamic open var text: String? {
-        didSet { update() }
-    }
-    
-    @objc dynamic open var normalFont: UIFont = .systemFont(ofSize: 16) {
-        didSet { update() }
-    }
-    
-    open func update() {
-        if #available(iOS 14.0, *) {
-            var content = UIListContentConfiguration.groupedHeader()
-            content.textProperties.transform = .none
-            content.textProperties.color = normalTextColor
-            content.text = text
-            content.textProperties.font = normalFont
-            contentConfiguration = content
-        } else {
-            textLabel?.text = text
-            textLabel?.font = normalFont
-            textLabel?.textColor = normalTextColor
-        }
-        
-        tintColor = normalBackgroundColor
-    }
-}
-
-/// :nodoc:
 @objc(MBStylableView)
 open class StylableView: UIView {
     @objc dynamic public var borderWidth: CGFloat = 0.0 {

--- a/Sources/MapboxNavigation/Style.swift
+++ b/Sources/MapboxNavigation/Style.swift
@@ -255,6 +255,43 @@ open class StylableLabel: UILabel {
 }
 
 /// :nodoc:
+@objc(MBStepsTableHeaderView)
+open class StepsTableHeaderView: UITableViewHeaderFooterView {
+    @objc dynamic open var normalTextColor: UIColor = .black {
+        didSet { update() }
+    }
+    
+    @objc dynamic open var normalBackgroundColor: UIColor = .white {
+        didSet { update() }
+    }
+    
+    @objc dynamic open var text: String? {
+        didSet { update() }
+    }
+    
+    @objc dynamic open var normalFont: UIFont = .systemFont(ofSize: 16) {
+        didSet { update() }
+    }
+    
+    open func update() {
+        if #available(iOS 14.0, *) {
+            var content = UIListContentConfiguration.groupedHeader()
+            content.textProperties.transform = .none
+            content.textProperties.color = normalTextColor
+            content.text = text
+            content.textProperties.font = normalFont
+            contentConfiguration = content
+        } else {
+            textLabel?.text = text
+            textLabel?.font = normalFont
+            textLabel?.textColor = normalTextColor
+        }
+        
+        tintColor = normalBackgroundColor
+    }
+}
+
+/// :nodoc:
 @objc(MBStylableView)
 open class StylableView: UIView {
     @objc dynamic public var borderWidth: CGFloat = 0.0 {


### PR DESCRIPTION
### Description
This PR is to fix #3756 to allow the leg separator view in `StepsViewController` table to be updated with style. This PR also fix the issue where the bottom padding color of `StepsViewController` is not stylable, and the issue where dragging up the table view of the  `StepsViewController` would show white color.

### Implementation
Because #3756 only exits in the iOS verison before 15. So before iOS15.0, we change the background color of the section header of the  `StepsViewController` to the same as the table cell , which is also the default color since iOS 15.0. And we also update the text color of the leg separator to the same as the `DistanceRemainingLabel` in the top banner.


### Screenshots or Gifs
Before iOS 15, the night mode:
![14_night](https://user-images.githubusercontent.com/48976398/156453532-e8f4cf4c-938e-4886-9351-be7f40d9be39.png)

After iOS 15, the night mode, which has the same width as before iOS15.
![15_night](https://user-images.githubusercontent.com/48976398/156453597-7ae3e7d1-8d57-4649-8aaa-78f8e6f6ba1e.png)

Also removed the highlighted effect of the section header that introduced to iOS 15 to align with other iOS version.
![15_Top_night](https://user-images.githubusercontent.com/48976398/156453715-b96a0079-e28a-4e21-998d-867445ad9578.png)

