### PR TITLE
Mapbox Navigation `v2.7.0-alpha.1`.

### DIFF
--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
 	<key>LSApplicationCategoryType</key>

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = "MapboxCoreNavigation"
-  s.version = '2.6.0'
+  s.version = '2.7.0-alpha.1'
   s.summary = "Core components for turn-by-turn navigation on iOS."
 
   s.description  = <<-DESC

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = "MapboxNavigation"
-  s.version = '2.6.0'
+  s.version = '2.7.0-alpha.1'
   s.summary = "Complete turn-by-turn navigation interface for iOS."
 
   s.description  = <<-DESC

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To install the MapboxNavigation framework in another package rather than an appl
 // Latest stable release
 .package(name: "MapboxNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", from: "2.6.0")
 // Latest prerelease
-.package(name: "MapboxNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", .exact("2.6.0-rc.2"))
+.package(name: "MapboxNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", .exact("2.7.0-alpha.1"))
 ```
 
 ### Using CocoaPods
@@ -75,8 +75,8 @@ To install the MapboxNavigation framework using [CocoaPods](https://cocoapods.or
    pod 'MapboxCoreNavigation', '~> 2.6'
    pod 'MapboxNavigation', '~> 2.6'
    # Latest prerelease
-   pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.6.0-rc.2'
-   pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.6.0-rc.2'
+   pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.7.0-alpha.1'
+   pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.7.0-alpha.1'
    ```
 
 1. Run `pod repo update && pod install` and open the resulting Xcode workspace.
@@ -103,7 +103,7 @@ To install the MapboxNavigation framework using [Carthage](https://github.com/Ca
    # Latest stable release
    github "mapbox/mapbox-navigation-ios" ~> 2.6
    # Latest prerelease
-   github "mapbox/mapbox-navigation-ios" "v2.6.0-rc.2"
+   github "mapbox/mapbox-navigation-ios" "v2.7.0-alpha.1"
    ```
 
 1. Run `carthage bootstrap --platform iOS --use-xcframeworks --cache-builds --use-netrc`.

--- a/Sources/CarPlayTestHelper/Info.plist
+++ b/Sources/CarPlayTestHelper/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
 </dict>

--- a/Sources/MapboxCoreNavigation/Info.plist
+++ b/Sources/MapboxCoreNavigation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/MapboxCoreNavigation/MBXInfo.plist
+++ b/Sources/MapboxCoreNavigation/MBXInfo.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/MapboxNavigation/Info.plist
+++ b/Sources/MapboxNavigation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/MapboxNavigation/MBXInfo.plist
+++ b/Sources/MapboxNavigation/MBXInfo.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/TestHelper/Info.plist
+++ b/Sources/TestHelper/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
 </dict>

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - MapboxCommon (22.1.0-beta.1)
   - MapboxCoreMaps (10.7.0-beta.1):
     - MapboxCommon (~> 22.1.0-beta)
-  - MapboxCoreNavigation (2.6.0):
+  - MapboxCoreNavigation (2.7.0-alpha.1):
     - MapboxDirections (~> 2.6)
     - MapboxMobileEvents (~> 1.0)
     - MapboxNavigationNative (~> 108.0)
@@ -15,8 +15,8 @@ PODS:
     - MapboxMobileEvents (= 1.0.8)
     - Turf (~> 2.0)
   - MapboxMobileEvents (1.0.8)
-  - MapboxNavigation (2.6.0):
-    - MapboxCoreNavigation (= 2.6.0)
+  - MapboxNavigation (2.7.0-alpha.1):
+    - MapboxCoreNavigation (= 2.7.0-alpha.1)
     - MapboxMaps (= 10.7.0-beta.1)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
@@ -54,11 +54,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: c11cccc12d43fc60eee90eef0ceca5215d4ce6bb
   MapboxCoreMaps: 5bdc0e1f510cbdabd8a76df75bb5d9338ba44a97
-  MapboxCoreNavigation: 7405c98ec8d13b71253c7a0c9355114d00c99cc8
+  MapboxCoreNavigation: c4cd60618c94ec3ba58b4107a297b7a1bf771326
   MapboxDirections: 4a51348c02146bd246ce67c3e3d06e809003fbba
   MapboxMaps: 3ede96e14347d3b5a88ca64c02ef5b5d670cab70
   MapboxMobileEvents: febdd92835daa258ca1c1faad0821c0b3394ef40
-  MapboxNavigation: f3b871ff3e3eab254993a6fa6083fe155dd75453
+  MapboxNavigation: 5840fbc91de88b988e9eeed37e256e7644432a35
   MapboxNavigationNative: d72e9cc111b315f521d2aaa03b040e8704ad10b4
   MapboxSpeech: fb9129e1ca7cc2dd465397d2aea1f5f510de260e
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff

--- a/Tests/MapboxCoreNavigationTests/Info.plist
+++ b/Tests/MapboxCoreNavigationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location Usage Description</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/Tests/MapboxNavigationTests/Info.plist
+++ b/Tests/MapboxNavigationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Location Usage Description</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/custom-navigation.md
+++ b/custom-navigation.md
@@ -39,7 +39,7 @@ To install the MapboxCoreNavigation framework in another package rather than an 
 // Latest stable release
 .package(name: "MapboxCoreNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", from: "2.6.0")
 // Latest prerelease
-.package(name: "MapboxCoreNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", .exact("2.6.0-rc.2"))
+.package(name: "MapboxCoreNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", .exact("2.7.0-alpha.1"))
 ```
 
 ### Using CocoaPods
@@ -59,7 +59,7 @@ To install Mapbox Core Navigation using [CocoaPods](https://cocoapods.org/):
    # Latest stable release
    pod 'MapboxCoreNavigation', '~> 2.6'
    # Latest prerelease
-   pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.6.0-rc.2'
+   pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.7.0-alpha.1'
    ```
 
 1. Run `pod repo update && pod install` and open the resulting Xcode workspace.
@@ -86,7 +86,7 @@ To install Mapbox Navigation using [Carthage](https://github.com/Carthage/Cartha
    # Latest stable release
    github "mapbox/mapbox-navigation-ios" ~> 2.6
    # Latest prerelease
-   github "mapbox/mapbox-navigation-ios" "v2.6.0-rc.2"
+   github "mapbox/mapbox-navigation-ios" "v2.7.0-alpha.1"
    ```
 
 1. Run `carthage bootstrap --platform iOS --use-xcframeworks --cache-builds --use-netrc`.


### PR DESCRIPTION
### Description

Update Mapbox Navigation to `v2.7.0-alpha.1`.

Current PR should be only merged after landing https://github.com/mapbox/mapbox-navigation-ios/pull/3978.