### PR TITLE
Add notifications management delegate methods to `CarPlayManagerDelegate`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed an issue where restricted-access roads would sometimes be incorrectly drawn. ([#3811](https://github.com/mapbox/mapbox-navigation-ios/pull/3811))
 
+### CarPlay
+
+* Added the `CarPlayManagerDelegate.carPlayManager(_:shouldUpdateNotificationFor:with:in:)` and `CarPlayManagerDelegate.carPlayManager(_:shouldShowNotificationFor:in:)` to provide the ability to control notifications presentation while CarPlay application is in the background. ([#3828](https://github.com/mapbox/mapbox-navigation-ios/pull/3828))
+
 ## v2.4.0
 
 ### Pricing

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -310,6 +310,25 @@ extension AppDelegate: CarPlayManagerDelegate {
 
         return nil
     }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldShowNotificationFor maneuver: CPManeuver,
+                        in mapTemplate: CPMapTemplate) -> Bool {
+        return true
+    }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldShowNotificationFor navigationAlert: CPNavigationAlert,
+                        in mapTemplate: CPMapTemplate) -> Bool {
+        return true
+    }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldUpdateNotificationFor maneuver: CPManeuver,
+                        with travelEstimates: CPTravelEstimates,
+                        in mapTemplate: CPMapTemplate) -> Bool {
+        return true
+    }
 }
 
 // MARK: - CarPlaySearchControllerDelegate methods

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -964,6 +964,29 @@ extension CarPlayManager: CPMapTemplateDelegate {
             mapTemplate.trailingNavigationBarButtons = [exitButton]
         }
     }
+    
+    public func mapTemplate(_ mapTemplate: CPMapTemplate,
+                            shouldShowNotificationFor maneuver: CPManeuver) -> Bool {
+        return delegate?.carPlayManager(self,
+                                        shouldShowNotificationFor: maneuver,
+                                        in: mapTemplate) ?? false
+    }
+    
+    public func mapTemplate(_ mapTemplate: CPMapTemplate,
+                            shouldShowNotificationFor navigationAlert: CPNavigationAlert) -> Bool {
+        return delegate?.carPlayManager(self,
+                                        shouldShowNotificationFor: navigationAlert,
+                                        in: mapTemplate) ?? false
+    }
+    
+    public func mapTemplate(_ mapTemplate: CPMapTemplate,
+                            shouldUpdateNotificationFor maneuver: CPManeuver,
+                            with travelEstimates: CPTravelEstimates) -> Bool {
+        return delegate?.carPlayManager(self,
+                                        shouldUpdateNotificationFor: maneuver,
+                                        with: travelEstimates,
+                                        in: mapTemplate) ?? false
+    }
 }
 
 // MARK: CarPlayNavigationViewControllerDelegate Methods

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -347,8 +347,7 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      - parameter carPlayManager: The `CarPlayManager` object.
      - parameter navigationAlert: Banner alert, for which notification will be shown.
      - parameter mapTemplate: The map template that is visible during either preview or navigation sessions.
-     - returns: A boolean value indicating whether updated estimates should appear in the
-     notification.
+     - returns: A boolean value indicating whether alert should appear as a notification.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         shouldShowNotificationFor navigationAlert: CPNavigationAlert,
@@ -363,7 +362,8 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
      - parameter travelEstimates: Object that describes the time and distance remaining for the
      active navigation session.
      - parameter mapTemplate: The map template that is visible during either preview or navigation sessions.
-     - returns: A boolean value indicating whether alert should appear as a notification.
+     - returns: A boolean value indicating whether updated estimates should appear in the
+     notification.
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         shouldUpdateNotificationFor maneuver: CPManeuver,

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -324,6 +324,51 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging {
                         routeCasingLineLayerWithIdentifier identifier: String,
                         sourceIdentifier: String,
                         for parentViewController: UIViewController) -> LineLayer?
+    
+    // MARK: Notifications Management
+    
+    /**
+     Determines if the maneuver should be presented as a notification when the app is in the
+     background.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter maneuver: Maneuver, for which notification will be shown.
+     - parameter mapTemplate: The map template that is visible during either preview or navigation sessions.
+     - returns: A boolean value indicating whether maneuver should appear as a notification.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldShowNotificationFor maneuver: CPManeuver,
+                        in mapTemplate: CPMapTemplate) -> Bool
+    
+    /**
+     Determines if the updated distance remaining for the maneuver should be presented as a
+     notification when the app is in the background.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter navigationAlert: Banner alert, for which notification will be shown.
+     - parameter mapTemplate: The map template that is visible during either preview or navigation sessions.
+     - returns: A boolean value indicating whether updated estimates should appear in the
+     notification.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldShowNotificationFor navigationAlert: CPNavigationAlert,
+                        in mapTemplate: CPMapTemplate) -> Bool
+    
+    /**
+     Determines if the navigation alert should be presented as a notification when the app
+     is in the background.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter maneuver: Maneuver, for which notification will be shown.
+     - parameter travelEstimates: Object that describes the time and distance remaining for the
+     active navigation session.
+     - parameter mapTemplate: The map template that is visible during either preview or navigation sessions.
+     - returns: A boolean value indicating whether alert should appear as a notification.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldUpdateNotificationFor maneuver: CPManeuver,
+                        with travelEstimates: CPTravelEstimates,
+                        in mapTemplate: CPMapTemplate) -> Bool
 }
 
 @available(iOS 12.0, *)
@@ -533,5 +578,33 @@ public extension CarPlayManagerDelegate {
                         for parentViewController: UIViewController) -> LineLayer? {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
         return nil
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldShowNotificationFor maneuver: CPManeuver,
+                        in mapTemplate: CPMapTemplate) -> Bool {
+        return false
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldShowNotificationFor navigationAlert: CPNavigationAlert,
+                        in mapTemplate: CPMapTemplate) -> Bool {
+        return false
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        shouldUpdateNotificationFor maneuver: CPManeuver,
+                        with travelEstimates: CPTravelEstimates,
+                        in mapTemplate: CPMapTemplate) -> Bool {
+        return false
     }
 }


### PR DESCRIPTION
### Description

PR adds `CarPlayManagerDelegate.carPlayManager(_:shouldUpdateNotificationFor:with:in:)` and `CarPlayManagerDelegate.carPlayManager(_:shouldShowNotificationFor:in:)` methods that allow to control notifications presentation on CarPlay while application is in background.