### PR TITLE
Stop previewing when swipe to current banner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Deprecated the optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method. All views appearance will be refreshed based on `StyleManager`. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
 * Fixed an issue where the map’s floating buttons are misaligned with its attribution button and sometimes untappable after rotating the device during turn-by-turn navigation. ([#3776](https://github.com/mapbox/mapbox-navigation-ios/pull/3776))
 
+### Visual instructions
+
+* Fixed an issue where the top instruction banner couldn't be swiped back to the current one. ([#3785](https://github.com/mapbox/mapbox-navigation-ios/pull/3785))
+
 ### Other changes
 
 * Fixed an issue where the route line appeared to begin away from the user’s current location after the route was refreshed. ([#3781](https://github.com/mapbox/mapbox-navigation-ios/pull/3781))

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -26,7 +26,7 @@ class CustomViewController: UIViewController {
     var previewStepIndex: Int?
     
     // View that is placed over the instructions banner while we are previewing
-    var previewInstructionsView: StepInstructionsView?
+    var previewInstructionsView: InstructionsBannerView?
     
     @IBOutlet var navigationMapView: NavigationMapView!
     @IBOutlet weak var cancelButton: UIButton!
@@ -223,10 +223,9 @@ class CustomViewController: UIViewController {
         guard let instructions = step.instructionsDisplayedAlongStep?.last else { return }
         
         // create a StepInstructionsView and display that over the current instructions banner
-        let previewInstructionsView = StepInstructionsView(frame: instructionsBannerView.frame)
+        let previewInstructionsView = InstructionsBannerView(frame: instructionsBannerView.frame)
         previewInstructionsView.delegate = self
         previewInstructionsView.swipeable = true
-        previewInstructionsView.backgroundColor = instructionsBannerView.backgroundColor
         view.addSubview(previewInstructionsView)
         
         // update instructions banner to show all information about this step

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -26,7 +26,7 @@ class CustomViewController: UIViewController {
     var previewStepIndex: Int?
     
     // View that is placed over the instructions banner while we are previewing
-    var previewInstructionsView: InstructionsBannerView?
+    var previewBannerView: InstructionsBannerView?
     
     @IBOutlet var navigationMapView: NavigationMapView!
     @IBOutlet weak var cancelButton: UIButton!
@@ -115,7 +115,7 @@ class CustomViewController: UIViewController {
     // Notifications sent on all location updates
     @objc func progressDidChange(_ notification: NSNotification) {
         // do not update if we are previewing instruction steps
-        guard previewInstructionsView == nil,
+        guard previewBannerView == nil,
               let routeProgress = notification.userInfo?[RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress,
               let location = notification.userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation else { return }
         
@@ -223,27 +223,27 @@ class CustomViewController: UIViewController {
         guard let instructions = step.instructionsDisplayedAlongStep?.last else { return }
         
         // create a StepInstructionsView and display that over the current instructions banner
-        let previewInstructionsView = InstructionsBannerView(frame: instructionsBannerView.frame)
-        previewInstructionsView.delegate = self
-        previewInstructionsView.swipeable = true
-        view.addSubview(previewInstructionsView)
+        let previewBannerView = InstructionsBannerView(frame: instructionsBannerView.frame)
+        previewBannerView.delegate = self
+        previewBannerView.swipeable = true
+        view.addSubview(previewBannerView)
         
         // update instructions banner to show all information about this step
-        previewInstructionsView.updateDistance(for: RouteStepProgress(step: step))
-        previewInstructionsView.update(for: instructions)
+        previewBannerView.updateDistance(for: RouteStepProgress(step: step))
+        previewBannerView.update(for: instructions)
         
-        self.previewInstructionsView = previewInstructionsView
+        self.previewBannerView = previewBannerView
     }
     
     func removePreviewInstruction() {
-        guard let view = previewInstructionsView else { return }
+        guard let view = previewBannerView else { return }
         view.removeFromSuperview()
         
         // reclaim the delegate, from the preview banner
         instructionsBannerView.delegate = self
         
         // nil out both the view and index
-        previewInstructionsView = nil
+        previewBannerView = nil
         previewStepIndex = nil
     }
 }

--- a/Sources/MapboxNavigation/InstructionsCardViewController.swift
+++ b/Sources/MapboxNavigation/InstructionsCardViewController.swift
@@ -189,25 +189,35 @@ open class InstructionsCardViewController: UIViewController {
             instructionCollectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ]
         
-        // Device is in landscape mode and notch (if present) is located on the left side.
-        if UIApplication.shared.statusBarOrientation == .landscapeRight {
-            if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-                // Language with right-to-left interface layout is used.
-                instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor,
-                                                                                                              constant: 10.0))
+        switch traitCollection.verticalSizeClass {
+        case .unspecified:
+            fallthrough
+        case .regular:
+            instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                                                                          constant: 10.0))
+        case .compact:
+            // Device is in landscape mode and notch (if present) is located on the left side.
+            if UIApplication.shared.statusBarOrientation == .landscapeRight {
+                if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+                    // Language with right-to-left interface layout is used.
+                    instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                                                                                  constant: 10.0))
+                } else {
+                    // Language with left-to-right interface layout is used.
+                    instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor,
+                                                                                                                  constant: 10.0))
+                }
             } else {
-                // Language with left-to-right interface layout is used.
-                instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor,
-                                                                                                              constant: 10.0))
+                if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+                    instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor,
+                                                                                                                  constant: 10.0))
+                } else {
+                    instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                                                                                  constant: 10.0))
+                }
             }
