### PR TITLE
Remove the `PassiveLocationManager ` before active navigation.

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -576,7 +576,9 @@ class ViewController: UIViewController {
         
         present(navigationViewController, animated: true) {
             completion?()
+            // Cleaning up the `PassiveLocationManager`. The `PassiveLocationManager` during active navigation may lead to location jump.
             self.navigationMapView = nil
+            self.passiveLocationManager = nil
             navigationViewController.navigationMapView?.showsRestrictedAreasOnRoute = true
         }
     }


### PR DESCRIPTION
### Description
This PR is to update the `Example` app by removing the `PassiveLocationManager` for active navigation. 

Because `PassiveLocationManager` shares a strong reference to an instance of `Navigator`. So when we used it for the `locationProvider` of `mapView` for previewing or passive navigation, we nil out the `NavigationMapView` to avoid its influence on the `Navigator` as in #2931. It may lead to the rerouting and simulation issues as in #2883.

And right now we have the `PassiveLocationManager` instance in `ViewController` in the `Example` app. When we start active navigation, the `NavigationMapView` for previewing is removed, but the `ViewController.passiveLocationManager` is still working while the `NavigationViewController` has no idea about it. And it would lead to the location update in the background of active navigation, affect the `Navigator`, cause the location jump, the rerouting triggered, the route line flickering and the `courseView` moving back and forth.

### Implementation
This PR simply removed the `PassiveLocationManager` after the active navigation starts and add comment as reminder in the `Example` app.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->