### PR TITLE
Fix the crash of non-stop shield update in instruction guidance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Removed a transparent gap that appeared between the top banner and step table if the user completed a maneuver while the step table was visible. ([#3805](https://github.com/mapbox/mapbox-navigation-ios/pull/3805))
 * Fixed an issue where a gray dashed line, which normally indicates a restricted-access road, appeared at the beginning of the route line even if there was no restriction. ([#3811](https://github.com/mapbox/mapbox-navigation-ios/pull/3811))
 * Lanes guidance views will now be shown even when all lanes a valid for the current route. ([#3903](https://github.com/mapbox/mapbox-navigation-ios/pull/3903))
+* Fixed the crash of nonstop road shield updates when no valid road information contained in guidance instruction. ([#3911](https://github.com/mapbox/mapbox-navigation-ios/pull/3911))
 
 ### User feedback
 

--- a/Sources/MapboxNavigation/ExitView.swift
+++ b/Sources/MapboxNavigation/ExitView.swift
@@ -164,7 +164,6 @@ public class ExitView: StylableView {
         
         var criticalProperties: [AnyHashable?] = [
             side,
-            styleID,
             dataSource.font.pointSize,
             appearance.backgroundColor,
             appearance.foregroundColor,
@@ -176,6 +175,10 @@ public class ExitView: StylableView {
         
         if #available(iOS 12.0, *) {
             criticalProperties.append(traitCollection.userInterfaceStyle.rawValue)
+        }
+        
+        if let styleID = styleID {
+            criticalProperties.append(styleID)
         }
         
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0)}))

--- a/Sources/MapboxNavigation/GenericRouteShield.swift
+++ b/Sources/MapboxNavigation/GenericRouteShield.swift
@@ -110,7 +110,6 @@ public class GenericRouteShield: StylableView {
         }
         
         var criticalProperties: [AnyHashable?] = [
-            styleID,
             dataSource.font.pointSize,
             appearance.backgroundColor,
             appearance.foregroundColor,
@@ -122,6 +121,10 @@ public class GenericRouteShield: StylableView {
         
         if #available(iOS 12.0, *) {
             criticalProperties.append(traitCollection.userInterfaceStyle.rawValue)
+        }
+        
+        if let styleID = styleID {
+            criticalProperties.append(styleID)
         }
         
         return String(describing: criticalProperties.reduce(0, { $0 ^ ($1?.hashValue ?? 0) }))

--- a/Sources/MapboxNavigation/InstructionPresenter.swift
+++ b/Sources/MapboxNavigation/InstructionPresenter.swift
@@ -182,7 +182,7 @@ class InstructionPresenter {
             if shield.name == "circle-white" {
                 if let legacyIcon = repository.legacyCache.image(forKey: representation.legacyCacheKey) {
                     return legacyAttributedString(for: legacyIcon, dataSource: dataSource)
-                } else if representation.imageBaseURL != nil {
+                } else if representation.legacyCacheKey != nil {
                     spriteRepository.updateRepresentation(for: representation, completion: onImageDownload)
                     return nil
                 }
@@ -197,7 +197,10 @@ class InstructionPresenter {
         }
 
         // Return nothing in the meantime, triggering downstream behavior (generic shield or text).
-        spriteRepository.updateRepresentation(for: representation, completion: onImageDownload)
+        // Update the SpriteRepository with the ImageRepresentation only when it has valid shield or legacy shield.
+        if representation.shield != nil || representation.legacyCacheKey != nil {
+            spriteRepository.updateRepresentation(for: representation, completion: onImageDownload)
+        }
         return nil
     }
     


### PR DESCRIPTION
### Description
This PR is to fix the nonstop call of `SpriteRepository.updateRepresentation(for:completion:) ` when the instruction contains a road with no shield or legacy shield information in `VisualInstruction.Component.ImageRepresentation`.

### Implementation
Update the `SpriteRepository` with the `ImageRepresentation` only when it has valid shield or legacy shield, otherwise, keep using generic shields or plain string without downstream downloading.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->