### PR TITLE
Pause the update of free drive in CarPlay after active navigation session starts

### DIFF
--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -107,6 +107,7 @@ public class CarPlayManager: NSObject {
             locationProvider.stopUpdatingHeading()
             if let passiveLocationProvider = locationProvider as? PassiveLocationProvider {
                 passiveLocationProvider.locationManager.pauseTripSession()
+                carPlayMapViewController?.unsubscribeFromFreeDriveNotifications()
             }
         }
         
@@ -804,6 +805,7 @@ extension CarPlayManager: CPMapTemplateDelegate {
         navigationMapView.removeWaypoints()
         if let passiveLocationProvider = navigationMapView.mapView.location.locationProvider as? PassiveLocationProvider {
             passiveLocationProvider.locationManager.resumeTripSession()
+            carPlayMapViewController.subscribeForFreeDriveNotifications()
         }
         delegate?.carPlayManagerDidEndNavigation(self)
         delegate?.carPlayManagerDidEndNavigation(self, byCanceling: false)
@@ -1076,6 +1078,7 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
 
         if let passiveLocationProvider = navigationMapView?.mapView.location.locationProvider as? PassiveLocationProvider {
             passiveLocationProvider.locationManager.resumeTripSession()
+            carPlayMapViewController?.subscribeForFreeDriveNotifications()
         }
         
         self.carPlayNavigationViewController = nil


### PR DESCRIPTION
### Description
This PR is to pause the update from `PassiveLocationManager` for free drive in CarPlay after the active navigation session starts.  Because even the trip session is paused, it still provides updates in CarPlay.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->