### PR TITLE
Align the margin of floating buttons with map attribution button during active navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The v2.2.0 release notes [clarified](https://github.com/mapbox/mapbox-navigation
 * Fixed an issue where changing `NavigationViewController.showsReportFeedback`, `NavigationViewController.showsSpeedLimits`, `NavigationViewController.detailedFeedbackEnabled`, `NavigationViewController.floatingButtonsPosition` and `NavigationViewController.floatingButtons` before presenting `NavigationViewController` had no effect. ([#3718](https://github.com/mapbox/mapbox-navigation-ios/pull/3718))
 * Fixed an issue where `SpeechSynthesizing.managesAudioSession` was ignored by `RouteVoiceController`. ([#3572](https://github.com/mapbox/mapbox-navigation-ios/pull/3572))
 * Fixed the gap between the end-of-route feedback panel and the bottom of the screen in landscape orientation. ([#3769](https://github.com/mapbox/mapbox-navigation-ios/pull/3769))
+* Fixed an issue where the floating buttons not aligned with map attribution button when device rotates during active navigation. ([#3776](https://github.com/mapbox/mapbox-navigation-ios/pull/3776))
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ The v2.2.0 release notes [clarified](https://github.com/mapbox/mapbox-navigation
 * Fixed an issue where changing `NavigationViewController.showsReportFeedback`, `NavigationViewController.showsSpeedLimits`, `NavigationViewController.detailedFeedbackEnabled`, `NavigationViewController.floatingButtonsPosition` and `NavigationViewController.floatingButtons` before presenting `NavigationViewController` had no effect. ([#3718](https://github.com/mapbox/mapbox-navigation-ios/pull/3718))
 * Fixed an issue where `SpeechSynthesizing.managesAudioSession` was ignored by `RouteVoiceController`. ([#3572](https://github.com/mapbox/mapbox-navigation-ios/pull/3572))
 * Fixed the gap between the end-of-route feedback panel and the bottom of the screen in landscape orientation. ([#3769](https://github.com/mapbox/mapbox-navigation-ios/pull/3769))
-* Fixed an issue where the floating buttons not aligned with map attribution button when device rotates during active navigation. ([#3776](https://github.com/mapbox/mapbox-navigation-ios/pull/3776))
+* Fixed an issue where the map’s floating buttons are misaligned with its attribution button and sometimes untappable after rotating the device during turn-by-turn navigatio. ([#3776](https://github.com/mapbox/mapbox-navigation-ios/pull/3776))
 
 ## v2.2.0
 

--- a/Sources/MapboxNavigation/NavigationViewLayout.swift
+++ b/Sources/MapboxNavigation/NavigationViewLayout.swift
@@ -281,4 +281,10 @@ extension NavigationView {
         compactConstraints.forEach({ $0.isActive = traitCollection.verticalSizeClass == .compact })
         regularConstraints.forEach({ $0.isActive = traitCollection.verticalSizeClass == .regular })
     }
+    
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection == traitCollection { return }
+        
+        setupConstraints()
+    }
 }

--- a/Sources/MapboxNavigation/NavigationViewLayout.swift
+++ b/Sources/MapboxNavigation/NavigationViewLayout.swift
@@ -281,10 +281,4 @@ extension NavigationView {
         compactConstraints.forEach({ $0.isActive = traitCollection.verticalSizeClass == .compact })
         regularConstraints.forEach({ $0.isActive = traitCollection.verticalSizeClass == .regular })
     }
-    
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        if previousTraitCollection == traitCollection { return }
-        
-        setupConstraints()
-    }
 }

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -47,6 +47,7 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
     }
     
     @objc func orientationDidChange(_ notification: Notification) {
+        navigationViewData.navigationView.setupConstraints()
         updateMapViewOrnaments()
     }
     
@@ -153,10 +154,10 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
                                                                                             y: y - navigationView.safeAreaInsets.bottom)
         case .compact:
             if UIApplication.shared.statusBarOrientation == .landscapeRight {
-                navigationMapView.mapView.ornaments.options.attributionButton.margins = CGPoint(x: -navigationView.safeAreaInsets.right,
+                navigationMapView.mapView.ornaments.options.attributionButton.margins = CGPoint(x: x - navigationView.safeAreaInsets.right,
                                                                                                 y: defaultOffset - navigationView.safeAreaInsets.bottom)
             } else {
-                navigationMapView.mapView.ornaments.options.attributionButton.margins = CGPoint(x: 0.0,
+                navigationMapView.mapView.ornaments.options.attributionButton.margins = CGPoint(x: x,
                                                                                                 y: defaultOffset - navigationView.safeAreaInsets.bottom)
             }
         @unknown default:


### PR DESCRIPTION
### Description
This PR is to fix #3775 and to align the floatings buttons margin with the map info button during active navigation.

### Implementation
Update the layout of the `NavigationView` when the device orientation change instead of the `traitCollectionDidChange`. And increase the distance of the map info button to the same as the floating buttons. It could fix the issue where the map info button at the safe area margin and sometimes unclickable.

### Screenshots or Gifs
The updated `landscapeLeft` mode.
![updatedLandscapeLeft](https://user-images.githubusercontent.com/48976398/157322790-82382f4c-0e9f-455f-bce3-3ac9d2ee14e8.png)

The updated `landscapeRight` mode.
![updated_landscapeRight](https://user-images.githubusercontent.com/48976398/157322796-4cc51907-659f-4572-a4ec-f61b9da6c36d.png)

