### PR TITLE
Route response parsing credentials fix

### DIFF
--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -276,7 +276,8 @@ open class RouteController: NSObject {
                   return
         }
         
-        let routeRequest = NavigationSettings.shared.directions.url(forCalculating: routeOptions).absoluteString
+        let routeRequest = Directions(credentials: indexedRouteResponse.routeResponse.credentials)
+                                .url(forCalculating: routeOptions).absoluteString
         
         let parsedRoutes = RouteParser.parseDirectionsResponse(forResponse: routeJSONString,
                                                                request: routeRequest, routeOrigin: RouterOrigin.custom)

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -276,7 +276,7 @@ open class RouteController: NSObject {
                   return
         }
         
-        let routeRequest = Directions().url(forCalculating: routeOptions).absoluteString
+        let routeRequest = NavigationSettings.shared.directions.url(forCalculating: routeOptions).absoluteString
         
         let parsedRoutes = RouteParser.parseDirectionsResponse(forResponse: routeJSONString,
                                                                request: routeRequest, routeOrigin: RouterOrigin.custom)


### PR DESCRIPTION
### Description
When setting a route to Navigator, we should use the correct credentials to parse it.

### Implementation
Replaced usage of a newly created Directions instance which uses credentials from a plist with credentials existing in incoming `indexedRouteResponse` which may be configured differently. Thus maintained credentials consistency in the SDK components.