### PR TITLE
History Recorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * All logs that Navigation SDK produces are now sent to the `MapboxCommon` framework. You can intercept these logs in your own code using `LogConfiguration.registerLogWriterBackend(forLogWriter:)` method from `MapboxCommon` framework. ([#3944](https://github.com/mapbox/mapbox-navigation-ios/pull/3944))
 * Fixed an issue where popped window doesn't get updated in appearance when style changes on phone. ([#3954](https://github.com/mapbox/mapbox-navigation-ios/pull/3954))
 * Fixed an issue where detailed feedback items don't change color in different style. ([#3954](https://github.com/mapbox/mapbox-navigation-ios/pull/3954))
+* Update method deprecation for `HistoryRecording` protocol. Static methods are now preferred over instance ones. ([#3960](https://github.com/mapbox/mapbox-navigation-ios/pull/3960))
 
 ## v2.5.1
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		2B01E4B7274671550002A5F7 /* RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B4274671540002A5F7 /* RoutingProvider.swift */; };
 		2B01E4B8274671550002A5F7 /* Directions+RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */; };
 		2B07444124B4832400615E87 /* TokenTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B07444024B4832400615E87 /* TokenTestViewController.swift */; };
+		2B27557F2860B01A002D1CAD /* HistoryRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B27557E2860B01A002D1CAD /* HistoryRecorder.swift */; };
 		2B28AD7D284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28AD7C284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift */; };
 		2B28E22127EB48C60029E4C1 /* RerouteControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28E22027EB48C60029E4C1 /* RerouteControllerDelegate.swift */; };
 		2B3ED38C2609FA7900861A84 /* ArrivalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3ED38B2609FA7900861A84 /* ArrivalController.swift */; };
@@ -597,6 +598,7 @@
 		2B01E4B4274671540002A5F7 /* RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutingProvider.swift; sourceTree = "<group>"; };
 		2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Directions+RoutingProvider.swift"; sourceTree = "<group>"; };
 		2B07444024B4832400615E87 /* TokenTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenTestViewController.swift; sourceTree = "<group>"; };
+		2B27557E2860B01A002D1CAD /* HistoryRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryRecorder.swift; sourceTree = "<group>"; };
 		2B28AD7C284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlternativeRouteDetectionStrategy.swift; sourceTree = "<group>"; };
 		2B28E22027EB48C60029E4C1 /* RerouteControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RerouteControllerDelegate.swift; sourceTree = "<group>"; };
 		2B3ED38B2609FA7900861A84 /* ArrivalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrivalController.swift; sourceTree = "<group>"; };
@@ -1988,6 +1990,7 @@
 				C5ADFBCC1DDCC7840011824B /* MapboxCoreNavigation.h */,
 				2BEF16462775C8FD0085E3C6 /* MapMatchingResult.swift */,
 				41B901EA271048BD007F9F78 /* HistoryRecording.swift */,
+				2B27557E2860B01A002D1CAD /* HistoryRecorder.swift */,
 				E2108B2F285866C200CB0875 /* NavigationLog.swift */,
 				2BF398C2274FE99A000C9A72 /* HandlerFactory.swift */,
 				2BBED92E265E2C7D00F90032 /* NativeHandlersFactory.swift */,
@@ -2920,6 +2923,7 @@
 				E2C623A726CBFCE1005769FA /* OnMainQueue.swift in Sources */,
 				C5C94C1C1DDCD2340097296A /* LegacyRouteController.swift in Sources */,
 				3A8187C924BDAE9C00708F19 /* URLSession.swift in Sources */,
