### PR TITLE
Improve `SpriteRepository` update under poor network connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Deprecated the optional `StyleManagerDelegate.styleManager(_:viewForApplying:)` method. All views appearance will be refreshed based on `StyleManager`. ([#3764](https://github.com/mapbox/mapbox-navigation-ios/pull/3764))
 * Fixed an issue where the map’s floating buttons are misaligned with its attribution button and sometimes untappable after rotating the device during turn-by-turn navigation. ([#3776](https://github.com/mapbox/mapbox-navigation-ios/pull/3776))
 * Fixed an issue where the top instruction banner couldn't be swiped back to the current one. ([#3785](https://github.com/mapbox/mapbox-navigation-ios/pull/3785))
+* Fixed an issue where the road name label shows wrong shield image when applying custom style under poor network connection. ([#3792](https://github.com/mapbox/mapbox-navigation-ios/pull/3792))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/SpriteInfoCache.swift
+++ b/Sources/MapboxNavigation/SpriteInfoCache.swift
@@ -34,9 +34,9 @@ class SpriteInfoCache {
      - returns: `true` if the data was successful parsed to SpriteInfo Dictionary and saved in the memory.
      */
     @discardableResult
-    func store(_ data: Data) -> Bool {
+    func store(_ data: Data, spriteKey: String) -> Bool {
         guard let spriteInfoDictionary = parseSpriteInfo(data: data) else { return false }
-        spriteInfoDictionary.forEach({ storeDataInMemoryCache($0.value, forKey: $0.key) })
+        spriteInfoDictionary.forEach({ storeDataInMemoryCache($0.value, forKey: $0.key + "-\(spriteKey)") })
         return true
     }
 

--- a/Sources/MapboxNavigation/SpriteRepository.swift
+++ b/Sources/MapboxNavigation/SpriteRepository.swift
@@ -174,7 +174,7 @@ class SpriteRepository {
         guard let styleID = styleURI.rawValue.components(separatedBy: "styles")[safe: 1] else { return nil }
         let spriteKey = "\(styleID)-\(shield.baseURL.absoluteString)"
 
-        let iconLeght = (shield.text.count < 2 ) ? 2 : shield.text.count
+        let iconLeght = max(shield.text.count, 2)
         let shieldKey = shield.name + "-\(iconLeght)" + "-\(spriteKey)"
         
         // Retrieve the single shield icon if it has been cached.

--- a/Sources/MapboxNavigation/SpriteRepository.swift
+++ b/Sources/MapboxNavigation/SpriteRepository.swift
@@ -4,7 +4,11 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 class SpriteRepository {
-    let imageCache = ImageCache()
+    // Caching the Sprite and single shield icon images.
+    let spriteCache = ImageCache()
+    // Caching the single legacy shield icon images.
+    let legacyCache = ImageCache()
+    // Caching the metadata info for Sprite.
     let infoCache =  SpriteInfoCache()
     var styleURI: StyleURI = .navigationDay
     var baseURL: URL = URL(string: "https://api.mapbox.com/styles/v1")!
@@ -15,41 +19,94 @@ class SpriteRepository {
             imageDownloader = ImageDownloader(sessionConfiguration: sessionConfiguration)
         }
     }
+    
+    func updateStyle(styleURI: StyleURI,
+                     representation: VisualInstruction.Component.ImageRepresentation? = nil,
+                     completion: @escaping CompletionHandler) {
+        guard styleURI != self.styleURI else {
+            completion()
+            return
+        }
+        
+        // Reset the default styleURI when style changes without valid ImageRepresentation.
+        guard let baseURL = representation?.shield?.baseURL else {
+            self.styleURI = styleURI
+            completion()
+            return
+        }
+        
+        // Reset Sprite cache when style changes with valid ImageRepresentation.
+        updateSprite(styleURI: styleURI, baseURL: baseURL, completion: completion)
+    }
 
-    func updateRepository(styleURI: StyleURI? = nil, representation: VisualInstruction.Component.ImageRepresentation? = nil, completion: @escaping CompletionHandler) {
+    func updateRepresentation(representation: VisualInstruction.Component.ImageRepresentation? = nil, completion: @escaping CompletionHandler) {
         let dispatchGroup = DispatchGroup()
 
-        // Reset cache and download the Sprite image and Sprite info only when the map style changes or the shield baseURL changes.
-        if (styleURI != self.styleURI) || (representation?.shield?.baseURL != self.baseURL) {
-            resetCache()
-            let styleURI = styleURI ?? self.styleURI
-            let baseURL = representation?.shield?.baseURL ?? self.baseURL
-            
-            if let styleID = styleURI.rawValue.components(separatedBy: "styles")[safe: 1],
-               let infoRequestURL = spriteURL(isImage: false, baseURL: baseURL, styleID: styleID),
-               let spriteRequestURL = spriteURL(isImage: true, baseURL: baseURL, styleID: styleID) {
-                
-                dispatchGroup.enter()
-                downloadInfo(infoRequestURL) { (_) in
-                    dispatchGroup.leave()
-                }
-                
-                dispatchGroup.enter()
-                downloadSprite(spriteRequestURL) { (_) in
-                    self.styleURI = styleURI
-                    self.baseURL = baseURL
-                    dispatchGroup.leave()
-                }
+        // Reset Sprite cache when the baseURL changes or no valid Sprite image cached.
+        let baseURL = representation?.shield?.baseURL ?? self.baseURL
+        if baseURL != self.baseURL || (getSpriteImage() == nil) {
+            dispatchGroup.enter()
+            updateSprite(styleURI: self.styleURI, baseURL: baseURL) {
+                dispatchGroup.leave()
             }
         }
         
         dispatchGroup.enter()
-        downloadLegacyShield(representation: representation) { (_) in
+        updateLegacy(representation: representation) {
             dispatchGroup.leave()
         }
         
         dispatchGroup.notify(queue: .main) {
             completion()
+        }
+    }
+    
+    func updateSprite(styleURI: StyleURI, baseURL: URL, completion: @escaping CompletionHandler) {
+        spriteCache.clearMemory()
+        infoCache.clearMemory()
+        
+        // Update the styleURI and baseURL just after the Sprite memory reset. When the connection is poor, the next round of style update
+        // or the representation update could use the correct ones.
+        self.styleURI = styleURI
+        self.baseURL = baseURL
+        
+        guard let styleID = styleURI.rawValue.components(separatedBy: "styles")[safe: 1],
+              let infoRequestURL = spriteURL(isImage: false, baseURL: baseURL, styleID: styleID),
+              let spriteRequestURL = spriteURL(isImage: true, baseURL: baseURL, styleID: styleID) else {
+                  completion()
+                  return
+              }
+        
+        let spriteKey = "\(styleID)-\(baseURL.absoluteString)"
+        let dispatchGroup = DispatchGroup()
+        
+        dispatchGroup.enter()
+        downloadInfo(infoRequestURL, spriteKey: spriteKey) { (_) in
+            dispatchGroup.leave()
+        }
+        
+        dispatchGroup.enter()
+        downloadSprite(spriteRequestURL, spriteKey: spriteKey) { (_) in
+            dispatchGroup.leave()
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            completion()
+        }
+    }
+    
+    func updateLegacy(representation: VisualInstruction.Component.ImageRepresentation? = nil, completion: @escaping CompletionHandler) {
+        guard let cacheKey = representation?.legacyCacheKey else {
+            completion()
+            return
+        }
+        
+        if let _ = legacyCache.image(forKey: cacheKey) {
+            completion()
+        } else {
+            downloadLegacyShield(representation: representation) { (_) in
+                completion()
+            }
         }
     }
     
@@ -64,14 +121,14 @@ class SpriteRepository {
         return urlComponent.url
     }
     
-    func downloadInfo(_ infoURL: URL, completion: @escaping (Data?) -> Void) {
+    func downloadInfo(_ infoURL: URL, spriteKey: String, completion: @escaping (Data?) -> Void) {
         let _ = imageDownloader.downloadImage(with: infoURL, completion: { [weak self] (_, data, error)  in
             guard let strongSelf = self, let data = data else {
                 completion(nil)
                 return
             }
 
-            guard strongSelf.infoCache.store(data) else {
+            guard strongSelf.infoCache.store(data, spriteKey: spriteKey) else {
                 completion(nil)
                 return
             }
@@ -80,24 +137,25 @@ class SpriteRepository {
         })
     }
     
-    func downloadSprite(_ spriteURL: URL, completion: @escaping (UIImage?) -> Void) {
+    func downloadSprite(_ spriteURL: URL, spriteKey: String, completion: @escaping (UIImage?) -> Void) {
         let _ = imageDownloader.downloadImage(with: spriteURL, completion: { [weak self] (image, data, error) in
             guard let strongSelf = self, let image = image else {
                 completion(nil)
                 return
             }
 
-            strongSelf.imageCache.store(image, forKey: "Sprite", toDisk: false, completion: {
+            strongSelf.spriteCache.store(image, forKey: spriteKey, toDisk: false, completion: {
                 completion(image)
             })
         })
     }
     
     func downloadLegacyShield(representation: VisualInstruction.Component.ImageRepresentation? = nil, completion: @escaping (UIImage?) -> Void) {
-        guard let legacyURL = representation?.imageURL(scale: VisualInstruction.Component.scale, format: .png) else {
-            completion(nil)
-            return
-        }
+        guard let legacyURL = representation?.imageURL(scale: VisualInstruction.Component.scale, format: .png),
+              let cacheKey = representation?.legacyCacheKey else {
+                  completion(nil)
+                  return
+              }
         
         let _ = imageDownloader.downloadImage(with: legacyURL, completion: { [weak self] (image, data, error) in
             guard let strongSelf = self, let image = image else {
@@ -105,30 +163,34 @@ class SpriteRepository {
                 return
             }
 
-            strongSelf.imageCache.store(image, forKey: "Legacy", toDisk: false, completion: {
+            strongSelf.legacyCache.store(image, forKey: cacheKey, toDisk: false, completion: {
                 completion(image)
             })
         })
     }
     
-    func getShield(displayRef: String, name: String) -> UIImage? {
-        let iconLeght = (displayRef.count < 2 ) ? 2 : displayRef.count
-        let infoName = name + "-\(iconLeght)"
+    func getShieldIcon(shield: VisualInstruction.Component.ShieldRepresentation) -> UIImage? {
+        // Use the styleURI and baseURL of current repository for spriteKey.
+        guard let styleID = styleURI.rawValue.components(separatedBy: "styles")[safe: 1] else { return nil }
+        let spriteKey = "\(styleID)-\(shield.baseURL.absoluteString)"
+
+        let iconLeght = (shield.text.count < 2 ) ? 2 : shield.text.count
+        let shieldKey = shield.name + "-\(iconLeght)" + "-\(spriteKey)"
         
         // Retrieve the single shield icon if it has been cached.
-        if let shieldIcon = imageCache.image(forKey: infoName) {
+        if let shieldIcon = spriteCache.image(forKey: shieldKey) {
             return shieldIcon
         }
         
-        guard let spriteImage = imageCache.image(forKey: "Sprite"),
-              let spriteInfo = infoCache.spriteInfo(forKey: infoName) else { return nil }
+        guard let spriteImage = spriteCache.image(forKey: spriteKey),
+              let spriteInfo = infoCache.spriteInfo(forKey: shieldKey) else { return nil }
         
         let shieldRect = CGRect(x: spriteInfo.x, y: spriteInfo.y, width: spriteInfo.width, height: spriteInfo.height)
         if let croppedCGIImage = spriteImage.cgImage?.cropping(to: shieldRect) {
             
             // Cache the single shield icon if it hasn't been stored.
             let shieldIcon = UIImage(cgImage: croppedCGIImage)
-            imageCache.store(shieldIcon, forKey: infoName, toDisk: false, completion: nil)
+            spriteCache.store(shieldIcon, forKey: shieldKey, toDisk: false, completion: nil)
             
             return UIImage(cgImage: croppedCGIImage)
         }
@@ -136,13 +198,21 @@ class SpriteRepository {
         return nil
     }
     
-    func getLegacyShield() -> UIImage? {
-        return imageCache.image(forKey: "Legacy")
+    func getLegacyShield(with cacheKey: String?) -> UIImage? {
+        return legacyCache.image(forKey: cacheKey)
+    }
+    
+    func getSpriteImage() -> UIImage? {
+        // Use the styleURI and baseURL of current repository to retrieve Sprite image.
+        guard let styleID = styleURI.rawValue.components(separatedBy: "styles")[safe: 1] else { return nil }
+        let spriteKey = "\(styleID)-\(baseURL.absoluteString)"
+        return spriteCache.image(forKey: spriteKey)
     }
     
     func resetCache() {
-        imageCache.clearMemory()
+        spriteCache.clearMemory()
         infoCache.clearMemory()
+        legacyCache.clearMemory()
     }
 
 }

--- a/Sources/MapboxNavigation/VisualInstructionComponent.swift
+++ b/Sources/MapboxNavigation/VisualInstructionComponent.swift
@@ -10,16 +10,19 @@ extension VisualInstruction.Component {
             let exitCode = representation.text
             return "exit-" + exitCode + "-\(VisualInstruction.Component.scale)"
         case let .image(imageRepresentation, alternativeText):
-            guard let imageURL = imageRepresentation.imageBaseURL else {
-                return "generic-" + alternativeText.text
-            }
-            
-            return "\(imageURL.absoluteString)-\(VisualInstruction.Component.scale)"
+            return imageRepresentation.legacyCacheKey ?? "generic-" + alternativeText.text
         case .text, .delimiter, .lane:
             return nil
         case .guidanceView(let guidanceViewRepresentation, _):
             guard let imageURL = guidanceViewRepresentation.imageURL else { return nil }
             return "guidance-" + imageURL.absoluteString
         }
+    }
+}
+
+extension VisualInstruction.Component.ImageRepresentation {
+    var legacyCacheKey: String? {
+        guard let key = imageBaseURL?.absoluteString else { return nil }
+        return "\(key)-\(VisualInstruction.Component.scale)"
     }
 }

--- a/Sources/MapboxNavigation/WayNameView.swift
+++ b/Sources/MapboxNavigation/WayNameView.swift
@@ -24,7 +24,7 @@ open class WayNameLabel: StylableLabel {
     // When the map style changes, update the sprite repository and the label.
     func updateStyle(styleURI: StyleURI?) {
         guard let styleURI = styleURI else { return }
-        spriteRepository.updateRepository(styleURI: styleURI, representation: representation) { [weak self] in
+        spriteRepository.updateStyle(styleURI: styleURI, representation: representation) { [weak self] in
             guard let self = self else { return }
             if let roadName = self.text {
                 self.setUpWith(roadName: roadName)
@@ -35,13 +35,12 @@ open class WayNameLabel: StylableLabel {
     func updateRoad(roadName: String, representation: VisualInstruction.Component.ImageRepresentation? = nil) {
         // When the imageRepresentation of road shield changes, update the sprite repository and the label.
         if representation != self.representation {
-            spriteRepository.updateRepository(representation: representation) { [weak self] in
+            spriteRepository.updateRepresentation(representation: representation) { [weak self] in
                 guard let self = self else { return }
                 self.representation = representation
                 self.setUpWith(roadName: roadName)
             }
         }
-        self.representation = representation
         setUpWith(roadName: roadName)
     }
     
@@ -52,14 +51,13 @@ open class WayNameLabel: StylableLabel {
             // For `us-state` shield, use the legacy shield first, then fall back to use the generic shield icon.
             // For non `us-state` shield, use the generic shield icon first, then fall back to use the legacy shield.
             if shield.name == "us-state",
-               setAttributedText(roadName: roadName) {
+               setAttributedText(roadName: roadName, cacheKey: representation?.legacyCacheKey) {
                 return
             } else if setAttributedText(roadName: roadName, shield: shield) {
                 return
             }
         }
-        
-        if setAttributedText(roadName: roadName) {
+        if setAttributedText(roadName: roadName, cacheKey: representation?.legacyCacheKey) {
             return
         }
         
@@ -73,8 +71,8 @@ open class WayNameLabel: StylableLabel {
      - returns: `true` if operation was successful, `false` otherwise.
      */
     @discardableResult
-    private func setAttributedText(roadName: String) -> Bool {
-        guard let shieldIcon = spriteRepository.getLegacyShield() else { return false }
+    private func setAttributedText(roadName: String, cacheKey: String?) -> Bool {
+        guard let shieldIcon = spriteRepository.getLegacyShield(with: cacheKey) else { return false }
         var currentShieldName: NSAttributedString?, currentRoadName: String?
         var didSetup = false
 
@@ -108,7 +106,7 @@ open class WayNameLabel: StylableLabel {
      */
     @discardableResult
     private func setAttributedText(roadName: String, shield: VisualInstruction.Component.ShieldRepresentation) -> Bool {
-        guard let shieldIcon = spriteRepository.getShield(displayRef: shield.text, name: shield.name) else { return false }
+        guard let shieldIcon = spriteRepository.getShieldIcon(shield: shield) else { return false }
 
         var currentShieldName: NSAttributedString?, currentRoadName: String?
         var didSetup = false

--- a/Tests/MapboxNavigationTests/SpriteInfoCacheTests.swift
+++ b/Tests/MapboxNavigationTests/SpriteInfoCacheTests.swift
@@ -4,6 +4,8 @@ import TestHelper
 
 class SpriteInfoCacheTests: TestCase {
     let cache: SpriteInfoCache = SpriteInfoCache()
+    let spriteKey = "SpriteKey"
+    var dataKey = "default-3"
 
     override func setUp() {
         super.setUp()
@@ -12,11 +14,11 @@ class SpriteInfoCacheTests: TestCase {
         cache.clearMemory()
     }
 
-    let dataKey = "default-3"
-
     func storeData() {
         let data = Fixture.JSONFromFileNamed(name: "sprite-info")
-        cache.store(data)
+        cache.store(data, spriteKey: spriteKey)
+        // The cached Sprite info object attaches spriteKey to its key.
+        dataKey += "-\(spriteKey)"
     }
 
     func testStoringAndRetrievingData() {

--- a/Tests/MapboxNavigationTests/WayNameViewTests.swift
+++ b/Tests/MapboxNavigationTests/WayNameViewTests.swift
@@ -114,7 +114,7 @@ class WayNameViewTests: TestCase {
 }
 
 class SpriteRepositoryStub: SpriteRepository {    
-    override func getShield(displayRef: String, name: String) -> UIImage? {
-        return displayRef == "280" ? ShieldImage.shield.image : nil
+    override func getShieldIcon(shield: VisualInstruction.Component.ShieldRepresentation) -> UIImage? {
+        return shield.text == "280" ? ShieldImage.shield.image : nil
     }
 }


### PR DESCRIPTION
### Description
This Pr is to improve the functionality for the `SpriteRepository` under poor network connection.

### Implementation
- [x] Separate the legacy shield icon cache with the Sprite cache. When `style` change or the road shield `baseURL`, we only reset the cache of the Sprite images and the Sprite metadata without cleaning the legacy icons. So when the Sprite icons are downloading under poor network connection, the `WayNameView` could use the previously cached legacy shield icon for road label.
- [x] Add `spriteKey` to both the Sprite images and the Sprite metadata. When the network connection is poor, the `styleURI` and `baseURL` of the repository will be updated first. And the Sprite metadata will be downloaded and stored with the `spriteKey` first. If during the Sprite image downloading process, the `SpriteRepository.getShieldIcon(shield:)` or the `SpriteRepository.getSpriteImage`, it will use the current correct `spriteKey` to retrieve the matched metadata and image. So it won't lead to the wrong cutting of shield icon. Instead, it would be `nil` and use the legacy icon instead.