### PR TITLE
Fix various edge-cases while changing `CLAccuracyAuthorization` and `CLAuthorizationStatus`. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fixed an issue where `RouteControllerWillReroute` notification was incorrectly sent when a reroute was already in progress. ([#3772](https://github.com/mapbox/mapbox-navigation-ios/pull/3772))
 * Fixed an issue when `SimulatedLocationManager` could freeze the main thread when working with long routes. The manager now calls delegate methods from a background thread. ([#3672](https://github.com/mapbox/mapbox-navigation-ios/pull/3672))
 * Fixed an issue where initial puck position can be incorrect when `NavigationViewController` is presented. ([#3773](https://github.com/mapbox/mapbox-navigation-ios/pull/3773))
+* Fixed an issue where `UserHaloCourseView` was not correctly shown while changing `CLLocationManager.accuracyAuthorization` and `CLLocationManager.authorizationStatus`. ([#3804](https://github.com/mapbox/mapbox-navigation-ios/pull/3804))
 
 ### Offline routing
 

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -52,7 +52,6 @@ class CustomViewController: UIViewController {
                                                     credentials: NavigationSettings.shared.directions.credentials,
                                                     locationSource: locationManager,
                                                     simulating: simulateLocation ? .always : .inTunnels)
-        navigationService.delegate = self
         
         navigationMapView.mapView.ornaments.options.compass.visibility = .hidden
         
@@ -314,19 +313,6 @@ extension CustomViewController: StepsViewControllerDelegate {
                              cell: StepTableViewCell) {
         viewController.dismiss { [weak self] in
             self?.stepsViewController = nil
-        }
-    }
-}
-
-extension CustomViewController: NavigationServiceDelegate {
-    
-    public func navigationServiceDidChangeAuthorization(_ service: NavigationService,
-                                                        didChangeAuthorizationFor locationManager: CLLocationManager) {
-        if #available(iOS 14.0, *),
-           locationManager.accuracyAuthorization == .reducedAccuracy {
-            navigationMapView?.reducedAccuracyActivatedMode = true
-        } else {
-            navigationMapView?.reducedAccuracyActivatedMode = false
         }
     }
 }

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		8A88FF74274C252100B9995C /* BuildingHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A88FF73274C252100B9995C /* BuildingHighlighting.swift */; };
 		8A8C3D98260175D20071D274 /* CLLocationDirection+Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8C3D97260175D20071D274 /* CLLocationDirection+Camera.swift */; };
 		8A9270EA2704F6CC00B606D9 /* BundleAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9270E82704F6CC00B606D9 /* BundleAdditionsTests.swift */; };
+		8AA0385B27F39CCC0007BD2D /* CLLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0385A27F39CCC0007BD2D /* CLLocationManager.swift */; };
+		8AA0385D27F3B5740007BD2D /* NavigationMapView+CLLocationManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0385C27F3B5740007BD2D /* NavigationMapView+CLLocationManagerDelegate.swift */; };
 		8AA849E924E722410008EE59 /* WaypointStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA849E824E722410008EE59 /* WaypointStyle.swift */; };
 		8AAE94A126A60ADE00AA1127 /* CarPlayMapViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAE94A026A60ADE00AA1127 /* CarPlayMapViewControllerDelegate.swift */; };
 		8AB316A926BA026B00C3AC76 /* MapTemplateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB316A826BA026B00C3AC76 /* MapTemplateProvider.swift */; };
