### PR TITLE
Fix `LaneView` styling on CarPlay.

### DIFF
--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -258,8 +258,8 @@ open class DayStyle: Style {
             NextInstructionLabel.appearance(for: phoneTraitCollection, whenContainedInInstancesOf: [NextBannerView.self]).textColorHighlighted = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
             NextInstructionLabel.appearance(for: phoneTraitCollection, whenContainedInInstancesOf: [NextBannerView.self]).normalFont = UIFont.systemFont(ofSize: 14.0).adjustedFont
             
-            LaneView.appearance(for: phoneTraitCollection).primaryColor = .defaultLaneArrowPrimaryCarPlay
-            LaneView.appearance(for: phoneTraitCollection).secondaryColor = .defaultLaneArrowSecondaryCarPlay
+            LaneView.appearance(for: phoneTraitCollection).primaryColor = .defaultLaneArrowPrimary
+            LaneView.appearance(for: phoneTraitCollection).secondaryColor = .defaultLaneArrowSecondary
             LaneView.appearance(for: phoneTraitCollection).primaryColorHighlighted = .defaultLaneArrowPrimaryHighlighted
             LaneView.appearance(for: phoneTraitCollection).secondaryColorHighlighted = .defaultLaneArrowSecondaryHighlighted
             LaneView.appearance(for: phoneTraitCollection, whenContainedInInstancesOf: [LanesView.self]).primaryColor = .defaultLaneArrowPrimary
@@ -355,12 +355,6 @@ open class DayStyle: Style {
             SpeedLimitView.appearance(for: carPlayTraitCollection).textColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
             SpeedLimitView.appearance(for: carPlayTraitCollection).regulatoryBorderColor = #colorLiteral(red: 0.800, green: 0, blue: 0, alpha: 1)
             
-            LaneView.appearance(for: carPlayTraitCollection).primaryColor = .defaultLaneArrowPrimaryCarPlay
-            LaneView.appearance(for: carPlayTraitCollection).secondaryColor = .defaultLaneArrowSecondaryCarPlay
-            
-            LaneView.appearance(for: carPlayTraitCollection).primaryColorHighlighted = .defaultLaneArrowPrimaryHighlighted
-            LaneView.appearance(for: carPlayTraitCollection).secondaryColorHighlighted = .defaultLaneArrowSecondaryHighlighted
-            
             ManeuverView.appearance(for: carPlayTraitCollection).backgroundColor = .clear
             ManeuverView.appearance(for: carPlayTraitCollection).primaryColorHighlighted = .defaultTurnArrowPrimaryHighlighted
             ManeuverView.appearance(for: carPlayTraitCollection).secondaryColorHighlighted = .defaultTurnArrowSecondaryHighlighted
@@ -369,21 +363,19 @@ open class DayStyle: Style {
             // `UITraitCollection`, which contains both `UIUserInterfaceIdiom` and `UIUserInterfaceStyle`.
             // If not, `UITraitCollection` will only contain `UIUserInterfaceIdiom`.
             if #available(iOS 12.0, *) {
-                let carPlayTraitCollection = UITraitCollection(userInterfaceIdiom: .carPlay)
-                
                 let carPlayLightTraitCollection = UITraitCollection(traitsFrom: [
                     carPlayTraitCollection,
                     UITraitCollection(userInterfaceStyle: .light)
                 ])
-                setCarPlayInstructionsStyling(for: carPlayLightTraitCollection)
+                applyCarPlayStyling(for: carPlayLightTraitCollection)
                 
                 let carPlayDarkTraitCollection = UITraitCollection(traitsFrom: [
                     carPlayTraitCollection,
                     UITraitCollection(userInterfaceStyle: .dark)
                 ])
-                setCarPlayInstructionsStyling(for: carPlayDarkTraitCollection)
+                applyCarPlayStyling(for: carPlayDarkTraitCollection)
             } else {
-                setDefaultCarPlayInstructionsStyling()
+                applyDefaultCarPlayStyling()
             }
         default:
             break
@@ -391,12 +383,7 @@ open class DayStyle: Style {
     }
     
     @available(iOS 12.0, *)
-    func setCarPlayInstructionsStyling(for traitCollection: UITraitCollection?) {
-        guard let traitCollection = traitCollection,
-              traitCollection.userInterfaceIdiom == .carPlay else { return }
-        
-        let carPlayTraitCollection = UITraitCollection(userInterfaceIdiom: .carPlay)
-        
+    func applyCarPlayStyling(for traitCollection: UITraitCollection) {
         // On CarPlay, `ExitView` and `GenericRouteShield` styling depends on `UIUserInterfaceStyle`,
         // which was set on CarPlay external screen.
         // In case if it was set to `UIUserInterfaceStyle.light` white color will be used, otherwise
@@ -405,51 +392,55 @@ open class DayStyle: Style {
         // property of which returns incorrect value), this property has to be taken from callbacks
         // similar to: `UITraitEnvironment.traitCollectionDidChange(_:)`, or by creating `UITraitCollection`
         // directly.
+        let defaultInstructionColor: UIColor
+        
+        let defaultLaneViewPrimaryColor: UIColor
+        let defaultLaneViewSecondaryColor: UIColor
+        
+        let defaultLaneArrowPrimaryHighlightedColor: UIColor
+        let defaultLaneArrowSecondaryHighlightedColor: UIColor
+        
         switch traitCollection.userInterfaceStyle {
-        case .dark:
-            let defaultColor = UIColor.white
-            
-            let carPlayDarkTraitCollection = UITraitCollection(traitsFrom: [
-                carPlayTraitCollection,
-                UITraitCollection(userInterfaceStyle: .dark)
-            ])
-            
-            ExitView.appearance(for: carPlayDarkTraitCollection).backgroundColor = .clear
-            ExitView.appearance(for: carPlayDarkTraitCollection).borderWidth = 1.0
-            ExitView.appearance(for: carPlayDarkTraitCollection).cornerRadius = 5.0
-            ExitView.appearance(for: carPlayDarkTraitCollection).foregroundColor = defaultColor
-            ExitView.appearance(for: carPlayDarkTraitCollection).borderColor = defaultColor
-            
-            GenericRouteShield.appearance(for: carPlayDarkTraitCollection).backgroundColor = .clear
-            GenericRouteShield.appearance(for: carPlayDarkTraitCollection).borderWidth = 1.0
-            GenericRouteShield.appearance(for: carPlayDarkTraitCollection).cornerRadius = 5.0
-            GenericRouteShield.appearance(for: carPlayDarkTraitCollection).foregroundColor = defaultColor
-            GenericRouteShield.appearance(for: carPlayDarkTraitCollection).borderColor = defaultColor
         case .light, .unspecified:
-            let defaultColor = UIColor.black
+            defaultInstructionColor = UIColor.black
             
-            let carPlayLightTraitCollection = UITraitCollection(traitsFrom: [
-                carPlayTraitCollection,
-                UITraitCollection(userInterfaceStyle: .light)
-            ])
+            defaultLaneViewPrimaryColor = .defaultLaneArrowPrimary
+            defaultLaneViewSecondaryColor = .defaultLaneArrowSecondary
             
-            ExitView.appearance(for: carPlayLightTraitCollection).backgroundColor = .clear
-            ExitView.appearance(for: carPlayLightTraitCollection).borderWidth = 1.0
-            ExitView.appearance(for: carPlayLightTraitCollection).cornerRadius = 5.0
-            ExitView.appearance(for: carPlayLightTraitCollection).foregroundColor = defaultColor
-            ExitView.appearance(for: carPlayLightTraitCollection).borderColor = defaultColor
+            defaultLaneArrowPrimaryHighlightedColor = .defaultLaneArrowPrimaryHighlighted
+            defaultLaneArrowSecondaryHighlightedColor = .defaultLaneArrowSecondaryHighlighted
+        case .dark:
+            defaultInstructionColor = UIColor.white
             
-            GenericRouteShield.appearance(for: carPlayLightTraitCollection).backgroundColor = .clear
-            GenericRouteShield.appearance(for: carPlayLightTraitCollection).borderWidth = 1.0
-            GenericRouteShield.appearance(for: carPlayLightTraitCollection).cornerRadius = 5.0
-            GenericRouteShield.appearance(for: carPlayLightTraitCollection).foregroundColor = defaultColor
-            GenericRouteShield.appearance(for: carPlayLightTraitCollection).borderColor = defaultColor
+            defaultLaneViewPrimaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+            defaultLaneViewSecondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.3)
+            
+            defaultLaneArrowPrimaryHighlightedColor = .defaultLaneArrowPrimaryHighlighted
+            defaultLaneArrowSecondaryHighlightedColor = .defaultLaneArrowSecondaryHighlighted
         @unknown default:
             fatalError("Unknown userInterfaceStyle.")
         }
+        
+        ExitView.appearance(for: traitCollection).backgroundColor = .clear
+        ExitView.appearance(for: traitCollection).borderWidth = 1.0
+        ExitView.appearance(for: traitCollection).cornerRadius = 5.0
+        ExitView.appearance(for: traitCollection).foregroundColor = defaultInstructionColor
+        ExitView.appearance(for: traitCollection).borderColor = defaultInstructionColor
+
+        GenericRouteShield.appearance(for: traitCollection).backgroundColor = .clear
+        GenericRouteShield.appearance(for: traitCollection).borderWidth = 1.0
+        GenericRouteShield.appearance(for: traitCollection).cornerRadius = 5.0
+        GenericRouteShield.appearance(for: traitCollection).foregroundColor = defaultInstructionColor
+        GenericRouteShield.appearance(for: traitCollection).borderColor = defaultInstructionColor
+
+        LaneView.appearance(for: traitCollection).primaryColor = defaultLaneViewPrimaryColor
+        LaneView.appearance(for: traitCollection).secondaryColor = defaultLaneViewSecondaryColor
+
+        LaneView.appearance(for: traitCollection).primaryColorHighlighted = defaultLaneArrowPrimaryHighlightedColor
+        LaneView.appearance(for: traitCollection).secondaryColorHighlighted = defaultLaneArrowSecondaryHighlightedColor
     }
     
-    func setDefaultCarPlayInstructionsStyling() {
+    func applyDefaultCarPlayStyling() {
         let defaultColor = UIColor.black
         let carPlayTraitCollection = UITraitCollection(userInterfaceIdiom: .carPlay)
         
@@ -458,5 +449,11 @@ open class DayStyle: Style {
         
         GenericRouteShield.appearance(for: carPlayTraitCollection).foregroundColor = defaultColor
         GenericRouteShield.appearance(for: carPlayTraitCollection).borderColor = defaultColor
+        
+        LaneView.appearance(for: carPlayTraitCollection).primaryColor = .defaultLaneArrowPrimary
+        LaneView.appearance(for: carPlayTraitCollection).secondaryColor = .defaultLaneArrowSecondary
+        
+        LaneView.appearance(for: carPlayTraitCollection).primaryColorHighlighted = .defaultLaneArrowPrimaryHighlighted
+        LaneView.appearance(for: carPlayTraitCollection).secondaryColorHighlighted = .defaultLaneArrowSecondaryHighlighted
     }
 }

--- a/Sources/MapboxNavigation/LaneView.swift
+++ b/Sources/MapboxNavigation/LaneView.swift
@@ -336,24 +336,37 @@ extension ManeuverDirection {
 
 /// :nodoc:
 open class LaneView: UIView {
+    
+    /**
+     The direction or directions of travel that the lane is reserved for.
+     */
     var indications: LaneIndication {
         didSet {
             setNeedsDisplay()
         }
     }
     
+    /**
+     Denotes which of the `indications` is applicable to the current route when there is more than one.
+     */
     var maneuverDirection: ManeuverDirection? {
         didSet {
             setNeedsDisplay()
         }
     }
     
-    var isValid: Bool = false {
+    /**
+     Denotes whether or not the user can use this lane to continue along the current route.
+     */
+    var isUsable: Bool = false {
         didSet {
             setNeedsDisplay()
         }
     }
     
+    /**
+     Indicates which side of the road cars and traffic flow.
+     */
     var drivingSide: DrivingSide = .right {
         didSet {
             setNeedsDisplay()
@@ -364,30 +377,52 @@ open class LaneView: UIView {
         return bounds.size
     }
     
+    /**
+     Color of the maneuver direction (applied only when `LaneView.isUsable` is set to `true`). In case if
+     `LaneView.showHighlightedColors` is set to `true` this value is not used, `LaneView.primaryColorHighlighted`
+     is used instead.
+     */
     @objc public dynamic var primaryColor: UIColor = .defaultLaneArrowPrimary {
         didSet {
             setNeedsDisplay()
         }
     }
     
+    /**
+     Color of the directions that the lane is reserved for (except the one that is applicable to the
+     current route). In case if `LaneView.showHighlightedColors` is set to `true` this value is not used,
+     `LaneView.secondaryColorHighlighted` is used instead.
+     */
     @objc public dynamic var secondaryColor: UIColor = .defaultLaneArrowSecondary {
         didSet {
             setNeedsDisplay()
         }
     }
-
+    
+    /**
+     Highlighted color of the directions that the lane is reserved for (except the one that is
+     applicable to the current route).
+     */
     @objc public dynamic var primaryColorHighlighted: UIColor = .defaultLaneArrowPrimaryHighlighted {
         didSet {
             setNeedsDisplay()
         }
     }
-
+    
+    /**
+     Highlighted color of the directions that the lane is reserved for (except the one that is applicable
+     to the current route).
+     */
     @objc public dynamic var secondaryColorHighlighted: UIColor = .defaultLaneArrowSecondaryHighlighted {
         didSet {
             setNeedsDisplay()
         }
     }
-
+    
+    /**
+     Controls whether highighted colors (either `LaneView.primaryColorHighlighted` or
+     `LaneView.secondaryColorHighlighted`) should be used.
+     */
     public var showHighlightedColors: Bool = false {
         didSet {
             setNeedsDisplay()
@@ -395,7 +430,7 @@ open class LaneView: UIView {
     }
     
     var appropriatePrimaryColor: UIColor {
-        if isValid {
+        if isUsable {
             return showHighlightedColors ? primaryColorHighlighted : primaryColor
         } else {
             return showHighlightedColors ? secondaryColorHighlighted : secondaryColor
@@ -408,12 +443,16 @@ open class LaneView: UIView {
     
     static let defaultFrame: CGRect = CGRect(origin: .zero, size: 30.0)
     
-    convenience init(indications: LaneIndication, isUsable: Bool, direction: ManeuverDirection?) {
+    convenience init(indications: LaneIndication,
+                     isUsable: Bool,
+                     direction: ManeuverDirection?,
+                     showHighlightedColors: Bool = false) {
         self.init(frame: LaneView.defaultFrame)
         backgroundColor = .clear
         self.indications = indications
         maneuverDirection = direction ?? ManeuverDirection(rawValue: indications.description)
-        isValid = isUsable
+        self.isUsable = isUsable
+        self.showHighlightedColors = showHighlightedColors
     }
 
     override init(frame: CGRect) {
@@ -422,9 +461,9 @@ open class LaneView: UIView {
         commonInit()
     }
 
-    @objc public required init?(coder aDecoder: NSCoder) {
+    @objc public required init?(coder decoder: NSCoder) {
         indications = []
-        super.init(coder: aDecoder)
+        super.init(coder: decoder)
         commonInit()
     }
 
@@ -444,7 +483,7 @@ open class LaneView: UIView {
         #endif
         
         let resizing = LanesStyleKit.ResizingBehavior.aspectFit
-        let appropriateColor = isValid ? appropriatePrimaryColor : appropriateSecondaryColor
+        let appropriateColor = isUsable ? appropriatePrimaryColor : appropriateSecondaryColor
         let size = CGSize(width: 32, height: 32)
         
         let isFlipped = indications.dominantSide(maneuverDirection: maneuverDirection, drivingSide: drivingSide) == .left

--- a/Sources/MapboxNavigation/LanesView.swift
+++ b/Sources/MapboxNavigation/LanesView.swift
@@ -59,7 +59,7 @@ open class LanesView: UIView, NavigationComponent {
             }
         }
         
-        guard !subviews.isEmpty && subviews.contains(where: { $0.isValid }) else {
+        guard !subviews.isEmpty && subviews.contains(where: { $0.isUsable }) else {
             hide(animated: animated,
                  duration: duration) { completed in
                 completion?(completed)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -880,7 +880,9 @@ extension NavigationViewController: NavigationServiceDelegate {
             imageColor = .black
         }
         
-        if let image = instruction.primaryInstruction.maneuverImage(side: instruction.drivingSide, color: imageColor, size: CGSize(width: 72, height: 72)) {
+        if let image = instruction.primaryInstruction.maneuverImage(drivingSide: instruction.drivingSide,
+                                                                    color: imageColor,
+                                                                    size: CGSize(width: 72, height: 72)) {
             // Bake in any transform required for left turn arrows etc.
             let imageData = UIGraphicsImageRenderer(size: image.size).pngData { (context) in
                 image.draw(at: .zero)
@@ -888,7 +890,9 @@ extension NavigationViewController: NavigationServiceDelegate {
             let temporaryURL = FileManager.default.temporaryDirectory.appendingPathComponent("com.mapbox.navigation.notification-icon.png")
             do {
                 try imageData.write(to: temporaryURL)
-                let iconAttachment = try UNNotificationAttachment(identifier: "maneuver", url: temporaryURL, options: [UNNotificationAttachmentOptionsTypeHintKey: kUTTypePNG])
+                let iconAttachment = try UNNotificationAttachment(identifier: "maneuver",
+                                                                  url: temporaryURL,
+                                                                  options: [UNNotificationAttachmentOptionsTypeHintKey: kUTTypePNG])
                 content.attachments = [iconAttachment]
             } catch {
                 Log.error("Failed to create UNNotificationAttachment with error: \(error.localizedDescription).",

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -169,9 +169,6 @@ open class NightStyle: DayStyle {
             // `StylableLabel` is used in `CarPlayCompassView` to show compass direction.
             StylableLabel.appearance(for: carPlayTraitCollection, whenContainedInInstancesOf: [CarPlayCompassView.self]).normalTextColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
             
-            LaneView.appearance(for: carPlayTraitCollection).primaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-            LaneView.appearance(for: carPlayTraitCollection).secondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.3)
-            
             WayNameView.appearance(for: carPlayTraitCollection).borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)
             WayNameLabel.appearance(for: carPlayTraitCollection).roadShieldBlackColor = #colorLiteral(red: 0.08, green: 0.09, blue: 0.12, alpha: 1)
             WayNameLabel.appearance(for: carPlayTraitCollection).roadShieldBlueColor = #colorLiteral(red: 0.18, green: 0.26, blue: 0.66, alpha: 1)

--- a/Sources/MapboxNavigation/UIColor.swift
+++ b/Sources/MapboxNavigation/UIColor.swift
@@ -16,17 +16,16 @@ extension UIColor {
     class var defaultManeuverArrow: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
     
     class var defaultTurnArrowPrimary: UIColor { #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) }
-    class var defaultTurnArrowPrimaryHighlighted: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
     class var defaultTurnArrowSecondary: UIColor { #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) }
+    
+    class var defaultTurnArrowPrimaryHighlighted: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
     class var defaultTurnArrowSecondaryHighlighted: UIColor { UIColor.white.withAlphaComponent(0.4) }
-
+    
     class var defaultLaneArrowPrimary: UIColor { #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) }
     class var defaultLaneArrowSecondary: UIColor { #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) }
+    
     class var defaultLaneArrowPrimaryHighlighted: UIColor { #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
     class var defaultLaneArrowSecondaryHighlighted: UIColor { UIColor(white: 0.7, alpha: 1.0) }
-
-    class var defaultLaneArrowPrimaryCarPlay: UIColor { #colorLiteral(red: 0.7649999857, green: 0.7649999857, blue: 0.7570000291, alpha: 1) }
-    class var defaultLaneArrowSecondaryCarPlay: UIColor { #colorLiteral(red: 0.4198532104, green: 0.4398920536, blue: 0.4437610507, alpha: 1) }
     
     class var trafficUnknown: UIColor { defaultRouteLayer }
     class var trafficLow: UIColor { defaultRouteLayer }
@@ -82,5 +81,19 @@ extension UIColor {
                   green: CGFloat(styleColor.green / 255.0),
                   blue: CGFloat(styleColor.blue / 255.0),
                   alpha: CGFloat(styleColor.alpha))
+    }
+    
+    /**
+     Returns hex representation of a `UIColor`.
+     */
+    var hexString: String {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        
+        let rgb: Int = (Int)(r * 255) << 16 | (Int)(g * 255) << 8 | (Int)(b * 255) << 0
+        return String(format:"#%06x", rgb)
     }
 }


### PR DESCRIPTION
### Description

PR fixes #3974. 

CarPlay was using incorrect `LaneView` styling due to two issues:
- Actual colors for CarPlay were not selected correctly. This created effect of colors inversion.
- `CPImageSet` uses `lightContentImage` for dark appearance and `darkContentImage` for light appearance (looks like a system bug).