### PR TITLE
Fixes default logging level

### DIFF
--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -54,7 +54,7 @@ class NativeHandlersFactory {
     lazy var navigator: MapboxNavigationNative.Navigator = {
         onMainQueueSync { // Make sure that Navigator pick ups Main Thread RunLoop.
             let loggingLevel = NSNumber(value: LoggingLevel.info.rawValue)
-            LogConfiguration.setLoggingLevelForCategory("*", upTo: loggingLevel)
+            LogConfiguration.setLoggingLevelForUpTo(loggingLevel)
             
             let router = routingProviderSource.map {
                 MapboxNavigationNative.RouterFactory.build(for: $0,


### PR DESCRIPTION
After upgrade to MapboxCommon the API for setting default logging level
was changed. This PR adopts new API.