@@ -779,6 +781,8 @@
 		8A88FF73274C252100B9995C /* BuildingHighlighting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingHighlighting.swift; sourceTree = "<group>"; };
 		8A8C3D97260175D20071D274 /* CLLocationDirection+Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationDirection+Camera.swift"; sourceTree = "<group>"; };
 		8A9270E82704F6CC00B606D9 /* BundleAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleAdditionsTests.swift; sourceTree = "<group>"; };
+		8AA0385A27F39CCC0007BD2D /* CLLocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLLocationManager.swift; sourceTree = "<group>"; };
+		8AA0385C27F3B5740007BD2D /* NavigationMapView+CLLocationManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationMapView+CLLocationManagerDelegate.swift"; sourceTree = "<group>"; };
 		8AA849E824E722410008EE59 /* WaypointStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointStyle.swift; sourceTree = "<group>"; };
 		8AAE94A026A60ADE00AA1127 /* CarPlayMapViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayMapViewControllerDelegate.swift; sourceTree = "<group>"; };
 		8AB316A826BA026B00C3AC76 /* MapTemplateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTemplateProvider.swift; sourceTree = "<group>"; };
@@ -1810,10 +1814,12 @@
 		C51923B41EA55C5E002AF9E1 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				8AA0385A27F39CCC0007BD2D /* CLLocationManager.swift */,
 				8A50A3D026EC0AA300894A8E /* StyleURI.swift */,
 				F46FF186260277F7007CC0E0 /* DateComponentsFormatter+NavigationAdditions.swift */,
 				8A41F63B25BF631500BD6FCF /* NavigationMapView+BuildingHighlighting.swift */,
 				8A41F63A25BF631500BD6FCF /* NavigationMapView+VanishingRouteLine.swift */,
+				8AA0385C27F3B5740007BD2D /* NavigationMapView+CLLocationManagerDelegate.swift */,
 				C5381F01204E03B600A5493E /* UIDevice.swift */,
 				DA66062F23B32F99007832E5 /* Array.swift */,
 				2B5407EA24470B0A006C820B /* AVAudioSession.swift */,
@@ -2686,6 +2692,7 @@
 				DA8F3A7823B5DB7900B56786 /* SpeedLimitStyleKit.swift in Sources */,
 				35B7837E1F9547B300291F9A /* Transitioning.swift in Sources */,
 				8A41F5B225BF61AE00BD6FCF /* CarPlayActivity.swift in Sources */,
+				8AA0385D27F3B5740007BD2D /* NavigationMapView+CLLocationManagerDelegate.swift in Sources */,
 				DA66063023B32F99007832E5 /* Array.swift in Sources */,
 				8AD635BD278F66FC00218D5A /* StepsViewControllerDelegate.swift in Sources */,
 				8DEDEF3421E3FBE80049E114 /* NavigationViewControllerDelegate.swift in Sources */,
@@ -2722,6 +2729,7 @@
 				8A50A3C626EC09FB00894A8E /* PassiveNavigationFeedbackType+FeedbackItem.swift in Sources */,
 				8A2DFA8626168A300034A87E /* NavigationCameraDebugView.swift in Sources */,
 				8A50A3C326EC09FB00894A8E /* FeedbackSubtypeViewController.swift in Sources */,
+				8AA0385B27F39CCC0007BD2D /* CLLocationManager.swift in Sources */,
 				8AD2210927C42E9E000734A5 /* DistanceLabel.swift in Sources */,
 				351BEC021E5BCC63006FE110 /* UIView.swift in Sources */,
 				2EBF20AE25D6F89000DB7BF2 /* Utils.swift in Sources */,

--- a/Sources/MapboxNavigation/CLLocationManager.swift
+++ b/Sources/MapboxNavigation/CLLocationManager.swift
@@ -1,0 +1,29 @@
+import CoreLocation
+
+extension CLLocationManager {
+    
+    /**
+     Allows to detect whether application is authorized to use location services.
+     
+     - returns: `true` if authorized to use location services, `false` otherwise.
+     */
+    func isAuthorized() -> Bool {
+        let currentAuthorizationStatus: CLAuthorizationStatus
+        if #available(iOS 14.0, *) {
+            currentAuthorizationStatus = authorizationStatus
+        } else {
+            currentAuthorizationStatus = CLLocationManager.authorizationStatus()
+        }
+        
+        let allowedAuthorizationStatuses: [CLAuthorizationStatus] = [
+            .authorizedAlways,
+            .authorizedWhenInUse
+        ]
+        
+        if allowedAuthorizationStatuses.contains(currentAuthorizationStatus) {
+            return true
+        }
+        
+        return false
+    }
+}

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -301,6 +301,11 @@ open class CarPlayMapViewController: UIViewController {
             wayNameView.text = nil
             wayNameView.containerView.isHidden = true
         }
