### PR TITLE
Use default `0.0` bearing while previewing routes on CarPlay.

### DIFF
--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -230,6 +230,7 @@ open class CarPlayMapViewController: UIViewController {
         
         navigationMapView.mapView.ornaments.options.logo.visibility = .hidden
         navigationMapView.mapView.ornaments.options.attributionButton.visibility = .hidden
+        navigationMapView.mapView.ornaments.options.compass.visibility = .hidden
         
         self.view = navigationMapView
     }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -2125,7 +2125,15 @@ open class NavigationMapView: UIView {
         }
         
         let edgeInsets = safeArea + UIEdgeInsets.centerEdgeInsets
-        let bearing = customCameraOptions.flatMap({ $0.bearing }).map({ CGFloat($0) })
+        
+        let bearing: CGFloat?
+        // In case of CarPlay while previewing routes always use bearing that is set to zero.
+        if traitCollection.userInterfaceIdiom == .carPlay {
+            bearing = 0.0
+        } else {
+            bearing = customCameraOptions.flatMap({ $0.bearing }).map({ CGFloat($0) })
+        }
+        
         if let cameraOptions = mapView?.mapboxMap.camera(for: geometry,
                                                             padding: customCameraOptions?.padding ?? edgeInsets,
                                                             bearing: bearing,


### PR DESCRIPTION
### Description

PR allows to set `0.0` bearing while previewing routes on CarPlay. It also allows to stop showing compass view on CarPlay in route preview mode to match other states.