### PR TITLE
Add the ability to show route line layers based on the custom layer position.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added `Router.finishRouting()` method to finish routing session without dismissing related UI and logic components.([#3880](https://github.com/mapbox/mapbox-navigation-ios/pull/3880))
 
+### Map
+
+* Added the `layerPosition` parameter to the `NavigationMapView.show(_:layerPosition:legIndex:)` method for controlling the position of the main route layer while presenting routes. ([#3897](https://github.com/mapbox/mapbox-navigation-ios/pull/3897))
+
 ## v2.5.0
 
 ### Packaging
@@ -57,6 +61,7 @@
 * Added the `CarPlayManagerDelegate.carPlayManager(_:shouldUpdateNotificationFor:with:in:)` and `CarPlayManagerDelegate.carPlayManager(_:shouldShowNotificationFor:in:)` to provide the ability to control notifications presentation while CarPlay application is in the background. ([#3828](https://github.com/mapbox/mapbox-navigation-ios/pull/3828))
 
 ### Other Changes
+
 * During turn-by-turn navigation, incidents along the route are now refreshed periodically along with traffic congestion.
 * When the user passes a named toll collection point, the `TollCollection` object obtained through the `Notification.Name.electronicHorizonDidPassRoadObject` notification now has the `TollCollection.name` property set.
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -218,10 +218,14 @@ open class NavigationMapView: UIView {
      are currently deselected or inactive. The order of routes in this array may differ from the
      order in the original `RouteResponse`, for example in response to a user selecting a preferred
      route.
+     - parameter layerPosition: Position of the first route layer. Remaining routes and their casings
+     are always displayed below the first and all other subsequent route layers. Defaults to `nil`.
      - parameter legIndex: The zero-based index of the currently active leg along the active route.
      The active leg is highlighted more prominently than inactive legs.
      */
-    public func show(_ routes: [Route], legIndex: Int? = nil) {
+    public func show(_ routes: [Route],
+                     layerPosition: MapboxMaps.LayerPosition? = nil,
+                     legIndex: Int? = nil) {
         removeRoutes()
         
         self.routes = routes
@@ -239,10 +243,23 @@ open class NavigationMapView: UIView {
             }
             
             if showsRestrictedAreasOnRoute {
-                parentLayerIdentifier = addRouteRestrictedAreaLayer(route, below: parentLayerIdentifier)
+                parentLayerIdentifier = addRouteRestrictedAreaLayer(route,
+                                                                    below: parentLayerIdentifier)
             }
-            parentLayerIdentifier = addRouteLayer(route, below: parentLayerIdentifier, isMainRoute: index == 0, legIndex: legIndex)
-            parentLayerIdentifier = addRouteCasingLayer(route, below: parentLayerIdentifier, isMainRoute: index == 0)
+            
+            // Use custom layer position for the main route layer. All other alternative route layers
+            // will be placed below it.
+            let customLayerPosition = index == 0 ? layerPosition : nil
+            
+            parentLayerIdentifier = addRouteLayer(route,
+                                                  customLayerPosition: customLayerPosition,
+                                                  below: parentLayerIdentifier,
+                                                  isMainRoute: index == 0,
+                                                  legIndex: legIndex)
+            
+            parentLayerIdentifier = addRouteCasingLayer(route,
+                                                        below: parentLayerIdentifier,
+                                                        isMainRoute: index == 0)
         }
     }
     
@@ -571,6 +588,7 @@ open class NavigationMapView: UIView {
     }
     
     @discardableResult func addRouteLayer(_ route: Route,
+                                          customLayerPosition: MapboxMaps.LayerPosition? = nil,
                                           below parentLayerIndentifier: String? = nil,
                                           isMainRoute: Bool = true,
                                           legIndex: Int? = nil) -> String? {
@@ -640,13 +658,20 @@ open class NavigationMapView: UIView {
             do {
                 var layerPosition: MapboxMaps.LayerPosition? = nil
                 
-                if isMainRoute {
-                    if let aboveLayerIdentifier = mapView.mainRouteLineParentLayerIdentifier {
-                        layerPosition = .above(aboveLayerIdentifier)
-                    }
+                // In case if custom layer position was set - use it, otherwise in case if the route
+                // is the main one place it above `MapView.mainRouteLineParentLayerIdentifier`. All
+                // other alternative routes will be placed below it.
+                if let customLayerPosition = customLayerPosition {
+                    layerPosition = customLayerPosition
                 } else {
-                    if let belowLayerIdentifier = parentLayerIndentifier {
-                        layerPosition = .below(belowLayerIdentifier)
+                    if isMainRoute {
+                        if let aboveLayerIdentifier = mapView.mainRouteLineParentLayerIdentifier {
+                            layerPosition = .above(aboveLayerIdentifier)
+                        }
+                    } else {
+                        if let belowLayerIdentifier = parentLayerIndentifier {
+                            layerPosition = .below(belowLayerIdentifier)
+                        }
                     }
                 }
                 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -220,6 +220,7 @@ open class NavigationMapView: UIView {
      route.
      - parameter layerPosition: Position of the first route layer. Remaining routes and their casings
      are always displayed below the first and all other subsequent route layers. Defaults to `nil`.
+     If layer position is set to `nil`, the route layer appears below the bottommost symbol layer.
      - parameter legIndex: The zero-based index of the currently active leg along the active route.
      The active leg is highlighted more prominently than inactive legs.
      */


### PR DESCRIPTION
### Description

PR adds the ability to place main route line below custom `MapboxMaps.LayerPosition` in `NavigationMapView.show(_:layerPosition:legIndex:)`. If such parameter is not provided `MapView.mainRouteLineParentLayerIdentifier` is used by default as a parent layer for the main route layer.

### Screenshots or Gifs

```swift
let layerPosition: MapboxMaps.LayerPosition? = .above("settlement-major-label")
NavigationMapView.show(routes, layerPosition: layerPosition)
```

![Simulator Screen Shot - iPhone 13 - 2022-05-19 at 11 48 54](https://user-images.githubusercontent.com/1496498/169267863-30f858a2-a090-476d-a883-583ae8062ebb.png)

```swift
let layerPosition: MapboxMaps.LayerPosition? = .below("settlement-major-label")
NavigationMapView.show(routes, layerPosition: layerPosition)
```

![Simulator Screen Shot - iPhone 13 - 2022-05-19 at 11 49 38](https://user-images.githubusercontent.com/1496498/169267997-74d4dfe1-b61f-4fc5-9118-b6cec6b135a4.png)