+        
+        if let location = notification.userInfo?[PassiveLocationManager.NotificationUserInfoKey.locationKey] as? CLLocation {            
+            // Update user puck to the most recent location.
+            navigationMapView.moveUserLocation(to: location, animated: true)
+        }
     }
     
     // MARK: UIViewController Lifecycle Methods

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -402,7 +402,6 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         navigationService.start()
         carPlayManager.delegate?.carPlayManager(carPlayManager, didBeginNavigationWith: navigationService)
         currentLegIndexMapped = navigationService.router.routeProgress.legIndex
-        navigationMapView?.inActiveNavigation = true
         navigationMapView?.simulatesLocation = navigationService.locationManager.simulatesLocation
         
         updateTripEstimateStyle(traitCollection.userInterfaceStyle)

--- a/Sources/MapboxNavigation/NavigationMapView+CLLocationManagerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+CLLocationManagerDelegate.swift
@@ -1,0 +1,29 @@
+import CoreLocation
+
+extension NavigationMapView: CLLocationManagerDelegate {
+    
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        updateUserLocation(manager)
+    }
+    
+    func updateUserLocation(_ manager: CLLocationManager) {
+        if #available(iOS 14.0, *) {
+            if manager.accuracyAuthorization == .reducedAccuracy {
+                reducedAccuracyActivatedMode = true
+            } else {
+                reducedAccuracyActivatedMode = false
+            }
+        }
+        
+        if locationManager.isAuthorized() {
+            setupUserLocation()
+        } else {
+            mapView.location.options.puckType = nil
+            reducedAccuracyUserHaloCourseView = nil
+            
+            if let currentCourseView = mapView.viewWithTag(NavigationMapView.userCourseViewTag) {
+                currentCourseView.removeFromSuperview()
+            }
+        }
+    }
+}

