### PR TITLE
Fixes missing CarPlay UI elements in active navigation

### DIFF
--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -476,8 +476,8 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         navigationMapView.mapView.ornaments.options.attributionButton.visibility = .hidden
         
         navigationMapView.navigationCamera.follow()
-        
-        view.addSubview(navigationMapView)
+
+        view.insertSubview(navigationMapView, at: 0)
         navigationMapView.pinInSuperview()
         
         self.navigationMapView = navigationMapView


### PR DESCRIPTION
The issue appeared after #3773 fix.

#3773 changed the order of setup methods in `CarPlayNavigationViewController.viewDidLoad()`. And this order is important because views are added on top one another.

The fix is to always add navigation map as the first view in hierarchy.

Fixes #3852