### PR TITLE
Allow the detailed feedback style change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 * Fixed an issue when alternative route lines overlapped the main route line during navigation. ([#3947](https://github.com/mapbox/mapbox-navigation-ios/pull/3947))
 * Fixed an issue when rerouting to the route which does not originate on current user location, route line and camera jumped to route origin. ([#3943](https://github.com/mapbox/mapbox-navigation-ios/pull/3943))
 * All logs that Navigation SDK produces are now sent to the `MapboxCommon` framework. You can intercept these logs in your own code using `LogConfiguration.registerLogWriterBackend(forLogWriter:)` method from `MapboxCommon` framework. ([#3944](https://github.com/mapbox/mapbox-navigation-ios/pull/3944))
+* Fixed an issue where popped window doesn't get updated in appearance when style changes on phone. ([#3954](https://github.com/mapbox/mapbox-navigation-ios/pull/3954))
+* Fixed an issue where detailed feedback items don't change color in different style. ([#3954](https://github.com/mapbox/mapbox-navigation-ios/pull/3954))
 
 ## v2.5.1
 

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -247,6 +247,7 @@ open class DayStyle: Style {
         FeedbackCollectionView.appearance().cellColor = .black
         FeedbackSubtypeCollectionViewCell.appearance().normalCircleColor = .white
         FeedbackSubtypeCollectionViewCell.appearance().normalCircleOutlineColor = .darkText
+        FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .systemBlue
         InstructionLabel.appearance().roadShieldBlackColor = .roadShieldBlackColor
         InstructionLabel.appearance().roadShieldBlueColor = .roadShieldBlueColor
         InstructionLabel.appearance().roadShieldGreenColor = .roadShieldGreenColor
@@ -261,12 +262,6 @@ open class DayStyle: Style {
             UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).sectionHeaderTopPadding = 0.0
         }
         #endif
-        
-        if #available(iOS 13.0, *) {
-            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .systemBlue
-        } else {
-            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .lightGray
-        }
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -245,6 +245,8 @@ open class DayStyle: Style {
         FeedbackStyleView.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).backgroundColor = .white
         FeedbackCollectionView.appearance().backgroundColor = .white
         FeedbackCollectionView.appearance().cellColor = .black
+        FeedbackSubtypeCollectionViewCell.appearance().normalCircleColor = .white
+        FeedbackSubtypeCollectionViewCell.appearance().normalCircleOutlineColor = .darkText
         InstructionLabel.appearance().roadShieldBlackColor = .roadShieldBlackColor
         InstructionLabel.appearance().roadShieldBlueColor = .roadShieldBlueColor
         InstructionLabel.appearance().roadShieldGreenColor = .roadShieldGreenColor
@@ -259,6 +261,12 @@ open class DayStyle: Style {
             UITableView.appearance(whenContainedInInstancesOf: [StepsViewController.self]).sectionHeaderTopPadding = 0.0
         }
         #endif
+        
+        if #available(iOS 13.0, *) {
+            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .systemBlue
+        } else {
+            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .lightGray
+        }
     }
     
     @available(iOS 12.0, *)

--- a/Sources/MapboxNavigation/Feedback/FeedbackSubtypeCollectionViewCell.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackSubtypeCollectionViewCell.swift
@@ -20,27 +20,39 @@ class FeedbackSubtypeCollectionViewCell: UICollectionViewCell {
         title.font = Constants.titleFont
         return title
     }()
-
-    @objc dynamic public var selectedCircleColor: UIColor = .lightGray {
+    
+    @objc dynamic var showSelectedColor: Bool = false {
         didSet {
-            if isSelected {
+            if showSelectedColor {
+                circleColor = selectedCircleColor
+                circleOutlineColor = selectedCircleColor
+            } else {
+                circleColor = normalCircleColor
+                circleOutlineColor = normalCircleOutlineColor
+            }
+        }
+    }
+
+    @objc dynamic var selectedCircleColor: UIColor = .lightGray {
+        didSet {
+            if showSelectedColor {
                 circleColor = selectedCircleColor
                 circleOutlineColor = selectedCircleColor
             }
         }
     }
     
-    @objc dynamic public var normalCircleColor: UIColor = .black {
+    @objc dynamic var normalCircleColor: UIColor = .black {
         didSet {
-            if !isSelected {
+            if !showSelectedColor {
                 circleColor = normalCircleColor
             }
         }
     }
 
-    @objc dynamic public var normalCircleOutlineColor: UIColor = .black {
+    @objc dynamic var normalCircleOutlineColor: UIColor = .black {
         didSet {
-            if !isSelected {
+            if !showSelectedColor {
                 circleOutlineColor = normalCircleOutlineColor
             }
         }
@@ -135,7 +147,7 @@ class FeedbackSubtypeCollectionViewCell: UICollectionViewCell {
 
         if #available(iOS 12.0, *),
            previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
-            circleView.layer.borderColor = circleOutlineColor.cgColor
+            circleOutlineColor = showSelectedColor ? normalCircleColor : selectedCircleColor
         }
     }
 }

--- a/Sources/MapboxNavigation/Feedback/FeedbackSubtypeCollectionViewCell.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackSubtypeCollectionViewCell.swift
@@ -21,6 +21,31 @@ class FeedbackSubtypeCollectionViewCell: UICollectionViewCell {
         return title
     }()
 
+    @objc dynamic public var selectedCircleColor: UIColor = .lightGray {
+        didSet {
+            if isSelected {
+                circleColor = selectedCircleColor
+                circleOutlineColor = selectedCircleColor
+            }
+        }
+    }
+    
+    @objc dynamic public var normalCircleColor: UIColor = .black {
+        didSet {
+            if !isSelected {
+                circleColor = normalCircleColor
+            }
+        }
+    }
+
+    @objc dynamic public var normalCircleOutlineColor: UIColor = .black {
+        didSet {
+            if !isSelected {
+                circleOutlineColor = normalCircleOutlineColor
+            }
+        }
+    }
+    
     public var circleColor: UIColor = .black {
         didSet {
             circleView.backgroundColor = circleColor

--- a/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
@@ -83,8 +83,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
 
         let cell = collectionView.cellForItem(at: indexPath) as! FeedbackSubtypeCollectionViewCell
-        cell.circleColor = cell.selectedCircleColor
-        cell.circleOutlineColor = cell.selectedCircleColor
+        cell.showSelectedColor = true
 
         let item = sections[indexPath.row]
         selectedItems.append(item)
@@ -94,8 +93,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         let cell = collectionView.cellForItem(at: indexPath) as! FeedbackSubtypeCollectionViewCell
-        cell.circleColor = cell.normalCircleColor
-        cell.circleOutlineColor = cell.normalCircleOutlineColor
+        cell.showSelectedColor = false
 
         let item = sections[indexPath.row]
         selectedItems.removeAll { existingItem -> Bool in

--- a/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
@@ -10,6 +10,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
     private let reportButton = UIButton()
 
     private var selectedItems = [FeedbackItem]()
+    private var selectedPath = Set<IndexPath>()
 
     /**
      Initialize a new FeedbackSubtypeViewController from a `NavigationEventsManager`.
@@ -77,6 +78,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
             }
         }
 
+        cell.showSelectedColor = selectedPath.contains(indexPath)
         return cell
     }
 
@@ -87,6 +89,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
 
         let item = sections[indexPath.row]
         selectedItems.append(item)
+        selectedPath.insert(indexPath)
 
         updateButtonTitle()
     }
@@ -99,6 +102,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
         selectedItems.removeAll { existingItem -> Bool in
             return existingItem.type == item.type
         }
+        selectedPath.remove(indexPath)
 
         updateButtonTitle()
     }

--- a/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
@@ -83,27 +83,28 @@ class FeedbackSubtypeViewController: FeedbackViewController {
     }
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-
-        let cell = collectionView.cellForItem(at: indexPath) as! FeedbackSubtypeCollectionViewCell
-        cell.showSelectedColor = true
-
-        let item = sections[indexPath.row]
-        selectedItems.append(item)
-        selectedPath.insert(indexPath)
-
-        updateButtonTitle()
+        guard let cell = collectionView.cellForItem(at: indexPath) as? FeedbackSubtypeCollectionViewCell else { return }
+        toggleSelected(cell: cell, at: indexPath)
     }
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        let cell = collectionView.cellForItem(at: indexPath) as! FeedbackSubtypeCollectionViewCell
-        cell.showSelectedColor = false
-
-        let item = sections[indexPath.row]
-        selectedItems.removeAll { existingItem -> Bool in
-            return existingItem.type == item.type
+        guard let cell = collectionView.cellForItem(at: indexPath) as? FeedbackSubtypeCollectionViewCell else { return }
+        toggleSelected(cell: cell, at: indexPath)
+    }
+    
+    private func toggleSelected(cell: FeedbackSubtypeCollectionViewCell, at indexPath: IndexPath) {
+        guard let item = sections[safe: indexPath.row] else { return }
+        if selectedPath.contains(indexPath) {
+            selectedItems.removeAll { existingItem -> Bool in
+                return existingItem.type == item.type
+            }
+            selectedPath.remove(indexPath)
+            cell.showSelectedColor = false
+        } else {
+            selectedItems.append(item)
+            selectedPath.insert(indexPath)
+            cell.showSelectedColor = true
         }
-        selectedPath.remove(indexPath)
-
         updateButtonTitle()
     }
 

--- a/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
@@ -5,7 +5,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
 
     var currentFeedbackType: FeedbackItemType?
 
-    private let reportButtonContainer = UIView()
+    private let reportButtonContainer = FeedbackStyleView()
     private let reportButtonSeparator = UIView()
     private let reportButton = UIButton()
 
@@ -83,12 +83,8 @@ class FeedbackSubtypeViewController: FeedbackViewController {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
 
         let cell = collectionView.cellForItem(at: indexPath) as! FeedbackSubtypeCollectionViewCell
-        if #available(iOS 13.0, *) {
-            cell.circleColor = .systemBlue
-        } else {
-            cell.circleColor = .lightGray
-        }
-        cell.circleOutlineColor = cell.circleColor
+        cell.circleColor = cell.selectedCircleColor
+        cell.circleOutlineColor = cell.selectedCircleColor
 
         let item = sections[indexPath.row]
         selectedItems.append(item)
@@ -98,13 +94,8 @@ class FeedbackSubtypeViewController: FeedbackViewController {
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         let cell = collectionView.cellForItem(at: indexPath) as! FeedbackSubtypeCollectionViewCell
-        if #available(iOS 13.0, *) {
-            cell.circleColor = .systemBackground
-            cell.circleOutlineColor = .label
-        } else {
-            cell.circleColor = .white
-            cell.circleOutlineColor = .darkText
-        }
+        cell.circleColor = cell.normalCircleColor
+        cell.circleOutlineColor = cell.normalCircleOutlineColor
 
         let item = sections[indexPath.row]
         selectedItems.removeAll { existingItem -> Bool in
@@ -169,7 +160,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
 
         let reportButtonContainerLeading = reportButtonContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor)
         let reportButtonContainerTrailing = reportButtonContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        let reportButtonContainerBottom = reportButtonContainer.bottomAnchor.constraint(equalTo: view.safeBottomAnchor)
+        let reportButtonContainerBottom = reportButtonContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let reportButtonContainerHeight = reportButtonContainer.heightAnchor.constraint(equalToConstant: 96)
 
         let reportButtonSeparatorLeading = reportButtonSeparator.leadingAnchor.constraint(equalTo: reportButtonContainer.leadingAnchor)

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -113,6 +113,14 @@ open class NightStyle: DayStyle {
         FeedbackStyleView.appearance(whenContainedInInstancesOf: [FeedbackViewController.self]).backgroundColor = .black
         FeedbackCollectionView.appearance().backgroundColor = .black
         FeedbackCollectionView.appearance().cellColor = .white
+        FeedbackSubtypeCollectionViewCell.appearance().normalCircleColor = .black
+        FeedbackSubtypeCollectionViewCell.appearance().normalCircleOutlineColor = .lightText
+        
+        if #available(iOS 13.0, *) {
+            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .systemBlue
+        } else {
+            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .darkGray
+        }
         
         WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
         WayNameLabel.appearance().roadShieldBlackColor = #colorLiteral(red: 0.08, green: 0.09, blue: 0.12, alpha: 1)

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -116,12 +116,6 @@ open class NightStyle: DayStyle {
         FeedbackSubtypeCollectionViewCell.appearance().normalCircleColor = .black
         FeedbackSubtypeCollectionViewCell.appearance().normalCircleOutlineColor = .lightText
         
-        if #available(iOS 13.0, *) {
-            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .systemBlue
-        } else {
-            FeedbackSubtypeCollectionViewCell.appearance().selectedCircleColor = .darkGray
-        }
-        
         WayNameView.appearance().borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
         WayNameLabel.appearance().roadShieldBlackColor = #colorLiteral(red: 0.08, green: 0.09, blue: 0.12, alpha: 1)
         WayNameLabel.appearance().roadShieldBlueColor = #colorLiteral(red: 0.18, green: 0.26, blue: 0.66, alpha: 1)

--- a/Sources/MapboxNavigation/StyleManager.swift
+++ b/Sources/MapboxNavigation/StyleManager.swift
@@ -215,7 +215,7 @@ open class StyleManager {
         if #available(iOS 13.0, *) {
             UIApplication.shared.connectedScenes.forEach {
                 if let windowScene = $0 as? UIWindowScene,
-                   traitCollection?.userInterfaceIdiom == .phone {
+                   windowScene.traitCollection.userInterfaceIdiom == .phone {
                     refreshAppearance(for: windowScene.windows)
                 } else if let templateApplicationScene = $0 as? CPTemplateApplicationScene,
                           traitCollection?.userInterfaceIdiom == .carPlay {


### PR DESCRIPTION
### Description
This Pr is to allow the detailed feedback style change. And it also fixed the issue where the popped window on phone won't get appearance refreshed when style changes.

### Implementation
In `FeedbackSubtypeViewController`, by changing the report container to `FeedbackStyleView`, it would share the same style change as the `FeedbackViewController`.
In `FeedbackSubtypeCollectionViewCell`, by adding the stylable color at select and normal state, it would allow the circle color change in different styles.
Because the `reloadData()` after the style change in `UICollectionView` will cause the selection loss. To keep the selected color and the selection function, using the `selectedPath` to store the `indexPath` for style change and selection loss.

### Screenshots or Gifs

![feedback](https://user-images.githubusercontent.com/48976398/174169549-dacaed93-64b8-4f0b-92e9-077169fb95dc.gif)



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->