### PR TITLE
MapboxDirections v2.5.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Packaging
 
 * MapboxNavigation now requires [MapboxMaps v10.5.0-rc.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.5.0-rc.1). ([#3834](https://github.com/mapbox/mapbox-navigation-ios/pull/3834))
+* MapboxCoreNavigation now requires [MapboxDirections v2.5.0-beta.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.5.0-beta.1). ([#3871](https://github.com/mapbox/mapbox-navigation-ios/pull/3871))
 * MapboxCoreNavigation now requires [MapboxNavigationNative v98._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/98.0.0). ([#3862](https://github.com/mapbox/mapbox-navigation-ios/pull/3862))
 
 ### Location tracking

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 21.3.0-rc.2
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 98.0
-github "mapbox/mapbox-directions-swift" ~> 2.4
+github "mapbox/mapbox-directions-swift" == 2.5.0-beta.1
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,7 @@ binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "98.0.0"
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v3.1.2"
-github "mapbox/mapbox-directions-swift" "v2.4.0"
+github "mapbox/mapbox-directions-swift" "v2.5.0-beta.1"
 github "mapbox/mapbox-events-ios" "v1.0.8"
 github "mapbox/turf-swift" "v2.4.0"
 github "pointfreeco/swift-snapshot-testing" "1.9.0"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxCoreNavigation"
 
   s.dependency "MapboxNavigationNative", "~> 98.0"
-  s.dependency "MapboxDirections", "~> 2.4"
+  s.dependency "MapboxDirections-pre", "2.5.0-beta.1"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 
   s.swift_version = "5.0"

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "a85b353688f7ffb22809fbc890518f9f1dff7c43",
-          "version": "2.4.0"
+          "revision": "58e4c443e90110d70c2c56ff91771332eab0d6ed",
+          "version": "2.5.0-beta.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "a85b353688f7ffb22809fbc890518f9f1dff7c43",
-          "version": "2.4.0"
+          "revision": "58e4c443e90110d70c2c56ff91771332eab0d6ed",
+          "version": "2.5.0-beta.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.4.0"),
+        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .exact("2.5.0-beta.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
         .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "98.0.0"),
         .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", .exact("10.5.0-rc.1")),

--- a/Sources/MapboxCoreNavigation/RestStop.swift
+++ b/Sources/MapboxCoreNavigation/RestStop.swift
@@ -7,9 +7,9 @@ extension RestStop {
     init(_ serviceArea: ServiceAreaInfo) {
         switch serviceArea.type {
         case .restArea:
-            self.init(type: .restArea)
+            self.init(type: .restArea, name: serviceArea.name)
         case .serviceArea:
-            self.init(type: .serviceArea)
+            self.init(type: .serviceArea, name: serviceArea.name)
         @unknown default:
             fatalError("Unknown ServiceAreaInfo type.")
         }

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
@@ -232,7 +232,7 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PodInstall/Pods-PodInstall-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
-				"${BUILT_PRODUCTS_DIR}/MapboxDirections/MapboxDirections.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxDirections-pre/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMaps/MapboxMaps.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxSpeech/MapboxSpeech.framework",

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - MapboxCoreMaps (10.5.0-rc.1):
     - MapboxCommon (~> 21.3.0-rc)
   - MapboxCoreNavigation (2.5.0-beta.2):
-    - MapboxDirections (~> 2.4)
+    - MapboxDirections-pre (= 2.5.0-beta.1)
     - MapboxMobileEvents (~> 1.0)
     - MapboxNavigationNative (~> 98.0)
-  - MapboxDirections (2.4.0):
+  - MapboxDirections-pre (2.5.0-beta.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.0)
   - MapboxMaps (10.5.0-rc.1):
@@ -36,7 +36,7 @@ SPEC REPOS:
   trunk:
     - MapboxCommon
     - MapboxCoreMaps
-    - MapboxDirections
+    - MapboxDirections-pre
     - MapboxMaps
     - MapboxMobileEvents
     - MapboxNavigationNative
@@ -54,8 +54,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 4c7bbe5e3a06f6d5711cbbce0eb7d17d6f5ba5e7
   MapboxCoreMaps: 66b814bc79930848ebd8c37beb267385e1f85d01
-  MapboxCoreNavigation: 08cfa06d0187718a14f0ab7c378e9ad8424ee142
-  MapboxDirections: c3fd015787ff85b6bcfba7b12156d75fa74121b1
+  MapboxCoreNavigation: 9d3f2bf9d8d0871a4b8b9339985bea97807b5e90
+  MapboxDirections-pre: b267332f864b83bcdf8681d7e2a20ac045df1dad
   MapboxMaps: 68005489b42a825aeb0a8a31d92368d30578782d
   MapboxMobileEvents: f7f3e8daeb4b83688ae62a4172dce79169a97233
   MapboxNavigation: e3d026c39cb038ef1e18f2000cc5816040b972d4


### PR DESCRIPTION
Upgraded to MapboxDirections v2.5.0-beta.1. Technically, we don’t need to increase the minimum version yet, but it’ll unblock https://github.com/mapbox/mapbox-navigation-ios/pull/3869#issuecomment-1119876430. In the meantime, it’ll allow us to get some testing on mapbox/mapbox-directions-swift#669 and monitor its performance.

/cc @mapbox/navigation-ios