### PR TITLE
Use `line-trim-offset` to replace the line gradient stops for route line update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * Fixed the unmatched language issue of some localized strings in the feedback view. ([#4007](https://github.com/mapbox/mapbox-navigation-ios/pull/4007))
 * Added `NavigationSettings.utilizeSensorData` toggle to allow navigator to use additional device sensors data for better positioning. ([#3973](https://github.com/mapbox/mapbox-navigation-ios/pull/3973))
+* Fixed the issue of restricted layer over the whole route after the removal of continuous alternative route with a small portion of restricted road class at start. ([#4009](https://github.com/mapbox/mapbox-navigation-ios/pull/4009))
 
 ## v2.6.0
 

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -209,12 +209,12 @@ extension NavigationMapView {
         guard distance >= meterPerPixel else { return }
             
         updateFractionTraveled(coordinate: currentCoordinate)
-        updateRouteLineOffSet(along: route, offset: fractionTraveled)
+        updateRouteLineOffset(along: route, offset: fractionTraveled)
         
         pendingCoordinateForRouteLine = coordinate
     }
     
-    func updateRouteLineOffSet(along route: Route, offset: Double) {
+    func updateRouteLineOffset(along route: Route, offset: Double) {
         let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
         let mainRouteCasingLayerIdentifier = route.identifier(.routeCasing(isMainRoute: true))
         let restrictedAreaLayerIdentifier = route.identifier(.restrictedRouteAreaRoute)
@@ -367,11 +367,11 @@ extension NavigationMapView {
             }
             
             if gradientStops.isEmpty {
-                gradientStops[1.0] = lineSettings.baseColor
+                gradientStops[0.0] = lineSettings.baseColor
             }
             
         } else {
-            gradientStops[1.0] = lineSettings.baseColor
+            gradientStops[0.0] = lineSettings.baseColor
         }
         
         return gradientStops
@@ -432,7 +432,7 @@ extension NavigationMapView {
     func routeLineRestrictionsGradient(_ restrictionFeatures: [Turf.Feature]) -> [Double: UIColor] {
         // If there's no restricted feature, hide the restricted route line layer.
         guard restrictionFeatures.count > 0 else {
-            let gradientStops: [Double: UIColor] = [1.0: traversedRouteColor]
+            let gradientStops: [Double: UIColor] = [0.0: traversedRouteColor]
             return gradientStops
         }
         

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -244,6 +244,7 @@ extension NavigationMapView {
     }
     
     func setLayerLineGradient(for layerId: String, with offset: Double) {
+        guard offset >= 0.0 else { return }
         do {
             try mapView.mapboxMap.style.setLayerProperty(for: layerId, property: "line-trim-offset", value: [0.0, Double.minimum(1.0, offset)])
         } catch {

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -215,6 +215,7 @@ extension NavigationMapView {
     }
     
     func updateRouteLineOffset(along route: Route, offset: Double) {
+        guard offset >= 0.0 else { return }
         let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
         let mainRouteCasingLayerIdentifier = route.identifier(.routeCasing(isMainRoute: true))
         let restrictedAreaLayerIdentifier = route.identifier(.restrictedRouteAreaRoute)
@@ -331,7 +332,8 @@ extension NavigationMapView {
                     
                     if index + 1 < routeLineFeatures.count {
                         let segmentEndPercentTraveled = distanceTraveled / routeDistance
-                        let currentGradientStop = lineSettings.isSoft ? segmentEndPercentTraveled - stopGap : Double(CGFloat(segmentEndPercentTraveled).nextDown)
+                        var currentGradientStop = lineSettings.isSoft ? segmentEndPercentTraveled - stopGap : Double(CGFloat(segmentEndPercentTraveled).nextDown)
+                        currentGradientStop = max(currentGradientStop, 0.0)
                         gradientStops[currentGradientStop] = associatedFeatureColor
                         lastRecordSegment = (currentGradientStop, associatedFeatureColor)
                     }
@@ -344,7 +346,8 @@ extension NavigationMapView {
                         gradientStops[lastRecordSegment.0] = nil
                     } else {
                         let segmentStartPercentTraveled = distanceTraveled / routeDistance
-                        let currentGradientStop = lineSettings.isSoft ? segmentStartPercentTraveled + stopGap : Double(CGFloat(segmentStartPercentTraveled).nextUp)
+                        var currentGradientStop = lineSettings.isSoft ? segmentStartPercentTraveled + stopGap : Double(CGFloat(segmentStartPercentTraveled).nextUp)
+                        currentGradientStop = min(currentGradientStop, 1.0)
                         gradientStops[currentGradientStop] = associatedFeatureColor
                     }
                     
@@ -355,13 +358,15 @@ extension NavigationMapView {
                     gradientStops[lastRecordSegment.0] = nil
                 } else {
                     let segmentStartPercentTraveled = distanceTraveled / routeDistance
-                    let currentGradientStop = lineSettings.isSoft ? segmentStartPercentTraveled + stopGap : Double(CGFloat(segmentStartPercentTraveled).nextUp)
+                    var currentGradientStop = lineSettings.isSoft ? segmentStartPercentTraveled + stopGap : Double(CGFloat(segmentStartPercentTraveled).nextUp)
+                    currentGradientStop = min(currentGradientStop, 1.0)
                     gradientStops[currentGradientStop] = associatedFeatureColor
                 }
                 
                 distanceTraveled = distanceTraveled + distance
                 let segmentEndPercentTraveled = distanceTraveled / routeDistance
-                let currentGradientStop = lineSettings.isSoft ? segmentEndPercentTraveled - stopGap : Double(CGFloat(segmentEndPercentTraveled).nextDown)
+                var currentGradientStop = lineSettings.isSoft ? segmentEndPercentTraveled - stopGap : Double(CGFloat(segmentEndPercentTraveled).nextDown)
+                currentGradientStop = max(currentGradientStop, 0.0)
                 gradientStops[currentGradientStop] = associatedFeatureColor
                 lastRecordSegment = (currentGradientStop, associatedFeatureColor)
             }

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -383,14 +383,17 @@ extension NavigationMapView {
                                      isSoft: Bool = false) -> [Double: UIColor] {
         // If `congestionFeatures` is set to nil - check if overridden route line casing is used.
         let overriddenLineLayerColor: UIColor?
+        let baseColor: UIColor
         if let _ = congestionFeatures {
             overriddenLineLayerColor = lineLayerColorIfPresent(from: route)
+            baseColor = overriddenLineLayerColor ?? (isMain ? .trafficUnknown : .alternativeTrafficUnknown)
         } else {
             overriddenLineLayerColor = lineLayerCasingColorIfPresent(from: route)
+            baseColor = overriddenLineLayerColor ?? routeCasingColor
         }
         
         let lineSettings = LineGradientSettings(isSoft: isSoft,
-                                                baseColor: overriddenLineLayerColor ?? (isMain ? .trafficUnknown : .alternativeTrafficUnknown),
+                                                baseColor: baseColor,
                                                 featureColor: {
             if let overriddenLineLayerColor = overriddenLineLayerColor {
                 return overriddenLineLayerColor

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -162,7 +162,7 @@ open class NavigationMapView: UIView {
             let offset = fractionTraveled
             show(routes, legIndex: currentLegIndex)
             if let route = routes.first, routeLineTracksTraversal {
-                updateRouteLineOffSet(along: route, offset: offset)
+                updateRouteLineOffset(along: route, offset: offset)
             }
         }
     }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -137,6 +137,20 @@ open class NavigationMapView: UIView {
      */
     var pendingCoordinateForRouteLine: CLLocationCoordinate2D?
     
+    /**
+     Layer identifier for userLocationStyle that is used to track the layer position.
+     */
+    var puckLayerIdentifier: String? {
+        switch userLocationStyle {
+        case .puck2D(configuration: _):
+            return NavigationMapView.LayerIdentifier.puck2DLayer
+        case .puck3D(configuration: _):
+            return NavigationMapView.LayerIdentifier.puck3DLayer
+        default:
+            return nil
+        }
+    }
+    
     var showsRoute: Bool {
         get {
             guard let mainRouteLayerIdentifier = routes?.first?.identifier(.route(isMainRoute: true)),
@@ -383,15 +397,6 @@ open class NavigationMapView: UIView {
             let shaftLength = max(min(30 * metersPerPoint, 30), 10)
             let shaftPolyline = route.polylineAroundManeuver(legIndex: legIndex, stepIndex: stepIndex, distance: shaftLength)
             
-            var puckLayerIdentifier: String?
-            switch userLocationStyle {
-            case .puck2D(configuration: _):
-                puckLayerIdentifier = NavigationMapView.LayerIdentifier.puck2DLayer
-            case .puck3D(configuration: _):
-                puckLayerIdentifier = NavigationMapView.LayerIdentifier.puck3DLayer
-            default: break
-            }
-            
             if shaftPolyline.coordinates.count > 1 {
                 let allLayerIds = mapView.mapboxMap.style.allLayerIdentifiers.map{ $0.id }
                 let mainRouteLayerIdentifier = route.identifier(.route(isMainRoute: true))
@@ -606,6 +611,10 @@ open class NavigationMapView: UIView {
                 let allLayerIds = mapView.mapboxMap.style.allLayerIdentifiers.map{ $0.id }
                 if allLayerIds.contains(NavigationMapView.LayerIdentifier.arrowStrokeLayer) {
                     layerPosition = .below(NavigationMapView.LayerIdentifier.arrowStrokeLayer)
+                } else if allLayerIds.contains(NavigationMapView.LayerIdentifier.waypointCircleLayer) {
+                    layerPosition = .below(NavigationMapView.LayerIdentifier.waypointCircleLayer)
+                } else if let puckLayer = puckLayerIdentifier, allLayerIds.contains(puckLayer) {
+                    layerPosition = .below(puckLayer)
                 }
                 
                 if layerAlreadyExists {

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -410,10 +410,16 @@ class NavigationMapViewTests: TestCase {
         
         let featureBorderStop = 0.75.nextUp
         let routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features)
-        XCTAssertEqual(routeLineGradient[0.0], navigationMapView.routeRestrictedAreaColor)
-        XCTAssertEqual(routeLineGradient[0.25.nextUp], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(routeLineGradient[0.25.nextDown], navigationMapView.routeRestrictedAreaColor)
-        XCTAssertEqual(routeLineGradient[featureBorderStop.nextUp], navigationMapView.traversedRouteColor)
+        let expectedGradientStops: [Double: UIColor] = [
+            0.0: navigationMapView.routeRestrictedAreaColor,
+            0.25.nextDown: navigationMapView.routeRestrictedAreaColor,
+            0.25.nextUp: navigationMapView.traversedRouteColor,
+            0.5.nextDown: navigationMapView.traversedRouteColor,
+            0.5.nextUp: navigationMapView.routeRestrictedAreaColor,
+            0.75: navigationMapView.routeRestrictedAreaColor,
+            featureBorderStop.nextUp: navigationMapView.traversedRouteColor
+        ]
+        XCTAssertEqual(routeLineGradient, expectedGradientStops)
     }
     
     func testRoadClassesWithOverriddenCongestionLevelsRemovesDuplicates() {

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -381,7 +381,6 @@ class NavigationMapViewTests: TestCase {
         
         var fractionTraveled = 0.0
         var routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestionFeatures,
-                                                                              fractionTraveled: fractionTraveled,
                                                                               isMain: true,
                                                                               isSoft: false)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.trafficLowColor)
@@ -389,7 +388,6 @@ class NavigationMapViewTests: TestCase {
         fractionTraveled = 0.3
         var fractionTraveledNextDown = Double(CGFloat(fractionTraveled).nextDown)
         routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestionFeatures,
-                                                                          fractionTraveled: fractionTraveled,
                                                                           isMain: true,
                                                                           isSoft: false)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.traversedRouteColor)
@@ -399,7 +397,6 @@ class NavigationMapViewTests: TestCase {
         fractionTraveled = 0.999999999
         fractionTraveledNextDown = Double(CGFloat(fractionTraveled).nextDown)
         routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestionFeatures,
-                                                                          fractionTraveled: fractionTraveled,
                                                                           isMain: true,
                                                                           isSoft: true)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.traversedRouteColor)
@@ -412,7 +409,6 @@ class NavigationMapViewTests: TestCase {
         var congestions = route.congestionFeatures()
         var fractionTraveled = 0.0
         var lineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestions,
-                                                                         fractionTraveled: fractionTraveled,
                                                                          isMain: true,
                                                                          isSoft: true)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.trafficUnknownColor)
@@ -427,78 +423,11 @@ class NavigationMapViewTests: TestCase {
         ]
         fractionTraveled = 0.3
         let nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled,
-                                                                      gradientStops: lineGradient,
-                                                                      baseColor: navigationMapView.trafficUnknownColor)
-        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficSevereColor)
-        XCTAssertEqual(lineGradient[0.305], navigationMapView.trafficModerateColor)
         
         congestions = [Turf.Feature]()
         lineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestions,
-                                                                     fractionTraveled: fractionTraveled,
                                                                      isMain: true,
                                                                      isSoft: true)
-        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)
-        
-    }
-    
-    func testUpdateRouteLineGradient() {
-        let route = loadRoute(from: "route-with-road-classes-single-congestion")
-        let congestions = route.congestionFeatures()
-        var lineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestions,
-                                                                         fractionTraveled: 0.0,
-                                                                         isMain: true)
-        XCTAssertEqual(lineGradient[0.0], navigationMapView.trafficUnknownColor)
-        
-        var fractionTraveled = 0.5
-        var nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled,
-                                                                      gradientStops: lineGradient,
-                                                                      baseColor: navigationMapView.trafficUnknownColor)
-
-        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)
-        
-        let nexDownModerateFraction = Double(CGFloat(0.3).nextDown)
-        let nexDownHeavyFraction = Double(CGFloat(0.4).nextDown)
-        lineGradient = [
-            0.0: navigationMapView.trafficSevereColor,
-            nexDownModerateFraction: navigationMapView.trafficSevereColor,
-            0.3: navigationMapView.trafficModerateColor,
-            nexDownHeavyFraction: navigationMapView.trafficModerateColor,
-            0.4: navigationMapView.trafficHeavyColor
-        ]
-        
-        fractionTraveled = 0.3
-        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient, baseColor: navigationMapView.trafficUnknownColor)
-        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficModerateColor)
-        
-        fractionTraveled = 0.35
-        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient, baseColor: navigationMapView.trafficUnknownColor)
-        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficModerateColor)
-        
-        fractionTraveled = 0.45
-        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient, baseColor: navigationMapView.trafficUnknownColor)
-        XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
-        XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficHeavyColor)
-        
-        lineGradient = [Double:UIColor]()
-        fractionTraveled = 0.45
-        nextDownFractionTraveled = Double(CGFloat(fractionTraveled).nextDown)
-        lineGradient = navigationMapView.updateRouteLineGradientStops(fractionTraveled: fractionTraveled, gradientStops: lineGradient, baseColor: navigationMapView.trafficUnknownColor)
         XCTAssertEqual(lineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[nextDownFractionTraveled], navigationMapView.traversedRouteColor)
         XCTAssertEqual(lineGradient[fractionTraveled], navigationMapView.trafficUnknownColor)
@@ -529,7 +458,7 @@ class NavigationMapViewTests: TestCase {
         let featureBorderStop = 0.75.nextUp
         
         var fractionTraveled = 0.0 // not traversed at all
-        var routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features, fractionTraveled: fractionTraveled)
+        var routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.routeRestrictedAreaColor)
         XCTAssertEqual(routeLineGradient[0.25.nextUp], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[0.25.nextDown], navigationMapView.routeRestrictedAreaColor)
@@ -537,7 +466,7 @@ class NavigationMapViewTests: TestCase {
         
         fractionTraveled = 0.25 // border between restricted and not restricted
         var fractionTraveledNextDown = Double(CGFloat(fractionTraveled).nextDown)
-        routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features, fractionTraveled: fractionTraveled)
+        routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[featureBorderStop.nextUp], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[fractionTraveled], navigationMapView.traversedRouteColor)
@@ -545,7 +474,7 @@ class NavigationMapViewTests: TestCase {
         
         fractionTraveled = 0.999999999 // almost finished
         fractionTraveledNextDown = Double(CGFloat(fractionTraveled).nextDown)
-        routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features, fractionTraveled: fractionTraveled)
+        routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features)
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[fractionTraveled], navigationMapView.routeRestrictedAreaColor)
         XCTAssertEqual(routeLineGradient[fractionTraveledNextDown], navigationMapView.traversedRouteColor)
@@ -575,8 +504,7 @@ class NavigationMapViewTests: TestCase {
         let featureBorderStop = 0.6666666666666667
 
         let fractionTraveled = 0.44 // not traversed at all
-        let routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features,
-                                                                                fractionTraveled: fractionTraveled)
+        let routeLineGradient = navigationMapView.routeLineRestrictionsGradient(features)
         XCTAssertEqual(routeLineGradient[0.44], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[0.44.nextDown], navigationMapView.traversedRouteColor)
         XCTAssertEqual(routeLineGradient[featureBorderStop], navigationMapView.routeRestrictedAreaColor)


### PR DESCRIPTION
### Description
This Pr is to support using the `lineLayer.line-trim-offset` to update the route line when `routeLineTracksTraversal` is enabled during active navigation. 

### Implementation
- [x] Use `lineLayer.line-trim-offset` to trim the route line layer instead of updating the gradient stops.
- [x] Remove the stored gradient stops for route line and restricted area in `NavigationMapView`.
- [x] Support the instant route line change when `showsRestrictedAreasOnRoute`, `crossfadesCongestionSegments` and `routeLineTracksTraversal` property change during active navigation session.
- [x] Fix the test.

### Screenshots or Gifs
in `Example` App, switch the route line property during active navigation with `Resume` button.

switch `navigationMapView.crossfadesCongestionSegments` when `routeLineTracksTraversal` enabled.
![crossfadesCongestionSegments](https://user-images.githubusercontent.com/48976398/179121414-105eba9d-5a18-4c56-a869-827b62159c1a.gif)

switch `navigationMapView.showsRestrictedAreasOnRoute` when `routeLineTracksTraversal` enabled with mock restricted area.
![showsRestrictedAreasOnRoute](https://user-images.githubusercontent.com/48976398/179121464-b594dd84-527f-43b9-b67e-a8bab76cb976.gif)

switch `routeLineTracksTraversal` in active navigation
![routeLineTracksTraversal](https://user-images.githubusercontent.com/48976398/179121494-859f395c-2147-4528-b648-8859f2b8db44.gif)

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->