### PR TITLE
make viewportpadding public

### DIFF
--- a/Sources/MapboxNavigation/NavigationViewportDataSource.swift
+++ b/Sources/MapboxNavigation/NavigationViewportDataSource.swift
@@ -47,7 +47,7 @@ public class NavigationViewportDataSource: ViewportDataSource {
     /**
      Value of default viewport padding.
      */
-    var viewportPadding: UIEdgeInsets = .zero
+    public var viewportPadding: UIEdgeInsets = .zero
     
     weak var mapView: MapView?
     


### PR DESCRIPTION
We use the NavigationViewportDataSource but this value is not public even if it's part of how the camera will behave.
It seems a lot of public classes do not provide the necessary value visibility....