### PR TITLE
Allow SpeedLimitView to display unknown speed limit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Fixed an issue where the map’s floating buttons are misaligned with its attribution button and sometimes untappable after rotating the device during turn-by-turn navigation. ([#3776](https://github.com/mapbox/mapbox-navigation-ios/pull/3776))
 * Fixed an issue where the top instruction banner couldn't be swiped back to the current one. ([#3785](https://github.com/mapbox/mapbox-navigation-ios/pull/3785))
 * Fixed an issue where the road name label shows wrong shield image when applying custom style under poor network connection. ([#3792](https://github.com/mapbox/mapbox-navigation-ios/pull/3792))
-* Added a `SpeedLimitView.shouldShowUknownSpeedLimit` property which defines the view behavior if the `SpeedLimitView.speedLimit` property is `nil`. Setting this flag to `true` will cause the view to display `"--"` as a speed limit instead of being invisible. ([#3798](https://github.com/mapbox/mapbox-navigation-ios/pull/3798))
+* Added the `SpeedLimitView.shouldShowUnknownSpeedLimit` property which defines the view behavior if the `SpeedLimitView.speedLimit` property is `nil`. Setting this property to `true` will cause the view to display `"--"` as a speed limit instead of the `SpeedLimitView` being invisible. ([#3798](https://github.com/mapbox/mapbox-navigation-ios/pull/3798))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed an issue where the map’s floating buttons are misaligned with its attribution button and sometimes untappable after rotating the device during turn-by-turn navigation. ([#3776](https://github.com/mapbox/mapbox-navigation-ios/pull/3776))
 * Fixed an issue where the top instruction banner couldn't be swiped back to the current one. ([#3785](https://github.com/mapbox/mapbox-navigation-ios/pull/3785))
 * Fixed an issue where the road name label shows wrong shield image when applying custom style under poor network connection. ([#3792](https://github.com/mapbox/mapbox-navigation-ios/pull/3792))
+* Added a `SpeedLimitView.shouldShowUknownSpeedLimit` property which defines the view behavior if the `SpeedLimitView.speedLimit` property is `nil`. Setting this flag to `true` will cause the view to display `"--"` as a speed limit instead of being invisible. ([#3798](https://github.com/mapbox/mapbox-navigation-ios/pull/3798))
 
 ### Location tracking
 

--- a/Sources/MapboxNavigation/SpeedLimitView.swift
+++ b/Sources/MapboxNavigation/SpeedLimitView.swift
@@ -70,6 +70,16 @@ public class SpeedLimitView: UIView {
             update()
         }
     }
+
+    /**
+     Defines the view behavior if the `speedLimit` property is `nil`.
+     Setting this flag to `true` will cause the speed limit view to display `"--"` as a speed limit instead of being invisible.
+     */
+    public var shouldShowUknownSpeedLimit: Bool = false {
+        didSet {
+            update()
+        }
+    }
     
     let measurementFormatter: MeasurementFormatter = {
         let formatter = MeasurementFormatter()
@@ -91,7 +101,7 @@ public class SpeedLimitView: UIView {
     }
     
     var canDraw: Bool {
-        return !isAlwaysHidden && speedLimit != nil && signStandard != nil
+        return !isAlwaysHidden && signStandard != nil && (speedLimit != nil || shouldShowUknownSpeedLimit)
     }
     
     func update() {
@@ -106,15 +116,22 @@ public class SpeedLimitView: UIView {
     override public func draw(_ rect: CGRect) {
         super.draw(rect)
         
-        guard let speedLimit = speedLimit, let signStandard = signStandard else {
+        guard let signStandard = signStandard else {
             return
         }
         
         let formattedSpeedLimit: String
-        if speedLimit.value.isInfinite {
-            formattedSpeedLimit = "∞"
+
+        if let speedLimit = speedLimit {
+            if speedLimit.value.isInfinite {
+                formattedSpeedLimit = "∞"
+            } else {
+                formattedSpeedLimit = measurementFormatter.numberFormatter.string(for: speedLimit.value) ?? "\(speedLimit.value)"
+            }
+        } else if shouldShowUknownSpeedLimit {
+            formattedSpeedLimit = "--"
         } else {
-            formattedSpeedLimit = measurementFormatter.numberFormatter.string(for: speedLimit.value) ?? "\(speedLimit.value)"
+            return
         }
         
         switch signStandard {

--- a/Sources/MapboxNavigation/SpeedLimitView.swift
+++ b/Sources/MapboxNavigation/SpeedLimitView.swift
@@ -75,7 +75,7 @@ public class SpeedLimitView: UIView {
      Defines the view behavior if the `speedLimit` property is `nil`.
      Setting this flag to `true` will cause the view to display `"--"` as a speed limit instead of being invisible.
      */
-    public var shouldShowUknownSpeedLimit: Bool = false {
+    public var shouldShowUnknownSpeedLimit: Bool = false {
         didSet {
             update()
         }
@@ -101,7 +101,7 @@ public class SpeedLimitView: UIView {
     }
     
     var canDraw: Bool {
-        return !isAlwaysHidden && signStandard != nil && (speedLimit != nil || shouldShowUknownSpeedLimit)
+        return !isAlwaysHidden && signStandard != nil && (speedLimit != nil || shouldShowUnknownSpeedLimit)
     }
     
     func update() {
@@ -126,7 +126,7 @@ public class SpeedLimitView: UIView {
             } else {
                 formattedSpeedLimit = measurementFormatter.numberFormatter.string(for: speedLimit.value) ?? "\(speedLimit.value)"
             }
-        } else if shouldShowUknownSpeedLimit {
+        } else if shouldShowUnknownSpeedLimit {
             formattedSpeedLimit = "--"
         } else {
             return

--- a/Sources/MapboxNavigation/SpeedLimitView.swift
+++ b/Sources/MapboxNavigation/SpeedLimitView.swift
@@ -73,7 +73,7 @@ public class SpeedLimitView: UIView {
 
     /**
      Defines the view behavior if the `speedLimit` property is `nil`.
-     Setting this flag to `true` will cause the view to display `"--"` as a speed limit instead of being invisible.
+     Setting this property to `true` will cause the view to display `"--"` as a speed limit instead of the `SeedLimitView` being invisible.
      */
     public var shouldShowUnknownSpeedLimit: Bool = false {
         didSet {

--- a/Sources/MapboxNavigation/SpeedLimitView.swift
+++ b/Sources/MapboxNavigation/SpeedLimitView.swift
@@ -116,9 +116,7 @@ public class SpeedLimitView: UIView {
     override public func draw(_ rect: CGRect) {
         super.draw(rect)
         
-        guard let signStandard = signStandard else {
-            return
-        }
+        guard let signStandard = signStandard else { return }
         
         let formattedSpeedLimit: String
 

--- a/Sources/MapboxNavigation/SpeedLimitView.swift
+++ b/Sources/MapboxNavigation/SpeedLimitView.swift
@@ -73,7 +73,7 @@ public class SpeedLimitView: UIView {
 
     /**
      Defines the view behavior if the `speedLimit` property is `nil`.
-     Setting this flag to `true` will cause the speed limit view to display `"--"` as a speed limit instead of being invisible.
+     Setting this flag to `true` will cause the view to display `"--"` as a speed limit instead of being invisible.
      */
     public var shouldShowUknownSpeedLimit: Bool = false {
         didSet {


### PR DESCRIPTION
The new property `SpeedLimitView.shouldShowUknownSpeedLimit` will define the speed limit view behavior if the speed limit is unknown. 

The default value is `false` which saves the old behavior – the speed limit view will be invisible if the speed limit is unknown.
Setting the new flag to `true` will cause SpeedLimitView to display `--` instead of being invisible.
<img width="176" alt="image" src="https://user-images.githubusercontent.com/1976216/159994698-401599f3-d9c6-4956-be69-c384b1897f2d.png">