+				2B27557F2860B01A002D1CAD /* HistoryRecorder.swift in Sources */,
 				359574A81F28CC5A00838209 /* CLLocation.swift in Sources */,
 				DA2A01F025F308B100AAB4C6 /* RoadGraphPath.swift in Sources */,
 				DAF27248264E028B00C0AC37 /* Geometry.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -96,17 +96,15 @@ class Navigator {
         let factory = NativeHandlersFactory(tileStorePath: tileStorePath ?? "",
                                             credentials: NavigationSettings.shared.directions.credentials,
                                             tilesVersion: Self.tilesVersion,
-                                            historyDirectoryURL: Self.historyDirectoryURL,
                                             datasetProfileIdentifier: Self.datasetProfileIdentifier,
                                             routingProviderSource: NavigationSettings.shared.routingProviderSource.nativeSource)
         tileStore = factory.tileStore
-        historyRecorder = factory.historyRecorder
         cacheHandle = factory.cacheHandle
         roadGraph = factory.roadGraph
         navigator = factory.navigator
         roadObjectStore = RoadObjectStore(navigator.roadObjectStore())
         roadObjectMatcher = RoadObjectMatcher(MapboxNavigationNative.RoadObjectMatcher(cache: cacheHandle))
-        rerouteController = RerouteController(navigator, config: factory.navigatorConfig)
+        rerouteController = RerouteController(navigator, config: NativeHandlersFactory.navigatorConfig)
         
         subscribeNavigator()
         setupAlternativesControllerIfNeeded()
@@ -125,19 +123,17 @@ class Navigator {
         let factory = NativeHandlersFactory(tileStorePath: NavigationSettings.shared.tileStoreConfiguration.navigatorLocation.tileStoreURL?.path ?? "",
                                             credentials: NavigationSettings.shared.directions.credentials,
                                             tilesVersion: version ?? Self.tilesVersion,
-                                            historyDirectoryURL: Self.historyDirectoryURL,
                                             targetVersion: version.map { _ in Self.tilesVersion },
                                             datasetProfileIdentifier: Self.datasetProfileIdentifier,
                                             routingProviderSource: NavigationSettings.shared.routingProviderSource.nativeSource)
         tileStore = factory.tileStore
-        historyRecorder = factory.historyRecorder
         cacheHandle = factory.cacheHandle
         roadGraph = factory.roadGraph
         navigator = factory.navigator
         
         roadObjectStore.native = navigator.roadObjectStore()
         roadObjectMatcher.native = MapboxNavigationNative.RoadObjectMatcher(cache: cacheHandle)
-        rerouteController = RerouteController(navigator, config: factory.navigatorConfig)
+        rerouteController = RerouteController(navigator, config: NativeHandlersFactory.navigatorConfig)
         
         subscribeNavigator()
         setupAlternativesControllerIfNeeded()
@@ -206,18 +202,7 @@ class Navigator {
             self.navigatorAlternativesObserver = nil
         }
     }
-    
-    // MARK: History
-    
-    /**
-     Path to the directory where history file could be stored when `HistoryRecording.stopRecordingHistory(writingFileWith:)` is called.
-     
-     Setting `nil` disables history recording. Defaults to `nil`.
-     */
-    static var historyDirectoryURL: URL? = nil
-    
-    private(set) var historyRecorder: HistoryRecorderHandle?
-    
+        
     // MARK: Electronic horizon
     
     private(set) var roadGraph: RoadGraph

