### PR TITLE
Allow `Always show dark maps` option on CarPlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### CarPlay
 
-* Fixed an issue where `StyleManager` appearance update on CarPlay would cause appearance update on iOS as well. ([#3914](https://github.com/mapbox/mapbox-navigation-ios/pull/3914))
+* Fixed an issue where shields would become invisible when users drive through the tunnel. ([#3882](https://github.com/mapbox/mapbox-navigation-ios/pull/3882))
+* Added the ability to change map style depending on the option that was set in `Always show dark maps`. ([#3882](https://github.com/mapbox/mapbox-navigation-ios/pull/3882))
 
 ## v2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
 
 ### CarPlay
 
-* Fixed an issue where shields would become invisible when users drive through the tunnel. ([#3882](https://github.com/mapbox/mapbox-navigation-ios/pull/3882))
-* Added the ability to change map style depending on the option that was set in `Always show dark maps`. ([#3882](https://github.com/mapbox/mapbox-navigation-ios/pull/3882))
+* Fixed an issue where route shields disappeared when the user enters a tunnel. ([#3882](https://github.com/mapbox/mapbox-navigation-ios/pull/3882))
+* The map automatically chooses the night style when "Always Show Dark Maps" is enabled in the Appearance section of Settings. ([#3882](https://github.com/mapbox/mapbox-navigation-ios/pull/3882))
+* Renamed the `VisualInstruction.carPlayManeuverLabelAttributedText(bounds:shieldHeight:window:)` to the `VisualInstruction.carPlayManeuverLabelAttributedText(bounds:shieldHeight:window:traitCollection:instructionLabelType:)` to have the ability to change color of the shield icons depending on provided trait collection. ([#3882](https://github.com/mapbox/mapbox-navigation-ios/pull/3882))
 
 ## v2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Routing
 
-* Added `Router.finishRouting()` method to finish routing session without dismissing related UI and logic components.([#3880](https://github.com/mapbox/mapbox-navigation-ios/pull/3880))
+* Added `Router.finishRouting()` method to finish routing session without dismissing related UI and logic components. ([#3880](https://github.com/mapbox/mapbox-navigation-ios/pull/3880))
 
 ### Map
 
 * Added the `layerPosition` parameter to the `NavigationMapView.show(_:layerPosition:legIndex:)` method for controlling the position of the main route layer while presenting routes. ([#3897](https://github.com/mapbox/mapbox-navigation-ios/pull/3897))
+
+### CarPlay
+
+* Fixed an issue where `StyleManager` appearance update on CarPlay would cause appearance update on iOS as well. ([#3914](https://github.com/mapbox/mapbox-navigation-ios/pull/3914))
 
 ## v2.5.0
 

--- a/Example/ViewController+StyleManager.swift
+++ b/Example/ViewController+StyleManager.swift
@@ -4,12 +4,18 @@ import MapboxNavigation
 import MapboxMaps
 
 extension ViewController : StyleManagerDelegate {
+    
     func location(for styleManager: MapboxNavigation.StyleManager) -> CLLocation? {
+        // Sometimes when style changes user might be already actively navigating, this means that
+        // `navigationMapView` is no longer available.
+        if navigationMapView == nil { return nil }
+        
         if let location = navigationMapView.mapView.location.latestLocation?.location {
             return location
         } else if let location = CLLocationManager.init().location {
             return location
         }
+        
         return nil
     }
     

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -48,6 +48,11 @@ open class CarPlayMapViewController: UIViewController {
     public var wayNameView: WayNameView!
     
     /**
+     Session configuration that is used to track `CPContentStyle` related changes.
+     */
+    var sessionConfiguration: CPSessionConfiguration!
+    
+    /**
      The interface styles available to `styleManager` for display.
      */
     var styles: [Style] {
@@ -186,6 +191,8 @@ open class CarPlayMapViewController: UIViewController {
         self.styles = styles
         
         super.init(nibName: nil, bundle: nil)
+        
+        sessionConfiguration = CPSessionConfiguration(delegate: self)
     }
     
     /**
@@ -325,6 +332,23 @@ open class CarPlayMapViewController: UIViewController {
         navigationMapView.navigationCamera.follow()
     }
     
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        if #available(iOS 13.0, *) {
+            applyStyleIfNeeded(sessionConfiguration.contentStyle)
+        }
+    }
+    
+    @available(iOS 13.0, *)
+    func applyStyleIfNeeded(_ contentStyle: CPContentStyle) {
+        if contentStyle.contains(.dark) {
+            styleManager?.applyStyle(type: .night)
+        } else if contentStyle.contains(.light) {
+            styleManager?.applyStyle(type: .day)
+        }
+    }
+    
     public override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         
@@ -419,6 +443,16 @@ extension CarPlayMapViewController: NavigationMapViewDelegate {
         delegate?.carPlayMapViewController(self,
                                            routeCasingLineLayerWithIdentifier: identifier,
                                            sourceIdentifier: sourceIdentifier)
+    }
+}
+
+@available(iOS 12.0, *)
+extension CarPlayMapViewController: CPSessionConfigurationDelegate {
+    
+    @available(iOS 13.0, *)
+    public func sessionConfiguration(_ sessionConfiguration: CPSessionConfiguration,
+                                     contentStyleChanged contentStyle: CPContentStyle) {
+        applyStyleIfNeeded(contentStyle)
     }
 }
 #endif

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -787,7 +787,7 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         if let attributedPrimary = visualInstruction.primaryInstruction.carPlayManeuverLabelAttributedText(bounds: bounds,
                                                                                                            shieldHeight: shieldHeight,
                                                                                                            window: carPlayManager.carWindow,
-                                                                                                           customTraitCollection: traitCollection,
+                                                                                                           traitCollection: traitCollection,
                                                                                                            instructionLabelType: PrimaryLabel.self) {
             
             let instruction = NSMutableAttributedString(attributedString: attributedPrimary)
@@ -795,7 +795,7 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
             if let attributedSecondary = visualInstruction.secondaryInstruction?.carPlayManeuverLabelAttributedText(bounds: bounds,
                                                                                                                     shieldHeight: shieldHeight,
                                                                                                                     window: carPlayManager.carWindow,
-                                                                                                                    customTraitCollection: traitCollection,
+                                                                                                                    traitCollection: traitCollection,
                                                                                                                     instructionLabelType: SecondaryLabel.self) {
                 instruction.append(NSAttributedString(string: "\n"))
                 instruction.append(attributedSecondary)
@@ -829,7 +829,7 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
                 if let attributedTertiary = tertiaryInstruction.carPlayManeuverLabelAttributedText(bounds: bounds,
                                                                                                    shieldHeight: shieldHeight,
                                                                                                    window: carPlayManager.carWindow,
-                                                                                                   customTraitCollection: traitCollection) {
+                                                                                                   traitCollection: traitCollection) {
                     let attributedTertiary = NSMutableAttributedString(attributedString: attributedTertiary)
                     attributedTertiary.canonicalizeAttachments(maximumImageSize: maximumImageSize, imageRendererFormat: imageRendererFormat)
                     tertiaryManeuver.attributedInstructionVariants = [attributedTertiary]

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -150,10 +150,9 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
      */
     func updateMapTemplateStyle() {
         var currentUserInterfaceStyle = traitCollection.userInterfaceStyle
-        // `Style` that is currently used on CarPlay. Regardless of the user interface
-        // style that was set in CarPlay settings style that is currently used in `StyleManager` will have
-        // precedence. Precedence of the style over trait collection is required for custom cases
-        // (e.g. when user is driving through the tunnel).
+        // Regardless of the user interface style that was set in CarPlay settings style that is
+        // currently used in `StyleManager` will have precedence. Precedence of the style over
+        // trait collection is required for custom cases (e.g. when user is driving through the tunnel).
         if usesNightStyleWhileInTunnel,
            isTraversingTunnel,
            let styleType = styleManager?.currentStyleType {

--- a/Sources/MapboxNavigation/InstructionLabel.swift
+++ b/Sources/MapboxNavigation/InstructionLabel.swift
@@ -22,6 +22,7 @@ open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
     var shieldHeight: CGFloat = 30
     var imageDownloadCompletion: (() -> Void)?
     weak var instructionDelegate: VisualInstructionDelegate?
+    var customTraitCollection: UITraitCollection?
     
     var instruction: VisualInstruction? {
         didSet {
@@ -43,7 +44,7 @@ open class InstructionLabel: StylableLabel, InstructionPresenterDataSource {
         
         let presenter = InstructionPresenter(instruction,
                                              dataSource: self,
-                                             traitCollection: traitCollection,
+                                             traitCollection: customTraitCollection ?? traitCollection,
                                              downloadCompletion: update)
         
         let attributed = presenter.attributedText()

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -104,7 +104,7 @@ extension VisualInstruction {
      - parameter bounds: A closure that calculates the available bounds for the maneuver text.
      - parameter shieldHeight: The height of the shield.
      - parameter window: A `UIWindow` that holds the `UIAppearance` styling properties, preferably the CarPlay window.
-     - parameter customTraitCollection: Custom `UITraitCollection` that is used to control color of
+     - parameter traitCollection: Custom `UITraitCollection` that is used to control color of
      the shield icons depending on various custom situations when actual trait collection is different
      (e.g. when driving through the tunnel).
      - parameter instructionLabelType: Type, which is inherited from `InstructionLabel` and will be
@@ -116,10 +116,10 @@ extension VisualInstruction {
     public func carPlayManeuverLabelAttributedText<T: InstructionLabel>(bounds: @escaping () -> (CGRect),
                                                                         shieldHeight: CGFloat,
                                                                         window: UIWindow?,
-                                                                        customTraitCollection: UITraitCollection? = nil,
+                                                                        traitCollection: UITraitCollection? = nil,
                                                                         instructionLabelType: T.Type? = nil) -> NSAttributedString? {
         let instructionLabel = T.init()
-        instructionLabel.customTraitCollection = customTraitCollection
+        instructionLabel.customTraitCollection = traitCollection
         instructionLabel.availableBounds = bounds
         instructionLabel.shieldHeight = shieldHeight
         

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -104,6 +104,9 @@ extension VisualInstruction {
      - parameter bounds: A closure that calculates the available bounds for the maneuver text.
      - parameter shieldHeight: The height of the shield.
      - parameter window: A `UIWindow` that holds the `UIAppearance` styling properties, preferably the CarPlay window.
+     - parameter customTraitCollection: Custom `UITraitCollection` that is used to control color of
+     the shield icons depending on various custom situations when actual trait collection is different
+     (e.g. when driving through the tunnel).
      - parameter instructionLabelType: Type, which is inherited from `InstructionLabel` and will be
      used for showing a visual instruction.
      
@@ -113,8 +116,10 @@ extension VisualInstruction {
     public func carPlayManeuverLabelAttributedText<T: InstructionLabel>(bounds: @escaping () -> (CGRect),
                                                                         shieldHeight: CGFloat,
                                                                         window: UIWindow?,
+                                                                        customTraitCollection: UITraitCollection? = nil,
                                                                         instructionLabelType: T.Type? = nil) -> NSAttributedString? {
-        let instructionLabel = T.init() 
+        let instructionLabel = T.init()
+        instructionLabel.customTraitCollection = customTraitCollection
         instructionLabel.availableBounds = bounds
         instructionLabel.shieldHeight = shieldHeight
         


### PR DESCRIPTION
### Description

- PR implements the ability to track changes to `Always show dark maps` option as it was described in https://github.com/mapbox/mapbox-navigation-ios/issues/3879.
- PR fixes an issue when shield icons become invisible when users drive through the tunnel. Fixes https://github.com/mapbox/mapbox-navigation-ios/issues/3878.