### PR TITLE
Fix bug where transparent `LanesView` displays on update when `StepsTable` is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fixed an issue where `EndOfRouteCommentView` is using dark style when only light style is allowed. ([#3845](https://github.com/mapbox/mapbox-navigation-ios/pull/3845))
 * Fixed an issue where exit views and generic shields in top banner don't get updated when style changes in active navigation. ([#3864](https://github.com/mapbox/mapbox-navigation-ios/pull/3864))
 * Fixed an issue where the current road name label used a generic white circle instead of the correct shield to represent a state route in the United States. ([#3870](https://github.com/mapbox/mapbox-navigation-ios/pull/3870))
+* Fixed an issue where there was a transparent gap caused by a `LanesView` update when `StepsTable` is displayed during a maneuver update. `LanesView` now stays visible when `StepsTable` is displayed. ([#3805](https://github.com/mapbox/mapbox-navigation-ios/pull/3805))
 
 ### CarPlay
 

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -74,6 +74,53 @@ open class LanesView: UIView, NavigationComponent {
         }
     }
     
+    public func update(for visualInstruction: VisualInstructionBanner?,
+                       animated: Bool = true,
+                       duration: TimeInterval = 0.5,
+                       isDisplayingSteps: Bool,
+                       completion: CompletionHandler? = nil) {
+        clearLaneViews()
+
+        guard let tertiaryInstruction = visualInstruction?.tertiaryInstruction else {
+            hide(animated: animated,
+                 duration: duration) { completed in
+                completion?(completed)
+            }
+            return
+        }
+
+        let subviews = tertiaryInstruction.components.compactMap { (component) -> LaneView? in
+            if case let .lane(indications: indications,
+                              isUsable: isUsable,
+                              preferredDirection: preferredDirection) = component {
+                let maneuverDirection = preferredDirection ?? visualInstruction?.primaryInstruction.maneuverDirection
+                let laneView = LaneView(indications: indications,
+                                isUsable: isUsable,
+                                direction: maneuverDirection)
+                return laneView
+            } else {
+                return nil
+            }
+        }
+
+        guard !subviews.isEmpty && subviews.contains(where: { !$0.isValid }) else {
+            hide(animated: animated,
+                 duration: duration) { completed in
+                completion?(completed)
+            }
+            return
+        }
+
+        stackView.addArrangedSubviews(subviews)
+        
+        if !isDisplayingSteps {
+            show(animated: animated,
+                 duration: duration) { completed in
+                completion?(completed)
+            }
+        }
+    }
+    
     /**
      Shows lanes view.
      

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -10,6 +10,8 @@ open class LanesView: UIView, NavigationComponent {
     
     public var isCurrentlyVisible: Bool = false
     
+    var isTopBannerDisplayingSteps: Bool = false
+    
     /**
      A vertical separator for the trailing side of the view.
      */
@@ -58,50 +60,6 @@ open class LanesView: UIView, NavigationComponent {
                 return nil
             }
         }
-        
-        guard !subviews.isEmpty && subviews.contains(where: { !$0.isValid }) else {
-            hide(animated: animated,
-                 duration: duration) { completed in
-                completion?(completed)
-            }
-            return
-        }
-        
-        stackView.addArrangedSubviews(subviews)
-        show(animated: animated,
-             duration: duration) { completed in
-            completion?(completed)
-        }
-    }
-    
-    public func update(for visualInstruction: VisualInstructionBanner?,
-                       animated: Bool = true,
-                       duration: TimeInterval = 0.5,
-                       isDisplayingSteps: Bool,
-                       completion: CompletionHandler? = nil) {
-        clearLaneViews()
-
-        guard let tertiaryInstruction = visualInstruction?.tertiaryInstruction else {
-            hide(animated: animated,
-                 duration: duration) { completed in
-                completion?(completed)
-            }
-            return
-        }
-
-        let subviews = tertiaryInstruction.components.compactMap { (component) -> LaneView? in
-            if case let .lane(indications: indications,
-                              isUsable: isUsable,
-                              preferredDirection: preferredDirection) = component {
-                let maneuverDirection = preferredDirection ?? visualInstruction?.primaryInstruction.maneuverDirection
-                let laneView = LaneView(indications: indications,
-                                isUsable: isUsable,
-                                direction: maneuverDirection)
-                return laneView
-            } else {
-                return nil
-            }
-        }
 
         guard !subviews.isEmpty && subviews.contains(where: { !$0.isValid }) else {
             hide(animated: animated,
@@ -113,7 +71,7 @@ open class LanesView: UIView, NavigationComponent {
 
         stackView.addArrangedSubviews(subviews)
         
-        if !isDisplayingSteps {
+        if !isTopBannerDisplayingSteps {
             show(animated: animated,
                  duration: duration) { completed in
                 completion?(completed)

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -58,7 +58,7 @@ open class LanesView: UIView, NavigationComponent {
                 return nil
             }
         }
-
+        
         guard !subviews.isEmpty && subviews.contains(where: { !$0.isValid }) else {
             hide(animated: animated,
                  duration: duration) { completed in
@@ -66,11 +66,10 @@ open class LanesView: UIView, NavigationComponent {
             }
             return
         }
-
-        stackView.addArrangedSubviews(subviews)
         
+        stackView.addArrangedSubviews(subviews)
         show(animated: animated,
-            duration: duration) { completed in
+             duration: duration) { completed in
             completion?(completed)
         }
     }

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -10,8 +10,6 @@ open class LanesView: UIView, NavigationComponent {
     
     public var isCurrentlyVisible: Bool = false
     
-    var isTopBannerDisplayingSteps: Bool = false
-    
     /**
      A vertical separator for the trailing side of the view.
      */
@@ -71,11 +69,9 @@ open class LanesView: UIView, NavigationComponent {
 
         stackView.addArrangedSubviews(subviews)
         
-        if !isTopBannerDisplayingSteps {
-            show(animated: animated,
-                 duration: duration) { completed in
-                completion?(completed)
-            }
+        show(animated: animated,
+            duration: duration) { completed in
+            completion?(completed)
         }
     }
     

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -363,7 +363,8 @@ extension TopBannerViewController: NavigationComponent {
     
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
         instructionsBannerView.update(for: instruction)
-        lanesView.update(for: instruction)
+//        lanesView.update(for: instruction)
+        lanesView.update(for: instruction, isDisplayingSteps: isDisplayingSteps)
         nextBannerView.navigationService(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress)
         junctionView.update(for: instruction, service: service)
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -121,6 +121,7 @@ open class TopBannerViewController: UIViewController {
         statusView.isHidden = !statusView.isCurrentlyVisible
         junctionView.isHidden = !junctionView.isCurrentlyVisible
         lanesView.isHidden = !lanesView.isCurrentlyVisible
+        lanesView.update(for: currentInstruction)
         nextBannerView.isHidden = !nextBannerView.isCurrentlyVisible
         
         UIView.animate(withDuration: 0.20, delay: 0.0, options: [.curveEaseOut], animations: { [weak self] in
@@ -333,7 +334,6 @@ open class TopBannerViewController: UIViewController {
             
             if !self.isDisplayingPreviewInstructions {
                 self.showSecondaryChildren(completion: complete)
-                self.lanesView.update(for: self.currentInstruction)
             } else {
                 complete()
             }
@@ -365,9 +365,12 @@ extension TopBannerViewController: NavigationComponent {
     }
     
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
-        instructionsBannerView.update(for: instruction)
         currentInstruction = instruction
-        lanesView.isTopBannerDisplayingSteps = isDisplayingSteps
+        instructionsBannerView.update(for: instruction)
+        
+        if isDisplayingSteps {
+            return
+        }
         lanesView.update(for: instruction)
         nextBannerView.navigationService(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress)
         junctionView.update(for: instruction, service: service)

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -19,6 +19,8 @@ open class TopBannerViewController: UIViewController {
     
     var routeProgress: RouteProgress?
     
+    var currentInstruction: VisualInstructionBanner?
+    
     lazy var informationStackBottomPinConstraint: NSLayoutConstraint = view.bottomAnchor.constraint(equalTo: informationStackView.bottomAnchor)
     
     lazy var informationStackView = UIStackView(orientation: .vertical, autoLayout: true)
@@ -331,6 +333,7 @@ open class TopBannerViewController: UIViewController {
             
             if !self.isDisplayingPreviewInstructions {
                 self.showSecondaryChildren(completion: complete)
+                self.lanesView.update(for: self.currentInstruction)
             } else {
                 complete()
             }
@@ -363,8 +366,9 @@ extension TopBannerViewController: NavigationComponent {
     
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
         instructionsBannerView.update(for: instruction)
-//        lanesView.update(for: instruction)
-        lanesView.update(for: instruction, isDisplayingSteps: isDisplayingSteps)
+        currentInstruction = instruction
+        lanesView.isTopBannerDisplayingSteps = isDisplayingSteps
+        lanesView.update(for: instruction)
         nextBannerView.navigationService(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress)
         junctionView.update(for: instruction, service: service)
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -119,17 +119,26 @@ open class TopBannerViewController: UIViewController {
     
     private func showSecondaryChildren(completion: CompletionHandler? = nil) {
         statusView.isHidden = !statusView.isCurrentlyVisible
-        junctionView.isHidden = !junctionView.isCurrentlyVisible
-        lanesView.isHidden = !lanesView.isCurrentlyVisible
-        lanesView.update(for: currentInstruction)
-        nextBannerView.isHidden = !nextBannerView.isCurrentlyVisible
         
-        UIView.animate(withDuration: 0.20, delay: 0.0, options: [.curveEaseOut], animations: { [weak self] in
-            guard let children = self?.informationChildren else {
-                return
+        if let tertiary = currentInstruction?.tertiaryInstruction {
+            lanesView.isHidden = !lanesView.isCurrentlyVisible
+            lanesView.update(for: currentInstruction)
+            if !tertiary.laneComponents.isEmpty {
+                nextBannerView.isHidden = !nextBannerView.isCurrentlyVisible
             }
+        }
+        
+        if let _ = currentInstruction?.quaternaryInstruction {
+            junctionView.isHidden = !junctionView.isCurrentlyVisible
+        }
+        
+        let notHiddenChildren = [instructionsBannerView] + secondaryChildren.filter {
+            $0.isHidden == false
+        }
+        
+        UIView.animate(withDuration: 0.20, delay: 0.0, options: [.curveEaseOut], animations: {
             
-            for child in children {
+            for child in notHiddenChildren {
                 child.alpha = 1.0
             }
         }, completion: { _ in

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -118,7 +118,7 @@ open class TopBannerViewController: UIViewController {
     }
     
     
-    private func showSecondaryChildren(completion: CompletionHandler? = nil) {
+    private func showSecondaryChildren(including secondaryView: UIView? = nil, completion: CompletionHandler? = nil) {
         statusView.isHidden = !statusView.isCurrentlyVisible
         
         if let tertiary = currentInstruction?.tertiaryInstruction {
@@ -133,8 +133,12 @@ open class TopBannerViewController: UIViewController {
             junctionView.isHidden = !junctionView.isCurrentlyVisible
         }
         
-        let notHiddenChildren = [instructionsBannerView] + secondaryChildren.filter {
+        var notHiddenChildren = [instructionsBannerView] + secondaryChildren.filter {
             $0.isHidden == false
+        }
+        
+        if let secondaryView = secondaryView {
+            notHiddenChildren += [secondaryView]
         }
         
         UIView.animate(withDuration: 0.20, delay: 0.0, options: [.curveEaseOut], animations: {
@@ -147,12 +151,15 @@ open class TopBannerViewController: UIViewController {
         })
     }
     
-    private func hideSecondaryChildren(excluding secondaryView: UIView? = nil, completion: CompletionHandler? = nil) {
+    private func hideSecondaryChildren(including secondaryView: UIView? = nil, completion: CompletionHandler? = nil) {
         UIView.animate(withDuration: 0.20, delay: 0.0, options: [.curveEaseIn], animations: { [weak self] in
             guard var children = self?.secondaryChildren else {
                 return
             }
-            children.removeAll(where: { $0 == secondaryView })
+            
+            if let secondaryView = secondaryView {
+                children += [secondaryView]
+            }
             
             for child in children {
                 child.alpha = 0.0
@@ -210,7 +217,7 @@ open class TopBannerViewController: UIViewController {
         instructionsView.update(for: instructions)
         previewBannerView = instructionsView
         
-        hideSecondaryChildren(completion: completion)
+        hideSecondaryChildren(including: lanesView, completion: completion)
     }
     
     public func stopPreviewing(showingSecondaryChildren: Bool = true) {
@@ -227,7 +234,7 @@ open class TopBannerViewController: UIViewController {
         previewBannerView = nil
         
         if showingSecondaryChildren {
-            showSecondaryChildren()
+            showSecondaryChildren(including: lanesView)
         }
     }
     
@@ -316,7 +323,7 @@ open class TopBannerViewController: UIViewController {
             UIView.animate(withDuration: 0.35, delay: 0.0, options: [.curveEaseOut], animations: parent.view.layoutIfNeeded, completion: finally)
         }
         
-        hideSecondaryChildren(excluding: lanesView, completion: stepsInAnimation)
+        hideSecondaryChildren(completion: stepsInAnimation)
     }
     
     public func dismissStepsTable(completion: CompletionHandler? = nil) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -376,13 +376,12 @@ extension TopBannerViewController: NavigationComponent {
     public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
         currentInstruction = instruction
         instructionsBannerView.update(for: instruction)
-        
-        if isDisplayingSteps {
-            return
-        }
-        lanesView.update(for: instruction)
         nextBannerView.navigationService(service, didPassVisualInstructionPoint: instruction, routeProgress: routeProgress)
         junctionView.update(for: instruction, service: service)
+        
+        if !isDisplayingSteps {
+            lanesView.update(for: instruction)
+        }
     }
     
     public func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {


### PR DESCRIPTION
### Description
This PR fixes a bug where a transparent gap would display between the `TopBannerViewController` and `StepsTable` when instructions are updated while `StepsTable` is displayed.

### Implementation
Added `TopBannerViewController.currentInstruction` and `LanesView.isTopBannerDisplayingSteps` properties to be able to update `LanesView` to the current instruction when the `StepsTable` is hidden and only show the `LanesView` when the `StepsTable` is not being displayed.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
Before vs After:

https://user-images.githubusercontent.com/43434254/162985983-edb7c4e1-6ca3-44a3-b509-f92920553abe.mp4

https://user-images.githubusercontent.com/43434254/162986000-722731cd-64da-4130-a616-81ace20b313d.mp4


