### PR TITLE
Change default datasetProfileIdentifier in Navigator to match other defaults

### DIFF
--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -86,7 +86,7 @@ class Navigator {
      This property can only be modified before creating `Navigator` shared instance, all
      further changes to this property will have no effect. Defaults to `automobile`.
      */
-    static var datasetProfileIdentifier: ProfileIdentifier = .automobile
+    static var datasetProfileIdentifier: ProfileIdentifier = .automobileAvoidingTraffic
     
     /**
      Restrict direct initializer access.

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -84,7 +84,7 @@ class Navigator {
      Profile setting, used for selecting tiles type for navigation.
      
      This property can only be modified before creating `Navigator` shared instance, all
-     further changes to this property will have no effect. Defaults to `automobile`.
+     further changes to this property will have no effect. Defaults to `automobileAvoidingTraffic`.
      */
     static var datasetProfileIdentifier: ProfileIdentifier = .automobileAvoidingTraffic
     

--- a/Sources/MapboxCoreNavigation/TilesetDescriptorFactory.swift
+++ b/Sources/MapboxCoreNavigation/TilesetDescriptorFactory.swift
@@ -14,7 +14,7 @@ extension TilesetDescriptorFactory {
      */
     public class func getSpecificVersion(version: String,
                                          completionQueue: DispatchQueue = .main,
-                                         datasetProfileIdentifier: ProfileIdentifier = .automobile,
+                                         datasetProfileIdentifier: ProfileIdentifier = .automobileAvoidingTraffic,
                                          completion: @escaping (TilesetDescriptor) -> Void) {
         let factory = NativeHandlersFactory(tileStorePath: NavigationSettings.shared.tileStoreConfiguration.navigatorLocation.tileStoreURL?.path ?? "",
                                             credentials: NavigationSettings.shared.directions.credentials,
@@ -35,7 +35,7 @@ extension TilesetDescriptorFactory {
        - completion: A completion that will be used to pass the latest tileset descriptor.
      */
     public class func getLatest(completionQueue: DispatchQueue = .main,
-                                datasetProfileIdentifier: ProfileIdentifier = .automobile,
+                                datasetProfileIdentifier: ProfileIdentifier = .automobileAvoidingTraffic,
                                 completion: @escaping (_ latestTilesetDescriptor: TilesetDescriptor) -> Void) {
         let factory = NativeHandlersFactory(tileStorePath: NavigationSettings.shared.tileStoreConfiguration.navigatorLocation.tileStoreURL?.path ?? "",
                                             credentials: NavigationSettings.shared.directions.credentials,


### PR DESCRIPTION
Otherwise, there will be two cache handles in our Example app:
- for driving profile
- for driving-avoiding-traffic profile.

Navigation SDK uses automobileAvoidingTraffic in most places. 