### PR TITLE
Support the style change of `FeedbackViewController` during active navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ The v2.2.0 release notes [clarified](https://github.com/mapbox/mapbox-navigation
 * Fixed a crash when approaching an intersection in which one of the lanes is a merge lane. ([#3699](https://github.com/mapbox/mapbox-navigation-ios/pull/3699))
 * Fixed an issue where the step list in `StepsViewController` is empty whle the user is on the final step of a route leg. ([#3729](https://github.com/mapbox/mapbox-navigation-ios/pull/3729))
 * Fixed the color of leg section headers in `StepsViewController` to switch between the day and night styles like the rest of the view controller. ([#3760](https://github.com/mapbox/mapbox-navigation-ios/pull/3760))
-* The `FeedbackViewController` now supports the style change. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
+* `FeedbackViewController` now supports changing styles based on `StyleManager`. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
+* Removed the optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method to refresh all views appearance based on `StyleManager`. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The v2.2.0 release notes [clarified](https://github.com/mapbox/mapbox-navigation
 * Fixed an issue where the step list in `StepsViewController` is empty whle the user is on the final step of a route leg. ([#3729](https://github.com/mapbox/mapbox-navigation-ios/pull/3729))
 * Fixed the color of leg section headers in `StepsViewController` to switch between the day and night styles like the rest of the view controller. ([#3760](https://github.com/mapbox/mapbox-navigation-ios/pull/3760))
 * `FeedbackViewController` now supports changing styles based on `StyleManager`. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
-* Removed the optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method to refresh all views appearance based on `StyleManager`. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
+* Deprecated the optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method. All views appearance will be refreshed based on `StyleManager`. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The v2.2.0 release notes [clarified](https://github.com/mapbox/mapbox-navigation
 * Fixed a crash when approaching an intersection in which one of the lanes is a merge lane. ([#3699](https://github.com/mapbox/mapbox-navigation-ios/pull/3699))
 * Fixed an issue where the step list in `StepsViewController` is empty whle the user is on the final step of a route leg. ([#3729](https://github.com/mapbox/mapbox-navigation-ios/pull/3729))
 * Fixed the color of leg section headers in `StepsViewController` to switch between the day and night styles like the rest of the view controller. ([#3760](https://github.com/mapbox/mapbox-navigation-ios/pull/3760))
+* The `FeedbackViewController` now supports the style change. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
 
 ### Location tracking
 

--- a/Example/ViewController+StyleManager.swift
+++ b/Example/ViewController+StyleManager.swift
@@ -1,0 +1,25 @@
+import UIKit
+import CoreLocation
+import MapboxNavigation
+import MapboxMaps
+
+extension ViewController : StyleManagerDelegate {
+    func location(for styleManager: MapboxNavigation.StyleManager) -> CLLocation? {
+        if let location = navigationMapView.mapView.location.latestLocation?.location {
+            return location
+        } else if let location = CLLocationManager.init().location {
+            return location
+        }
+        return nil
+    }
+    
+    func styleManager(_ styleManager: MapboxNavigation.StyleManager, didApply style: MapboxNavigation.Style) {
+        updateMapStyle(style)
+    }
+    
+    func updateMapStyle(_ style: MapboxNavigation.Style) {
+        if navigationMapView?.mapView.mapboxMap.style.uri?.rawValue != style.mapStyleURL.absoluteString {
+            navigationMapView?.mapView.mapboxMap.style.uri = StyleURI(url: style.mapStyleURL)
+        }
+    }
+}

--- a/Example/ViewController+StyleManager.swift
+++ b/Example/ViewController+StyleManager.swift
@@ -21,18 +21,5 @@ extension ViewController : StyleManagerDelegate {
         if navigationMapView?.mapView.mapboxMap.style.uri?.rawValue != style.mapStyleURL.absoluteString {
             navigationMapView?.mapView.mapboxMap.style.uri = StyleURI(url: style.mapStyleURL)
         }
-        updateFeedbackViewControllerStyle()
-    }
-    
-    func updateFeedbackViewControllerStyle() {
-        if let feedbackViewController = presentedViewController as? FeedbackViewController {
-            for window in UIApplication.shared.windows {
-                if !window.isKind(of: NSClassFromString("UITextEffectsWindow") ?? NSString.classForCoder()),
-                   feedbackViewController.view.isDescendant(of: window) {
-                    feedbackViewController.view.removeFromSuperview()
-                    window.addSubview(feedbackViewController.view)
-                }
-            }
-        }
     }
 }

--- a/Example/ViewController+StyleManager.swift
+++ b/Example/ViewController+StyleManager.swift
@@ -21,5 +21,18 @@ extension ViewController : StyleManagerDelegate {
         if navigationMapView?.mapView.mapboxMap.style.uri?.rawValue != style.mapStyleURL.absoluteString {
             navigationMapView?.mapView.mapboxMap.style.uri = StyleURI(url: style.mapStyleURL)
         }
+        updateFeedbackViewControllerStyle()
+    }
+    
+    func updateFeedbackViewControllerStyle() {
+        if let feedbackViewController = presentedViewController as? FeedbackViewController {
+            for window in UIApplication.shared.windows {
+                if !window.isKind(of: NSClassFromString("UITextEffectsWindow") ?? NSString.classForCoder()),
+                   feedbackViewController.view.isDescendant(of: window) {
+                    feedbackViewController.view.removeFromSuperview()
+                    window.addSubview(feedbackViewController.view)
+                }
+            }
+        }
     }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -48,6 +48,8 @@ class ViewController: UIViewController {
         }
     }
     
+    var styleManager = MapboxNavigation.StyleManager()
+    
     var waypoints: [Waypoint] = [] {
         didSet {
             waypoints.forEach {
@@ -183,8 +185,8 @@ class ViewController: UIViewController {
         navigationMapView.mapView.ornaments.options.attributionButton.margins.y = mapOrnamentsMargin
         navigationMapView.delegate = self
         navigationMapView.userLocationStyle = .puck2D()
-        navigationMapView.mapView.mapboxMap.loadStyleURI(.navigationDay)
         
+        setupStyleManager()
         setupGestureRecognizers()
         setupPerformActionBarButtonItem()
         if let cameraState = activeNavigationViewController?.navigationMapView?.mapView.cameraState {
@@ -193,6 +195,11 @@ class ViewController: UIViewController {
                                                  duration: 0,
                                                  completion: nil)
         }
+    }
+    
+    private func setupStyleManager() {
+        styleManager.delegate = self
+        styleManager.styles = [DayStyle(), NightStyle()]
     }
     
     private func uninstall(_ navigationMapView: NavigationMapView) {
@@ -463,11 +470,10 @@ class ViewController: UIViewController {
     }
     
     func toggleDayNightStyle() {
-        let style = navigationMapView.mapView?.mapboxMap.style
-        if style?.uri == .navigationNight {
-            style?.uri = .navigationDay
+        if styleManager.currentStyleType == .day {
+            styleManager.applyStyle(type: .night)
         } else {
-            style?.uri = .navigationNight
+            styleManager.applyStyle(type: .day)
         }
     }
     

--- a/MapboxNavigation-SPM.xcodeproj/project.pbxproj
+++ b/MapboxNavigation-SPM.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		8A0D5DB625DF2A86006F0919 /* StyledFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */; };
 		8A0D5DB725DF2A86006F0919 /* StyledFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */; };
 		AED6285622CBE4CE00058A51 /* ViewController+InstructionsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED6285522CBE4CE00058A51 /* ViewController+InstructionsCard.swift */; };
+		B4FC994927D19E3A00FB6D4A /* ViewController+StyleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FC994827D19E3A00FB6D4A /* ViewController+StyleManager.swift */; };
+		B4FC994A27D19E3A00FB6D4A /* ViewController+StyleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FC994827D19E3A00FB6D4A /* ViewController+StyleManager.swift */; };
 		C51FC31720F689F800400CE7 /* CustomStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51FC31620F689F800400CE7 /* CustomStyles.swift */; };
 		C53F2EE420EBC95600D9798F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358D14671E5E3B7700ADE590 /* ViewController.swift */; };
 		C53F2EE520EBC95600D9798F /* CustomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D9800C1EFA8BA9006DBF2E /* CustomViewController.swift */; };
@@ -68,6 +70,7 @@
 		8DF8E4E52202696800B29FEF /* MapboxNavigation.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = MapboxNavigation.podspec; sourceTree = "<group>"; };
 		8DF8E4E62202696800B29FEF /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		AED6285522CBE4CE00058A51 /* ViewController+InstructionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ViewController+InstructionsCard.swift"; path = "Example/ViewController+InstructionsCard.swift"; sourceTree = "<group>"; };
+		B4FC994827D19E3A00FB6D4A /* ViewController+StyleManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ViewController+StyleManager.swift"; path = "Example/ViewController+StyleManager.swift"; sourceTree = "<group>"; };
 		C51FC31620F689F800400CE7 /* CustomStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomStyles.swift; path = Example/CustomStyles.swift; sourceTree = "<group>"; };
 		C53F2F0720EBC95600D9798F /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C57AD98920EAA39A0087B24B /* Entitlements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Entitlements.plist; sourceTree = "<group>"; };
@@ -141,6 +144,7 @@
 				35002D721E5F6C830090E733 /* Supporting files */,
 				AED6285522CBE4CE00058A51 /* ViewController+InstructionsCard.swift */,
 				8A092F9A25DEE81900CA7CF5 /* ViewController+FreeDrive.swift */,
+				B4FC994827D19E3A00FB6D4A /* ViewController+StyleManager.swift */,
 				3577B877214FF35800094294 /* FavoritesList.swift */,
 				358D14651E5E3B7700ADE590 /* AppDelegate.swift */,
 				35379CFB21480BFB00FD402E /* AppDelegate+CarPlay.swift */,
@@ -390,6 +394,7 @@
 				8A092F9B25DEE81900CA7CF5 /* ViewController+FreeDrive.swift in Sources */,
 				C51FC31720F689F800400CE7 /* CustomStyles.swift in Sources */,
 				8A0D5DB625DF2A86006F0919 /* StyledFeature.swift in Sources */,
+				B4FC994927D19E3A00FB6D4A /* ViewController+StyleManager.swift in Sources */,
 				358D14661E5E3B7700ADE590 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -404,6 +409,7 @@
 				8A0D5DB725DF2A86006F0919 /* StyledFeature.swift in Sources */,
 				DA8805002316EAED00B54D87 /* ViewController+InstructionsCard.swift in Sources */,
 				8A092F9C25DEE81900CA7CF5 /* ViewController+FreeDrive.swift in Sources */,
+				B4FC994A27D19E3A00FB6D4A /* ViewController+StyleManager.swift in Sources */,
 				35379CFD21480C0500FD402E /* AppDelegate+CarPlay.swift in Sources */,
 				C53F2EE820EBC95600D9798F /* AppDelegate.swift in Sources */,
 				3577B878214FF35800094294 /* FavoritesList.swift in Sources */,

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -322,7 +322,6 @@ open class DayStyle: Style {
             UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).sectionHeaderTopPadding = 0.0
         }
         #endif
-        
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -311,12 +311,18 @@ open class DayStyle: Style {
         WayNameView.appearance().borderWidth = 1.0
         StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
         StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
+        UILabel.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).backgroundColor = .white
+        UILabel.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).textColor = .black
+        FeedbackStyleView.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).backgroundColor = .white
+        FeedbackCollectionView.appearance().backgroundColor = .white
+        FeedbackCollectionView.appearance().cellColor = .black
         
         #if swift(>=5.5)
         if #available(iOS 15.0, *) {
             UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).sectionHeaderTopPadding = 0.0
         }
         #endif
+        
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/Feedback/FeedbackViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackViewController.swift
@@ -79,10 +79,9 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
         type.feedbackItems
     }
 
-    lazy var collectionView: UICollectionView = {
-        let view: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+    lazy var collectionView: FeedbackCollectionView = {
+        let view: FeedbackCollectionView = FeedbackCollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .clear
         view.delegate = self
         view.dataSource = self
         view.contentInset = FeedbackViewController.contentInset
@@ -96,6 +95,8 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
         label.text = FeedbackViewController.sceneTitle
         return label
     }()
+    
+    lazy var bottomPaddingView: FeedbackStyleView = .forAutoLayout()
     
     lazy var flowLayout: UICollectionViewFlowLayout = {
         let layout = UICollectionViewFlowLayout()
@@ -229,24 +230,34 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     }
     
     internal func setupViews() {
-        let children = [reportIssueLabel, collectionView]
+        let children = [reportIssueLabel, collectionView, bottomPaddingView]
         view.addSubviews(children)
     }
     
     internal func setupConstraints() {
-        let labelTop = reportIssueLabel.topAnchor.constraint(equalTo: view.topAnchor)
-        let labelHeight = reportIssueLabel.heightAnchor.constraint(equalToConstant: FeedbackViewController.titleHeaderHeight)
-        let labelLeading = reportIssueLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        let labelTrailing = reportIssueLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        let collectionLabelSpacing = collectionView.topAnchor.constraint(equalTo: reportIssueLabel.bottomAnchor)
-        let collectionLeading = collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        let collectionTrailing = collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        let collectionBarSpacing = collectionView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor)
+        let labelConstraints = [
+            reportIssueLabel.topAnchor.constraint(equalTo: view.topAnchor),
+            reportIssueLabel.heightAnchor.constraint(equalToConstant: FeedbackViewController.titleHeaderHeight),
+            reportIssueLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            reportIssueLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ]
         
-        let constraints = [labelTop, labelHeight, labelLeading, labelTrailing,
-                           collectionLabelSpacing, collectionLeading, collectionTrailing, collectionBarSpacing]
+        let collectionConstraints = [
+            collectionView.topAnchor.constraint(equalTo: reportIssueLabel.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor)
+        ]
         
-        NSLayoutConstraint.activate(constraints)
+        let bottomPaddingConstraints = [
+            bottomPaddingView.topAnchor.constraint(equalTo: view.safeBottomAnchor),
+            bottomPaddingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomPaddingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomPaddingView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ]
+        
+        let layoutConstraints = labelConstraints + collectionConstraints + bottomPaddingConstraints
+        NSLayoutConstraint.activate(layoutConstraints)
     }
     
     func send(_ item: FeedbackItem) {
@@ -263,8 +274,11 @@ extension FeedbackViewController: UICollectionViewDataSource {
         let item = sections[indexPath.row]
         
         cell.titleLabel.text = item.title
-        cell.imageView.tintColor = .white
         cell.imageView.image = item.image
+        
+        cell.titleLabel.textColor = self.collectionView.cellColor
+        cell.circleColor = self.collectionView.cellColor
+        cell.imageView.tintColor = self.collectionView.backgroundColor
         
         return cell
     }
@@ -332,5 +346,15 @@ extension String {
         let constraintRect = CGSize(width: width, height: .greatestFiniteMagnitude)
         let boundingBox = self.boundingRect(with: constraintRect, options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil)
         return ceil(boundingBox.height)
+    }
+}
+
+class FeedbackStyleView: UIView {}
+
+class FeedbackCollectionView: UICollectionView {
+    @objc dynamic var cellColor: UIColor = .black {
+        didSet {
+            reloadData()
+        }
     }
 }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -997,6 +997,18 @@ extension NavigationViewController: StyleManagerDelegate {
         
         currentStatusBarStyle = style.statusBarStyle ?? .default
         setNeedsStatusBarAppearanceUpdate()
+        updateFeedbackViewControllerStyle()
+    }
+    
+    private func updateFeedbackViewControllerStyle() {
+        if let feedbackViewController = presentedViewController as? FeedbackViewController {
+            for window in UIApplication.shared.windows {
+                if !window.isKind(of: NSClassFromString("UITextEffectsWindow") ?? NSString.classForCoder()) {
+                    feedbackViewController.view.removeFromSuperview()
+                    window.addSubview(feedbackViewController.view)
+                }
+            }
+        }
     }
     
     public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -1003,7 +1003,8 @@ extension NavigationViewController: StyleManagerDelegate {
     private func updateFeedbackViewControllerStyle() {
         if let feedbackViewController = presentedViewController as? FeedbackViewController {
             for window in UIApplication.shared.windows {
-                if !window.isKind(of: NSClassFromString("UITextEffectsWindow") ?? NSString.classForCoder()) {
+                if !window.isKind(of: NSClassFromString("UITextEffectsWindow") ?? NSString.classForCoder()),
+                   feedbackViewController.view.isDescendant(of: window) {
                     feedbackViewController.view.removeFromSuperview()
                     window.addSubview(feedbackViewController.view)
                 }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -997,19 +997,6 @@ extension NavigationViewController: StyleManagerDelegate {
         
         currentStatusBarStyle = style.statusBarStyle ?? .default
         setNeedsStatusBarAppearanceUpdate()
-        updateFeedbackViewControllerStyle()
-    }
-    
-    private func updateFeedbackViewControllerStyle() {
-        if let feedbackViewController = presentedViewController as? FeedbackViewController {
-            for window in UIApplication.shared.windows {
-                if !window.isKind(of: NSClassFromString("UITextEffectsWindow") ?? NSString.classForCoder()),
-                   feedbackViewController.view.isDescendant(of: window) {
-                    feedbackViewController.view.removeFromSuperview()
-                    window.addSubview(feedbackViewController.view)
-                }
-            }
-        }
     }
     
     public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -110,6 +110,11 @@ open class NightStyle: DayStyle {
         TopBannerView.appearance().backgroundColor = backgroundColor
         StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
         StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.9996390939, green: 1, blue: 0.9997561574, alpha: 1)
+        UILabel.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).backgroundColor = .black
+        UILabel.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).textColor = .white
+        FeedbackStyleView.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).backgroundColor = .black
+        FeedbackCollectionView.appearance().backgroundColor = .black
+        FeedbackCollectionView.appearance().cellColor = .white
         
         WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
         WayNameLabel.appearance().roadShieldBlackColor = #colorLiteral(red: 0.08, green: 0.09, blue: 0.12, alpha: 1)

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -13,14 +13,6 @@ public protocol StyleManagerDelegate: AnyObject, UnimplementedLogging {
     func location(for styleManager: StyleManager) -> CLLocation?
     
     /**
-     Asks the delegate for the view to be used when refreshing appearance. 
-     
-     The default implementation of this method will attempt to cast the delegate to type
-     `UIViewController` and use its `view` property.
-     */
-    func styleManager(_ styleManager: StyleManager, viewForApplying currentStyle: Style?) -> UIView?
-    
-    /**
      Informs the delegate that a style was applied.
      
      This delegate method is the equivalent of `Notification.Name.styleManagerDidApplyStyle`.
@@ -54,16 +46,6 @@ public extension StyleManagerDelegate {
      */
     func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
         logUnimplemented(protocolType: StyleManagerDelegate.self, level: .debug)
-    }
-    
-    func styleManager(_ styleManager: StyleManager, viewForApplying currentStyle: Style?) -> UIView? {
-        // Short-circuit refresh logic if the view hasn't yet loaded since we don't want the `self.view` 
-        // call to trigger `loadView`.
-        if let vc = self as? UIViewController, vc.isViewLoaded { 
-            return vc.view
-        }
-        
-        return nil
     }
 }
 
@@ -257,15 +239,16 @@ open class StyleManager {
         forceRefreshAppearance()
     }
     
-    // workaround to refresh appearance by removing the view and then adding it again
+    // Workaround to refresh appearance by removing all views and then adding them again.
+    // UITextEffectsWindow will be created when system keyboard is shown and cannot be safely removed.
     func forceRefreshAppearance() {
-        if 
-            let view = delegate?.styleManager(self, viewForApplying: currentStyle), 
-            let superview = view.superview, 
-            let index = superview.subviews.firstIndex(of: view) 
-        {
-            view.removeFromSuperview()
-            superview.insertSubview(view, at: index)
+        for window in UIApplication.shared.windows {
+            if !window.isKind(of: NSClassFromString("UITextEffectsWindow") ?? NSString.classForCoder()) {
+                for view in window.subviews {
+                    view.removeFromSuperview()
+                    window.addSubview(view)
+                }
+            }
         }
         
         delegate?.styleManagerDidRefreshAppearance(self)

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -177,9 +177,9 @@ open class StyleManager {
      Applies the `Style` with type matching `type`and notifies `StyleManager.delegate` upon completion. 
      */
     public func applyStyle(type styleType: StyleType) {
-        guard currentStyleType != styleType else { return }
-        
-        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(timeOfDayChanged), object: nil)
+        if currentStyleType != styleType {
+            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(timeOfDayChanged), object: nil)
+        }
         
         for style in styles {
             if style.styleType == styleType {

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -13,6 +13,15 @@ public protocol StyleManagerDelegate: AnyObject, UnimplementedLogging {
     func location(for styleManager: StyleManager) -> CLLocation?
     
     /**
+     Asks the delegate for the view to be used when refreshing appearance.
+     
+     The default implementation of this method will attempt to cast the delegate to type
+     `UIViewController` and use its `view` property.
+     */
+    @available(*, deprecated, message: "All views appearance will be refreshed without the `UITextEffectsWindow`.")
+    func styleManager(_ styleManager: StyleManager, viewForApplying currentStyle: Style?) -> UIView?
+    
+    /**
      Informs the delegate that a style was applied.
      
      This delegate method is the equivalent of `Notification.Name.styleManagerDidApplyStyle`.
@@ -46,6 +55,17 @@ public extension StyleManagerDelegate {
      */
     func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {
         logUnimplemented(protocolType: StyleManagerDelegate.self, level: .debug)
+    }
+    
+    @available(*, deprecated, message: "All views appearance will be refreshed without the `UITextEffectsWindow`.")
+    func styleManager(_ styleManager: StyleManager, viewForApplying currentStyle: Style?) -> UIView? {
+        // Short-circuit refresh logic if the view hasn't yet loaded since we don't want the `self.view`
+        // call to trigger `loadView`.
+        if let vc = self as? UIViewController, vc.isViewLoaded {
+            return vc.view
+        }
+        
+        return nil
     }
 }
 


### PR DESCRIPTION
### Description
This pr is to fix the issue that the `FeedbackViewController` shows light theme during active navigation in Night style.

### Implementation
- [x] Added stylable `FeedbackStyleView`,  and `FeedbackCollectionView` to support color change. Also added `bottomPaddingView` to `FeedbackViewController` view to support the background color change. `FeedbackViewController` now supports the style change based on `StyleManager`. If no style applied, it would default show the default Day style mode.
- [x] Removed the `styleType` check in `StyleManager.applyStyle(type:)`. When switching between active navigation and passive navigation, it would forcefully update the style to avoid the previous style remaining.
- [x] Add example to the `Example` by adding `StyleManager` to `ViewController` to automatically update the map style during free driving and preview mode.
- [x] Deprecated the optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method. All views appearance except `UITextEffectsWindow` will be refreshed based on `StyleManager` when style applies.

### Screenshots or Gifs
![FeedbackDay_Active](https://user-images.githubusercontent.com/48976398/155403385-be6f22e2-01ed-48f6-b5e8-06decf73a38f.png)
![FeedbackNight_Active](https://user-images.githubusercontent.com/48976398/155403393-838c466d-2e5c-4731-b443-365865d262d4.png)

