### PR TITLE
Suppress departure instruction after proactive reroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Snapped locations are spaced more evenly when the application is connected to an external GPS or CarPlay device capable of high-frequency location updates and the user rounds a corner. ([#3913](https://github.com/mapbox/mapbox-navigation-ios/pull/3913))
 * Fixed an issue where the user’s location would be snapped to the nearest road while the user moved around in a parking garage where the [parking aisles](https://wiki.openstreetmap.org/wiki/Tag:service%3Dparking_aisle) have not been mapped in detail. ([#3913](https://github.com/mapbox/mapbox-navigation-ios/pull/3913))
 * Fixed an issue where `RouteController` sometimes took too long to detect that the user went off the route after making a turn or taking an off-ramp. ([#3913](https://github.com/mapbox/mapbox-navigation-ios/pull/3913))
+* When proactive reroute happens, new departure voice instruction will not be pronounced anymore. ([#3937](https://github.com/mapbox/mapbox-navigation-ios/pull/3937))
 
 ### Map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fixed an issue where the user’s location would be snapped to the nearest road while the user moved around in a parking garage where the [parking aisles](https://wiki.openstreetmap.org/wiki/Tag:service%3Dparking_aisle) have not been mapped in detail. ([#3913](https://github.com/mapbox/mapbox-navigation-ios/pull/3913))
 * Fixed an issue where `RouteController` sometimes took too long to detect that the user went off the route after making a turn or taking an off-ramp. ([#3913](https://github.com/mapbox/mapbox-navigation-ios/pull/3913))
 * When proactive reroute happens, new departure voice instruction will not be pronounced anymore. ([#3937](https://github.com/mapbox/mapbox-navigation-ios/pull/3937))
+* Fixed an issue where a departure instruction (e.g., “Head west”) was announced periodically in the middle of a trip due to proactive rerouting. ([#3937](https://github.com/mapbox/mapbox-navigation-ios/pull/3937))
 
 ### Map
 

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -808,7 +808,7 @@ extension RouteController: Router {
                 self.routeProgress = routeProgress
                 self.announce(reroute: route, at: self.location, proactive: isProactive)
                 self.indexedRouteResponse = indexedRouteResponse
-                self.didProactiveReroute = true
+                self.didProactiveReroute = isProactive
                 completion?(true)
             case .failure:
                 completion?(false)

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -194,6 +194,8 @@ open class RouteController: NSObject {
         sharedNavigator.rerouteController
     }
     
+    var didProactiveReroute: Bool = false
+    
     public var reroutesProactively: Bool = true
     
     var lastProactiveRerouteDate: Date?
@@ -456,7 +458,10 @@ open class RouteController: NSObject {
         // Announce voice instruction if it was updated and we are not going to reroute
         if didUpdate && !willReRoute,
             let spokenInstruction = routeProgress.currentLegProgress.currentStepProgress.currentSpokenInstruction {
-            announcePassage(of: spokenInstruction, routeProgress: routeProgress)
+            if !didProactiveReroute {
+                announcePassage(of: spokenInstruction, routeProgress: routeProgress)
+            }
+            didProactiveReroute = false
         }
     }
     
@@ -803,6 +808,7 @@ extension RouteController: Router {
                 self.routeProgress = routeProgress
                 self.announce(reroute: route, at: self.location, proactive: isProactive)
                 self.indexedRouteResponse = indexedRouteResponse
+                self.didProactiveReroute = true
                 completion?(true)
             case .failure:
                 completion?(false)


### PR DESCRIPTION
### Description
When a faster route is found an applied, we should skip the first voice instruction because it will be a duplicate of what was already announced by the original route.

### Implementation
Added a flag to skip first instruction after a proactive reroute.