### PR TITLE
Fix datasetProfileIdentifier in PassiveLocationManager constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Other changes
 
 * Added the `NavigationViewControllerDelegate.navigationViewController(_:, didSubmitArrivalFeedback:)` method which is called to notify that the user submitted the end of route feedback. Implementation of this method receives an `EndOfRouteFeedback` object with user's rating and comment. ([#3842](https://github.com/mapbox/mapbox-navigation-ios/pull/3842))
+* Fixed an issue where value of `datasetProfileIdentifier` argument was ignored in `PassiveLocationManager` constructor. ([#3867](https://github.com/mapbox/mapbox-navigation-ios/pull/3867))
 
 ## v2.4.1
 

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -57,7 +57,7 @@ open class PassiveLocationManager: NSObject {
     
     private var _eventsManager: NavigationEventsManager?
     
-    private let sharedNavigator = Navigator.shared
+    private let sharedNavigator: Navigator
     
     /**
      The underlying navigator that performs map matching.
@@ -268,6 +268,8 @@ open class PassiveLocationManager: NSObject {
         if let datasetProfileIdentifier = datasetProfileIdentifier {
             Navigator.datasetProfileIdentifier = datasetProfileIdentifier
         }
+
+        self.sharedNavigator = Navigator.shared
         
         self.directions = directions
         


### PR DESCRIPTION
### Description
The value of `datasetProfileIdentifier` argument was ignored in `PassiveLocationManager` constructor as `sharedNavigator: Navigator` was created before `Navigator.datasetProfileIdentifier` is set.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->