### PR TITLE
Fix status bar appearance.

### DIFF
--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -12,7 +12,12 @@ open class DayStyle: Style {
         mapStyleURL = URL(string: StyleURI.navigationDay.rawValue)!
         previewMapStyleURL = mapStyleURL
         styleType = .day
-        statusBarStyle = .default
+        
+        if #available(iOS 13.0, *) {
+            statusBarStyle = .darkContent
+        } else {
+            statusBarStyle = .default
+        }
     }
     
     open override func apply() {


### PR DESCRIPTION
### Description

Use dark status bar appearance on iOS 13 and higher when using `DayStyle`.