### PR TITLE
Fix the language unmatch issue in `MapboxNavigation` in some localized strings.

### DIFF
--- a/Sources/MapboxNavigation/Feedback/DialogViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/DialogViewController.swift
@@ -8,7 +8,7 @@ class DialogViewController: UIViewController {
         static let labelFont = UIFont.systemFont(ofSize: 17.0)
         static let stackSpacing = CGFloat(20.0)
         static let checkmark = UIImage(named: "report_checkmark", in: .mapboxNavigation, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
-        static let labelText = NSLocalizedString("FEEDBACK_THANK_YOU", value: "Thank you for your report!", comment: "Message confirming that the user has successfully sent feedback")
+        static let labelText = NSLocalizedString("FEEDBACK_THANK_YOU", bundle: .mapboxNavigation, value: "Thank you for your report!", comment: "Message confirming that the user has successfully sent feedback")
     }
     
     lazy var dialogView: UIView = {

--- a/Sources/MapboxNavigation/Feedback/FeedbackViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackViewController.swift
@@ -65,7 +65,7 @@ public class FeedbackViewController: UIViewController, DismissDraggable, UIGestu
     
     // MARK: UI Configuration
     
-    static let sceneTitle = NSLocalizedString("FEEDBACK_TITLE", value: "Report Problem", comment: "Title of view controller for sending feedback")
+    static let sceneTitle = NSLocalizedString("FEEDBACK_TITLE", bundle: .mapboxNavigation, value: "Report Problem", comment: "Title of view controller for sending feedback")
     static let cellReuseIdentifier = "collectionViewCellId"
     static let autoDismissInterval: TimeInterval = 10
     static let verticalCellPadding: CGFloat = 20.0

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1644,14 +1644,14 @@ open class NavigationMapView: UIView {
         var labelWithTolls = label
         let hasTolls = (route?.tollIntersections?.count ?? 0) > 0
         if hasTolls {
-            labelWithTolls += "\n" + NSLocalizedString("ROUTE_HAS_TOLLS", value: "Tolls", comment: "This route does have tolls")
+            labelWithTolls += "\n" + NSLocalizedString("ROUTE_HAS_TOLLS", bundle: .mapboxNavigation, value: "Tolls", comment: "This route does have tolls")
             if let symbol = Locale.current.currencySymbol {
                 labelWithTolls += " " + symbol
             }
         } else if tolls {
             // If one of the routes has tolls, but this one does not then it needs to explicitly say that it has no tolls
             // If no routes have tolls at all then we can omit this portion of the string.
-            labelWithTolls += "\n" + NSLocalizedString("ROUTE_HAS_NO_TOLLS", value: "No Tolls", comment: "This route does not have tolls")
+            labelWithTolls += "\n" + NSLocalizedString("ROUTE_HAS_NO_TOLLS", bundle: .mapboxNavigation, value: "No Tolls", comment: "This route does not have tolls")
         }
         
         return labelWithTolls


### PR DESCRIPTION
### Description
This Pr is to fix #4006 by adding the bundle information to the localized string generating.

### Implementation
This Pr is to fix #4006 by adding the bundle information to the localized string generating, to provide the localized string when the language changes.

### Screenshots or Gifs
![After](https://user-images.githubusercontent.com/48976398/178812095-a18d2d05-4524-4e5b-9b7b-f94e325695ce.png)

<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->