--- a/Sources/MapboxCoreNavigation/HandlerFactory.swift
+++ b/Sources/MapboxCoreNavigation/HandlerFactory.swift
@@ -5,7 +5,6 @@ protocol HandlerData {
     var tileStorePath: String { get }
     var credentials: Credentials { get }
     var tilesVersion: String { get }
-    var historyDirectoryURL: URL? { get }
     var targetVersion: String? { get }
     var configFactoryType: ConfigFactory.Type { get }
     var datasetProfileIdentifier: ProfileIdentifier { get }
@@ -25,7 +24,6 @@ class HandlerFactory<HandlerType, Arguments> {
         let tileStorePath: String
         let credentials: Credentials
         let tilesVersion: String
-        let historyDirectoryURL: URL?
         let targetVersion: String?
         let configFactoryType: ConfigFactory.Type
         let datasetProfileIdentifier: ProfileIdentifier
@@ -34,7 +32,6 @@ class HandlerFactory<HandlerType, Arguments> {
             self.tileStorePath = data.tileStorePath
             self.credentials = data.credentials
             self.tilesVersion = data.tilesVersion
-            self.historyDirectoryURL = data.historyDirectoryURL
             self.targetVersion = data.targetVersion
             self.configFactoryType = data.configFactoryType
             self.datasetProfileIdentifier = data.datasetProfileIdentifier
@@ -44,7 +41,6 @@ class HandlerFactory<HandlerType, Arguments> {
             return lhs.tileStorePath != rhs.tileStorePath ||
                 lhs.credentials != rhs.credentials ||
                 lhs.tilesVersion != rhs.tilesVersion ||
-                lhs.historyDirectoryURL?.absoluteString != rhs.historyDirectoryURL?.absoluteString ||
                 lhs.targetVersion != rhs.targetVersion ||
                 lhs.configFactoryType != rhs.configFactoryType ||
                 lhs.datasetProfileIdentifier != rhs.datasetProfileIdentifier
@@ -74,12 +70,6 @@ class HandlerFactory<HandlerType, Arguments> {
         }
         return cachedHandle
     }
-}
-
-let historyRecorderHandlerFactory = HandlerFactory { (path: String,
-                                                      configHandle: ConfigHandle) in
-    HistoryRecorderHandle.build(forHistoryDir: path,
-                                config: configHandle)
 }
 
 let cacheHandlerFactory = HandlerFactory { (tilesConfig: TilesConfig,

--- a/Sources/MapboxCoreNavigation/HistoryRecorder.swift
+++ b/Sources/MapboxCoreNavigation/HistoryRecorder.swift
@@ -5,13 +5,15 @@ class HistoryRecorder {
     /**
      Path to the directory where history file could be stored when `HistoryRecording.stopRecordingHistory(writingFileWith:)` is called.
      
-     Setting `nil` disables history recording. Defaults to `nil`.
+     Setting `nil` disables history recording. Defaults to `nil`. Updating value from `nil` to `non-nil` value results in recreating the shared instance since `nil` guaranteed an invalid handler. Further updates have no effect.
      */
     static var historyDirectoryURL: URL? = nil
     {
         didSet {
             if _historyRecorder?.handle == nil && historyDirectoryURL != nil {
                 _historyRecorder = nil
+            } else if oldValue != nil {
+                Log.warning("`historyDirectoryURL` is updated excessively.", category: .settings)
             }
         }
     }

--- a/Sources/MapboxCoreNavigation/HistoryRecorder.swift
+++ b/Sources/MapboxCoreNavigation/HistoryRecorder.swift
@@ -1,0 +1,49 @@
+import MapboxNavigationNative
+
+
+class HistoryRecorder {
+    /**
+     Path to the directory where history file could be stored when `HistoryRecording.stopRecordingHistory(writingFileWith:)` is called.
+     
+     Setting `nil` disables history recording. Defaults to `nil`.
+     */
+    static var historyDirectoryURL: URL? = nil
+    {
+        didSet {
+            if _historyRecorder?.handle == nil && historyDirectoryURL != nil {
+                _historyRecorder = nil
+            }
+        }
+    }
+    
+    /**
+     The shared instance
+     */
+    static var shared: HistoryRecorder {
+        guard let historyRecorder = _historyRecorder else {
+            let historyRecorder = HistoryRecorder()
+            _historyRecorder = historyRecorder
+            return historyRecorder
+        }
+        return historyRecorder
+    }
+
+    /// `True` when `HistoryRecorder.shared` requested at least once.
+    static var isSharedInstanceCreated: Bool {
+        _historyRecorder != nil
+    }
+    
+    // Used in tests to recreate the history recorder
+    static func _recreateHistoryRecorder() { _historyRecorder = nil }
+    
+    private static var _historyRecorder: HistoryRecorder?
+    
+    private(set) var handle: HistoryRecorderHandle? = nil
+    
+    private init() {
+        Self.historyDirectoryURL.flatMap {
+            handle = HistoryRecorderHandle.build(forHistoryDir: $0.path,
+                                                 config: NativeHandlersFactory.configHandle())
+        }
+    }
+}

--- a/Sources/MapboxCoreNavigation/HistoryRecording.swift
+++ b/Sources/MapboxCoreNavigation/HistoryRecording.swift
@@ -86,10 +86,10 @@ public protocol HistoryRecording {
 public extension HistoryRecording {
     static var historyDirectoryURL: URL? {
         get {
-            Navigator.historyDirectoryURL
+            HistoryRecorder.historyDirectoryURL
         }
         set {
-            Navigator.historyDirectoryURL = newValue
+            HistoryRecorder.historyDirectoryURL = newValue
         }
     }
 
@@ -102,9 +102,7 @@ public extension HistoryRecording {
     }
 
     static func startRecordingHistoryImplementation() {
-        if Navigator.isSharedInstanceCreated {
-            Navigator.shared.historyRecorder?.startRecording()
-        }
+        HistoryRecorder.shared.handle?.startRecording()
     }
     
     static func pushHistoryEvent(type: String, jsonData: Data?) throws {
@@ -124,8 +122,8 @@ public extension HistoryRecording {
             }
             jsonString = value
         }
-        if Navigator.isSharedInstanceCreated {
-            Navigator.shared.historyRecorder?.pushHistory(forEventType: type, eventJson: jsonString ?? "")
+        if HistoryRecorder.isSharedInstanceCreated {
+            HistoryRecorder.shared.handle?.pushHistory(forEventType: type, eventJson: jsonString ?? "")
         }
     }
 
@@ -138,8 +136,8 @@ public extension HistoryRecording {
     }
     
     private static func stopRecordingHistoryImplementation(writingFileWith completionHandler: @escaping HistoryFileWritingCompletionHandler) {
-        guard Navigator.isSharedInstanceCreated,
-              let historyRecorder = Navigator.shared.historyRecorder else {
+        guard HistoryRecorder.isSharedInstanceCreated,
+              let historyRecorder = HistoryRecorder.shared.handle else {
             completionHandler(nil)
             return
         }

--- a/Sources/MapboxCoreNavigation/HistoryRecording.swift
+++ b/Sources/MapboxCoreNavigation/HistoryRecording.swift
@@ -14,7 +14,7 @@ public protocol HistoryRecording {
     /**
      Path to the directory where history file could be stored when `stopRecordingHistory(writingFileWith:)` is called.
 
-     Setting `nil` disables history recording. Defaults to `nil`.
+     Setting `nil` disables history recording. Defaults to `nil`. Updating value from `nil` to `non-nil` value results in recreating the shared instance since `nil` guaranteed an invalid handler. Further updates have no effect.
      */
     static var historyDirectoryURL: URL? { get set }
 

--- a/Sources/MapboxCoreNavigation/HistoryRecording.swift
+++ b/Sources/MapboxCoreNavigation/HistoryRecording.swift
@@ -23,7 +23,6 @@ public protocol HistoryRecording {
 
      - postcondition: Use the `stopRecordingHistory(writingFileWith:)` method to stop recording history and write the recorded history to a file.
      */
-    @available(*, deprecated, message: "Use corresponding instance method instead.")
     static func startRecordingHistory()
     
     /**
@@ -31,6 +30,7 @@ public protocol HistoryRecording {
 
      - postcondition: Use the `stopRecordingHistory(writingFileWith:)` method to stop recording history and write the recorded history to a file.
      */
+    @available(*, deprecated, message: "Use corresponding static method instead.")
     func startRecordingHistory()
 
     /**
@@ -41,7 +41,6 @@ public protocol HistoryRecording {
 
      - precondition: Use the `startRecordingHistory()` method to begin recording history. If the `startRecordingHistory()` method has not been called, this method has no effect.
      */
-    @available(*, deprecated, message: "Use corresponding instance method instead.")
     static func pushHistoryEvent(type: String, jsonData: Data?) throws
     
     /**
@@ -52,6 +51,7 @@ public protocol HistoryRecording {
 
      - precondition: Use the `startRecordingHistory()` method to begin recording history. If the `startRecordingHistory()` method has not been called, this method has no effect.
      */
+    @available(*, deprecated, message: "Use corresponding static method instead.")
     func pushHistoryEvent(type: String, jsonData: Data?) throws
 
     /**
@@ -64,7 +64,6 @@ public protocol HistoryRecording {
 
      - parameter completionHandler: A closure to be executed when the history file is ready.
      */
-    @available(*, deprecated, message: "Use corresponding instance method instead.")
     static func stopRecordingHistory(writingFileWith completionHandler: @escaping HistoryFileWritingCompletionHandler)
     
     /**
@@ -77,6 +76,7 @@ public protocol HistoryRecording {
 
      - parameter completionHandler: A closure to be executed when the history file is ready.
      */
+    @available(*, deprecated, message: "Use corresponding static method instead.")
     func stopRecordingHistory(writingFileWith completionHandler: @escaping HistoryFileWritingCompletionHandler)
 }
 

--- a/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
@@ -122,13 +122,12 @@ public class MapboxRoutingProvider: RoutingProvider {
         let factory = NativeHandlersFactory(tileStorePath: settings.tileStoreConfiguration.navigatorLocation.tileStoreURL?.path ?? "",
                                             credentials: settings.directions.credentials,
                                             tilesVersion: Navigator.tilesVersion,
-                                            historyDirectoryURL: Navigator.historyDirectoryURL,
                                             datasetProfileIdentifier: datasetProfileIdentifier ?? Navigator.datasetProfileIdentifier,
                                             routingProviderSource: source.nativeSource)
         return RouterFactory.build(for: source.nativeSource,
-                                      cache: factory.cacheHandle,
-                                      config: factory.configHandle,
-                                      historyRecorder: factory.historyRecorder)
+                                   cache: factory.cacheHandle,
+                                   config: NativeHandlersFactory.configHandle(),
+                                   historyRecorder: HistoryRecorder.shared.handle)
     } ()
     
     private func complete(requestId: RequestId, with result: @escaping () -> Void) {

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -17,7 +17,6 @@ class NativeHandlersFactory {
     let tileStorePath: String
     let credentials: Credentials
     let tilesVersion: String
-    let historyDirectoryURL: URL?
     let targetVersion: String?
     let configFactoryType: ConfigFactory.Type
     let datasetProfileIdentifier: ProfileIdentifier
@@ -26,7 +25,6 @@ class NativeHandlersFactory {
     init(tileStorePath: String,
          credentials: Credentials,
          tilesVersion: String = "",
-         historyDirectoryURL: URL? = nil,
          targetVersion: String? = nil,
          configFactoryType: ConfigFactory.Type = ConfigFactory.self,
          datasetProfileIdentifier: ProfileIdentifier = ProfileIdentifier.automobile,
@@ -34,7 +32,6 @@ class NativeHandlersFactory {
         self.tileStorePath = tileStorePath
         self.credentials = credentials
         self.tilesVersion = tilesVersion
-        self.historyDirectoryURL = historyDirectoryURL
         self.targetVersion = targetVersion
         self.configFactoryType = configFactoryType
         self.datasetProfileIdentifier = datasetProfileIdentifier
@@ -43,18 +40,13 @@ class NativeHandlersFactory {
     
     // MARK: - Native Handlers
     
-    lazy var historyRecorder: HistoryRecorderHandle? = {
-        historyDirectoryURL.flatMap {
-            historyRecorderHandlerFactory.getHandler(with: (path: $0.path,
-                                                            configHandle: configHandle),
-                                                     cacheData: self)
-        }
-    }()
-    
     lazy var navigator: MapboxNavigationNative.Navigator = {
         onMainQueueSync { // Make sure that Navigator pick ups Main Thread RunLoop.
             let loggingLevel = NSNumber(value: LoggingLevel.info.rawValue)
             LogConfiguration.setLoggingLevelForUpTo(loggingLevel)
+            
+            let historyRecorder = HistoryRecorder.shared.handle
+            let configHandle = Self.configHandle(by: configFactoryType)
             
             let router = routingProviderSource.map {
                 MapboxNavigationNative.RouterFactory.build(for: $0,
@@ -71,8 +63,8 @@ class NativeHandlersFactory {
     
     lazy var cacheHandle: CacheHandle = {
         cacheHandlerFactory.getHandler(with: (tilesConfig: tilesConfig,
-                                              configHandle: configHandle,
-                                              historyRecorder: historyRecorder),
+                                              configHandle: Self.configHandle(by: configFactoryType),
+                                              historyRecorder: HistoryRecorder.shared.handle),
                                        cacheData: self)
     }()
     
@@ -86,10 +78,10 @@ class NativeHandlersFactory {
     
     // MARK: - Support Objects
     
-    lazy var settingsProfile: SettingsProfile = {
+    static var settingsProfile: SettingsProfile {
         SettingsProfile(application: .mobile,
                         platform: .IOS)
-    }()
+    }
     
     lazy var endpointConfig: TileEndpointConfiguration = {
         TileEndpointConfiguration(credentials: credentials,
@@ -109,7 +101,7 @@ class NativeHandlersFactory {
                     endpointConfig: endpointConfig)
     }()
     
-    lazy var navigatorConfig: NavigatorConfig = {
+    static var navigatorConfig: NavigatorConfig {
         return NavigatorConfig(voiceInstructionThreshold: nil,
                                electronicHorizonOptions: nil,
                                polling: nil,
@@ -117,9 +109,9 @@ class NativeHandlersFactory {
                                noSignalSimulationEnabled: nil,
                                avoidManeuverSeconds: NSNumber(value: RerouteController.DefaultManeuverAvoidanceRadius),
                                useSensors: false)
-    }()
+    }
     
-    lazy var configHandle: ConfigHandle = {
+    static func configHandle(by configFactoryType: ConfigFactory.Type = ConfigFactory.self) -> ConfigHandle {
         let defaultConfig = [
             customConfigFeaturesKey: [
                 "useInternalReroute": true
@@ -138,8 +130,8 @@ class NativeHandlersFactory {
             customConfigJSON = ""
         }
         
-        return configFactoryType.build(for: settingsProfile,
-                                       config: navigatorConfig,
+        return configFactoryType.build(for: Self.settingsProfile,
+                                       config: Self.navigatorConfig,
                                        customConfig: customConfigJSON)
-    }()
+    }
 }

--- a/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NativeHandlersFactoryTests.swift
@@ -25,9 +25,6 @@ class NativeHandlersFactoryTests: TestCase {
     override func setUp() {
         super.setUp()
         UserDefaults.standard.set(nil, forKey: customConfigKey)
-        handlersFactory = NativeHandlersFactory(tileStorePath: "tile store path",
-                                                credentials: .mocked,
-                                                configFactoryType: ConfigFactorySpy.self)
     }
     
     func testDefaultCustomConfig() {
@@ -36,7 +33,7 @@ class NativeHandlersFactoryTests: TestCase {
                 "useInternalReroute": true
             ]
         ]
-        _ = handlersFactory.configHandle
+        _ = NativeHandlersFactory.configHandle(by: ConfigFactorySpy.self)
         let config = customConfig(from: ConfigFactorySpy.passedCustomConfig)
         XCTAssertTrue(config == expectedCustomConfig)
     }
@@ -53,7 +50,7 @@ class NativeHandlersFactoryTests: TestCase {
                 "useInternalReroute": true
             ]
         ]
-        _ = handlersFactory.configHandle
+        _ = NativeHandlersFactory.configHandle(by: ConfigFactorySpy.self)
         let config = customConfig(from: ConfigFactorySpy.passedCustomConfig)
         XCTAssertTrue(config == expectedCustomConfig)
     }
@@ -70,7 +67,7 @@ class NativeHandlersFactoryTests: TestCase {
                 "useInternalReroute": true
             ]
         ]
-        _ = handlersFactory.configHandle
+        _ = NativeHandlersFactory.configHandle(by: ConfigFactorySpy.self)
         let config = customConfig(from: ConfigFactorySpy.passedCustomConfig)
         XCTAssertTrue(config == expectedCustomConfig)
     }

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
@@ -73,7 +73,7 @@ class PassiveLocationManagerTests: TestCase {
         super.tearDown()
         PassiveLocationManager.historyDirectoryURL = nil
         NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .default, mapLocation: nil), routingProviderSource: .hybrid, alternativeRouteDetectionStrategy: .init())
-        Navigator._recreateNavigator()
+        HistoryRecorder._recreateHistoryRecorder()
     }
     
     func testManualLocations() {
@@ -116,7 +116,7 @@ class PassiveLocationManagerTests: TestCase {
         let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("test")
         
         PassiveLocationManager.historyDirectoryURL = supportDir
-        withExtendedLifetime(Navigator.shared) { _ in
+        withExtendedLifetime(HistoryRecorder.shared) { _ in
             PassiveLocationManager.startRecordingHistory()
 
             let historyCallbackExpectation = XCTestExpectation(description: "History callback should be called")


### PR DESCRIPTION
vk-history-recorder: added HistoryRecorder; untied Navigation and His……toryRecorderHandler; Updated relative parts and tests to use new handler

### Description
`HistoryRecorderHandle` is aggregated by `Navigator` singleton instance so that it is not possible to control history recording without instantiating it, which leads to problems when we want to record every event, starting Navigator initialization. This PR separates `HistoryRecorderHandle` and `Navigator` lifecycles.

### Implementation
Introducing `HistoryRecorder` to cache and manage the `HistoryRecorderHandle` and ensure the shared instance is available on time and used by all consumers.