### PR TITLE
Fix sine xcode 14 warnings

### DIFF
--- a/Sources/MapboxCoreNavigation/Directions.swift
+++ b/Sources/MapboxCoreNavigation/Directions.swift
@@ -16,7 +16,7 @@ extension Directions {
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
      - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel this task.
      */
-    @discardableResult open func calculateWithCache(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) -> URLSessionDataTask? {
+    @discardableResult public func calculateWithCache(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) -> URLSessionDataTask? {
         return calculate(options) { (session, result) in
             switch result {
             case .success(_):
@@ -43,7 +43,7 @@ extension Directions {
      - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.
      */
-    open func calculateOffline(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) {
+    public func calculateOffline(options: RouteOptions, completionHandler: @escaping RouteCompletionHandler) {
         MapboxRoutingProvider(.offline).calculateRoutes(options: options,
                                                         completionHandler: completionHandler)
     }

--- a/Sources/MapboxCoreNavigation/RouteStep.swift
+++ b/Sources/MapboxCoreNavigation/RouteStep.swift
@@ -16,7 +16,7 @@ extension RouteStep {
     /**
      Returns true if the route step is on a motorway.
      */
-    open var isMotorway: Bool {
+    public var isMotorway: Bool {
         return intersections?.first?.outletRoadClasses?.contains(.motorway) ?? false
     }
     
@@ -34,7 +34,7 @@ extension RouteStep {
     /**
      Returns the last instruction for a given step.
      */
-    open var lastInstruction: SpokenInstruction? {
+    public var lastInstruction: SpokenInstruction? {
         return instructionsSpokenAlongStep?.last
     }
 }

--- a/Sources/MapboxNavigation/BottomBannerViewControllerLayout.swift
+++ b/Sources/MapboxNavigation/BottomBannerViewControllerLayout.swift
@@ -134,7 +134,7 @@ extension BottomBannerViewController {
         layoutConstraints.append(trailingSeparatorView.leadingAnchor.constraint(equalTo: bottomBannerView.trailingAnchor))
     }
     
-    open func reinstallConstraints() {
+    public func reinstallConstraints() {
         NSLayoutConstraint.deactivate(verticalCompactConstraints)
         NSLayoutConstraint.deactivate(verticalRegularConstraints)
         


### PR DESCRIPTION
The warnings say that you can't override methods/properties that are declared in an extension. That means there is no reason to mark methods as open.

- In one case, I just move the method to the main declaration so that it can be overridden. 
- In the other cases, I can't simply do it because the type is in "MapboxDirections". **But** it is possible to move some of these to "MapboxDirections" but it would be considered a breaking change, so I'm keeping them as is.