### PR TITLE
Continuous Alternatives CarPlay selection and callouts

### DIFF
--- a/Sources/MapboxCoreNavigation/AlternativeRoute.swift
+++ b/Sources/MapboxCoreNavigation/AlternativeRoute.swift
@@ -38,7 +38,11 @@ public struct AlternativeRoute: Identifiable {
     public let infoFromDeviationPoint: RouteInfo
     /// Alternative route statistics, counting from it's origin.
     public let infoFromOrigin: RouteInfo
-
+    /// The difference of distances between alternative and the main routes
+    public let distanceDelta: LocationDistance
+    /// The difference of expected travel time between alternative and the main routes
+    public let expectedTravelTimeDelta: TimeInterval
+    
     init?(mainRoute: Route, alternativeRoute nativeRouteAlternative: RouteAlternative) {
         self.id = nativeRouteAlternative.id
         guard let decoded = RerouteController.decode(routeRequest: nativeRouteAlternative.route.getRequestUri(),
@@ -70,6 +74,9 @@ public struct AlternativeRoute: Identifiable {
                                             duration: nativeRouteAlternative.infoFromFork.duration)
         self.infoFromOrigin = .init(distance: nativeRouteAlternative.infoFromStart.distance,
                                     duration: nativeRouteAlternative.infoFromStart.duration)
+        
+        self.distanceDelta = infoFromOrigin.distance - mainRoute.distance
+        self.expectedTravelTimeDelta = infoFromOrigin.duration - mainRoute.expectedTravelTime
     }
     
     /**
@@ -83,13 +90,17 @@ public struct AlternativeRoute: Identifiable {
                 mainRouteIntersection: Intersection,
                 alternativeRouteIntersection: Intersection,
                 infoFromDeviationPoint: RouteInfo,
-                infoFromOrigin: RouteInfo) {
+                infoFromOrigin: RouteInfo,
+                distanceDelta: LocationDistance,
+                expectedTravelTimeDelta: TimeInterval) {
         self.id = id
         self.indexedRouteResponse = indexedRouteResponse
         self.mainRouteIntersection = mainRouteIntersection
         self.alternativeRouteIntersection = alternativeRouteIntersection
         self.infoFromDeviationPoint = infoFromDeviationPoint
         self.infoFromOrigin = infoFromOrigin
+        self.distanceDelta = distanceDelta
+        self.expectedTravelTimeDelta = expectedTravelTimeDelta
     }
 }
 

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -301,6 +301,26 @@ public class CarPlayManager: NSObject {
     }()
     
     /**
+     The bar button that brings alternative routes selection during navigation.
+     */
+    public lazy var alternativeRoutesButton: CPBarButton = {
+        let altsButton = CPBarButton(type: .text) { (button: CPBarButton) in
+            guard let template = self.carPlayNavigationViewController?.alternativesListTemplate() else {
+                return
+            }
+            self.interfaceController?.pushTemplate(template,
+                                                   animated: true)
+        }
+        
+        altsButton.title = NSLocalizedString("CARPLAY_ALTERNATIVES",
+                                             bundle: .mapboxNavigation,
+                                             value: "Alternatives",
+                                             comment: "Title for alternatives selection list button")
+        
+        return altsButton
+    }()
+    
+    /**
      The bar button that prompts the presented navigation view controller to display the feedback screen.
      */
     public lazy var showFeedbackButton: CPMapButton = {
@@ -986,7 +1006,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
                                                          for: currentActivity) {
             mapTemplate.leadingNavigationBarButtons = leadingButtons
         } else {
-            mapTemplate.leadingNavigationBarButtons = [muteButton]
+            mapTemplate.leadingNavigationBarButtons = [muteButton, alternativeRoutesButton]
         }
         
         if let trailingButtons = delegate?.carPlayManager(self,

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -93,16 +93,13 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
     func alternativesListTemplate() -> CPListTemplate {
         var variants: [CPListSection] = []
         let distanceFormatter = DistanceFormatter()
-        let dateComponentsFormatter = DateComponentsFormatter()
         self.continuousAlternatives.forEach { alternative in
             guard let title = alternative.indexedRouteResponse.currentRoute?.description else {
                 return
             }
-            dateComponentsFormatter.unitsStyle = alternative.expectedTravelTimeDelta < 3600 ? .short : .abbreviated
-            let timeDelta = dateComponentsFormatter.string(from: alternative.expectedTravelTimeDelta) ?? ""
             let distanceDelta = distanceFormatter.string(from: alternative.distanceDelta)
             
-            let items: [CPListItem] = [CPListItem(text: "\(alternative.expectedTravelTimeDelta >= 0 ? "+":"")\(timeDelta) / \(alternative.distanceDelta >= 0 ? "+":"")\(distanceDelta)",
+            let items: [CPListItem] = [CPListItem(text: "\(DateComponentsFormatter.travelTimeString(alternative.expectedTravelTimeDelta, signed: true)) / \(alternative.distanceDelta >= 0 ? "+":"")\(distanceDelta)",
                                                   detailText: nil)]
             items.forEach { [weak self] (item: CPListItem) -> Void in
                 if #available(iOS 14.0, *) {

--- a/Sources/MapboxNavigation/DateComponentsFormatter+NavigationAdditions.swift
+++ b/Sources/MapboxNavigation/DateComponentsFormatter+NavigationAdditions.swift
@@ -21,4 +21,12 @@ extension DateComponentsFormatter {
         formatter.allowedUnits = [.day, .hour, .minute]
         return formatter
     }()
+    
+    public static func travelTimeString(_ interval: TimeInterval, signed: Bool) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = interval < 3600 ? .short : .abbreviated
+        let timeString = formatter.string(from: interval) ?? ""
+        
+        return signed ? "\(interval >= 0 ? "+":"")\(timeString)" : timeString
+    }
 }

--- a/Sources/MapboxNavigation/NavigationMapView+ContinuousAlternatives.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+ContinuousAlternatives.swift
@@ -20,6 +20,8 @@ extension NavigationMapView {
         
         self.continuousAlternatives = continuousAlternatives
         
+        showContinuousAlternativeRoutesDurations()
+        
         guard let routes = self.routes,
               !routes.isEmpty else { return }
         
@@ -52,6 +54,8 @@ extension NavigationMapView {
         removeContinuousAlternativesRoutesLayers()
         
         continuousAlternatives = nil
+        
+        showContinuousAlternativeRoutesDurations()
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationMapViewIdentifiers.swift
+++ b/Sources/MapboxNavigation/NavigationMapViewIdentifiers.swift
@@ -15,6 +15,7 @@ extension NavigationMapView {
         static let waypointSymbolLayer = "\(identifier)_waypointSymbolLayer"
         static let buildingExtrusionLayer = "\(identifier)_buildingExtrusionLayer"
         static let routeDurationAnnotationsLayer: String = "\(identifier)_routeDurationAnnotationsLayer"
+        static let continuousAlternativeRoutesDurationAnnotationsLayer: String = "\(identifier)_continuousAlternativeRoutesDurationAnnotationsLayer"
         static let puck2DLayer: String = "puck"
         static let puck3DLayer: String = "puck-model-layer"
     }
@@ -26,6 +27,7 @@ extension NavigationMapView {
         static let voiceInstructionSource = "\(identifier)_instructionSource"
         static let waypointSource = "\(identifier)_waypointSource"
         static let routeDurationAnnotationsSource: String = "\(identifier)_routeDurationAnnotationsSource"
+        static let continuousAlternativeRoutesDurationAnnotationsSource: String = "\(identifier)_continuousAlternativeRoutesDurationAnnotationsSource"
         static let puck3DSource: String = "puck-model-source"
     }
     

--- a/Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
+++ b/Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Title for alternatives selection list button */
+"CARPLAY_ALTERNATIVES" = "Alternatives";
+
 /* Title on arrival action sheet */
 "CARPLAY_ARRIVED" = "You have arrived";
 
@@ -151,7 +154,7 @@
 /* Feedback that a street is permanently blocked off. */
 "PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_PERMANENTLY_BLOCKED_OFF" = "Street permanently blocked off";
 
-/* Feedback that a street is temporary blocked off. */
+/* Feedback that a street is temporarily blocked off. */
 "PASSIVE_NAVIGATION_FEEDBACK_ROAD_ISSUE_STREET_TEMPORARILY_BLOCKED_OFF" = "Street temporarily blocked off";
 
 /* Feedback that there is a congestion on the road. */


### PR DESCRIPTION
Vk/3927 alternatives selection
### Description
Adds CarPlay UI for switching between alternative routes during navigation. Also Introduces map callouts for alternative routes displaying relative duration to the main (current) route.

### Implementation
Added "Alternatives" button to the top bar.
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-06-17 at 11 23 07](https://user-images.githubusercontent.com/23082783/174258429-54125216-21ac-4772-8679-7fc99b701d68.png)

"Alternatives" button brings in the list of existing routes, suggesting it's short description, relative duration and distance.
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-06-17 at 11 23 11](https://user-images.githubusercontent.com/23082783/174258583-6cda0611-48fe-43b7-9f41-0f3210df7ede.png)

Relative duration callouts mark alternative routes.
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-06-17 at 11 23 34](https://user-images.githubusercontent.com/23082783/174258602-3571ce2d-0260-4319-8e3b-12c3a1861b78.png)

Same for CarPlay screen.
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-06-17 at 11 23 35](https://user-images.githubusercontent.com/23082783/174258659-b12c0666-f8c4-4687-af6e-edcabb9200a5.png)

