### PR TITLE
Pass `EndOfRouteFeedback` to the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Other changes
 
-* Added the `NavigationViewControllerDelegate.navigationViewController(_:, didSubmitArrivalFeedback:)` method which is called to notify that the user submitted the end of route feedback. Implementation of this method receives an `EndOfRouteFeedback` object with user's rating and comment. en
+* Added the `NavigationViewControllerDelegate.navigationViewController(_:, didSubmitArrivalFeedback:)` method which is called to notify that the user submitted the end of route feedback. Implementation of this method receives an `EndOfRouteFeedback` object with user's rating and comment. ([#3842](https://github.com/mapbox/mapbox-navigation-ios/pull/3842))
 
 ## v2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 * Added the `CarPlayManagerDelegate.carPlayManager(_:shouldUpdateNotificationFor:with:in:)` and `CarPlayManagerDelegate.carPlayManager(_:shouldShowNotificationFor:in:)` to provide the ability to control notifications presentation while CarPlay application is in the background. ([#3828](https://github.com/mapbox/mapbox-navigation-ios/pull/3828))
 
+### Other changes
+
+* Added the `NavigationViewControllerDelegate.navigationViewController(_:, didSubmitArrivalFeedback:)` method which is called to notify that the user submitted the end of route feedback. Implementation of this method receives an `EndOfRouteFeedback` object with user's rating and comment. en
+
 ## v2.4.0
 
 ### Pricing

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -621,11 +621,6 @@ class ViewController: UIViewController {
 // MARK: - NavigationMapViewDelegate methods
 
 extension ViewController: NavigationMapViewDelegate {
-    
-    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitFeedback feedback: EndOfRouteFeedback?) {
-        print(feedback)
-    }
-    
     func navigationMapView(_ mapView: NavigationMapView, didSelect waypoint: Waypoint) {
         guard let responseOptions = response?.options, case let .route(routeOptions) = responseOptions else { return }
         let modifiedOptions = routeOptions.without(waypoint)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -622,6 +622,10 @@ class ViewController: UIViewController {
 
 extension ViewController: NavigationMapViewDelegate {
     
+    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitFeedback feedback: EndOfRouteFeedback?) {
+        print(feedback)
+    }
+    
     func navigationMapView(_ mapView: NavigationMapView, didSelect waypoint: Waypoint) {
         guard let responseOptions = response?.options, case let .route(routeOptions) = responseOptions else { return }
         let modifiedOptions = routeOptions.without(waypoint)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -621,6 +621,7 @@ class ViewController: UIViewController {
 // MARK: - NavigationMapViewDelegate methods
 
 extension ViewController: NavigationMapViewDelegate {
+
     func navigationMapView(_ mapView: NavigationMapView, didSelect waypoint: Waypoint) {
         guard let responseOptions = response?.options, case let .route(routeOptions) = responseOptions else { return }
         let modifiedOptions = routeOptions.without(waypoint)

--- a/Sources/MapboxCoreNavigation/Feedback/EndOfRouteFeedback.swift
+++ b/Sources/MapboxCoreNavigation/Feedback/EndOfRouteFeedback.swift
@@ -7,12 +7,12 @@ open class EndOfRouteFeedback {
     /**
      Rating: The user's rating for the route. Normalized between 0 and 100.
      */
-    let rating: Int?
+    public let rating: Int?
     
     /**
      Comment: Any comments that the user had about the route.
      */
-    let comment: String?
+    public let comment: String?
     
     @nonobjc public init(rating: Int? = nil, comment: String? = nil) {
         self.rating = rating

--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -4,6 +4,10 @@ import MapboxCoreNavigation
 import MapboxMobileEvents
 import MapboxMaps
 
+public protocol ArrivalControllerProtocol {
+//    showEndOfRoute
+}
+
 /// A component to encapsulate `EndOfRouteViewController` presenting logic such as enabling/disabling, handling autolayout, keyboard, positioning camera, etc.
 class ArrivalController: NavigationComponentDelegate {
     
@@ -43,7 +47,7 @@ class ArrivalController: NavigationComponentDelegate {
                                 advancesToNextLeg: Bool,
                                 duration: TimeInterval = 1.0,
                                 completion: ((Bool) -> Void)? = nil,
-                                onDismiss: EndOfRouteDismissalHandler? = nil) {
+                                onDismiss: @escaping EndOfRouteDismissalHandler) {
         guard navigationViewData.router.routeProgress.isFinalLeg &&
                 advancesToNextLeg &&
                 showsEndOfRoute else {

--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -4,10 +4,6 @@ import MapboxCoreNavigation
 import MapboxMobileEvents
 import MapboxMaps
 
-public protocol ArrivalControllerProtocol {
-//    showEndOfRoute
-}
-
 /// A component to encapsulate `EndOfRouteViewController` presenting logic such as enabling/disabling, handling autolayout, keyboard, positioning camera, etc.
 class ArrivalController: NavigationComponentDelegate {
     

--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -11,7 +11,7 @@ public protocol ArrivalControllerProtocol {
 /// A component to encapsulate `EndOfRouteViewController` presenting logic such as enabling/disabling, handling autolayout, keyboard, positioning camera, etc.
 class ArrivalController: NavigationComponentDelegate {
     
-    typealias EndOfRouteDismissalHandler = (EndOfRouteFeedback?) -> ()
+    typealias EndOfRouteDismissalHandler = (EndOfRouteFeedback) -> ()
     
     // MARK: Properties
     
@@ -92,7 +92,7 @@ class ArrivalController: NavigationComponentDelegate {
     
     // MARK: Private Methods
     
-    private func embedEndOfRoute(into viewController: UIViewController, onDismiss: EndOfRouteDismissalHandler? = nil) {
+    private func embedEndOfRoute(into viewController: UIViewController, onDismiss: @escaping EndOfRouteDismissalHandler) {
         let endOfRoute = endOfRouteViewController
         viewController.addChild(endOfRoute)
         navigationViewData.navigationView.endOfRouteView = endOfRoute.view
@@ -101,7 +101,7 @@ class ArrivalController: NavigationComponentDelegate {
 
         endOfRoute.dismissHandler = { [weak self] (stars, comment) in
             guard let rating = self?.rating(for: stars) else { return }
-            onDismiss?(EndOfRouteFeedback(rating: rating, comment: comment))
+            onDismiss(EndOfRouteFeedback(rating: rating, comment: comment))
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -455,7 +455,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         return true
     }
     
-    fileprivate func handleCancelAction() {
+    fileprivate func handleCancelAction(with feedback: EndOfRouteFeedback? = nil) {
+        delegate?.navigationViewController(self, didSubmitFeedback: feedback)
         if delegate?.navigationViewControllerDidDismiss(self, byCanceling: true) != nil {
             // The receiver should handle dismissal of the NavigationViewController
         } else {
@@ -711,7 +712,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
 
 extension NavigationViewController: NavigationViewDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton) {
-        handleCancelAction()
+        handleCancelAction(with: nil)
     }
 }
 
@@ -900,7 +901,7 @@ extension NavigationViewController: NavigationServiceDelegate {
                                                   advancesToNextLeg: advancesToNextLeg,
                                                   onDismiss: { [weak self] in
                                                     self?.navigationService.endNavigation(feedback: $0)
-                                                    self?.handleCancelAction()
+                                                    self?.handleCancelAction(with: $0)
                                                   })
         return advancesToNextLeg
     }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -455,7 +455,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         return true
     }
     
-    fileprivate func handleCancelAction(with feedback: EndOfRouteFeedback? = nil) {
+    fileprivate func handleCancelAction() {
         if delegate?.navigationViewControllerDidDismiss(self, byCanceling: true) != nil {
             // The receiver should handle dismissal of the NavigationViewController
         } else {
@@ -711,7 +711,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
 
 extension NavigationViewController: NavigationViewDelegate {
     func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton) {
-        handleCancelAction(with: nil)
+        handleCancelAction()
     }
 }
 
@@ -899,7 +899,7 @@ extension NavigationViewController: NavigationServiceDelegate {
         let dismissCallback: (EndOfRouteFeedback) -> Void = { [weak self] in
             guard let self = self else { return }
             self.navigationService.endNavigation(feedback: $0)
-            self.handleCancelAction(with: $0)
+            self.handleCancelAction()
             self.delegate?.navigationViewController(self, didSubmitArrivalFeedback: $0)
         }
         arrivalController?.showEndOfRouteIfNeeded(self, advancesToNextLeg: advancesToNextLeg, onDismiss: dismissCallback)

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -238,7 +238,13 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool
     
-    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitFeedback feedback: EndOfRouteFeedback?)
+    /**
+     Called to notify that the user submitted the end of route feedback.
+     
+     - parameter navigationViewController: The `NavigationViewController` object.
+     - parameter feedback: The `EndOfRouteFeedback` that was submitted by the user.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitArrivalFeedback feedback: EndOfRouteFeedback)
 }
 
 public extension NavigationViewControllerDelegate {
@@ -389,8 +395,11 @@ public extension NavigationViewControllerDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, didAdd finalDestinationAnnotation: PointAnnotation, pointAnnotationManager: PointAnnotationManager) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
-    
-    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitFeedback feedback: EndOfRouteFeedback?) {
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitArrivalFeedback feedback: EndOfRouteFeedback) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self, level: .debug)
     }
 }

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -237,6 +237,8 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      - returns: If `true`, the location is discarded and the `NavigationViewController` will not consider it. If `false`, the location will not be thrown out.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, shouldDiscard location: CLLocation) -> Bool
+    
+    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitFeedback feedback: EndOfRouteFeedback?)
 }
 
 public extension NavigationViewControllerDelegate {
@@ -386,5 +388,9 @@ public extension NavigationViewControllerDelegate {
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didAdd finalDestinationAnnotation: PointAnnotation, pointAnnotationManager: PointAnnotationManager) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+    }
+    
+    func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitFeedback feedback: EndOfRouteFeedback?) {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self, level: .debug)
     }
 }


### PR DESCRIPTION
### Description
Added a new method to `NavigationViewControllerDelegate` which is called to notify that the user submitted the end of route feedback.