### PR TITLE
Route line layers reusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 ### Other changes
 
 * Reduced peak memory usage.
+* Fixed an issue when alternative route lines overlapped the main route line during navigation. ([#3947](https://github.com/mapbox/mapbox-navigation-ios/pull/3947))
 * Fixed an issue when rerouting to the route which does not originate on current user location, route line and camera jumped to route origin. ([#3943](https://github.com/mapbox/mapbox-navigation-ios/pull/3943))
 * All logs that Navigation SDK produces are now sent to the `MapboxCommon` framework. You can intercept these logs in your own code using `LogConfiguration.registerLogWriterBackend(forLogWriter:)` method from `MapboxCommon` framework. ([#3944](https://github.com/mapbox/mapbox-navigation-ios/pull/3944))
 


### PR DESCRIPTION
### Description
Adds re-using existing line layers instead of re-creating it each time. This resolves incorrect layers ordering issue because creation mechanism ignored existing layers and thus messing up it's order. 

### Implementation
Added flag to try to use existing line layer instead of forcing creating new ones. This comes useful when there are both Main and Alternative routes display, but only 1 of them is updated, for example due to route refreshing. When updating Main route (via `show(routes:)`), SDK removes old layers, keeping the alternatives and vice versa. In result some of the layers persist, while other created anew, introducing incorrect layer ordering.