### PR TITLE
Lanes view filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Lane guidance remains visible while the step table is visible. ([#3805](https://github.com/mapbox/mapbox-navigation-ios/pull/3805))
 * Removed a transparent gap that appeared between the top banner and step table if the user completed a maneuver while the step table was visible. ([#3805](https://github.com/mapbox/mapbox-navigation-ios/pull/3805))
 * Fixed an issue where a gray dashed line, which normally indicates a restricted-access road, appeared at the beginning of the route line even if there was no restriction. ([#3811](https://github.com/mapbox/mapbox-navigation-ios/pull/3811))
+* Lanes guidance views will now be shown even when all lanes a valid for the curren route. ([#3903](https://github.com/mapbox/mapbox-navigation-ios/pull/3903))
 
 ### User feedback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Lane guidance remains visible while the step table is visible. ([#3805](https://github.com/mapbox/mapbox-navigation-ios/pull/3805))
 * Removed a transparent gap that appeared between the top banner and step table if the user completed a maneuver while the step table was visible. ([#3805](https://github.com/mapbox/mapbox-navigation-ios/pull/3805))
 * Fixed an issue where a gray dashed line, which normally indicates a restricted-access road, appeared at the beginning of the route line even if there was no restriction. ([#3811](https://github.com/mapbox/mapbox-navigation-ios/pull/3811))
-* Lanes guidance views will now be shown even when all lanes a valid for the curren route. ([#3903](https://github.com/mapbox/mapbox-navigation-ios/pull/3903))
+* Lanes guidance views will now be shown even when all lanes a valid for the current route. ([#3903](https://github.com/mapbox/mapbox-navigation-ios/pull/3903))
 
 ### User feedback
 

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -59,7 +59,7 @@ open class LanesView: UIView, NavigationComponent {
             }
         }
         
-        guard !subviews.isEmpty && subviews.contains(where: { !$0.isValid }) else {
+        guard !subviews.isEmpty && subviews.contains(where: { $0.isValid }) else {
             hide(animated: animated,
                  duration: duration) { completed in
                 completion?(completed)


### PR DESCRIPTION
### Description
PR removes hiding lanes view when all of the suggested lanes are valid for the current route. This is done for parity with Android and for additional user info since it may still matter and affect lane selection to avoid slow left/right turning lanes on the way

### Implementation
Replaced filtering check with a sanity check that at least 1 of the proposed lanes is valid.