### PR TITLE
Automatic switching to Online Route

### DIFF
--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -47,8 +47,7 @@ class CustomViewController: UIViewController {
         navigationMapView.userLocationStyle = .courseView()
         
         let locationManager = simulateLocation ? SimulatedLocationManager(route: indexedUserRouteResponse!.routeResponse.routes!.first!) : NavigationLocationManager()
-        navigationService = MapboxNavigationService(routeResponse: indexedUserRouteResponse!.routeResponse,
-                                                    routeIndex: indexedUserRouteResponse!.routeIndex,
+        navigationService = MapboxNavigationService(indexedRouteResponse: indexedUserRouteResponse!,
                                                     routeOptions: userRouteOptions!,
                                                     customRoutingProvider: nil,
                                                     credentials: NavigationSettings.shared.directions.credentials,

--- a/Sources/MapboxCoreNavigation/CoreConstants.swift
+++ b/Sources/MapboxCoreNavigation/CoreConstants.swift
@@ -209,6 +209,13 @@ public extension Notification.Name {
     static let routeControllerDidFailToUpdateAlternatives: Notification.Name = .init(rawValue: "RouteControllerDidFailToUpdateAlternatives")
     
     /**
+     Posted when `RouteController` has switched to coincide online version of the current route.
+     
+     The user info dictionary contains `RouteController.NotificationUserInfoKey.coincideRouteKey`.
+     */
+    static let routeControllerDidSwitchToCoincideOnlineRoute: Notification.Name = .init(rawValue: "RouteControllerDidSwitchToCoincideOnlineRoute")
+    
+    /**
      Posted when `RouteController` has detected user taking an alternative route and before updated the main route.
      
      The user info dictionary contains `RouteController.NotificationUserInfoKey.locationKey` and `RouteController.NotificationUserInfoKey.routeKey` keys.
@@ -380,6 +387,11 @@ extension RouteController {
          A key in the user info dictionary of a `Notification.Name.routeControllerDidFailToUpdateAlternatives` notification. The corresponding value is a `AlternativeRouteError` object representing the error ocurred during alternatives list update.
          */
         public static let alternativesErrorKey: NotificationUserInfoKey = .init(rawValue: "alternativesError")
+        
+        /**
+         A key in the user info dictionary of a `Notification.Name.routeControllerDidSwitchToCoincideOnlineRoute` notification. The corresponding value is an `AlternativeRoute` object representing the selected route.
+         */
+        public static let coincideRouteKey: NotificationUserInfoKey = .init(rawValue: "coincideRoute")
     }
 }
 

--- a/Sources/MapboxCoreNavigation/Directions+RoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/Directions+RoutingProvider.swift
@@ -9,6 +9,21 @@ extension URLSessionDataTask: NavigationProviderRequest {
 
 extension Directions: RoutingProvider {
     
+    @discardableResult public func calculateRoutes(options: RouteOptions,
+                                            completionHandler: @escaping IndexedRouteResponseCompletionHandler) -> NavigationProviderRequest? {
+        return calculate(options, completionHandler: { _, result in
+            switch result {
+            case .success(let routeResponse):
+                completionHandler(.success(IndexedRouteResponse(routeResponse: routeResponse,
+                                                                routeIndex: 0,
+                                                                responseOrigin: .online)))
+            case .failure(let error):
+                completionHandler(.failure(error))
+            }
+        })
+    }
+    
+    @available(*, deprecated, renamed: "calculateRoutes(options:completionHandler:)")
     @discardableResult public func calculateRoutes(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) -> NavigationProviderRequest? {
         return calculate(options, completionHandler: completionHandler)
     }

--- a/Sources/MapboxCoreNavigation/Directions.swift
+++ b/Sources/MapboxCoreNavigation/Directions.swift
@@ -16,6 +16,36 @@ extension Directions {
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
      - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel this task.
      */
+    @discardableResult open func calculateWithCache(options: RouteOptions, completionHandler: @escaping IndexedRouteResponseCompletionHandler) -> URLSessionDataTask? {
+        return calculate(options) { (session, result) in
+            switch result {
+            case .success(let routeResponse):
+                completionHandler(.success(IndexedRouteResponse(routeResponse: routeResponse,
+                                                                routeIndex: 0)))
+            case .failure(let error):
+                if case DirectionsError.network(_) = error {
+                    // we're offline
+                    self.calculateOffline(options: options, completionHandler: completionHandler)
+                } else {
+                    completionHandler(.failure(error))
+                }
+            }
+            
+        }
+    }
+    
+    /**
+     Begins asynchronously calculating routes using the given options and delivers the results to a closure.
+     
+     This method retrieves the routes asynchronously from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/navigation/#directions) over a network connection. If a  server error occurs, details about the error are passed into the given completion handler in lieu of the routes. If network error is encountered, onboard routing engine will attempt to provide directions using existing cached tiles.
+     
+     Routes may be displayed atop a [Mapbox map](https://www.mapbox.com/maps/).
+     
+     - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
+     - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
+     - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel this task.
+     */
+    @available(*, deprecated, renamed: "calculateWithCache(options:completionHandler:)")
     @discardableResult open func calculateWithCache(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) -> URLSessionDataTask? {
         return calculate(options) { (session, result) in
             switch result {
@@ -43,6 +73,22 @@ extension Directions {
      - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
      */
+    open func calculateOffline(options: RouteOptions, completionHandler: @escaping IndexedRouteResponseCompletionHandler) {
+        MapboxRoutingProvider(.offline).calculateRoutes(options: options,
+                                                        completionHandler: completionHandler)
+    }
+    
+    /**
+     Begins asynchronously calculating routes using the given options and delivers the results to a closure.
+     
+     This method retrieves the routes asynchronously from onboard routing engine using existing cached tiles.
+     
+     Routes may be displayed atop a [Mapbox map](https://www.mapbox.com/maps/).
+     
+     - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
+     - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
+     */
+    @available(*, deprecated, renamed: "calculateOffline(options:completionHandler:)")
     open func calculateOffline(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) {
         MapboxRoutingProvider(.offline).calculateRoutes(options: options,
                                                         completionHandler: completionHandler)

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -246,14 +246,24 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                   dataSource: source)
     }
     
-    required public init(alongRouteAtIndex routeIndex: Int,
+    required public convenience init(alongRouteAtIndex routeIndex: Int,
                          in routeResponse: RouteResponse,
                          options: RouteOptions,
                          customRoutingProvider: RoutingProvider? = nil,
                          dataSource source: RouterDataSource) {
+        self.init(with: .init(routeResponse: routeResponse,  routeIndex: routeIndex),
+                  options: options,
+                  customRoutingProvider: customRoutingProvider,
+                  dataSource: source)
+    }
+    
+    required public init(with indexedRouteResponse: IndexedRouteResponse,
+                         options: RouteOptions,
+                         customRoutingProvider: RoutingProvider? = nil,
+                         dataSource source: RouterDataSource) {
         self.customRoutingProvider = customRoutingProvider
-        self.indexedRouteResponse = .init(routeResponse: routeResponse, routeIndex: routeIndex)
-        self.routeProgress = RouteProgress(route: routeResponse.routes![routeIndex], options: options)
+        self.indexedRouteResponse = indexedRouteResponse
+        self.routeProgress = RouteProgress(route: indexedRouteResponse.currentRoute!, options: options)
         self.dataSource = source
         self.refreshesRoute = options.profileIdentifier == .automobileAvoidingTraffic && options.refreshingEnabled
         UIDevice.current.isBatteryMonitoringEnabled = true
@@ -497,7 +507,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
 
         self.lastRerouteLocation = location
 
-        calculateRoutes(from: location, along: progress) { [weak self] (session, result) in
+        calculateRoutes(from: location, along: progress) { [weak self] (result) in
             guard let self = self else { return }
             
             switch result {

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -317,7 +317,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -350,7 +350,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -383,8 +383,40 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    required public init(routeResponse: RouteResponse,
-                         routeIndex: Int,
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
+    public convenience init(routeResponse: RouteResponse,
+                            routeIndex: Int,
+                            routeOptions: RouteOptions,
+                            customRoutingProvider: RoutingProvider? = nil,
+                            credentials: Credentials,
+                            locationSource: NavigationLocationManager? = nil,
+                            eventsManagerType: NavigationEventsManager.Type? = nil,
+                            simulating simulationMode: SimulationMode? = nil,
+                            routerType: Router.Type? = nil) {
+        self.init(indexedRouteResponse: .init(routeResponse: routeResponse,
+                                              routeIndex: routeIndex),
+                  routeOptions: routeOptions,
+                  customRoutingProvider: customRoutingProvider,
+                  credentials: credentials,
+                  locationSource: locationSource,
+                  eventsManagerType: eventsManagerType,
+                  simulating: simulationMode,
+                  routerType: routerType)
+    }
+    
+    /**
+     Intializes a new `NavigationService`.
+     
+     - parameter indexedRouteResponse: `IndexedRouteResponse` object, containing selection of routes to follow.
+     - parameter routeOptions: The route options used to get the route.
+     - parameter customRoutingProvider: Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
+     - parameter credentials: Credentials to authorize additional data requests throughout the route.
+     - parameter locationSource: An optional override for the default `NaviationLocationManager`.
+     - parameter eventsManagerType: An optional events manager type to use while tracking the route.
+     - parameter simulationMode: The simulation mode desired.
+     - parameter routerType: An optional router type to use for traversing the route.
+     */
+    required public init(indexedRouteResponse: IndexedRouteResponse,
                          routeOptions: RouteOptions,
                          customRoutingProvider: RoutingProvider? = nil,
                          credentials: Credentials,
@@ -406,8 +438,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         }
         
         let routerType = routerType ?? DefaultRouter.self
-        _router = routerType.init(alongRouteAtIndex: routeIndex,
-                                  in: routeResponse,
+        _router = routerType.init(with: indexedRouteResponse,
                                   options: routeOptions,
                                   customRoutingProvider: customRoutingProvider,
                                   dataSource: self)
@@ -681,6 +712,10 @@ extension MapboxNavigationService: RouterDelegate {
     
     public func router(_ router: Router, didFailToUpdateAlternatives error: AlternativeRouteError) {
         delegate?.navigationService(self, didFailToUpdateAlternatives: error)
+    }
+    
+    public func router(_ router: Router, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute) {
+        delegate?.navigationService(self, didSwitchToCoincideOnlineRoute: coincideRoute)
     }
     
     public func router(_ router: Router, willTakeAlternativeRoute route: Route, at location: CLLocation?) {

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -57,6 +57,14 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     func navigationService(_ service: NavigationService, didFailToUpdateAlternatives error: AlternativeRouteError)
     
     /**
+     Called when navigation service has automatically switched to the coincide online route.
+     
+     - parameter service: The navigation service reporting an update.
+     - parameter coincideRoute: A route taken.
+     */
+    func navigationService(_ service: NavigationService, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute)
+    
+    /**
      Called when navigation service has detected user taking an alternative route.
      
      This method is called before updating main route.
@@ -304,6 +312,13 @@ public extension NavigationServiceDelegate {
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
     func navigationService(_ service: NavigationService, didFailToUpdateAlternatives error: AlternativeRouteError) {
+        logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .info)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationService(_ service: NavigationService, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .info)
     }
     

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -212,14 +212,14 @@ extension RerouteController: RerouteControllerInterface {
             return
         }
         
-        reroutingRequest = customRoutingProvider.calculateRoutes(options: routeOptions) { session, result in
+        reroutingRequest = customRoutingProvider.calculateRoutes(options: routeOptions) { result in
             switch result {
             case .failure(let error):
                 callback(.init(error: RerouteError(message: error.localizedDescription,
                                                    type: .routerError)))
-            case .success(let routeResponse):
-                if let responseString = routeResponse.identifier {
-                    self.latestRouteResponse = (routeResponse, routeOptions)
+            case .success(let indexedRouteResponse):
+                if let responseString = indexedRouteResponse.routeResponse.identifier {
+                    self.latestRouteResponse = (indexedRouteResponse.routeResponse, routeOptions)
                     callback(.init(value: RerouteInfo(routeResponse: responseString,
                                                       routeRequest: url,
                                                       origin: .onboard)))

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -78,6 +78,16 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     func router(_ router: Router, didFailToUpdateAlternatives error: AlternativeRouteError)
     
     /**
+     Called when router has automatically switched to the coincide online route.
+     
+     - note: `LegacyRouteController` will never do that.
+     
+     - parameter router: The router reporting an update.
+     - parameter coincideRoute: A route taken.
+     */
+    func router(_ router: Router, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute)
+    
+    /**
      Called when router has detected user taking an alternative route.
      
      This method is called before updating router's main route.
@@ -269,6 +279,10 @@ public extension RouterDelegate {
     }
     
     func router(_ router: Router, didFailToUpdateAlternatives error: AlternativeRouteError) {
+        logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
+    }
+    
+    func router(_ router: Router, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute) {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
     }
     

--- a/Sources/MapboxCoreNavigation/RoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/RoutingProvider.swift
@@ -8,6 +8,8 @@ import MapboxDirections
  */
 public protocol RoutingProvider {
     
+    typealias IndexedRouteResponseCompletionHandler = (_ result: Result<IndexedRouteResponse, DirectionsError>) -> Void
+    
     /**
      Routing caluclation method.
      
@@ -15,6 +17,17 @@ public protocol RoutingProvider {
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
      - returns: Related request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel corresponding task using this handle.
      */
+    @discardableResult func calculateRoutes(options: RouteOptions,
+                                            completionHandler: @escaping IndexedRouteResponseCompletionHandler) -> NavigationProviderRequest?
+    
+    /**
+     Routing caluclation method.
+     
+     - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
+     - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
+     - returns: Related request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel corresponding task using this handle.
+     */
+    @available(*, deprecated, renamed: "calculateRoutes(options:completionHandler:)")
     @discardableResult func calculateRoutes(options: RouteOptions,
                                             completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest?
     

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -566,14 +566,13 @@ extension CarPlayManager {
      - parameter completionHandler: A closure to be executed when the calculation completes.
      */
     public func previewRoutes(for options: RouteOptions, completionHandler: @escaping CompletionHandler) {
-        calculate(options) { [weak self] (session, result) in
+        calculate(options) { [weak self] (result) in
             guard let self = self else {
                 completionHandler()
                 return
             }
             
             self.didCalculate(result,
-                              in: session,
                               for: options,
                               completionHandler: completionHandler)
         }
@@ -611,12 +610,11 @@ extension CarPlayManager {
         interfaceController.pushTemplate(previewMapTemplate, animated: true)
     }
     
-    func calculate(_ options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) {
+    func calculate(_ options: RouteOptions, completionHandler: @escaping RoutingProvider.IndexedRouteResponseCompletionHandler) {
         resolvedRoutingProvider.calculateRoutes(options: options, completionHandler: completionHandler)
     }
     
-    func didCalculate(_ result: Result<RouteResponse, DirectionsError>,
-                      in session: Directions.Session,
+    func didCalculate(_ result: Result<IndexedRouteResponse, DirectionsError>,
                       for routeOptions: RouteOptions,
                       completionHandler: CompletionHandler) {
         defer {
@@ -637,8 +635,8 @@ extension CarPlayManager {
             popToRootTemplate(interfaceController: interfaceController, animated: true)
             mapTemplate?.present(navigationAlert: alert, animated: true)
             return
-        case let .success(routeResponse):
-            previewRoutes(for: routeResponse)
+        case let .success(indexedRouteResponse):
+            previewRoutes(for: indexedRouteResponse.routeResponse)
         }
     }
 
@@ -693,8 +691,8 @@ extension CarPlayManager: CPMapTemplateDelegate {
                                  routeIndex: routeResponse.routeIndex,
                                  routeOptions: routeOptions,
                                  desiredSimulationMode: desiredSimulationMode) ??
-        MapboxNavigationService(routeResponse: routeResponse.response,
-                                routeIndex: routeResponse.routeIndex,
+        MapboxNavigationService(indexedRouteResponse: .init(routeResponse: routeResponse.response,
+                                                            routeIndex: routeResponse.routeIndex),
                                 routeOptions: routeOptions,
                                 customRoutingProvider: customRoutingProvider,
                                 credentials: NavigationSettings.shared.directions.credentials,

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -131,6 +131,14 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, didFailToUpdateAlternatives error: AlternativeRouteError)
     
     /**
+     Called when navigation view controller has automatically switched to the coincide online route.
+     
+     - parameter navigationViewController: The navigation view controller reporting an update.
+     - parameter coincideRoute: A route taken.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute)
+    
+    /**
      Called when navigation view controller has detected user taking an alternative route.
      
      This method is called before updating main route.
@@ -365,6 +373,13 @@ public extension NavigationViewControllerDelegate {
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, didFailToUpdateAlternatives error: AlternativeRouteError) {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -21,6 +21,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onRouterShouldDisableBatteryMonitoring: (() -> Bool)?
     public var onDidUpdateAlternativeRoutes: (([AlternativeRoute], [AlternativeRoute]) -> Void)?
     public var onDidFailToUpdateAlternativeRoutes: ((AlternativeRouteError) -> Void)?
+    public var onDidSwitchToCoincideRoute: ((AlternativeRoute) -> Void)?
     public var onWillTakeAlternativeRoute: ((Route, CLLocation?) -> Void)?
     public var onDidTakeAlternativeRoute: ((CLLocation?) -> Void)?
     public var onDidFailToTakeAlternativeRoute: ((CLLocation?) -> Void)?
@@ -118,5 +119,9 @@ public final class RouterDelegateSpy: RouterDelegate {
     
     public func router(_ router: Router, didFailToTakeAlternativeRouteAt location: CLLocation?) {
         onDidFailToTakeAlternativeRoute?(location)
+    }
+    
+    public func router(_ router: Router, didSwitchToCoincideOnlineRoute coincideRoute: AlternativeRoute) {
+        onDidSwitchToCoincideRoute?(coincideRoute)
     }
 }

--- a/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/BillingHandlerTests.swift
@@ -537,10 +537,10 @@ final class BillingHandlerUnitTests: TestCase {
 
         let (initialRouteResponse, _) = Fixture.route(waypoints: initialRouteWaypoints)
         let (newRouteResponse, _) = Fixture.route(waypoints: newRouteWaypoints)
+        let initialIndexedRouteResponse = IndexedRouteResponse(routeResponse: initialRouteResponse, routeIndex: 0)
 
         let dataSource = DataSource()
-        let routeController = RouteController(alongRouteAtIndex: 0,
-                                              in: initialRouteResponse,
+        let routeController = RouteController(with: initialIndexedRouteResponse,
                                               options: NavigationRouteOptions(coordinates: initialRouteWaypoints),
                                               customRoutingProvider: MapboxRoutingProvider(.offline),
                                               dataSource: dataSource)
@@ -659,9 +659,9 @@ final class BillingHandlerUnitTests: TestCase {
                                               routes: [route],
                                               options: .route(.init(coordinates: waypointCoordinates)),
                                               credentials: .mocked)
-
-            let routeController = RouteController(alongRouteAtIndex: 0,
-                                                  in: routeResponse,
+            let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
+            
+            let routeController = RouteController(with: indexedRouteResponse,
                                                   options: routeOptions,
                                                   customRoutingProvider: MapboxRoutingProvider(.offline),
                                                   dataSource: self)

--- a/Tests/MapboxCoreNavigationTests/LeakTests.swift
+++ b/Tests/MapboxCoreNavigationTests/LeakTests.swift
@@ -6,8 +6,7 @@ import TestHelper
 final class LeakTests: TestCase {
     func testNavigationService() {
         let leakTester = LeakTest {
-            MapboxNavigationService(routeResponse: response,
-                                    routeIndex: 0,
+            MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                     routeOptions: routeOptions,
                                     customRoutingProvider: MapboxRoutingProvider(.offline),
                                     credentials: .mocked)

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -13,6 +13,9 @@ var routeOptions: NavigationRouteOptions {
     return NavigationRouteOptions(waypoints: [from, to])
 }
 let response = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName,
+                                                                                     options: routeOptions),
+                                                routeIndex: 0)
 let directions = DirectionsSpy()
 let route: Route = {
     return Fixture.route(from: jsonFileName, options: routeOptions)
@@ -40,8 +43,7 @@ class MapboxCoreNavigationTests: TestCase {
     }
     
     func testNavigationNotificationsInfoDict() {
-        navigation = MapboxNavigationService(routeResponse: response,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
@@ -85,8 +87,7 @@ class MapboxCoreNavigationTests: TestCase {
     }
     
     func testDepart() {
-        navigation = MapboxNavigationService(routeResponse: response,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
@@ -136,8 +137,7 @@ class MapboxCoreNavigationTests: TestCase {
         let locationManager = ReplayLocationManager(locations: coordinates
                                                         .map { CLLocation(coordinate: $0) }
                                                         .shiftedToPresent())
-        let navigationService = MapboxNavigationService(routeResponse: response,
-                                                        routeIndex: 0,
+        let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         routeOptions: routeOptions,
                                                         customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,
@@ -194,8 +194,7 @@ class MapboxCoreNavigationTests: TestCase {
         
         let locationManager = ReplayLocationManager(locations: locations)
         locationManager.speedMultiplier = 100
-        navigation = MapboxNavigationService(routeResponse: response,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
@@ -247,8 +246,7 @@ class MapboxCoreNavigationTests: TestCase {
         }
         
         let locationManager = DummyLocationManager()
-        navigation = MapboxNavigationService(routeResponse: response,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
@@ -277,10 +275,11 @@ class MapboxCoreNavigationTests: TestCase {
     func disabled_testArrive() {
         let route = Fixture.route(from: "multileg-route", options: routeOptions)
         let replayLocations = Array(Fixture.generateTrace(for: route).shiftedToPresent().qualified()[0..<100])
-        let routeResponse = RouteResponse(httpResponse: nil,
-                                          routes: [route],
-                                          options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
-                                          credentials: .mocked)
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: RouteResponse(httpResponse: nil,
+                                                                                     routes: [route],
+                                                                                     options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
+                                                                                     credentials: .mocked),
+                                                        routeIndex: 0)
 
         let locationManager = ReplayLocationManager(locations: replayLocations)
         let speedMultiplier: TimeInterval = 50
@@ -288,8 +287,7 @@ class MapboxCoreNavigationTests: TestCase {
         locationManager.startDate = Date()
         locationManager.startUpdatingLocation()
 
-        navigation = MapboxNavigationService(routeResponse: routeResponse,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
@@ -338,8 +336,7 @@ class MapboxCoreNavigationTests: TestCase {
         let locationManager = ReplayLocationManager(locations: trace)
         locationManager.speedMultiplier = 100
 
-        navigation = MapboxNavigationService(routeResponse: response,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,
@@ -461,8 +458,7 @@ class MapboxCoreNavigationTests: TestCase {
     }
     
     func testFailToReroute() {
-        navigation = MapboxNavigationService(routeResponse: response,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.online),
                                              credentials: Fixture.credentials,
@@ -484,8 +480,7 @@ class MapboxCoreNavigationTests: TestCase {
     }
     
     func testNoUpdatesAfterFinishingRouting() {
-        navigation = MapboxNavigationService(routeResponse: response,
-                                             routeIndex: 0,
+        navigation = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                              routeOptions: routeOptions,
                                              customRoutingProvider: MapboxRoutingProvider(.offline),
                                              credentials: Fixture.credentials,

--- a/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -20,7 +20,7 @@ class NavigationEventsManagerTests: TestCase {
             CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
         ])
         let firstRoute = Fixture.route(from: "DCA-Arboretum", options: firstRouteOptions)
-        let firstRouteResponse = Fixture.routeResponse(from: "DCA-Arboretum", options: firstRouteOptions)
+        let firstRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "DCA-Arboretum", options: firstRouteOptions), routeIndex: 0)
         
         let secondRouteOptions = NavigationRouteOptions(coordinates: [
             CLLocationCoordinate2D(latitude: 42.361634, longitude: -71.12852),
@@ -33,7 +33,7 @@ class NavigationEventsManagerTests: TestCase {
         let secondTrace = Fixture.generateTrace(for: secondRoute).shifted(to: firstTrace.last!.timestamp + 1).qualified()
         
         let locationManager = NavigationLocationManager()
-        let service = MapboxNavigationService(routeResponse: firstRouteResponse, routeIndex: 0,
+        let service = MapboxNavigationService(indexedRouteResponse: firstRouteResponse,
                                               routeOptions: firstRouteOptions,
                                               customRoutingProvider: MapboxRoutingProvider(.offline),
                                               credentials: Fixture.credentials,
@@ -88,14 +88,13 @@ class NavigationEventsManagerTests: TestCase {
         ])
         let eventTimeout = 0.3
         let route = Fixture.route(from: "DCA-Arboretum", options: routeOptions)
-        let routeResponse = Fixture.routeResponse(from: "DCA-Arboretum", options: routeOptions)
-        let dataSource = MapboxNavigationService(routeResponse: routeResponse,
-                                                 routeIndex: 0,
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "DCA-Arboretum", options: routeOptions), routeIndex: 0)
+        let dataSource = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                  routeOptions: routeOptions,
                                                  customRoutingProvider: MapboxRoutingProvider(.offline),
                                                  credentials: Fixture.credentials,
                                                  simulating: .onPoorGPS)
-        let sessionState = SessionState(currentRoute: route, originalRoute: route, routeIdentifier: routeResponse.identifier)
+        let sessionState = SessionState(currentRoute: route, originalRoute: route, routeIdentifier: indexedRouteResponse.routeResponse.identifier)
         
         // Attempt to create NavigationEventDetails object from global queue, no errors from Main Thread Checker
         // are expected.

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -23,8 +23,7 @@ class NavigationServiceTests: TestCase {
     var dependencies: (navigationService: NavigationService, routeLocations: RouteLocations)!
     
     func createDependencies(locationSource: NavigationLocationManager? = nil) -> (navigationService: NavigationService, routeLocations: RouteLocations) {
-        let navigationService = MapboxNavigationService(routeResponse: initialRouteResponse,
-                                                        routeIndex: 0,
+        let navigationService = MapboxNavigationService(indexedRouteResponse: initiaIndexedRouteResponse,
                                                         routeOptions: routeOptions,
                                                         customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,
@@ -50,6 +49,9 @@ class NavigationServiceTests: TestCase {
     }
 
     let initialRouteResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+    let initiaIndexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName,
+                                                                                               options: routeOptions),
+                                                          routeIndex: 0)
 
     let alternateRouteResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
     let alternateRoute = Fixture.route(from: jsonFileName, options: routeOptions)
@@ -354,8 +356,8 @@ class NavigationServiceTests: TestCase {
             CLLocationCoordinate2D(latitude: 37.77735, longitude: -122.461465),
             CLLocationCoordinate2D(latitude: 37.777016, longitude: -122.468832),
         ])
-        let routeResponse = Fixture.routeResponse(from: "straight-line", options: options)
-        let navigationService = MapboxNavigationService(routeResponse: routeResponse, routeIndex: 0, routeOptions: options, customRoutingProvider: nil, credentials: Fixture.credentials)
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "straight-line", options: options), routeIndex: 0)
+        let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse, routeOptions: options, customRoutingProvider: nil, credentials: Fixture.credentials)
         let router = navigationService.router
         let firstCoordinate = router.routeProgress.nearbyShape.coordinates.first!
         let firstLocation = CLLocation(latitude: firstCoordinate.latitude, longitude: firstCoordinate.longitude)
@@ -410,14 +412,13 @@ class NavigationServiceTests: TestCase {
     func testTurnstileEventSentUponInitialization() {
         // MARK: it sends a turnstile event upon initialization
 
-        let service = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
+        let service = MapboxNavigationService(indexedRouteResponse: initiaIndexedRouteResponse, routeOptions: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
         let eventsManagerSpy = service.eventsManager as! NavigationEventsManagerSpy
         XCTAssertTrue(eventsManagerSpy.hasFlushedEvent(with: MMEEventTypeAppUserTurnstile))
     }
 
     func testReroutingFromLocationUpdatesSimulatedLocationSource() {
-        let navigationService = MapboxNavigationService(routeResponse: initialRouteResponse,
-                                                        routeIndex: 0,
+        let navigationService = MapboxNavigationService(indexedRouteResponse: initiaIndexedRouteResponse,
                                                         routeOptions: routeOptions,
                                                         customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,
@@ -477,13 +478,13 @@ class NavigationServiceTests: TestCase {
 
         // MARK: Setupping a re-route stub
         MapboxRoutingProvider.__testRoutesStub = { (options, completionHandler) in
-            completionHandler(Directions.Session(options, Credentials()),
-                              .success(RouteResponse(httpResponse: nil,
-                                                     identifier: nil,
-                                                     routes: [self.alternateRoute],
-                                                     waypoints: nil,
-                                                     options: .route(options),
-                                                     credentials: Fixture.credentials)))
+            completionHandler(.success(.init(routeResponse: RouteResponse(httpResponse: nil,
+                                                                          identifier: nil,
+                                                                          routes: [self.alternateRoute],
+                                                                          waypoints: nil,
+                                                                          options: .route(options),
+                                                                          credentials: Fixture.credentials),
+                                             routeIndex: 0)))
             return nil
         }
         
@@ -612,7 +613,7 @@ class NavigationServiceTests: TestCase {
 
         autoreleasepool {
             let fakeDataSource = RouteControllerDataSourceFake()
-            let routeController = RouteController(alongRouteAtIndex: 0, in: initialRouteResponse, options: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
+            let routeController = RouteController(with: initiaIndexedRouteResponse, options: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
             subject = routeController
         }
 
@@ -624,7 +625,7 @@ class NavigationServiceTests: TestCase {
 
         autoreleasepool {
             let fakeDataSource = RouteControllerDataSourceFake()
-            _ = RouteController(alongRouteAtIndex: 0, in: initialRouteResponse, options: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
+            _ = RouteController(with: initiaIndexedRouteResponse, options: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: fakeDataSource)
             subject = fakeDataSource
         }
 
@@ -632,7 +633,10 @@ class NavigationServiceTests: TestCase {
     }
 
     func testCountdownTimerDefaultAndUpdate() {
-        let subject = MapboxNavigationService(routeResponse: initialRouteResponse, routeIndex: 0, routeOptions: routeOptions, customRoutingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials)
+        let subject = MapboxNavigationService(indexedRouteResponse: initiaIndexedRouteResponse,
+                                              routeOptions: routeOptions,
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
+                                              credentials: Fixture.credentials)
 
         XCTAssert(subject.poorGPSTimer.countdownInterval == .milliseconds(2500), "Default countdown interval should be 2500 milliseconds.")
 
@@ -694,7 +698,7 @@ class NavigationServiceTests: TestCase {
             CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
         ])
         let route = Fixture.route(from: "DCA-Arboretum", options: options)
-        let routeResponse = Fixture.routeResponse(from: "DCA-Arboretum", options: options)
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "DCA-Arboretum", options: options), routeIndex: 0)
         let trace = Fixture.generateTrace(for: route).shiftedToPresent()
         guard let firstLoction = trace.first,
               let lastLocation = trace.last,
@@ -708,8 +712,7 @@ class NavigationServiceTests: TestCase {
 
         let locationManager = ReplayLocationManager(locations: trace)
         locationManager.speedMultiplier = 100
-        let service = MapboxNavigationService(routeResponse: routeResponse,
-                                              routeIndex: 0,
+        let service = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                               routeOptions: options,
                                               customRoutingProvider: MapboxRoutingProvider(.online),
                                               credentials: Fixture.credentials,
@@ -737,8 +740,8 @@ class NavigationServiceTests: TestCase {
                                            options: .route(options),
                                            credentials: Fixture.credentials)
         MapboxRoutingProvider.__testRoutesStub = { (options, completionHandler) in
-            completionHandler(Directions.Session(options, Fixture.credentials),
-                              .success(fasterResponse))
+            completionHandler(.success(.init(routeResponse: fasterResponse,
+                                             routeIndex: 0)))
             return nil
         }
         
@@ -838,8 +841,7 @@ class NavigationServiceTests: TestCase {
     }
     
     func testNavigationServiceStopShouldStopLocationUpdates() {
-        let navigationService = MapboxNavigationService(routeResponse: response,
-                                                        routeIndex: 0,
+        let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         routeOptions: routeOptions,
                                                         customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,

--- a/Tests/MapboxNavigationTests/CarPlayManagerSpec.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerSpec.swift
@@ -64,8 +64,8 @@ class CarPlayManagerSpec: QuickSpec {
                                                    options: .route(navigationRouteOptions),
                                                    credentials: Fixture.credentials)
                 MapboxRoutingProvider.__testRoutesStub = { (options, completionHandler) in
-                    completionHandler(Directions.Session(options, Fixture.credentials),
-                                      .success(fasterResponse))
+                    completionHandler(.success(.init(routeResponse: fasterResponse,
+                                                     routeIndex: 0)))
                     return nil
                 }
                 

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -260,7 +260,6 @@ class CarPlayManagerTests: TestCase {
         carPlayManager.delegate = carPlayManagerDelegateMock
         let testError = DirectionsError.requestTooLarge
         carPlayManager.didCalculate(.failure(testError),
-                                    in: (options: routeOptions, credentials: Fixture.credentials),
                                     for: routeOptions,
                                     completionHandler: {})
         XCTAssertEqual(carPlayManagerDelegateMock.routeCalculationError,

--- a/Tests/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayNavigationViewControllerTests.swift
@@ -33,11 +33,11 @@ class CarPlayNavigationViewControllerTests: TestCase {
             CLLocationCoordinate2D(latitude: 47.212326, longitude: 9.512569),
         ])
         
-        let routeResponse = Fixture.routeResponse(from: "multileg-route",
-                                                  options: navigationRouteOptions)
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "multileg-route",
+                                                                                             options: navigationRouteOptions),
+                                                        routeIndex: 0)
         
-        let navigationService = MapboxNavigationService(routeResponse: routeResponse,
-                                                        routeIndex: 0,
+        let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         routeOptions: navigationRouteOptions,
                                                         customRoutingProvider: nil,
                                                         credentials: Fixture.credentials)

--- a/Tests/MapboxNavigationTests/CarPlayUtils.swift
+++ b/Tests/MapboxNavigationTests/CarPlayUtils.swift
@@ -85,9 +85,10 @@ class TestCarPlayManagerDelegate: CarPlayManagerDelegate {
                         routeIndex: Int,
                         routeOptions: RouteOptions,
                         desiredSimulationMode: SimulationMode) -> NavigationService? {
-        let routeResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
-        let navigationService = MapboxNavigationService(routeResponse: routeResponse,
-                                                        routeIndex: routeIndex,
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName,
+                                                                                             options: routeOptions),
+                                                        routeIndex: 0)
+        let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         routeOptions: routeOptions,
                                                         customRoutingProvider: MapboxRoutingProvider(.offline),
                                                         credentials: Fixture.credentials,

--- a/Tests/MapboxNavigationTests/Constants.swift
+++ b/Tests/MapboxNavigationTests/Constants.swift
@@ -29,3 +29,6 @@ var routeOptions: NavigationRouteOptions {
 
 let jsonFileName = "routeWithInstructions"
 let response = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName,
+                                                                                     options: routeOptions),
+                                                routeIndex: 0)

--- a/Tests/MapboxNavigationTests/EndOfRouteFeedbackTests.swift
+++ b/Tests/MapboxNavigationTests/EndOfRouteFeedbackTests.swift
@@ -11,10 +11,10 @@ final class EndOfRouteFeedbackTests: TestCase {
         let endLocation = CLLocationCoordinate2D(latitude: 32.714721,
                                                  longitude: -117.149314)
 
-        let route = Fixture.route(between: startLocation, and: endLocation)
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.route(between: startLocation, and: endLocation).response,
+                                                        routeIndex: 0)
         let options = NavigationRouteOptions(coordinates: [startLocation, endLocation])
-        let service = MapboxNavigationService(routeResponse: route.response,
-                                              routeIndex: 0,
+        let service = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                               routeOptions: options,
                                               customRoutingProvider: MapboxRoutingProvider(.offline),
                                               credentials: Fixture.credentials,

--- a/Tests/MapboxNavigationTests/InstructionsCardViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/InstructionsCardViewControllerTests.swift
@@ -11,6 +11,11 @@ class InstructionsCardViewControllerTests: TestCase {
         return Fixture.routeResponse(from: jsonFileName, options: routeOptions)
     }()
     
+    lazy var initialIndexedRouteResponse: IndexedRouteResponse = {
+        return IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions),
+                                    routeIndex: 0)
+    }()
+    
     var dataSource: (
         instructionsCardViewController: InstructionsCardViewController,
         routeProgress: RouteProgress,
@@ -46,8 +51,7 @@ class InstructionsCardViewControllerTests: TestCase {
             let route = Fixture.route(from: "route-with-banner-instructions",
                                       options: navigationRouteOptions)
             
-            let navigationService = MapboxNavigationService(routeResponse: initialRouteResponse,
-                                                            routeIndex: 0,
+            let navigationService = MapboxNavigationService(indexedRouteResponse: initialIndexedRouteResponse,
                                                             routeOptions: navigationRouteOptions,
                                                             customRoutingProvider: MapboxRoutingProvider(.offline),
                                                             credentials: Fixture.credentials,

--- a/Tests/MapboxNavigationTests/LeaksTests.swift
+++ b/Tests/MapboxNavigationTests/LeaksTests.swift
@@ -21,8 +21,7 @@ final class LeaksTests: TestCase {
     }
 
     func testRouteVoiceController() {
-        let dummySvc = MapboxNavigationService(routeResponse: response,
-                                               routeIndex: 0,
+        let dummySvc = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                routeOptions: initialOptions,
                                                customRoutingProvider: nil,
                                                credentials: Fixture.credentials)
@@ -39,8 +38,7 @@ final class LeaksTests: TestCase {
 
     func testNavigationViewController() {
         let leakTester = LeakTest {
-            let service = MapboxNavigationService(routeResponse: response,
-                                                  routeIndex: 0,
+            let service = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                   routeOptions: self.initialOptions,
                                                   customRoutingProvider: MapboxRoutingProvider(.offline),
                                                   credentials: Fixture.credentials,
@@ -48,10 +46,9 @@ final class LeaksTests: TestCase {
             let navOptions = NavigationOptions(navigationService: service, voiceController:
                                                 RouteVoiceControllerStub(navigationService: service))
 
-            return NavigationViewController(for: response,
-                                               routeIndex: 0,
-                                               routeOptions: self.initialOptions,
-                                               navigationOptions: navOptions)
+            return NavigationViewController(for: indexedRouteResponse,
+                                            routeOptions: self.initialOptions,
+                                            navigationOptions: navOptions)
         }
         XCTAssertFalse(leakTester.isLeaking())
     }

--- a/Tests/MapboxNavigationTests/NavigationCameraTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationCameraTests.swift
@@ -178,11 +178,11 @@ class NavigationCameraTests: TestCase {
         let navigationMapView = NavigationMapView(frame: .zero)
         XCTAssertEqual(navigationMapView.navigationCamera.state, .following)
         
-        let routeResponse = Fixture.routeResponse(from: jsonFileName,
-                                                  options: routeOptions)
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName,
+                                                                                             options: routeOptions),
+                                                        routeIndex: 0)
         
-        let navigationViewController = NavigationViewController(for: routeResponse,
-                                                                routeIndex: 0,
+        let navigationViewController = NavigationViewController(for: indexedRouteResponse,
                                                                 routeOptions: routeOptions)
         
         XCTAssertEqual(navigationViewController.navigationMapView?.navigationCamera.state, .following)

--- a/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
+++ b/Tests/MapboxNavigationTests/SpeechSynthesizersControllerTests.swift
@@ -74,6 +74,16 @@ class SpeechSynthesizersControllerTests: TestCase {
         options.shapeFormat = .polyline
         return Fixture.routeResponse(from: "route-with-instructions", options: options)
     }()
+    let indexedRouteResponse: IndexedRouteResponse = {
+        var options = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 40.311012, longitude: -112.47926),
+            CLLocationCoordinate2D(latitude: 29.99908, longitude: -102.828197),
+        ])
+        options.shapeFormat = .polyline
+        return IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "route-with-instructions",
+                                                                         options: options),
+                                    routeIndex: 0)
+    }()
     
     override func setUp() {
         super.setUp()
@@ -130,8 +140,7 @@ class SpeechSynthesizersControllerTests: TestCase {
         deinitExpectation.expectedFulfillmentCount = 2
         (synthesizers[0] as! FailingSpeechSynthesizerMock).deinitExpectation = deinitExpectation
         (synthesizers[1] as! FailingSpeechSynthesizerMock).deinitExpectation = deinitExpectation
-        let dummyService = MapboxNavigationService(routeResponse: routeResponse,
-                                                   routeIndex: 0,
+        let dummyService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                    routeOptions: routeOptions,
                                                    customRoutingProvider: nil,
                                                    credentials: Fixture.credentials)
@@ -150,8 +159,7 @@ class SpeechSynthesizersControllerTests: TestCase {
         let expectation = XCTestExpectation(description: "Synthesizers speak should be called")
         let sut = SystemSpeechSynthMock()
         sut.speakExpectation = expectation
-        let dummyService = MapboxNavigationService(routeResponse: routeResponse,
-                                                   routeIndex: 0,
+        let dummyService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                    routeOptions: routeOptions,
                                                    customRoutingProvider: MapboxRoutingProvider(.offline),
                                                    credentials: Fixture.credentials,
@@ -169,8 +177,7 @@ class SpeechSynthesizersControllerTests: TestCase {
         let expectation = XCTestExpectation(description: "Synthesizers speak should be called")
         let sut = MapboxSpeechSynthMock()
         sut.speakExpectation = expectation
-        let dummyService = MapboxNavigationService(routeResponse: routeResponse,
-                                                   routeIndex: 0,
+        let dummyService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                    routeOptions: routeOptions,
                                                    customRoutingProvider: MapboxRoutingProvider(.offline),
                                                    credentials: Fixture.credentials,

--- a/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -20,7 +20,7 @@ class StepsViewControllerTests: TestCase {
         dependencies = {
             let dataSource = RouteControllerDataSourceFake()
 
-            let routeController = RouteController(alongRouteAtIndex: 0, in: response, options: Constants.options, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: dataSource)
+            let routeController = RouteController(with: indexedRouteResponse, options: Constants.options, customRoutingProvider: MapboxRoutingProvider(.offline), dataSource: dataSource)
 
             let stepsViewController = StepsViewController(routeProgress: routeController.routeProgress)
 


### PR DESCRIPTION
### Description
Introduces the feature when we are driving the `onboard` build route and the same `online` version becomes available to automatically switch to it in order to receive live updates and refreshing.

### Implementation
In order to correctly detect source of the original route, we have to allow configuring all related entities (NavigationViewController, NavigationService and Router) with an `IndexedRouteResponse` since it contains such information. Thus we also need to update API to request routes to return the correct type as well as deprecating other init methods. 
Online coincide route is detected through alternatives mechanism by checking if it completely follows the main route (in this case the deviation intersection is the last intersection on the route).
User is able to disable the behavior via flag control.