### PR TITLE
Fix Maps SDK dependency in podspec

### DIFF
--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", "10.5.0"
+  s.dependency "MapboxMaps", "~> 10.5"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech", "~> 2.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
   - MapboxMobileEvents (1.0.7)
   - MapboxNavigation (2.5.0-rc.3):
     - MapboxCoreNavigation (= 2.5.0-rc.3)
-    - MapboxMaps (= 10.5.0)
+    - MapboxMaps (~> 10.5)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
@@ -58,7 +58,7 @@ SPEC CHECKSUMS:
   MapboxDirections-pre: a1a76617fe016918654d7d65bfb7cace31a1bcf7
   MapboxMaps: e85375aa3d6bea94bf9c0221aa59f35ee0b29f29
   MapboxMobileEvents: f7f3e8daeb4b83688ae62a4172dce79169a97233
-  MapboxNavigation: 2e22dd1a5050a987cfba5167d020d0d90fad1f35
+  MapboxNavigation: 33e23859a8dd8e4a941fb77ae9ad9e5bd3d7ae86
   MapboxNavigationNative: 2616c3107613454b3bedf1e54798e42e318d875c
   MapboxSpeech: e4ed02984444b6373374c72c369edaf045cc490c
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->
For parity reasons between SPM and CocoaPods, we should not lock the Maps SDK version to be exact `10.5.0`.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->