### PR TITLE
Use current location for route refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## Next
+
+* Fixed an issue where after a route was refreshed the vanishing route line would be incorrectly drawn. ([#3781](https://github.com/mapbox/mapbox-navigation-ios/pull/3781))
+
 ## v2.3.0
 
 The v2.2.0 release notes [clarified](https://github.com/mapbox/mapbox-navigation-ios/pull/3652) that is an error to have more than one instance of `NavigationViewController`, `NavigationService`, or `RouteController` running simultaneously. Now you will receive a log message at the fault level helping you to spot the issue. To pause the debugger when the SDK detect the problematic situation, enable the “All Runtime Issues” breakpoint in Xcode. Learn more about breakpoints in [Xcode documentation](https://developer.apple.com/documentation/xcode/setting-breakpoints-to-pause-your-running-app). ([#3740](https://github.com/mapbox/mapbox-navigation-ios/pull/3740))

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -246,7 +246,7 @@ extension InternalRouter where Self: Router {
                 return
             }
             
-            self.routeProgress.refreshRoute(with: currentRoute, at: location)
+            self.routeProgress.refreshRoute(with: currentRoute, at: self.location ?? location)
             
             var userInfo = [RouteController.NotificationUserInfoKey: Any]()
             userInfo[.routeProgressKey] = self.routeProgress


### PR DESCRIPTION
Making a refresh route API call can take some time and by the time it
completes the location won't be relevant anymore. It produces a an
incorrect distance traveled calculation.