### PR TITLE
Route Origin handling

### DIFF
--- a/Sources/MapboxCoreNavigation/AlternativeRoute.swift
+++ b/Sources/MapboxCoreNavigation/AlternativeRoute.swift
@@ -29,7 +29,7 @@ public struct AlternativeRoute: Identifiable {
     /// It is unique withing the same navigation session.
     public let id: ID
     /// Original (main) route data
-    public private(set) var indexedRouteResponse: IndexedRouteResponse
+    public let indexedRouteResponse: IndexedRouteResponse
     /// Intersection on the main route, where alternative route branches.
     public let mainRouteIntersection: Intersection
     /// Intersection on the alternative route, where it splits from the main route.

--- a/Sources/MapboxCoreNavigation/AlternativeRoute.swift
+++ b/Sources/MapboxCoreNavigation/AlternativeRoute.swift
@@ -29,7 +29,7 @@ public struct AlternativeRoute: Identifiable {
     /// It is unique withing the same navigation session.
     public let id: ID
     /// Original (main) route data
-    public let indexedRouteResponse: IndexedRouteResponse
+    public private(set) var indexedRouteResponse: IndexedRouteResponse
     /// Intersection on the main route, where alternative route branches.
     public let mainRouteIntersection: Intersection
     /// Intersection on the alternative route, where it splits from the main route.
@@ -48,7 +48,8 @@ public struct AlternativeRoute: Identifiable {
 
         self.indexedRouteResponse = .init(routeResponse: decoded.routeResponse,
                                           routeIndex: Int(nativeRouteAlternative.route.getRouteIndex()))
-
+        self.indexedRouteResponse.responseOrigin = nativeRouteAlternative.route.getRouterOrigin()
+        
         var legIndex = Int(nativeRouteAlternative.mainRouteFork.legIndex)
         var segmentIndex = Int(nativeRouteAlternative.mainRouteFork.segmentIndex)
 

--- a/Sources/MapboxCoreNavigation/AlternativeRoute.swift
+++ b/Sources/MapboxCoreNavigation/AlternativeRoute.swift
@@ -47,8 +47,8 @@ public struct AlternativeRoute: Identifiable {
         }
 
         self.indexedRouteResponse = .init(routeResponse: decoded.routeResponse,
-                                          routeIndex: Int(nativeRouteAlternative.route.getRouteIndex()))
-        self.indexedRouteResponse.responseOrigin = nativeRouteAlternative.route.getRouterOrigin()
+                                          routeIndex: Int(nativeRouteAlternative.route.getRouteIndex()),
+                                          responseOrigin: nativeRouteAlternative.route.getRouterOrigin())
         
         var legIndex = Int(nativeRouteAlternative.mainRouteFork.legIndex)
         var segmentIndex = Int(nativeRouteAlternative.mainRouteFork.segmentIndex)

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -94,7 +94,8 @@ extension RerouteController: RerouteObserver {
         delegate?.rerouteControllerWantsSwitchToAlternative(self,
                                                             response: decoded.routeResponse,
                                                             routeIndex: Int(route.getRouteIndex()),
-                                                            options: decoded.routeOptions)
+                                                            options: decoded.routeOptions,
+                                                            routeOrigin: route.getRouterOrigin())
     }
 
     func onRerouteDetected(forRouteRequest routeRequest: String) -> Bool {
@@ -116,7 +117,8 @@ extension RerouteController: RerouteObserver {
            decodedRequest.routeOptions == latestRouteResponse.options {
             delegate?.rerouteControllerDidRecieveReroute(self,
                                                          response: latestRouteResponse.response,
-                                                         options: latestRouteResponse.options)
+                                                         options: latestRouteResponse.options,
+                                                         routeOrigin: origin)
             self.latestRouteResponse = nil
         } else {
             guard let decodedResponse = Self.decode(routeResponse: routeResponse,
@@ -128,7 +130,8 @@ extension RerouteController: RerouteObserver {
             
             delegate?.rerouteControllerDidRecieveReroute(self,
                                                          response: decodedResponse,
-                                                         options: decodedRequest.routeOptions)
+                                                         options: decodedRequest.routeOptions,
+                                                         routeOrigin: origin)
         }
     }
 

--- a/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
@@ -7,9 +7,10 @@ protocol ReroutingControllerDelegate: AnyObject {
     func rerouteControllerWantsSwitchToAlternative(_ rerouteController: RerouteController,
                                                    response: RouteResponse,
                                                    routeIndex: Int,
-                                                   options: RouteOptions)
+                                                   options: RouteOptions,
+                                                   routeOrigin: RouterOrigin)
     func rerouteControllerDidDetectReroute(_ rerouteController: RerouteController) -> Bool
-    func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions)
+    func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions, routeOrigin: RouterOrigin)
     func rerouteControllerDidCancelReroute(_ rerouteController: RerouteController)
     func rerouteControllerDidFailToReroute(_ rerouteController: RerouteController, with error: DirectionsError)
 }

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -878,9 +878,9 @@ extension RouteController: ReroutingControllerDelegate {
                                                    routeIndex: Int,
                                                    options: RouteOptions,
                                                    routeOrigin: RouterOrigin) {
-        var newRouteResponse = IndexedRouteResponse(routeResponse: response,
-                                                    routeIndex: routeIndex)
-        newRouteResponse.responseOrigin = routeOrigin
+        let newRouteResponse = IndexedRouteResponse(routeResponse: response,
+                                                    routeIndex: routeIndex,
+                                                    responseOrigin: routeOrigin)
         guard let newMainRoute = newRouteResponse.currentRoute else {
             return
         }
@@ -930,9 +930,9 @@ extension RouteController: ReroutingControllerDelegate {
     }
     
     func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions, routeOrigin: RouterOrigin) {
-        var indexedRouteResponse = IndexedRouteResponse(routeResponse: response,
-                                                        routeIndex: 0)
-        indexedRouteResponse.responseOrigin = routeOrigin
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: response,
+                                                        routeIndex: 0,
+                                                        responseOrigin: routeOrigin)
         updateRoute(with: indexedRouteResponse,
                     routeOptions: options,
                     isProactive: false) { [weak self] _ in

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -287,7 +287,8 @@ open class RouteController: NSObject {
         }
         
         let parsedRoutes = RouteParser.parseDirectionsResponse(forResponse: routeJSONString,
-                                                               request: routeRequest, routeOrigin: RouterOrigin.custom)
+                                                               request: routeRequest,
+                                                               routeOrigin: indexedRouteResponse.responseOrigin)
         if parsedRoutes.isValue(),
            var routes = parsedRoutes.value as? [RouteInterface],
            routes.count > indexedRouteResponse.routeIndex {
@@ -875,10 +876,11 @@ extension RouteController: ReroutingControllerDelegate {
     func rerouteControllerWantsSwitchToAlternative(_ rerouteController: RerouteController,
                                                    response: RouteResponse,
                                                    routeIndex: Int,
-                                                   options: RouteOptions) {
-        let newRouteResponse = IndexedRouteResponse(routeResponse: response,
+                                                   options: RouteOptions,
+                                                   routeOrigin: RouterOrigin) {
+        var newRouteResponse = IndexedRouteResponse(routeResponse: response,
                                                     routeIndex: routeIndex)
-                                                    
+        newRouteResponse.responseOrigin = routeOrigin
         guard let newMainRoute = newRouteResponse.currentRoute else {
             return
         }
@@ -927,9 +929,11 @@ extension RouteController: ReroutingControllerDelegate {
         }
     }
     
-    func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions) {
-        updateRoute(with: IndexedRouteResponse(routeResponse: response,
-                                               routeIndex: 0),
+    func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions, routeOrigin: RouterOrigin) {
+        var indexedRouteResponse = IndexedRouteResponse(routeResponse: response,
+                                                        routeIndex: 0)
+        indexedRouteResponse.responseOrigin = routeOrigin
+        updateRoute(with: indexedRouteResponse,
                     routeOptions: options,
                     isProactive: false) { [weak self] _ in
             self?.isRerouting = false

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreLocation
 import MapboxDirections
+import MapboxNavigationNative
 
 /**
  A router data source, also known as a location manager, supplies location data to a `Router` instance. For example, a `MapboxNavigationService` supplies location data to a `RouteController` or `LegacyRouteController`.
@@ -46,6 +47,13 @@ public struct IndexedRouteResponse {
         self.routeResponse = routeResponse
         self.routeIndex = routeIndex
     }
+    
+    /**
+     Describes the origin of current route response.
+     
+     Used by `Navigator` for better understanding current state and various features functioning.
+     */
+    internal var responseOrigin: RouterOrigin = .custom
 }
 
 /**

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -44,8 +44,9 @@ public struct IndexedRouteResponse {
      - parameter routeIndex: Selected route index in an array.
      */
     public init(routeResponse: RouteResponse, routeIndex: Int) {
-        self.routeResponse = routeResponse
-        self.routeIndex = routeIndex
+        self.init(routeResponse: routeResponse,
+                  routeIndex: routeIndex,
+                  responseOrigin: .custom)
     }
     
     /**
@@ -53,7 +54,15 @@ public struct IndexedRouteResponse {
      
      Used by `Navigator` for better understanding current state and various features functioning.
      */
-    internal var responseOrigin: RouterOrigin = .custom
+    internal var responseOrigin: RouterOrigin
+    
+    init(routeResponse: RouteResponse,
+         routeIndex: Int,
+         responseOrigin: RouterOrigin) {
+        self.routeResponse = routeResponse
+        self.routeIndex = routeIndex
+        self.responseOrigin = responseOrigin
+    }
 }
 
 /**

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -54,7 +54,7 @@ public struct IndexedRouteResponse {
      
      Used by `Navigator` for better understanding current state and various features functioning.
      */
-    internal var responseOrigin: RouterOrigin
+    internal let responseOrigin: RouterOrigin
     
     init(routeResponse: RouteResponse,
          routeIndex: Int,


### PR DESCRIPTION
### Description
Adds route origin value to be passed to NavNative. This value is used then inside Navigator for various checks and heuristics, thus improving the navigation quality. This PR does not introduce or fixes any features, but this is the expected way to set Routes to Navigator, specifying it's correct origin.

### Implementation
Added internal value which is passed when parsing a route response to set to Navigator. Whenever route is reported by NN and we know it's origin - we specify it, in all other cases we consider route to be custom built.

I don't think there should be a changelog entry since this change is obscure and does not result in visible changes.