### PR TITLE
Use current location from `CLLocationManager` to center camera to it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Fixed an issue when `SimulatedLocationManager` could freeze the main thread when working with long routes. The manager now calls delegate methods from a background thread. ([#3672](https://github.com/mapbox/mapbox-navigation-ios/pull/3672))
 * Fixed an issue where initial puck position can be incorrect when `NavigationViewController` is presented. ([#3773](https://github.com/mapbox/mapbox-navigation-ios/pull/3773))
 * Fixed an issue where `UserHaloCourseView` was not correctly shown while changing `CLLocationManager.accuracyAuthorization` and `CLLocationManager.authorizationStatus`. ([#3804](https://github.com/mapbox/mapbox-navigation-ios/pull/3804))
+* Fixed an issue where camera was not centered to the current location during `NavigationMapView` initialization. ([#3826](https://github.com/mapbox/mapbox-navigation-ios/pull/3826))
 
 ### Offline routing
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1556,6 +1556,12 @@ open class NavigationMapView: UIView {
         setupGestureRecognizers()
         subscribeForNotifications()
         setupUserLocation()
+        
+        // To prevent the lengthy animation from the Null Island to the current location use
+        // location from the location manager and set map view's camera to it (without animation).
+        if let coordinate = locationManager.location?.coordinate {
+            setInitialCamera(coordinate)
+        }
     }
     
     deinit {


### PR DESCRIPTION
### Description

PR fixes an issue when camera is not centered to the current location when `NavigationMapView` gets created. As a result long animation is executed as it's shown in https://github.com/mapbox/mapbox-navigation-ios/issues/3825.

Result of the fix:

https://user-images.githubusercontent.com/1496498/163285115-77228b05-df88-4f42-a630-cd24ade8a802.mov


