### PR TITLE
Restore active navigation on CarPlay when it is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 ### CarPlay
 
 * Fixed an issue where an active navigation using CarPlay application with route that contains multiple legs would cause a memory leak. ([#3877](https://github.com/mapbox/mapbox-navigation-ios/pull/3877))
+* Added the `CarPlayManagerDelegate.carPlayManager(_:shouldUpdateNotificationFor:with:in:)` and `CarPlayManagerDelegate.carPlayManager(_:shouldShowNotificationFor:in:)` to provide the ability to control notifications presentation while CarPlay application is in the background. ([#3828](https://github.com/mapbox/mapbox-navigation-ios/pull/3828))
 
 ### Other Changes
 * During turn-by-turn navigation, incidents along the route are now refreshed periodically along with traffic congestion.

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -553,6 +553,11 @@ class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
         appDelegate.carPlayManager.templateApplicationScene(templateApplicationScene,
                                                             didConnectCarInterfaceController: interfaceController,
                                                             to: window)
+        // NOTE: When CarPlay is connected, we check if there is an active navigation in progress and start CarPlay
+        //       navigation as well, otherwise, CarPlay will be in passive navigation and stay out of sync with iOS app. 
+        if appDelegate.currentAppRootViewController?.activeNavigationViewController != nil {
+            appDelegate.currentAppRootViewController?.beginCarPlayNavigation()
+        }
     }
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,


### PR DESCRIPTION
Fixes an issue in Example app where CarPlay didn't transition to Active Navigation if, by the time CarPlay is connected, iPhone is already in Active Navigation.

https://user-images.githubusercontent.com/413986/166891359-36e0ec5a-33b8-44f6-9bb8-b94ff84f79d8.mov

