### PR TITLE
Alternatives length safety workaround

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -312,7 +312,8 @@ open class NavigationMapView: UIView {
                 return
             }
             
-            let offset = (route.distance - routeAlternative.infoFromDeviationPoint.distance) / route.distance
+            // workaround for NN routes distance calculation error
+            let offset = max(route.distance - routeAlternative.infoFromDeviationPoint.distance, 0.0) / route.distance
             parentLayerIdentifier = addRouteLayer(route,
                                                   fractionTraveled: offset,
                                                   below: parentLayerIdentifier,


### PR DESCRIPTION
### Description
NN uses different methods to calculated entire route distance and it's distance starting from the deviation point. Because of that it may happen that distance from a fork is bigger than entire route length. In this case SDK produces a negative fraction travelled key which crashes the map. Until NN fixes this on their side, we can add explicit check ourselves.

### Implementation
Added forcing non-negative check when calculating alternative route vanished part.