-        } else {
-            if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-                instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor,
-                                                                                                              constant: 10.0))
-            } else {
-                instructionCollectionViewContraints.append(instructionCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor,
-                                                                                                              constant: 10.0))
-            }
+        @unknown default:
+            break
         }
         
         NSLayoutConstraint.activate(instructionCollectionViewContraints)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -1057,7 +1057,11 @@ extension NavigationViewController: TopBannerViewControllerDelegate {
                 guard let currentStepIndex = banner.currentPreviewStep?.1 else { return }
                 let remainingSteps = progress.remainingSteps
                 let prevStepIndex = currentStepIndex.advanced(by: -1)
-                guard prevStepIndex >= 0 else { return }
+                guard prevStepIndex >= 0 else {
+                    banner.stopPreviewing()
+                    cameraController?.recenter(self)
+                    return
+                }
                 
                 let prevStep = remainingSteps[prevStepIndex]
                 preview(step: prevStep, in: banner, remaining: remainingSteps, route: route)

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -170,7 +170,7 @@ open class TopBannerViewController: UIViewController {
     private(set) var previewSteps: [RouteStep]?
     private(set) var currentPreviewStep: (RouteStep, Int)?
     
-    private(set) var previewInstructionsView: StepInstructionsView?
+    private(set) var previewInstructionsView: InstructionsBannerView?
     
     public func preview(step stepOverride: RouteStep? = nil, maneuverStep: RouteStep, distance: CLLocationDistance, steps: [RouteStep], completion: CompletionHandler? = nil) {
         guard !steps.isEmpty, let step = stepOverride ?? steps.first, let index = steps.firstIndex(of: step) else {
@@ -184,7 +184,7 @@ open class TopBannerViewController: UIViewController {
         
         guard let instructions = step.instructionsDisplayedAlongStep?.last else { return }
         
-        let instructionsView = StepInstructionsView(frame: instructionsBannerView.frame)
+        let instructionsView = InstructionsBannerView(frame: instructionsBannerView.frame)
         instructionsView.heightAnchor.constraint(equalToConstant: instructionsBannerHeight).isActive = true
         
         instructionsView.delegate = self

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -164,13 +164,13 @@ open class TopBannerViewController: UIViewController {
     // MARK: Previewing Steps
     
     public var isDisplayingPreviewInstructions: Bool {
-        return previewInstructionsView != nil
+        return previewBannerView != nil
     }
     
     private(set) var previewSteps: [RouteStep]?
     private(set) var currentPreviewStep: (RouteStep, Int)?
     
-    private(set) var previewInstructionsView: InstructionsBannerView?
+    private(set) var previewBannerView: InstructionsBannerView?
     
     public func preview(step stepOverride: RouteStep? = nil, maneuverStep: RouteStep, distance: CLLocationDistance, steps: [RouteStep], completion: CompletionHandler? = nil) {
         guard !steps.isEmpty, let step = stepOverride ?? steps.first, let index = steps.firstIndex(of: step) else {
@@ -194,13 +194,13 @@ open class TopBannerViewController: UIViewController {
         instructionsBannerView.removeFromSuperview()
         informationStackView.insertArrangedSubview(instructionsView, at: 0)
         instructionsView.update(for: instructions)
-        previewInstructionsView = instructionsView
+        previewBannerView = instructionsView
         
         hideSecondaryChildren(completion: completion)
     }
     
     public func stopPreviewing(showingSecondaryChildren: Bool = true) {
-        guard let view = previewInstructionsView else {
+        guard let view = previewBannerView else {
             return
         }
         
@@ -210,7 +210,7 @@ open class TopBannerViewController: UIViewController {
         informationStackView.removeArrangedSubview(view)
         view.removeFromSuperview()
         addInstructionsBanner()
-        previewInstructionsView = nil
+        previewBannerView = nil
         
         if showingSecondaryChildren {
             showSecondaryChildren()


### PR DESCRIPTION
### Description
This PR is to
- [x] fixed #3784 to allow the top banner could swipe to current step by stop previewing and recenter the map. 
- [x] fixed the preview instruction color un-match with the top banner in Night Style. 
- [x] fixed the broken layout constraints broken of instruction cards.

### Implementation
The `TopBannerViewController.previewInstructionsView` should conforms to `InstructionsBannerView` to match the color with top banner. And when in previewing mode and user swipe back to current step, stop previewing mode and recenter map.

### Screenshots or Gifs
![nightSwipeBanner](https://user-images.githubusercontent.com/48976398/157997279-4673d03c-b623-4193-acf7-92c5c4970388.gif)

