### PR TITLE
Upgrade to MapboxNavigationNative `v93.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Packaging
 
 * MapboxNavigation now requires [MapboxMaps v10.4.0-rc.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.4.0-rc.1). ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
-* MapboxCoreNavigation now requires [MapboxNavigationNative v93._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/93.0.0). (ADD PR LINK)
+* MapboxCoreNavigation now requires [MapboxNavigationNative v93._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/93.0.0). ([#3801](https://github.com/mapbox/mapbox-navigation-ios/pull/3801))
 * MapboxCoreNavigation now requires [MapboxDirections v2.4.0-beta.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.4.0-beta.1). ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
 
 ### User interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Packaging
 
 * MapboxNavigation now requires [MapboxMaps v10.4.0-rc.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.4.0-rc.1). ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
-* MapboxCoreNavigation now requires [MapboxNavigationNative v92._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/92.0.0). ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
+* MapboxCoreNavigation now requires [MapboxNavigationNative v93._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/93.0.0). (ADD PR LINK)
 * MapboxCoreNavigation now requires [MapboxDirections v2.4.0-beta.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.4.0-beta.1). ([#3765](https://github.com/mapbox/mapbox-navigation-ios/pull/3765))
 
 ### User interface

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 21.2.0-rc.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 92.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 93.0
 github "mapbox/mapbox-directions-swift" == 2.4.0-beta.1
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "21.2.0-rc.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "92.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "93.0.0"
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v3.1.2"
 github "mapbox/mapbox-directions-swift" "v2.4.0-beta.1"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 92.0"
+  s.dependency "MapboxNavigationNative", "~> 93.0"
   s.dependency "MapboxDirections-pre", "2.4.0-beta.1"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "5aae54182a7d4d829e4f458483df44cf13dcde03",
-          "version": "92.0.0"
+          "revision": "9cf092546bc30fcd5855e6603dd972f5526b3bff",
+          "version": "93.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     dependencies: [
         .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .exact("2.4.0-beta.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "92.0.0"),
+        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "93.0.0"),
         .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", .exact("10.4.0-rc.1")),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (92.0.0):
+  - MapboxNavigationNative (93.0.0):
     - MapboxCommon (~> 21.2.0-rc.1)
   - MapboxSpeech (2.0.0)
   - Polyline (5.0.2)

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - MapboxCoreNavigation (2.4.0-beta.2):
     - MapboxDirections-pre (= 2.4.0-beta.1)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (~> 92.0)
+    - MapboxNavigationNative (~> 93.0)
   - MapboxDirections-pre (2.4.0-beta.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.0)
@@ -54,12 +54,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 84983b2049b48100f62e4a0b9d285203a343c19f
   MapboxCoreMaps: 2a2408bc6ce189f8a10ea13b2dee58878e23b6d3
-  MapboxCoreNavigation: 2401883ec6510bfde75927543b10f29327a578de
+  MapboxCoreNavigation: 68812f243fa6766aeb1f9ebabf17177acc27a567
   MapboxDirections-pre: b31da472d0d8190602b8ceacd74c281743fa6255
   MapboxMaps: 368fecb71f65e3f87bc69dbfcb787a01d745cf7c
   MapboxMobileEvents: f7f3e8daeb4b83688ae62a4172dce79169a97233
   MapboxNavigation: c3d1cff1a21e3cfc86600793e325b4eec5b32b8f
-  MapboxNavigationNative: 8036fd05ee0e254d930eeb53d6948614d970f2f1
+  MapboxNavigationNative: c22ceb3a57fd6018e9af13bb7eeb8437386daaff
   MapboxSpeech: e4ed02984444b6373374c72c369edaf045cc490c
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0


### PR DESCRIPTION
PR updates dependencies to Mapbox Navigation Native `v93.0.0`.