### PR TITLE
Cherry-pick - Fix the crash of `routeRemainingDistancesIndex` after reroute. (#3896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Fixed an issue where `UserPuckCourseView`’s color desaturated during turn-by-turn navigation even as the location was being updated. ([#3836](https://github.com/mapbox/mapbox-navigation-ios/pull/3836))
 * Fixed an issue where the `PassiveLocationManager(directions:systemLocationManager:eventsManagerType:userInfo:datasetProfileIdentifier:)` initializer’s `datasetProfileIdentifier` argument was ignored. ([#3867](https://github.com/mapbox/mapbox-navigation-ios/pull/3867))
 * Fixed an issue where the user location was sometimes snapped to a parallel street just before it merges with the actual street. ([#3862](https://github.com/mapbox/mapbox-navigation-ios/pull/3862))
+* Fix the possible crash after rerouting when `routeLineTracksTraversal` enabled. ([#3896](https://github.com/mapbox/mapbox-navigation-ios/pull/3896))
 
 ### Routing
 

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -85,7 +85,7 @@ extension NavigationMapView {
         if currentStepProgress.distanceTraveled <= 0 {
             allRemainingPoints += currentLegSteps[currentLegProgress.stepIndex].dropLast().count
         } else if let startIndex = lineString.indexedCoordinateFromStart(distance: currentStepProgress.distanceTraveled)?.index,
-                  startIndex < lineString.coordinates.endIndex - 1 {
+                  lineString.coordinates.indices.contains(startIndex) {
             allRemainingPoints += lineString.coordinates.suffix(from: startIndex + 1).dropLast().count
         }
         
@@ -154,7 +154,7 @@ extension NavigationMapView {
     func updateFractionTraveled(coordinate: CLLocationCoordinate2D) {
         guard let granularDistances = routeLineGranularDistances,
               let index = routeRemainingDistancesIndex,
-              index < granularDistances.distanceArray.endIndex else { return }
+              granularDistances.distanceArray.indices.contains(index) else { return }
         let traveledIndex = granularDistances.distanceArray[index]
         let upcomingPoint = traveledIndex.point
         


### PR DESCRIPTION
### Description
Cherry-pick for this fix: #3896

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->