### PR TITLE
Fixes bug where non-restricted restricted area line become restricted in an edge case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.5.0
+
+### Location tracking
+
+- Fixed an issue where restricted-access roads would sometimes be incorrectly drawn. ([#3811](https://github.com/mapbox/mapbox-navigation-ios/pull/3811))
+
 ## v2.4.0
 
 ### Pricing

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -362,6 +362,9 @@ extension NavigationMapView {
                             gradientStops[currentGradientStop] = associatedFeatureColor
                             lastRecordSegment = (currentGradientStop, associatedFeatureColor)
                         }
+                        else {
+                            minimumSegment = (0.0, traversedRouteColor)
+                        }
                     }
                     
                     continue


### PR DESCRIPTION
### Description

`routeLineFeaturesGradient` inserts a gradient stop at `lineSettings.fractionTraveled` with minimumSegment color.

Minimum segment is set to the first one (which is restricted) and never updated.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

The fix is to reset the minimum segment to traversed color when it is appropriate. 

### Future directions

I found this method very difficult to read and understand and would propose to:
- Make logic more straightforward with less edge-case branches.
- Document the code.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

- A video that demonstrates the bug: 

https://user-images.githubusercontent.com/413986/163217946-711bc2eb-a336-47ee-bcb1-852fa4cabc6e.mp4



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->