### PR TITLE
Provide the ability to preview routes that are based on a `RouteResponse` on CarPlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Added the ability to style each route line differently on CarPlay during route preview and active navigation using such delegate methods ([#3744](https://github.com/mapbox/mapbox-navigation-ios/pull/3744)):
   * `CarPlayManagerDelegate.carPlayManager(_:routeLineLayerWithIdentifier:sourceIdentifier:for:)` to style the route.
   * `CarPlayManagerDelegate.carPlayManager(_:routeCasingLineLayerWithIdentifier:sourceIdentifier:for:)` to style the casing of the route.
+* Added `CarPlayManager.previewRoutes(for:)` to provide the ability to preview routes based on response from Mapbox Directions. ([#3807](https://github.com/mapbox/mapbox-navigation-ios/pull/3807))
 
 ### Other changes
 


### PR DESCRIPTION
PR allows to show routes that are located in `RouteResponse`. This allows users to execute their own Directions requests and preview `RouteResponse` from response. 