### PR TITLE
Stop navigation without dismissing UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## main
+
+### Routing
+
+* Added `Router.finishRouting()` method to finish routing session without dismissing related UI and logic components.([#3880](https://github.com/mapbox/mapbox-navigation-ios/pull/3880))
+
 ## v2.5.0
 
 ### Packaging

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -337,6 +337,7 @@ open class RouteController: NSObject {
 
     private var hasFinishedRouting = false
     public func finishRouting() {
+        guard !hasFinishedRouting else { return }
         hasFinishedRouting = true
         removeRoutes(completion: nil)
         BillingHandler.shared.stopBillingSession(with: sessionUUID)
@@ -635,10 +636,7 @@ open class RouteController: NSObject {
     }
     
     deinit {
-        removeRoutes(completion: nil)
-        BillingHandler.shared.stopBillingSession(with: sessionUUID)
-        unsubscribeNotifications()
-        routeTask?.cancel()
+        finishRouting()
         rerouteController.resetToDefaultSettings()
         Self.instanceLock.lock()
         Self.instance = nil

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -199,6 +199,12 @@ public protocol Router: CLLocationManagerDelegate {
     func updateRoute(with indexedRouteResponse: IndexedRouteResponse,
                      routeOptions: RouteOptions?,
                      completion: ((Bool) -> Void)?)
+    
+    /// Forcefully stop navigation process without ability to continue it.
+    ///
+    /// Use this method to indicate that you no longer need navigation experience for current session/UI.
+    /// After finishing, `Router` will not be able to update route, route leg, issue a reroute or do any other update, related to route traversing.
+    func finishRouting()
 }
 
 protocol InternalRouter: AnyObject {


### PR DESCRIPTION
### Description
This PR adds functionality to stop active navigation session without dismissing relate UI and components.

### Implementation
Implementation uses similar logic as on `RouteController.deinit`. It stops active billing session, unsubscribes from navigator updates and blocks any user API calls, related to updating or changing the route.