### PR TITLE
Fix crash related to templates dismissal on CarPlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 * Fixed an issue where street names in spoken instructions could be go unpronounced if tagged with a [pronunciation](https://wiki.openstreetmap.org/wiki/Key:name:pronunciation). ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
 * Added support for [the workaround](https://github.com/mapbox/mapbox-directions-swift/issues/662) for requesting a route that avoids an arbitrary set of coordinates. ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
 
+### CarPlay
+
+* Fixed an issue where CarPlay application was crashing during template dismissal on iOS 14 and higher. ([#3794](https://github.com/mapbox/mapbox-navigation-ios/pull/3794))
+
 ### Other changes
 
 * Added the `MapboxSpeechSynthesizer(remoteSpeechSynthesizer:)` initializer for creating a `MapboxSpeechSynthesizer` object that uses a custom `SpeechSynthesizer` instance. ([#3747](https://github.com/mapbox/mapbox-navigation-ios/pull/3747))

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -875,10 +875,14 @@ extension CarPlayManager: CPMapTemplateDelegate {
     }
 
     private func popToRootTemplate(interfaceController: CPInterfaceController?, animated: Bool) {
-        guard let interfaceController = interfaceController else { return }
-        if interfaceController.templates.count > 1 {
-            // TODO: CPInterfaceController.popToRootTemplate(animated:completion:) (available on iOS 14/Xcode 12)
-            // should be used after Xcode 11 support is dropped.
+        guard let interfaceController = interfaceController,
+              interfaceController.templates.count > 1 else { return }
+        
+        if #available(iOS 14.0, *) {
+            interfaceController.popToRootTemplate(animated: animated) { _, _ in
+                // No-op
+            }
+        } else {
             interfaceController.popToRootTemplate(animated: animated)
         }
     }


### PR DESCRIPTION
Fix crash in CarPlay while dismissing template after application was brought to the foreground after being in background.