### PR TITLE
Provide the ability to modify certain `ResumeButton` properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fixed the unmatched language issue of some localized strings in the feedback view. ([#4007](https://github.com/mapbox/mapbox-navigation-ios/pull/4007))
 * Added `NavigationSettings.utilizeSensorData` toggle to allow navigator to use additional device sensors data for better positioning. ([#3973](https://github.com/mapbox/mapbox-navigation-ios/pull/3973))
 * Fixed the issue of restricted layer over the whole route after the removal of continuous alternative route with a small portion of restricted road class at start. ([#4009](https://github.com/mapbox/mapbox-navigation-ios/pull/4009))
+* Added `ResumeButton.borderWidth`, `ResumeButton.cornerRadius` and `ResumeButton.borderColor` properties that allow `ResumeButton`'s style modification. ([#3996](https://github.com/mapbox/mapbox-navigation-ios/pull/3996))
 
 ## v2.6.0
 

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -239,6 +239,9 @@ open class DayStyle: Style {
             
             ResumeButton.appearance(for: phoneTraitCollection).backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
             ResumeButton.appearance(for: phoneTraitCollection).tintColor = .defaultPrimaryText
+            ResumeButton.appearance(for: phoneTraitCollection).borderColor = #colorLiteral(red: 0.737254902, green: 0.7960784314, blue: 0.8705882353, alpha: 1)
+            ResumeButton.appearance(for: phoneTraitCollection).borderWidth = 1 / UIScreen.main.scale
+            ResumeButton.appearance(for: phoneTraitCollection).cornerRadius = 5.0
             
             NextBannerView.appearance(for: phoneTraitCollection).backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)
             NextBannerView.appearance(for: phoneTraitCollection, whenContainedInInstancesOf: [InstructionsCardContainerView.self]).backgroundColor = #colorLiteral(red: 0.9675388083, green: 0.9675388083, blue: 0.9675388083, alpha: 1)

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -151,6 +151,7 @@ open class NightStyle: DayStyle {
             
             ResumeButton.appearance(for: phoneTraitCollection).backgroundColor = backgroundColor
             ResumeButton.appearance(for: phoneTraitCollection).tintColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
+            ResumeButton.appearance(for: phoneTraitCollection).borderColor = #colorLiteral(red: 0.3764705882, green: 0.4901960784, blue: 0.6117647059, alpha: 0.796599912)
             
             NextBannerView.appearance(for: phoneTraitCollection).backgroundColor = #colorLiteral(red: 0.103291966, green: 0.1482483149, blue: 0.2006777823, alpha: 1)
             

--- a/Sources/MapboxNavigation/ResumeButton.swift
+++ b/Sources/MapboxNavigation/ResumeButton.swift
@@ -5,10 +5,44 @@ import UIKit
 @objc(MBResumeButton)
 public class ResumeButton: UIControl {
     
+    /**
+     The tint color of the `ResumeButton`'s icon and title.
+     */
     public override dynamic var tintColor: UIColor! {
         didSet {
             imageView.tintColor = tintColor
             titleLabel.textColor = tintColor
+        }
+    }
+    
+    /**
+     The width of the `ResumeButton`'s border.
+     */
+    @objc public dynamic var borderWidth: CGFloat = 0.0 {
+        didSet {
+            layer.borderWidth = borderWidth
+        }
+    }
+    
+    /**
+     The radius of the `ResumeButton`'s corner.
+     */
+    @objc public dynamic var cornerRadius: CGFloat = 0.0 {
+        didSet {
+            layer.cornerRadius = cornerRadius
+        }
+    }
+    
+    /**
+     The color of the `ResumeButton`'s border.
+     */
+    @objc public dynamic var borderColor: UIColor? {
+        get {
+            guard let color = layer.borderColor else { return nil }
+            return UIColor(cgColor: color)
+        }
+        set {
+            layer.borderColor = newValue?.cgColor
         }
     }
     


### PR DESCRIPTION
### Description

Provide the ability to modify `ResumeButton`s `borderWidth`, `cornerRadius` and `borderColor` properties.

Closing https://github.com/mapbox/mapbox-navigation-ios/issues/2107.