### PR TITLE
Fix the memory cache loss when App in the background.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fixed an issue where `UserPuckCourseView`’s color desaturated during turn-by-turn navigation even as the location was being updated. ([#3836](https://github.com/mapbox/mapbox-navigation-ios/pull/3836))
 * `UserPuckCourseView` no longer desaturates its color based on the age of the last location update. `RouteController` simulates location updates whenever Location Services is unable to receive real location updates. To ensure a steady stream of location updates outside of turn-by-turn navigation, install a `PassiveLocationManager`. ([#3836](https://github.com/mapbox/mapbox-navigation-ios/pull/3836))
+* Fixed the image cache loss when App goes to background. ([#3840](https://github.com/mapbox/mapbox-navigation-ios/pull/3840))
 
 ### CarPlay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Fixed an issue where `UserPuckCourseView`’s color desaturated during turn-by-turn navigation even as the location was being updated. ([#3836](https://github.com/mapbox/mapbox-navigation-ios/pull/3836))
 * `UserPuckCourseView` no longer desaturates its color based on the age of the last location update. `RouteController` simulates location updates whenever Location Services is unable to receive real location updates. To ensure a steady stream of location updates outside of turn-by-turn navigation, install a `PassiveLocationManager`. ([#3836](https://github.com/mapbox/mapbox-navigation-ios/pull/3836))
-* Fixed the image cache loss when App goes to background. ([#3840](https://github.com/mapbox/mapbox-navigation-ios/pull/3840))
+* Fixed an issue where shields disappeared after the application returns to the foreground. ([#3840](https://github.com/mapbox/mapbox-navigation-ios/pull/3840))
 
 ### CarPlay
 

--- a/Sources/MapboxNavigation/ImageCache.swift
+++ b/Sources/MapboxNavigation/ImageCache.swift
@@ -1,11 +1,23 @@
 import UIKit
 
+internal class ImageMemory: NSObject, NSDiscardableContent {
+    func beginContentAccess() -> Bool { return true }
+    func endContentAccess() { }
+    func discardContentIfPossible() {}
+    func isContentDiscarded() -> Bool { return false }
+    let image: UIImage
+    
+    init(_ image: UIImage) {
+        self.image = image
+    }
+}
+
 internal class ImageCache: BimodalImageCache {
-    let memoryCache: NSCache<NSString, UIImage>
+    let memoryCache: NSCache<NSString, ImageMemory>
     let fileCache: FileCache
 
     init() {
-        memoryCache = NSCache<NSString, UIImage>()
+        memoryCache = NSCache<NSString, ImageMemory>()
         memoryCache.name = "In-Memory Image Cache"
 
         fileCache = FileCache()
@@ -64,11 +76,12 @@ internal class ImageCache: BimodalImageCache {
     }
 
     private func storeImageInMemoryCache(_ image: UIImage, forKey key: String) {
-        memoryCache.setObject(image, forKey: key as NSString, cost: image.memoryCost)
+        let imageMemory = ImageMemory(image)
+        memoryCache.setObject(imageMemory, forKey: key as NSString, cost: image.memoryCost)
     }
 
     private func imageFromMemoryCache(forKey key: String) -> UIImage? {
-        return memoryCache.object(forKey: key as NSString)
+        return memoryCache.object(forKey: key as NSString)?.image
     }
 
     private func imageFromDiskCache(forKey key: String?) -> UIImage? {

--- a/Sources/MapboxNavigation/SpriteInfoCache.swift
+++ b/Sources/MapboxNavigation/SpriteInfoCache.swift
@@ -10,7 +10,11 @@ struct SpriteInfo: Codable, Equatable {
     var visible: Bool
 }
 
-class SpriteInfoWrapper<SpriteSpriteInfo>: NSObject {
+class SpriteInfoWrapper<SpriteSpriteInfo>: NSObject, NSDiscardableContent {
+    func beginContentAccess() -> Bool { return true }
+    func endContentAccess() { }
+    func discardContentIfPossible() {}
+    func isContentDiscarded() -> Bool { return false }
     let spriteInfo: SpriteInfo
     
     init(_ spriteInfo: SpriteInfo) {


### PR DESCRIPTION
### Description
This PR is to fix #3839 by making the image stored in `ImageCache`, and the `SpriteInfo` in the `SpriteInfoCache` won't be discarded when App goes into the background state.

### Implementation
Right now the `SpriteInfo` in the `SpriteInfoCache` and the image in the `ImageCache` are both stored in `NSCache`. And when App goes into the background, the `NSCache` will discard its memory cache. Right now we're using the `ImageCache` for the road name shield and also the top banners. The would lead to the cached image loss. 

So this Pr wrap the `UIImage` as the `ImageMemory` and make it conform to `NSDiscardableContent` and won't allowed it to be discarded, same as the `SpriteInfoWrapper`. So when the App goes to the background and then back, the cached images and `SpriteInfo` would still be available.

### Screenshots or Gifs
![keepMemory](https://user-images.githubusercontent.com/48976398/164340490-c4d1a60d-c246-4d18-8ea0-79723df2dc01.gif)

