### PR TITLE
Add presentation transitions to `NavigationView` top and bottom banners.

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		8AB97C1A280A31C600792939 /* RoutesPreviewViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB97C19280A31C600792939 /* RoutesPreviewViewControllerDelegate.swift */; };
 		8AB97C1C280A323E00792939 /* RoutesPreviewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB97C1B280A323E00792939 /* RoutesPreviewDataSource.swift */; };
 		8AB97C1E280A364E00792939 /* PreviewViewControllerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB97C1D280A364E00792939 /* PreviewViewControllerState.swift */; };
+		8AB97C20280E021800792939 /* BannerContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB97C1F280E021800792939 /* BannerContainerView.swift */; };
 		8ABB9E75268E0140009013A5 /* NavigationCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABB9E74268E0140009013A5 /* NavigationCameraTests.swift */; };
 		8ABCD6A426AA0D9400B121B9 /* route-for-navigation-camera-bearing-smoothing.json in Resources */ = {isa = PBXBuildFile; fileRef = 8ABCD6A326AA0D9400B121B9 /* route-for-navigation-camera-bearing-smoothing.json */; };
 		8AC3965325DC66570027A035 /* NavigationCameraType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3965225DC66570027A035 /* NavigationCameraType.swift */; };
@@ -825,6 +826,7 @@
 		8AB97C19280A31C600792939 /* RoutesPreviewViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesPreviewViewControllerDelegate.swift; sourceTree = "<group>"; };
 		8AB97C1B280A323E00792939 /* RoutesPreviewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesPreviewDataSource.swift; sourceTree = "<group>"; };
 		8AB97C1D280A364E00792939 /* PreviewViewControllerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewViewControllerState.swift; sourceTree = "<group>"; };
+		8AB97C1F280E021800792939 /* BannerContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerContainerView.swift; sourceTree = "<group>"; };
 		8ABB9E74268E0140009013A5 /* NavigationCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCameraTests.swift; sourceTree = "<group>"; };
 		8ABCD6A326AA0D9400B121B9 /* route-for-navigation-camera-bearing-smoothing.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-for-navigation-camera-bearing-smoothing.json"; sourceTree = "<group>"; };
 		8AC3965225DC66570027A035 /* NavigationCameraType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCameraType.swift; sourceTree = "<group>"; };
@@ -1759,6 +1761,7 @@
 		8DFD94A52225AF5C00152F45 /* Banners */ = {
 			isa = PBXGroup;
 			children = (
+				8AB97C1F280E021800792939 /* BannerContainerView.swift */,
 				35F520BF1FB482A200FC9C37 /* NextBannerView.swift */,
 				8D63A7CF227A580A00520167 /* TopBannerViewController.swift */,
 				8A04DFBB275EBC1B00D87959 /* TopBannerViewControllerDelegate.swift */,
@@ -2790,6 +2793,7 @@
 				8AD2210F27C434CD000734A5 /* TitleLabel.swift in Sources */,
 				8AA0386127F7B3DF0007BD2D /* BottomBannerViewControllerLayout.swift in Sources */,
 				8A50A3CB26EC09FB00894A8E /* FeedbackSubtypeCollectionViewCell.swift in Sources */,
+				8AB97C20280E021800792939 /* BannerContainerView.swift in Sources */,
 				8A50A3D326EC0AE100894A8E /* IdleTimerManager.swift in Sources */,
 				8D5DFFF1207C04840093765A /* NSAttributedString.swift in Sources */,
 				8AD2211F27C43D11000734A5 /* FloatingButton.swift in Sources */,

--- a/Sources/MapboxNavigation/BannerContainerView.swift
+++ b/Sources/MapboxNavigation/BannerContainerView.swift
@@ -172,6 +172,7 @@ open class BannerContainerView: UIView {
     
     public func show(animated: Bool = true,
                      duration: TimeInterval = 0.2,
+                     animations: (() -> Void)? = nil,
                      completion: CompletionHandler? = nil) {
         guard isHidden else {
             completion?(true)
@@ -190,22 +191,23 @@ open class BannerContainerView: UIView {
         }
         
         if animated {
+            // TODO: Improve animation for devices with notch.
             switch type {
             case .top:
-                expansionConstraint.constant = -frame.height + self.topSafeAreaInset
+                expansionConstraint.constant = -frame.height //+ self.topSafeAreaInset
             case .bottom:
-                expansionConstraint.constant = frame.height - self.bottomSafeAreaInset
+                expansionConstraint.constant = frame.height //- self.bottomSafeAreaInset
             }
             
             isHidden = false
-            alpha = 0.0
             superview?.layoutIfNeeded()
             
             UIView.animate(withDuration: duration,
                            delay: 0.0,
                            options: [],
                            animations: {
-                self.alpha = 1.0
+                animations?()
+                
                 self.expansionConstraint.constant = 0.0
                 self.superview?.layoutIfNeeded()
             }) { completed in
@@ -219,6 +221,7 @@ open class BannerContainerView: UIView {
     
     public func hide(animated: Bool = true,
                      duration: TimeInterval = 0.2,
+                     animations: (() -> Void)? = nil,
                      completion: CompletionHandler? = nil) {
         guard !isHidden else {
             completion?(true)
@@ -230,6 +233,8 @@ open class BannerContainerView: UIView {
                            delay: 0.0,
                            options: [],
                            animations: {
+                animations?()
+                
                 switch self.type {
                 case .top:
                     self.expansionConstraint.constant = -self.frame.height

--- a/Sources/MapboxNavigation/BannerContainerView.swift
+++ b/Sources/MapboxNavigation/BannerContainerView.swift
@@ -1,0 +1,181 @@
+import UIKit
+
+// :nodoc:
+@objc(MBBannerContainerView)
+open class BannerContainerView: UIView {
+    
+    public enum `Type` {
+        case top
+        case bottom
+    }
+    
+    var type: BannerContainerView.`Type`
+    
+    enum State {
+        case expanded
+        case collapsed
+    }
+    
+    var isExpandable: Bool = false {
+        didSet {
+            guard let superview = superview else { return }
+            setupConstraints(superview)
+        }
+    }
+    
+    var expansionOffset: CGFloat = 50.0
+    
+    var state: State = .collapsed {
+        didSet {
+            if oldValue == state { return }
+            
+            if state == .expanded {
+                bottomConstraint.constant = 0.0
+            } else {
+                bottomConstraint.constant = expansionOffset
+            }
+        }
+    }
+    
+    var bottomConstraint: NSLayoutConstraint!
+    
+    var initialBottomOffset: CGFloat = 0.0
+    
+    public init(_ type: BannerContainerView.`Type`, frame: CGRect = .zero) {
+        self.type = type
+        
+        super.init(frame: frame)
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    open override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        
+        guard let superview = superview else { return }
+        
+        switch type {
+        case .top:
+            // TODO: Implement the ability to change top constraint.
+            break
+        case .bottom:
+            setupConstraints(superview)
+        }
+    }
+    
+    public typealias CompletionHandler = (_ completed: Bool) -> Void
+    
+    func setupConstraints(_ superview: UIView) {
+        if bottomConstraint != nil {
+            NSLayoutConstraint.deactivate([bottomConstraint])
+        }
+
+        bottomConstraint = bottomAnchor.constraint(equalTo: superview.bottomAnchor)
+
+        if isExpandable {
+            if state == .expanded {
+                bottomConstraint.constant = 0.0
+            } else {
+                bottomConstraint.constant = expansionOffset
+            }
+
+            let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(didPan))
+            addGestureRecognizer(panGestureRecognizer)
+        } else {
+            bottomConstraint.constant = 0.0
+        }
+
+        bottomConstraint.isActive = true
+    }
+    
+    @objc func didPan(_ recognizer: UIPanGestureRecognizer) {
+        guard let view = recognizer.view else { return }
+        
+        if recognizer.state == .began {
+            initialBottomOffset = bottomConstraint.constant
+        }
+        
+        let translation = recognizer.translation(in: view)
+        let currentOffset = initialBottomOffset + translation.y
+        
+        if currentOffset < 0.0 {
+            bottomConstraint.constant = 0.0
+        } else if currentOffset > expansionOffset {
+            bottomConstraint.constant = expansionOffset
+        } else {
+            bottomConstraint.constant = currentOffset
+        }
+        
+        if recognizer.state == .ended {
+            let velocity = recognizer.velocity(in: view)
+            
+            if velocity.y <= 0 {
+                state = .expanded
+            } else {
+                state = .collapsed
+            }
+            
+            UIView.animate(withDuration: 0.2,
+                           delay: 0.0,
+                           options: [.allowUserInteraction],
+                           animations: {
+                self.superview?.layoutIfNeeded()
+            }, completion: nil)
+        }
+    }
+    
+    func show(animated: Bool = true,
+              duration: TimeInterval = 0.5,
+              completion: CompletionHandler? = nil) {
+        guard isHidden else {
+            completion?(true)
+            return
+        }
+        
+        if animated {
+            bottomConstraint.constant = frame.height
+            isHidden = false
+            superview?.layoutIfNeeded()
+            
+            UIView.animate(withDuration: duration,
+                           delay: 0.0,
+                           options: [],
+                           animations: {
+                self.bottomConstraint.constant = 0.0
+                self.superview?.layoutIfNeeded()
+            }) { completed in
+                completion?(completed)
+            }
+        } else {
+            isHidden = false
+            completion?(true)
+        }
+    }
+    
+    public func hide(animated: Bool = true,
+                     duration: TimeInterval = 0.5,
+                     completion: CompletionHandler? = nil) {
+        guard !isHidden else {
+            completion?(true)
+            return
+        }
+        
+        if animated {
+            UIView.animate(withDuration: duration,
+                           delay: 0.0,
+                           options: [],
+                           animations: {
+                self.bottomConstraint.constant = self.frame.height
+                self.superview?.layoutIfNeeded()
+            }) { completed in
+                self.isHidden = true
+                completion?(completed)
+            }
+        } else {
+            isHidden = true
+            completion?(true)
+        }
+    }
+}

--- a/Sources/MapboxNavigation/BannerView.swift
+++ b/Sources/MapboxNavigation/BannerView.swift
@@ -1,12 +1,6 @@
 import UIKit
 
 // :nodoc:
-@objc(MBBannerContainerView)
-open class BannerContainerView: UIView {
-    
-}
-
-// :nodoc:
 @objc(MBTopBannerView)
 open class TopBannerView: UIView {
     

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -68,7 +68,9 @@ open class NavigationView: UIView {
     
     var tileStoreLocation: TileStoreConfiguration.Location? = .default
     private var _navigationMapView: NavigationMapView? = nil
-    lazy var navigationMapView: NavigationMapView = {
+    
+    // :nodoc:
+    public lazy var navigationMapView: NavigationMapView = {
         _navigationMapView?.frame = bounds
         let navigationMapView = _navigationMapView ?? NavigationMapView(frame: bounds, tileStoreLocation: tileStoreLocation)
         navigationMapView.isHidden = false
@@ -147,9 +149,19 @@ open class NavigationView: UIView {
     
     lazy var speedLimitView: SpeedLimitView = .forAutoLayout(hidden: true)
     
-    var topBannerContainerView: BannerContainerView
+    // :nodoc:
+    public lazy var topBannerContainerView: BannerContainerView = {
+        let topBannerContainerView = BannerContainerView(.top)
+        topBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
+        return topBannerContainerView
+    }()
     
-    var bottomBannerContainerView: BannerContainerView
+    // :nodoc:
+    public lazy var bottomBannerContainerView: BannerContainerView = {
+        let bottomBannerContainerView = BannerContainerView(.bottom)
+        bottomBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
+        return bottomBannerContainerView
+    }()
     
     func clearStackViews() {
         let oldFloatingButtons: [UIView] = floatingStackView.subviews
@@ -184,23 +196,11 @@ open class NavigationView: UIView {
         self.tileStoreLocation = tileStoreLocation
         self._navigationMapView = navigationMapView
         
-        topBannerContainerView = BannerContainerView(.top)
-        topBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
-        
-        bottomBannerContainerView = BannerContainerView(.bottom)
-        bottomBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
-        
         super.init(frame: frame)
         commonInit()
     }
     
     public required init?(coder decoder: NSCoder) {
-        topBannerContainerView = BannerContainerView(.top)
-        topBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
-        
-        bottomBannerContainerView = BannerContainerView(.bottom)
-        bottomBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
-        
         super.init(coder: decoder)
         commonInit()
     }


### PR DESCRIPTION
### Description

PR adds the ability to pan, expand/collapse and have animated transitions for the `BannerContainerView` that is used as top and bottom banner in `NavigationView`. Example:

https://user-images.githubusercontent.com/1496498/165241531-cdd084a0-f23e-46cc-8bef-acfb9b60d083.mov


