### PR TITLE
Simulation Rerouting fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.5.1
+
+### Other changes
+
+* Fixed an issue where `SimulatedLocationManager` would jump back to the beginning of the simulated route whenever `RouteController` reroutes the user onto a different route. ([#3929](https://github.com/mapbox/mapbox-navigation-ios/pull/3929))
+
 ## v2.5.0
 
 ### Packaging

--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -211,7 +211,14 @@ open class SimulatedLocationManager: NavigationLocationManager {
             return
         }
 
-        self.currentDistance = calculateCurrentDistance(router.routeProgress.distanceTraveled)
+        if let location = self.location,
+           let shape = router.route.shape,
+           let closestCoordinate = shape.closestCoordinate(to: location.coordinate) {
+            currentDistance = closestCoordinate.distance
+        } else {
+            currentDistance = calculateCurrentDistance(router.routeProgress.distanceTraveled)
+        }
+        
         routeProgress = router.routeProgress
         route = router.routeProgress.route
     }


### PR DESCRIPTION
### Description
When SimulatedLocationManager is used and user is rerouted with alternative route, the location manager would simulate the route from the origin, which for alternatives case does not match current simulated location. This PR modifies detection logic to find the closest coordinate to continue simulating.

Before the fix:
![before](https://user-images.githubusercontent.com/23082783/171426941-420f8858-0932-4bae-8b0f-3e2f365d4e69.gif)
Notice user puck is pushed backward to the alternative origin when switched.

After: 
![after](https://user-images.githubusercontent.com/23082783/171427056-c4d6c345-0589-4f0e-a1f6-5d6f0c8e7bdb.gif)
Notice puck pushed back just a bit when switching. 