### PR TITLE
Improve tests

### DIFF
--- a/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
@@ -644,7 +644,7 @@ final class BillingHandlerUnitTests: TestCase {
                 return true
             }
 
-            locationManager.speedMultiplier = 50
+            locationManager.speedMultiplier = 10
             locationManager.startUpdatingLocation()
             waitForExpectations(timeout: locationManager.expectedReplayTime, handler: nil)
             locationManager.stopUpdatingLocation()

--- a/Tests/MapboxNavigationTests/CarPlayManagerSpec.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerSpec.swift
@@ -31,6 +31,8 @@ class CarPlayManagerSpec: QuickSpec {
         
         afterEach {
             CarPlayMapViewController.unswizzleMethods()
+            carPlayManager = nil
+            delegate = nil
         }
         
         describe("Previewing routes.") {


### PR DESCRIPTION
SDK reported two RouteController instances. It badly influence tests
stability.