### PR TITLE
Support the style change of the road shield color.

### DIFF
--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -2,72 +2,72 @@ import UIKit
 import MapboxMaps
 
 extension UIColor {
-    class var defaultRouteCasing: UIColor { get { return .defaultTintStroke } }
-    class var defaultRouteLayer: UIColor { get { return #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 1) } }
-    class var defaultAlternateLine: UIColor { get { return #colorLiteral(red: 0.6, green: 0.6, blue: 0.6, alpha: 1) } }
-    class var defaultAlternateLineCasing: UIColor { get { return #colorLiteral(red: 0.5019607843, green: 0.4980392157, blue: 0.5019607843, alpha: 1) } }
-    class var defaultTraversedRouteColor: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0) } }
-    class var defaultManeuverArrowStroke: UIColor { get { return .defaultRouteLayer } }
-    class var defaultManeuverArrow: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
+    class var defaultRouteCasing: UIColor { .defaultTintStroke }
+    class var defaultRouteLayer: UIColor { #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 1) }
+    class var defaultAlternateLine: UIColor { #colorLiteral(red: 0.6, green: 0.6, blue: 0.6, alpha: 1) }
+    class var defaultAlternateLineCasing: UIColor { #colorLiteral(red: 0.5019607843, green: 0.4980392157, blue: 0.5019607843, alpha: 1) }
+    class var defaultTraversedRouteColor: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0) }
+    class var defaultManeuverArrowStroke: UIColor { .defaultRouteLayer }
+    class var defaultManeuverArrow: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
     
-    class var defaultTurnArrowPrimary: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) } }
-    class var defaultTurnArrowPrimaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
-    class var defaultTurnArrowSecondary: UIColor { get { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) } }
-    class var defaultTurnArrowSecondaryHighlighted: UIColor { get { return UIColor.white.withAlphaComponent(0.4) } }
+    class var defaultTurnArrowPrimary: UIColor { #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) }
+    class var defaultTurnArrowPrimaryHighlighted: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
+    class var defaultTurnArrowSecondary: UIColor { #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) }
+    class var defaultTurnArrowSecondaryHighlighted: UIColor { UIColor.white.withAlphaComponent(0.4) }
 
-    class var defaultLaneArrowPrimary: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) } }
-    class var defaultLaneArrowSecondary: UIColor { get { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) } }
-    class var defaultLaneArrowPrimaryHighlighted: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
-    class var defaultLaneArrowSecondaryHighlighted: UIColor { get { return UIColor(white: 0.7, alpha: 1.0) } }
+    class var defaultLaneArrowPrimary: UIColor { #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) }
+    class var defaultLaneArrowSecondary: UIColor { #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) }
+    class var defaultLaneArrowPrimaryHighlighted: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
+    class var defaultLaneArrowSecondaryHighlighted: UIColor { UIColor(white: 0.7, alpha: 1.0) }
 
-    class var defaultLaneArrowPrimaryCarPlay: UIColor { get { return #colorLiteral(red: 0.7649999857, green: 0.7649999857, blue: 0.7570000291, alpha: 1) } }
-    class var defaultLaneArrowSecondaryCarPlay: UIColor { get { return #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1) } }
+    class var defaultLaneArrowPrimaryCarPlay: UIColor { #colorLiteral(red: 0.7649999857, green: 0.7649999857, blue: 0.7570000291, alpha: 1) }
+    class var defaultLaneArrowSecondaryCarPlay: UIColor { #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1) }
     
-    class var trafficUnknown: UIColor { get { return defaultRouteLayer } }
-    class var trafficLow: UIColor { get { return defaultRouteLayer } }
-    class var trafficModerate: UIColor { get { return #colorLiteral(red: 1, green: 0.5843137255, blue: 0, alpha: 1) } }
-    class var trafficHeavy: UIColor { get { return #colorLiteral(red: 1, green: 0.3019607843, blue: 0.3019607843, alpha: 1) } }
-    class var trafficSevere: UIColor { get { return #colorLiteral(red: 0.5607843137, green: 0.1411764706, blue: 0.2784313725, alpha: 1) } }
+    class var trafficUnknown: UIColor { defaultRouteLayer }
+    class var trafficLow: UIColor { defaultRouteLayer }
+    class var trafficModerate: UIColor { #colorLiteral(red: 1, green: 0.5843137255, blue: 0, alpha: 1) }
+    class var trafficHeavy: UIColor { #colorLiteral(red: 1, green: 0.3019607843, blue: 0.3019607843, alpha: 1) }
+    class var trafficSevere: UIColor { #colorLiteral(red: 0.5607843137, green: 0.1411764706, blue: 0.2784313725, alpha: 1) }
     
-    class var alternativeTrafficUnknown: UIColor { get { return defaultAlternateLine } }
-    class var alternativeTrafficLow: UIColor { get { return defaultAlternateLine } }
-    class var alternativeTrafficModerate: UIColor { get { return #colorLiteral(red: 0.75, green: 0.63, blue: 0.53, alpha: 1.0) } }
-    class var alternativeTrafficHeavy: UIColor { get { return #colorLiteral(red: 0.71, green: 0.51, blue: 0.51, alpha: 1.0) } }
-    class var alternativeTrafficSevere: UIColor { get { return #colorLiteral(red: 0.71, green: 0.51, blue: 0.51, alpha: 1.0) } }
-    class var defaultBuildingColor: UIColor { get { return #colorLiteral(red: 0.9833194452, green: 0.9843137255, blue: 0.9331936657, alpha: 0.8019049658) } }
-    class var defaultBuildingHighlightColor: UIColor { get { return #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 0.949406036) } }
+    class var alternativeTrafficUnknown: UIColor { defaultAlternateLine }
+    class var alternativeTrafficLow: UIColor { defaultAlternateLine }
+    class var alternativeTrafficModerate: UIColor { #colorLiteral(red: 0.75, green: 0.63, blue: 0.53, alpha: 1.0) }
+    class var alternativeTrafficHeavy: UIColor { #colorLiteral(red: 0.71, green: 0.51, blue: 0.51, alpha: 1.0) }
+    class var alternativeTrafficSevere: UIColor { #colorLiteral(red: 0.71, green: 0.51, blue: 0.51, alpha: 1.0) }
+    class var defaultBuildingColor: UIColor { #colorLiteral(red: 0.9833194452, green: 0.9843137255, blue: 0.9331936657, alpha: 0.8019049658) }
+    class var defaultBuildingHighlightColor: UIColor { #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 0.949406036) }
     
-    class var defaultRouteRestrictedAreaColor: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)} }
+    class var defaultRouteRestrictedAreaColor: UIColor { #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) }
 
-    class var routeDurationAnnotationColor: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
-    class var selectedRouteDurationAnnotationColor: UIColor { get { return #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 1) } }
+    class var routeDurationAnnotationColor: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
+    class var selectedRouteDurationAnnotationColor: UIColor { #colorLiteral(red: 0.337254902, green: 0.6588235294, blue: 0.9843137255, alpha: 1) }
 
-    class var routeDurationAnnotationTextColor: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) } }
-    class var selectedRouteDurationAnnotationTextColor: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
+    class var routeDurationAnnotationTextColor: UIColor { #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) }
+    class var selectedRouteDurationAnnotationTextColor: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
     
-    class var roadShieldDefaultColor: UIColor { get { return #colorLiteral(red: 0.11, green: 0.11, blue: 0.15, alpha: 1) } }
-    class var roadShieldBlackColor: UIColor { get { return roadShieldDefaultColor } }
-    class var roadShieldBlueColor: UIColor { get { return #colorLiteral(red: 0.28, green: 0.36, blue: 0.8, alpha: 1) } }
-    class var roadShieldGreenColor: UIColor { get { return #colorLiteral(red: 0.1, green: 0.64, blue: 0.28, alpha: 1) } }
-    class var roadShieldRedColor: UIColor { get { return #colorLiteral(red: 0.95, green: 0.23, blue: 0.23, alpha: 1) } }
-    class var roadShieldWhiteColor: UIColor { get { return #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1) } }
-    class var roadShieldYellowColor: UIColor { get { return #colorLiteral(red: 1.0, green: 0.9, blue: 0.4, alpha: 1) } }
-    class var roadShieldOrangeColor: UIColor { get { return #colorLiteral(red: 1, green: 0.65, blue: 0, alpha: 1) } }
+    class var roadShieldDefaultColor: UIColor { #colorLiteral(red: 0.11, green: 0.11, blue: 0.15, alpha: 1) }
+    class var roadShieldBlackColor: UIColor { roadShieldDefaultColor }
+    class var roadShieldBlueColor: UIColor { #colorLiteral(red: 0.28, green: 0.36, blue: 0.8, alpha: 1) }
+    class var roadShieldGreenColor: UIColor { #colorLiteral(red: 0.1, green: 0.64, blue: 0.28, alpha: 1) }
+    class var roadShieldRedColor: UIColor { #colorLiteral(red: 0.95, green: 0.23, blue: 0.23, alpha: 1) }
+    class var roadShieldWhiteColor: UIColor { #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1) }
+    class var roadShieldYellowColor: UIColor { #colorLiteral(red: 1.0, green: 0.9, blue: 0.4, alpha: 1) }
+    class var roadShieldOrangeColor: UIColor { #colorLiteral(red: 1, green: 0.65, blue: 0, alpha: 1) }
 
 }
 
 extension UIColor {
     // General styling
-    fileprivate class var defaultTint: UIColor { get { return #colorLiteral(red: 0.1843137255, green: 0.4784313725, blue: 0.7764705882, alpha: 1) } }
-    fileprivate class var defaultTintStroke: UIColor { get { return #colorLiteral(red: 0.1843137255, green: 0.4784313725, blue: 0.7764705882, alpha: 1) } }
-    fileprivate class var defaultPrimaryText: UIColor { get { return #colorLiteral(red: 45.0/255.0, green: 45.0/255.0, blue: 45.0/255.0, alpha: 1) } }
+    fileprivate class var defaultTint: UIColor { #colorLiteral(red: 0.1843137255, green: 0.4784313725, blue: 0.7764705882, alpha: 1) }
+    fileprivate class var defaultTintStroke: UIColor { #colorLiteral(red: 0.1843137255, green: 0.4784313725, blue: 0.7764705882, alpha: 1) }
+    fileprivate class var defaultPrimaryText: UIColor { #colorLiteral(red: 45.0/255.0, green: 45.0/255.0, blue: 45.0/255.0, alpha: 1) }
 }
 
 extension UIFont {
     // General styling
-    fileprivate class var defaultPrimaryText: UIFont { get { return UIFont.systemFont(ofSize: 26) } }
-    fileprivate class var defaultSecondaryText: UIFont { get { return UIFont.systemFont(ofSize: 16) } }
-    fileprivate class var defaultNavigationSymbolLayerFontNames: [String] { return ["DIN Pro Medium", "Noto Sans CJK JP Medium", "Arial Unicode MS Regular"] }
+    fileprivate class var defaultPrimaryText: UIFont { UIFont.systemFont(ofSize: 26) }
+    fileprivate class var defaultSecondaryText: UIFont { UIFont.systemFont(ofSize: 16) }
+    fileprivate class var defaultNavigationSymbolLayerFontNames: [String] { ["DIN Pro Medium", "Noto Sans CJK JP Medium", "Arial Unicode MS Regular"] }
 }
 
 /**

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -45,13 +45,13 @@ extension UIColor {
     class var routeDurationAnnotationTextColor: UIColor { get { return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) } }
     class var selectedRouteDurationAnnotationTextColor: UIColor { get { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) } }
     
-    class var roadShieldDefaultColor: UIColor { get { return .black } }
+    class var roadShieldDefaultColor: UIColor { get { return #colorLiteral(red: 0.11, green: 0.11, blue: 0.15, alpha: 1) } }
     class var roadShieldBlackColor: UIColor { get { return roadShieldDefaultColor } }
-    class var roadShieldBlueColor: UIColor { get { return .blue } }
-    class var roadShieldGreenColor: UIColor { get { return #colorLiteral(red: 0, green: 0.5, blue: 0, alpha: 1) } }
-    class var roadShieldRedColor: UIColor { get { return .red } }
-    class var roadShieldWhiteColor: UIColor { get { return .white } }
-    class var roadShieldYellowColor: UIColor { get { return .yellow } }
+    class var roadShieldBlueColor: UIColor { get { return #colorLiteral(red: 0.28, green: 0.36, blue: 0.8, alpha: 1) } }
+    class var roadShieldGreenColor: UIColor { get { return #colorLiteral(red: 0.1, green: 0.64, blue: 0.28, alpha: 1) } }
+    class var roadShieldRedColor: UIColor { get { return #colorLiteral(red: 0.95, green: 0.23, blue: 0.23, alpha: 1) } }
+    class var roadShieldWhiteColor: UIColor { get { return #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1) } }
+    class var roadShieldYellowColor: UIColor { get { return #colorLiteral(red: 1.0, green: 0.9, blue: 0.4, alpha: 1) } }
     class var roadShieldOrangeColor: UIColor { get { return #colorLiteral(red: 1, green: 0.65, blue: 0, alpha: 1) } }
 
 }

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -108,8 +108,16 @@ open class NightStyle: DayStyle {
         TimeRemainingLabel.appearance().normalTextColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         TimeRemainingLabel.appearance().trafficUnknownColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
         TopBannerView.appearance().backgroundColor = backgroundColor
-        WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
         StepsTableHeaderView.appearance().tintColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
         StepsTableHeaderView.appearance().normalTextColor = #colorLiteral(red: 0.9996390939, green: 1, blue: 0.9997561574, alpha: 1)
+        
+        WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
+        WayNameLabel.appearance().roadShieldBlackColor = #colorLiteral(red: 0.08, green: 0.09, blue: 0.12, alpha: 1)
+        WayNameLabel.appearance().roadShieldBlueColor = #colorLiteral(red: 0.18, green: 0.26, blue: 0.66, alpha: 1)
+        WayNameLabel.appearance().roadShieldGreenColor = #colorLiteral(red: 0.07, green: 0.51, blue: 0.22, alpha: 1)
+        WayNameLabel.appearance().roadShieldRedColor = #colorLiteral(red: 0.86, green: 0.06, blue: 0.06, alpha: 1)
+        WayNameLabel.appearance().roadShieldWhiteColor = #colorLiteral(red: 0.78, green: 0.78, blue: 0.78, alpha: 1)
+        WayNameLabel.appearance().roadShieldYellowColor = #colorLiteral(red: 1.0, green: 0.85, blue: 0.08, alpha: 1)
+        WayNameLabel.appearance().roadShieldDefaultColor = #colorLiteral(red: 0.08, green: 0.09, blue: 0.12, alpha: 1)
     }
 }


### PR DESCRIPTION
### Description
This pr is to align the road shield text color with the legacy shield color, and also to support the style change of the road shield in `WayNameView`.

### Implementation
Applied the legacy shield color for `Day` and `Night` style to the road shield text color, allow the color change in `WayNameView` when style changes. If no `styleManager` presented, use the `DayStyle` as default.

### Screenshots or Gifs
Day mode:
![WayNameViewDay](https://user-images.githubusercontent.com/48976398/157532090-679806ea-456e-485f-95bf-a458294be88e.png)

Night mode:
![WayNameViewNight](https://user-images.githubusercontent.com/48976398/157532115-4c1fbc45-a232-404a-9b75-a673b89a5084.png)

