### PR TITLE
Add lazy initialization of Navigator.shared in RouteController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 * Added the `MapboxSpeechSynthesizer(remoteSpeechSynthesizer:)` initializer for creating a `MapboxSpeechSynthesizer` object that uses a custom `SpeechSynthesizer` instance. ([#3747](https://github.com/mapbox/mapbox-navigation-ios/pull/3747))
 * MapboxNavigationNative now sends messages to the Unified Logging subsystem `com.mapbox` for easier filtering. ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
+* Fixed a bug which caused `RouteOptions.profileIdentifier` to be ignored in active navigation. ([#3796](https://github.com/mapbox/mapbox-navigation-ios/pull/3796))
 
 ## v2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 * Added the `MapboxSpeechSynthesizer(remoteSpeechSynthesizer:)` initializer for creating a `MapboxSpeechSynthesizer` object that uses a custom `SpeechSynthesizer` instance. ([#3747](https://github.com/mapbox/mapbox-navigation-ios/pull/3747))
 * MapboxNavigationNative now sends messages to the Unified Logging subsystem `com.mapbox` for easier filtering. ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
-* Fixed a bug which caused `RouteOptions.profileIdentifier` to be ignored in active navigation. ([#3796](https://github.com/mapbox/mapbox-navigation-ios/pull/3796))
+* Fixed a bug which caused `RouteOptions.profileIdentifier` to be ignored in active navigation. This may have caused elevated network usage. ([#3796](https://github.com/mapbox/mapbox-navigation-ios/pull/3796))
 
 ## v2.3.0
 

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -208,7 +208,9 @@ open class RouteController: NSObject {
     
     // MARK: Navigating
     
-    private let sharedNavigator = Navigator.shared
+    private lazy var sharedNavigator: Navigator = {
+        return Navigator.shared
+    }()
     
     var navigator: MapboxNavigationNative.Navigator {
         return sharedNavigator.navigator


### PR DESCRIPTION
This fixes a bug that caused `RouteOptions.profileIdentifier` to be ignored in active navigation.

This happened because [`sharedNavigator` property](https://github.com/mapbox/mapbox-navigation-ios/blob/f8198e38e3e5579c22b4e46656736c0668de7180/Sources/MapboxCoreNavigation/RouteController.swift#L211) triggers Navigator singleton creation before the RouteController init is called, which [sets `profileIndentifier` to be used during the Navigator creation](https://github.com/mapbox/mapbox-navigation-ios/blob/f8198e38e3e5579c22b4e46656736c0668de7180/Sources/MapboxCoreNavigation/RouteController.swift#L557).