### PR TITLE
Fix ImageDownloader memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## Next 
+
+* Fixed an issue that caused `ImageDownloader` to leak. ([#3782](https://github.com/mapbox/mapbox-navigation-ios/pull/3782))
+
 ## v2.3.0
 
 The v2.2.0 release notes [clarified](https://github.com/mapbox/mapbox-navigation-ios/pull/3652) that is an error to have more than one instance of `NavigationViewController`, `NavigationService`, or `RouteController` running simultaneously. Now you will receive a log message at the fault level helping you to spot the issue. To pause the debugger when the SDK detect the problematic situation, enable the “All Runtime Issues” breakpoint in Xcode. Learn more about breakpoints in [Xcode documentation](https://developer.apple.com/documentation/xcode/setting-breakpoints-to-pause-your-running-app). ([#3740](https://github.com/mapbox/mapbox-navigation-ios/pull/3740))

--- a/Sources/MapboxNavigation/URLSessionDelegateProxy.swift
+++ b/Sources/MapboxNavigation/URLSessionDelegateProxy.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+final class URLSessionDelegateProxy: NSObject, URLSessionDataDelegate {
+    weak var delegate: URLSessionDataDelegate?
+
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        delegate?.urlSession?(session, dataTask: dataTask, didReceive: response, completionHandler: completionHandler)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        delegate?.urlSession?(session, dataTask: dataTask, didReceive: data)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        delegate?.urlSession?(session, task: task, didCompleteWithError: error)
+    }
+}


### PR DESCRIPTION
URLSession strongly retains its delegate.
In order to break the retain cycle, we proxy delegate calls through
URLSessionDelegateProxy.