### PR TITLE
Fix memory leak which occurred after presenting intermediate waypoint arrival dialog on CarPlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
    * Replaced the `Router.routingProvider` property with `Router.customRoutingProvider`.
 * Renamed the `NavigationSettings.initialize(directions:tileStoreConfiguration:)` method to  `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:)`. This method allows you to control whether the rerouting uses the network or offline routing data. ([#3754](https://github.com/mapbox/mapbox-navigation-ios/pull/3754), [#3824](https://github.com/mapbox/mapbox-navigation-ios/pull/3824))
 
+### CarPlay
+
+* Fixed an issue where an active navigation using CarPlay application with route that contains multiple legs would cause a memory leak. ([#3877](https://github.com/mapbox/mapbox-navigation-ios/pull/3877))
+
 ## v2.4.1
 
 * Fixed an issue where the current road name, speed limit, and compass were missing from the map in CarPlay’s navigating activity. ([#3858](https://github.com/mapbox/mapbox-navigation-ios/pull/3858))

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -390,6 +390,10 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        suspendNotifications()
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -803,7 +807,8 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
                                               value: "Continue",
                                               comment: "Title on continue button in CarPlay")
         
-        let continueAlert = CPAlertAction(title: continueTitle, style: .default) { (action) in
+        let continueAlert = CPAlertAction(title: continueTitle, style: .default) { [weak self] _ in
+            guard let self = self else { return }
             self.carInterfaceController.dismissTemplate(animated: true)
             self.updateRouteOnMap()
         }


### PR DESCRIPTION
### Description

This PR fixes an issue that occurs when using CarPlay and actively navigating with more than one route leg.

Closing #3876.