### PR TITLE
Pause and resume navigator when using `RouteController`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,14 @@
 * When proactive reroute happens, new departure voice instruction will not be pronounced anymore. ([#3937](https://github.com/mapbox/mapbox-navigation-ios/pull/3937))
 * Fixed an issue where a departure instruction (e.g., “Head west”) was announced periodically in the middle of a trip due to proactive rerouting. ([#3937](https://github.com/mapbox/mapbox-navigation-ios/pull/3937))
 
+### Pricing
+
+* When calling `MapboxNavigationService.start()` and `MapboxNavigationService.stop()` billing session will be resumed and paused respectively. ([#3928](https://github.com/mapbox/mapbox-navigation-ios/pull/3928))
+
 ### Map
 
 * Added the `layerPosition` parameter to the `NavigationMapView.show(_:layerPosition:legIndex:)` method for controlling the position of the main route layer while presenting routes. ([#3897](https://github.com/mapbox/mapbox-navigation-ios/pull/3897))
+* Fixed an issue where camera kept receiving updates even after stopping `MapboxNavigationService`. ([#3928](https://github.com/mapbox/mapbox-navigation-ios/pull/3928))
 
 ### CarPlay
 

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -358,12 +358,15 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     // MARK: Handling LocationManager Output
     
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
-        guard !hasFinishedRouting else { return }
+        guard !hasFinishedRouting,
+              BillingHandler.shared.sessionState(uuid: sessionUUID) == .running else { return }
+        
         heading = newHeading
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard !hasFinishedRouting else { return }
+        guard !hasFinishedRouting,
+              BillingHandler.shared.sessionState(uuid: sessionUUID) == .running else { return }
         
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -262,7 +262,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         router.delegate = self
         
         if let routeController = router as? RouteController {
-            routeController.navigator.resume()
+            BillingHandler.shared.resumeBillingSession(with: routeController.sessionUUID)
         }
     }
     
@@ -279,7 +279,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         
         // Navigator should also be paused to prevent further location updates.
         if let routeController = router as? RouteController {
-            routeController.navigator.pause()
+            BillingHandler.shared.pauseBillingSession(with: routeController.sessionUUID)
         }
     }
     

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -260,10 +260,13 @@ public class MapboxNavigationService: NSObject, NavigationService {
         
         eventsManager.sendRouteRetrievalEvent()
         router.delegate = self
+        
+        if let routeController = router as? RouteController {
+            routeController.navigator.resume()
+        }
     }
     
     public func stop() {
-        
         nativeLocationSource.stopUpdatingHeading()
         nativeLocationSource.stopUpdatingLocation()
         
@@ -273,6 +276,11 @@ public class MapboxNavigationService: NSObject, NavigationService {
         
         poorGPSTimer.disarm()
         router.delegate = nil
+        
+        // Navigator should also be paused to prevent further location updates.
+        if let routeController = router as? RouteController {
+            routeController.navigator.pause()
+        }
     }
     
     public func endNavigation(feedback: EndOfRouteFeedback? = nil) {

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -237,12 +237,10 @@ open class RouteController: NSObject {
     var previousArrivalWaypoint: MapboxDirections.Waypoint?
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard !hasFinishedRouting else { return }
-        guard let location = locations.last else { return }
-        
-        guard !(delegate?.router(self, shouldDiscard: location) ?? DefaultBehavior.shouldDiscardLocation) else {
-            return
-        }
+        guard !hasFinishedRouting,
+              BillingHandler.shared.sessionState(uuid: sessionUUID) == .running,
+              let location = locations.last,
+              !(delegate?.router(self, shouldDiscard: location) ?? DefaultBehavior.shouldDiscardLocation) else { return }
         
         rawLocation = location
         
@@ -254,7 +252,9 @@ open class RouteController: NSObject {
     }
     
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
-        guard !hasFinishedRouting else { return }
+        guard !hasFinishedRouting,
+              BillingHandler.shared.sessionState(uuid: sessionUUID) == .running else { return }
+        
         heading = newHeading
     }
     

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -35,8 +35,7 @@ open class RouteController: NSObject {
     private static weak var instance: RouteController?
     private static let instanceLock: NSLock = .init()
 
-
-    private let sessionUUID: UUID = .init()
+    let sessionUUID: UUID = .init()
     private var isInitialized: Bool = false
     
     // MARK: Configuring Route-Related Data

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -809,7 +809,7 @@ class NavigationServiceTests: TestCase {
         routeController.finishRouting()
         XCTAssertEqual(BillingHandler.shared.sessionState(uuid: routeController.sessionUUID), .stopped)
         
-        waitForNavNativeCallbacks(timeout: 0.1)
+        waitForNavNativeCallbacks()
     }
     
     func testNavigationServiceStartStopFinishSeveralTimes() {
@@ -834,7 +834,54 @@ class NavigationServiceTests: TestCase {
         routeController.finishRouting()
         XCTAssertEqual(BillingHandler.shared.sessionState(uuid: routeController.sessionUUID), .stopped)
         
-        waitForNavNativeCallbacks(timeout: 0.1)
+        waitForNavNativeCallbacks()
+    }
+    
+    func testNavigationServiceStopShouldStopLocationUpdates() {
+        let navigationService = MapboxNavigationService(routeResponse: response,
+                                                        routeIndex: 0,
+                                                        routeOptions: routeOptions,
+                                                        customRoutingProvider: MapboxRoutingProvider(.offline),
+                                                        credentials: Fixture.credentials,
+                                                        simulating: .never)
+        
+        guard let routeShape = route.legs[0].steps[0].shape else {
+            XCTFail("Invalid route shape.")
+            return
+        }
+        
+        let routeCoordinates = routeShape.coordinates
+        let now = Date()
+        let routeLocations = routeCoordinates.enumerated().map {
+            CLLocation(coordinate: $0.element,
+                       altitude: -1,
+                       horizontalAccuracy: 10,
+                       verticalAccuracy: -1,
+                       course: -1,
+                       speed: 10,
+                       timestamp: now + $0.offset)
+        }
+        
+        navigationService.start()
+        
+        var lastRawLocation: CLLocation?
+        
+        // There are 9 locations in the first step. Iterate over them and stop navigation service
+        // after reaching 4th location. Since billing session is paused (and navigator as well),
+        // it is expected that last raw location doesn't change after stopping.
+        routeLocations.enumerated().forEach {
+            if $0.offset == 4 {
+                navigationService.stop()
+            }
+            navigationService.locationManager(navigationService.locationManager, didUpdateLocations: [$0.element])
+            
+            lastRawLocation = navigationService.router.rawLocation
+        }
+        
+        let expectedLastRawLocation = routeLocations[3]
+        XCTAssertEqual(lastRawLocation, expectedLastRawLocation, "Unexpected last raw location.")
+        
+        waitForNavNativeCallbacks()
     }
 }
 

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import MapboxDirections
 import Turf
 import MapboxMobileEvents
-import os.log
-import Nimble
 @testable import TestHelper
 @testable import MapboxCoreNavigation
 

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -790,7 +790,7 @@ class NavigationServiceTests: TestCase {
         _ = XCTWaiter.wait(for: [waitExpectation], timeout: timeout)
     }
     
-    func testNavigationServiceStartStopFinish() {
+    func disabled_testNavigationServiceStartStopFinish() {
         dependencies = createDependencies()
         
         let navigationService = dependencies.navigationService
@@ -815,7 +815,7 @@ class NavigationServiceTests: TestCase {
     }
     
 #if arch(x86_64) && DEBUG
-    func testNavigationServiceStartStopFinishSeveralTimes() {
+    func disabled_testNavigationServiceStartStopFinishSeveralTimes() {
         dependencies = createDependencies()
         
         let navigationService = dependencies.navigationService

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -790,7 +790,7 @@ class NavigationServiceTests: TestCase {
         _ = XCTWaiter.wait(for: [waitExpectation], timeout: timeout)
     }
     
-    func disabled_testNavigationServiceStartStopFinish() {
+    func testNavigationServiceStartStopFinish() {
         dependencies = createDependencies()
         
         let navigationService = dependencies.navigationService
@@ -814,8 +814,7 @@ class NavigationServiceTests: TestCase {
         waitForNavNativeCallbacks(timeout: 0.1)
     }
     
-#if arch(x86_64) && DEBUG
-    func disabled_testNavigationServiceStartStopFinishSeveralTimes() {
+    func testNavigationServiceStartStopFinishSeveralTimes() {
         dependencies = createDependencies()
         
         let navigationService = dependencies.navigationService
@@ -837,14 +836,8 @@ class NavigationServiceTests: TestCase {
         routeController.finishRouting()
         XCTAssertEqual(BillingHandler.shared.sessionState(uuid: routeController.sessionUUID), .stopped)
         
-        // It should not be possible to start navigation session which was already finished.
-        expect {
-            navigationService.start()
-        }.to(throwAssertion())
-        
         waitForNavNativeCallbacks(timeout: 0.1)
     }
-#endif
 }
 
 class EmptyNavigationServiceDelegate: NavigationServiceDelegate {}

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -814,6 +814,7 @@ class NavigationServiceTests: TestCase {
         waitForNavNativeCallbacks(timeout: 0.1)
     }
     
+#if arch(x86_64) && DEBUG
     func testNavigationServiceStartStopFinishSeveralTimes() {
         dependencies = createDependencies()
         
@@ -836,15 +837,14 @@ class NavigationServiceTests: TestCase {
         routeController.finishRouting()
         XCTAssertEqual(BillingHandler.shared.sessionState(uuid: routeController.sessionUUID), .stopped)
         
-#if arch(x86_64) && DEBUG
         // It should not be possible to start navigation session which was already finished.
         expect {
             navigationService.start()
         }.to(throwAssertion())
-#endif
         
         waitForNavNativeCallbacks(timeout: 0.1)
     }
+#endif
 }
 
 class EmptyNavigationServiceDelegate: NavigationServiceDelegate {}


### PR DESCRIPTION
### Description

Fixes #3924.

PR allows to pause and resume navigator when using `RouteController` to prevent any issues with continuous status updates.

https://user-images.githubusercontent.com/1496498/171311510-52c0ae41-e5b8-489e-8b93-4d3906ccb641.mov


