### PR TITLE
Use legacy fallback icon for U.S. state road shields first.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fixed an issue where shields disappeared after the application returns to the foreground. ([#3840](https://github.com/mapbox/mapbox-navigation-ios/pull/3840))
 * Fixed an issue where `EndOfRouteCommentView` is using dark style when only light style is allowed. ([#3845](https://github.com/mapbox/mapbox-navigation-ios/pull/3845))
 * Fixed an issue where exit views and generic shields in top banner don't get updated when style changes in active navigation. ([#3864](https://github.com/mapbox/mapbox-navigation-ios/pull/3864))
+* Fixed an issue where the current road name label used a generic white circle instead of the correct shield to represent a state route in the United States. ([#3870](https://github.com/mapbox/mapbox-navigation-ios/pull/3870))
 
 ### CarPlay
 

--- a/Sources/MapboxNavigation/WayNameView.swift
+++ b/Sources/MapboxNavigation/WayNameView.swift
@@ -47,18 +47,14 @@ open class WayNameLabel: StylableLabel {
     // If there's no valid shield image, display the road name only.
     private func setUpWith(roadName: String) {
         if let shield = representation?.shield {
-            // For `us-state` shield, use the legacy shield first, then fall back to use the generic shield icon.
-            // For non `us-state` shield, use the generic shield icon first, then fall back to use the legacy shield.
-            if shield.name == "us-state",
-               setAttributedText(roadName: roadName, cacheKey: representation?.legacyCacheKey) {
-                return
-            } else if setAttributedText(roadName: roadName, shield: shield) {
-                return
-            }
+            // For US state road, use the legacy shield first, then fall back to use the generic shield icon.
+            // The shield name for US state road is `circle-white` in Streets source v8 style.
+            // For non US state road, use the generic shield icon first, then fall back to use the legacy shield.
+            if shield.name == "circle-white",
+               setAttributedText(roadName: roadName, cacheKey: representation?.legacyCacheKey) { return }
+            if setAttributedText(roadName: roadName, shield: shield) { return }
         }
-        if setAttributedText(roadName: roadName, cacheKey: representation?.legacyCacheKey) {
-            return
-        }
+        if setAttributedText(roadName: roadName, cacheKey: representation?.legacyCacheKey) { return }
         
         text = roadName
     }


### PR DESCRIPTION
### Description
This Pr is to fix #3868, to allow the U.S. state route shields using the legacy icon first, then fall back to the Mapbox designed shield.

### Implementation
In road name label, because we ask to update the `SpriteRepository.updateRepresentation(for:completion:)` first to prepare both the Mapbox designed shield and legacy icons already. We could directly check the `shield.name` to make a choice.

In `InstructionLabel`, we're using the singleton of `SpriteRepository` since #3864 , the Mapbox designed shield could be ready to use while the legacy icon hasn't been downloaded yet. 
So for the `circle-white` road, we check whether we have the legacy icon ready to use, if we have, we use it first. Then if the legacy icon isn't ready to use, we check whether it's a U.S. state road. If it's a U.S. state road, the `imageBaseURL` for the `ImageRepresentation` is not nil, then we should call the `SpriteRepository` to download it. If it doesn't have a valid `imageBaseURL` for the `ImageRepresentation`, it's not a  U.S. state road, we use the Mapbox designed shield instead.

For all the other road, we use the Mapbox designed shield first, and then legacy icon as the fallback.
 

### Screenshots or Gifs
![InstructionStateShield](https://user-images.githubusercontent.com/48976398/167197074-37a76d2c-4e1c-444a-867d-44312f827c5e.png)

![RoadLabelStateShield](https://user-images.githubusercontent.com/48976398/167197083-9ceef125-8c70-4408-ab15-fb02f46a6cb8.png)

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->