### PR TITLE
Remove the gap between `EndOfRouteViewController` view and screen bottom.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Renamed the `LanesView.update(for:)`, `LanesView.show()` and `LanesView.hide()` methods to `LanesView.update(for:animated:duration:completion:)`, `LanesView.show(animated:duration:completion:)`, `LanesView.hide(animated:duration:completion:)`, respectively. ([#3704](https://github.com/mapbox/mapbox-navigation-ios/pull/3704))
 * Added the `InstructionsCardContainerView.separatorColor` and `InstructionsCardContainerView.highlightedSeparatorColor` to be able to change instruction card's separator colors. ([#3704](https://github.com/mapbox/mapbox-navigation-ios/pull/3704))
 * Fixed an issue where the top banner instruction shows empty remaining steps in pull-down table when user is on final step. ([#3729](https://github.com/mapbox/mapbox-navigation-ios/pull/3729))
+* Fixed an issue where the end of route view has a gap between the screen bottom in landscape mode. ([#3769](https://github.com/mapbox/mapbox-navigation-ios/pull/3769))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/EndOfRouteViewController.swift
+++ b/Sources/MapboxNavigation/EndOfRouteViewController.swift
@@ -74,6 +74,10 @@ class EndOfRouteViewController: UIViewController {
         preferredContentSize.height = height(for: .normal)
         updateInterface()
     }
+    
+    override func viewDidLayoutSubviews() {
+        rating == 0 ? hideComments() : showComments()
+    }
 
     // MARK: IBActions
     @IBAction func endNavigationPressed(_ sender: Any) {

--- a/Sources/MapboxNavigation/EndOfRouteViewController.swift
+++ b/Sources/MapboxNavigation/EndOfRouteViewController.swift
@@ -76,6 +76,7 @@ class EndOfRouteViewController: UIViewController {
     }
     
     override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         rating == 0 ? hideComments() : showComments()
     }
 

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -83,7 +83,7 @@ open class NavigationView: UIView {
     
     // MARK: End of Route UI
     
-    lazy var endOfRouteShowConstraint: NSLayoutConstraint? = endOfRouteView?.bottomAnchor.constraint(equalTo: safeBottomAnchor)
+    lazy var endOfRouteShowConstraint: NSLayoutConstraint? = endOfRouteView?.bottomAnchor.constraint(equalTo: bottomAnchor)
     
     lazy var endOfRouteHideConstraint: NSLayoutConstraint? = endOfRouteView?.topAnchor.constraint(equalTo: bottomAnchor)
     


### PR DESCRIPTION
### Description
This PR is to fix #3766 by setting the bottom of `EndOfRouteViewController` view to the screen bottom to remove the gap between.

### Implementation
Set the `bottomAnchor` of `EndOfRouteViewController` view to the bottom of `NavigationView` instead of the safeArea's bottom. Fix the `safeAreaInsets` of the `EndOfRouteViewController` view is `0` when its height needs to change.

### Screenshots or Gifs
![FixEndView](https://user-images.githubusercontent.com/48976398/156230400-8f5b61e8-66c2-48d5-9908-c4f971faaa16.png)

