### PR TITLE
Improve the arrival event to leg waypoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * MapboxNavigationNative now sends messages to the Unified Logging subsystem `com.mapbox` for easier filtering. ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
 * `HistoryRecording` static methods are deprecated in favor of instance methods. Using these instance variants on `RouteController` or `PassiveLocationManager` ensures correct history events recording and storing. ([#3791](https://github.com/mapbox/mapbox-navigation-ios/pull/3791))
 * Fixed a bug which caused `RouteOptions.profileIdentifier` to be ignored in active navigation. This may have caused elevated network usage. ([#3796](https://github.com/mapbox/mapbox-navigation-ios/pull/3796))
+* Added `RouteControllerDistanceForArrival` to provide custom distance threshold to anounce the arrival of the waypoint. During active navigation, when the remaining distance of current route leg is equal or smaller than the `RouteControllerDistanceForArrival`, the arrival event at current leg waypoint would be announced. ([#3780](https://github.com/mapbox/mapbox-navigation-ios/pull/3780))
 
 ## v2.3.0
 

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -41,6 +41,11 @@ public var RouteControllerMinimumDurationRemainingForProactiveRerouting: TimeInt
 public var RouteControllerProactiveReroutingInterval: TimeInterval = 120
 
 /**
+ The distance threshold to the current leg destination to anounce the arrival of the waypoint.
+ */
+public var RouteControllerDistanceForArrival: CLLocationDistance = 10
+
+/**
  Minimum number of consecutive incorrect course updates before rerouting occurs.
  */
 public var RouteControllerMinNumberOfInCorrectCourses: Int = 4

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -42,8 +42,10 @@ public var RouteControllerProactiveReroutingInterval: TimeInterval = 120
 
 /**
  The distance threshold to the current leg destination to anounce the arrival of the waypoint.
+ 
+ During active navigation, when the remaining distance of current route leg is equal or smaller than the `RouteControllerDistanceForArrival`, the arrival event at current leg waypoint would be announced.
  */
-public var RouteControllerDistanceForArrival: CLLocationDistance = 10
+public var RouteControllerDistanceForArrival: CLLocationDistance = 50
 
 /**
  Minimum number of consecutive incorrect course updates before rerouting occurs.

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -456,7 +456,7 @@ open class RouteController: NSObject {
         // We are at least at the "You will arrive" instruction
         if legProgress.remainingSteps.count <= 2 && remainingVoiceInstructions.count <= 2 {
             let willArrive = status.routeState == .tracking
-            let didArrive = status.routeState == .complete && currentDestination != previousArrivalWaypoint
+            let didArrive = status.routeState == .complete && currentDestination != previousArrivalWaypoint && legProgress.distanceRemaining <= RouteControllerDistanceForArrival
             
             if willArrive {
                 delegate?.router(self, willArriveAt: currentDestination, after: legProgress.durationRemaining, distance: legProgress.distanceRemaining)

--- a/Sources/TestHelper/Fixture.swift
+++ b/Sources/TestHelper/Fixture.swift
@@ -159,6 +159,11 @@ public class Fixture: NSObject {
             locationManager.tick()
         }
         
+        // Include the last coodinate to the locationManager update to complete the final step of route.
+        if let lastCoordinate = route.shape?.coordinates.last {
+            locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [CLLocation(coordinate: lastCoordinate)])
+        }
+        
         return traceCollector.locations
     }
     

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -60,6 +60,7 @@ class NavigationServiceTests: TestCase {
 
         directionsClientSpy.reset()
         delegate.reset()
+        RouteControllerDistanceForArrival = 75
     }
     
     override func tearDown() {
@@ -642,6 +643,7 @@ class NavigationServiceTests: TestCase {
     }
 
     func testMultiLegRoute() {
+        RouteControllerDistanceForArrival = 10
         let route = Fixture.route(from: "multileg-route", options: routeOptions)
         let trace = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
         let locationManager = ReplayLocationManager(locations: trace)
@@ -669,7 +671,9 @@ class NavigationServiceTests: TestCase {
         }
         wait(for: [routeUpdated], timeout: 5)
         locationManager.onTick = { index, _ in
-            if index < 32 {
+            // By decreasing the RouteControllerDistanceForArrival, more locations will be included into the first leg
+            // when the distance to the current leg destination is larger than the threshold.
+            if index < 43 {
                 XCTAssertEqual(routeController.routeProgress.legIndex,0)
             } else {
                 XCTAssertEqual(routeController.routeProgress.legIndex, 1)


### PR DESCRIPTION
### Description
This pr is to improve the arrival event. Right now the distance to the route leg destination to announce the arrival event is long. It would cause the arrival feedback window pops too early to cover the user location indicator and the route line. And in multi-leg route, it would also result in the arrival event of the current leg triggers too early, as far as 75 meters from the current leg destination.

### Implementation
Added the public `RouteControllerDistanceForArrival` as the distance threshold for the route leg remanning distance  of current route. When the current route leg remanning distance equal or smaller than the `RouteControllerDistanceForArrival`, the `didArriveAt` event would be announced. It would make the arrival event more precise than the `complete` route status.

### Screenshots or Gifs