--- a/Sources/MapboxNavigation/NavigationMapView+CLLocationManagerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+CLLocationManagerDelegate.swift
@@ -8,11 +8,11 @@ extension NavigationMapView: CLLocationManagerDelegate {
     
     func updateUserLocation(_ manager: CLLocationManager) {
         if #available(iOS 14.0, *) {
-            if manager.accuracyAuthorization == .reducedAccuracy {
-                reducedAccuracyActivatedMode = true
-            } else {
-                reducedAccuracyActivatedMode = false
-            }
+            // `UserHaloCourseView` will be applied in two cases:
+            // 1. When user explicitly sets `NavigationMapView.reducedAccuracyActivatedMode` to `true`.
+            // 2. When user disables `Precise Location` property in the settings of current application.
+            let shouldApply = reducedAccuracyActivatedMode || manager.accuracyAuthorization == .reducedAccuracy
+            applyReducedAccuracyMode(shouldApply: shouldApply)
         }
         
         if locationManager.isAuthorized() {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -79,7 +79,7 @@ open class NavigationMapView: UIView {
     /**
      Location manager that is used to track accuracy and status authorization changes.
      */
-    var locationManager = CLLocationManager()
+    let locationManager = CLLocationManager()
     
     @objc dynamic public var trafficUnknownColor: UIColor = .trafficUnknown
     @objc dynamic public var trafficLowColor: UIColor = .trafficLow
@@ -794,7 +794,6 @@ open class NavigationMapView: UIView {
     }
     
     func setupLocationManager() {
-        locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
         locationManager.delegate = self
     }
     

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -805,21 +805,25 @@ open class NavigationMapView: UIView {
      */
     @objc dynamic public var reducedAccuracyActivatedMode: Bool = false {
         didSet {
-            if reducedAccuracyActivatedMode {
-                // In case if the most recent user location is available use it while adding
-                // `UserHaloCourseView` on a map.
-                let userHaloCourseViewOrigin: CGPoint
-                if let mostRecentUserCourseViewLocation = mostRecentUserCourseViewLocation {
-                    userHaloCourseViewOrigin = mapView.mapboxMap.point(for: mostRecentUserCourseViewLocation.coordinate)
-                } else {
-                    userHaloCourseViewOrigin = .zero
-                }
-                
-                let userHaloCourseViewFrame = CGRect(origin: userHaloCourseViewOrigin, size: 75.0)
-                reducedAccuracyUserHaloCourseView = UserHaloCourseView(frame: userHaloCourseViewFrame)
+            applyReducedAccuracyMode(shouldApply: reducedAccuracyActivatedMode)
+        }
+    }
+    
+    func applyReducedAccuracyMode(shouldApply: Bool) {
+        if shouldApply {
+            // In case if the most recent user location is available use it while adding
+            // `UserHaloCourseView` on a map.
+            let userHaloCourseViewOrigin: CGPoint
+            if let mostRecentUserCourseViewLocation = mostRecentUserCourseViewLocation {
+                userHaloCourseViewOrigin = mapView.mapboxMap.point(for: mostRecentUserCourseViewLocation.coordinate)
             } else {
-                reducedAccuracyUserHaloCourseView = nil
+                userHaloCourseViewOrigin = .zero
             }
+            
+            let userHaloCourseViewFrame = CGRect(origin: userHaloCourseViewOrigin, size: 75.0)
+            reducedAccuracyUserHaloCourseView = UserHaloCourseView(frame: userHaloCourseViewFrame)
+        } else {
+            reducedAccuracyUserHaloCourseView = nil
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -942,9 +942,14 @@ extension NavigationViewController: NavigationServiceDelegate {
         return navigationComponents.allSatisfy { $0.navigationServiceShouldDisableBatteryMonitoring(service) }
     }
     
-    public func navigationServiceDidChangeAuthorization(_ service: NavigationService, didChangeAuthorizationFor locationManager: CLLocationManager) {
-        if #available(iOS 14.0, *), locationManager.accuracyAuthorization == .reducedAccuracy {
-            let title = NSLocalizedString("ENABLE_PRECISE_LOCATION", bundle: .mapboxNavigation, value: "Enable precise location to navigate", comment: "Label indicating precise location is off and needs to be turned on to navigate")
+    public func navigationServiceDidChangeAuthorization(_ service: NavigationService,
+                                                        didChangeAuthorizationFor locationManager: CLLocationManager) {
+        if #available(iOS 14.0, *),
+           locationManager.accuracyAuthorization == .reducedAccuracy {
+            let title = NSLocalizedString("ENABLE_PRECISE_LOCATION",
+                                          bundle: .mapboxNavigation,
+                                          value: "Enable precise location to navigate",
+                                          comment: "Label indicating precise location is off and needs to be turned on to navigate")
             show(StatusView.Status(identifier: "ENABLE_PRECISE_LOCATION",
                                    title: title,
                                    spinner: false,
@@ -952,11 +957,6 @@ extension NavigationViewController: NavigationServiceDelegate {
                                    animated: true,
                                    interactive: false,
                                    priority: 1))
-            navigationMapView?.reducedAccuracyActivatedMode = true
-        } else {
-            // Fallback on earlier versions
-            navigationMapView?.reducedAccuracyActivatedMode = false
-            return
         }
     }
 }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -239,7 +239,6 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
                               routeProgress: navigationService.routeProgress)
         }
 
-        navigationMapView?.inActiveNavigation = true
         navigationMapView?.simulatesLocation = navigationService.locationManager.simulatesLocation
     }
     


### PR DESCRIPTION
`NavigationMapView` now tracks any changes to the `CLAccuracyAuthorization` and `CLAuthorizationStatus` and changes puck appearance accordingly.