### PR TITLE
Add expansion/collapsing and animated presentation APIs for banner containers.

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -611,10 +611,16 @@ class ViewController: UIViewController {
         }
     }
     
-    func dismissActiveNavigationViewController() {
-        activeNavigationViewController?.dismiss(animated: true) {
-            self.activeNavigationViewController = nil
-        }
+    func dismissActiveNavigationViewController(animated: Bool = false) {
+        guard let activeNavigationViewController = activeNavigationViewController else { return }
+        
+        activeNavigationViewController.navigationView.wayNameView.isHidden = true
+        activeNavigationViewController.navigationView.bottomBannerContainerView.hide(duration: 2.0)
+        activeNavigationViewController.navigationView.topBannerContainerView.hide(duration: 2.0, completion: { _ in
+            activeNavigationViewController.dismiss(animated: animated) {
+                self.activeNavigationViewController = nil
+            }
+        })
     }
 
     func navigationService(response: RouteResponse, routeIndex: Int, options: RouteOptions) -> NavigationService {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -587,7 +587,9 @@ class ViewController: UIViewController {
         navigationViewController.navigationView.bottomBannerContainerView.hide(animated: false)
         navigationViewController.navigationView.topBannerContainerView.hide(animated: false)
         
-        navigationViewController.navigationView.wayNameView.isHidden = true
+        // Hide `WayNameView` and `FloatingStackView` to smoothly present them.
+        navigationViewController.navigationView.wayNameView.alpha = 0.0
+        navigationViewController.navigationView.floatingStackView.alpha = 0.0
         
         present(navigationViewController, animated: animated) {
             completion?()
@@ -597,11 +599,12 @@ class ViewController: UIViewController {
             navigationViewController.navigationMapView?.showsRestrictedAreasOnRoute = true
             
             // Animate top and bottom banner views presentation.
-            navigationViewController.navigationView.bottomBannerContainerView.show(duration: 2.0, completion: { _ in
-                // Show `WayNameView` only after fully presenting bottom banner container view.
-                navigationViewController.navigationView.wayNameView.isHidden = false
+            navigationViewController.navigationView.bottomBannerContainerView.show(duration: 1.0,
+                                                                                   animations: {
+                navigationViewController.navigationView.wayNameView.alpha = 1.0
+                navigationViewController.navigationView.floatingStackView.alpha = 1.0
             })
-            navigationViewController.navigationView.topBannerContainerView.show(duration: 2.0)
+            navigationViewController.navigationView.topBannerContainerView.show(duration: 1.0)
         }
     }
     
@@ -614,9 +617,13 @@ class ViewController: UIViewController {
     func dismissActiveNavigationViewController(animated: Bool = false) {
         guard let activeNavigationViewController = activeNavigationViewController else { return }
         
-        activeNavigationViewController.navigationView.wayNameView.isHidden = true
-        activeNavigationViewController.navigationView.bottomBannerContainerView.hide(duration: 2.0)
-        activeNavigationViewController.navigationView.topBannerContainerView.hide(duration: 2.0, completion: { _ in
+        activeNavigationViewController.navigationView.bottomBannerContainerView.hide(duration: 1.0)
+        activeNavigationViewController.navigationView.topBannerContainerView.hide(duration: 1.0,
+                                                                                  animations: {
+            activeNavigationViewController.navigationView.wayNameView.alpha = 0.0
+            activeNavigationViewController.navigationView.floatingStackView.alpha = 0.0
+        },
+                                                                                  completion: { _ in
             activeNavigationViewController.dismiss(animated: animated) {
                 self.activeNavigationViewController = nil
             }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -334,8 +334,10 @@ class ViewController: UIViewController {
         
         // Control floating buttons position in a navigation view.
         navigationViewController.floatingButtonsPosition = .topTrailing
-        
-        presentAndRemoveNavigationMapView(navigationViewController, completion: beginCarPlayNavigation)
+
+        presentAndRemoveNavigationMapView(navigationViewController,
+                                          animated: false,
+                                          completion: beginCarPlayNavigation)
     }
     
     func startCustomNavigation() {
@@ -576,16 +578,30 @@ class ViewController: UIViewController {
     }
     
     func presentAndRemoveNavigationMapView(_ navigationViewController: NavigationViewController,
+                                           animated: Bool = true,
                                            completion: CompletionHandler? = nil) {
         navigationViewController.modalPresentationStyle = .fullScreen
         activeNavigationViewController = navigationViewController
         
-        present(navigationViewController, animated: true) {
+        // Hide top and bottom container views before animating their presentation.
+        navigationViewController.navigationView.bottomBannerContainerView.hide(animated: false)
+        navigationViewController.navigationView.topBannerContainerView.hide(animated: false)
+        
+        navigationViewController.navigationView.wayNameView.isHidden = true
+        
+        present(navigationViewController, animated: animated) {
             completion?()
             // Cleaning up the `PassiveLocationManager`. The `PassiveLocationManager` during active navigation may lead to location jump.
             self.navigationMapView = nil
             self.passiveLocationManager = nil
             navigationViewController.navigationMapView?.showsRestrictedAreasOnRoute = true
+            
+            // Animate top and bottom banner views presentation.
+            navigationViewController.navigationView.bottomBannerContainerView.show(duration: 2.0, completion: { _ in
+                // Show `WayNameView` only after fully presenting bottom banner container view.
+                navigationViewController.navigationView.wayNameView.isHidden = false
+            })
+            navigationViewController.navigationView.topBannerContainerView.show(duration: 2.0)
         }
     }
     

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -121,7 +121,6 @@
 		354A9BCB20EA9BDA00F03325 /* EventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354A9BCA20EA9BDA00F03325 /* EventDetails.swift */; };
 		355B469B22B902C9009CE634 /* SKUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B469A22B902C9009CE634 /* SKUTests.swift */; };
 		355B469D22B9031E009CE634 /* SKUTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B469C22B9031E009CE634 /* SKUTestable.swift */; };
-		355ED3701FAB724F00BCE1B8 /* BottomBannerViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355ED36F1FAB724F00BCE1B8 /* BottomBannerViewLayout.swift */; };
 		35726EE81F0856E900AFA1B6 /* DayStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35726EE71F0856E900AFA1B6 /* DayStyle.swift */; };
 		3582A25020EEC46B0029C5DE /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3582A24F20EEC46B0029C5DE /* Router.swift */; };
 		3582A25220EFA9680029C5DE /* RouterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3582A25120EFA9680029C5DE /* RouterDelegate.swift */; };
@@ -187,6 +186,12 @@
 		8A1943A92685DC680066E2F8 /* NavigationGeocodedPlacemark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1943A82685DC680066E2F8 /* NavigationGeocodedPlacemark.swift */; };
 		8A2081CB25E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2081C925E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift */; };
 		8A2081CC25E07CED00F9B8A6 /* RouteLineType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2081CA25E07CED00F9B8A6 /* RouteLineType.swift */; };
+		8A2354EE28877890003E42B4 /* BannerContainerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2354EA28877890003E42B4 /* BannerContainerViewDelegate.swift */; };
+		8A2354EF28877890003E42B4 /* BannerContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2354EB28877890003E42B4 /* BannerContainerView.swift */; };
+		8A2354F028877890003E42B4 /* BottomBannerViewControllerLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2354EC28877890003E42B4 /* BottomBannerViewControllerLayout.swift */; };
+		8A2354F128877890003E42B4 /* BottomBannerViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2354ED28877890003E42B4 /* BottomBannerViewControllerDelegate.swift */; };
+		8A2354F4288778D6003E42B4 /* NavigationMapView+ContinuousAlternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2354F2288778D6003E42B4 /* NavigationMapView+ContinuousAlternatives.swift */; };
+		8A2354F5288778D6003E42B4 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2354F3288778D6003E42B4 /* UIViewController.swift */; };
 		8A285E242637859800B11ECD /* OrnamentsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A285E232637859800B11ECD /* OrnamentsController.swift */; };
 		8A2DFA8626168A300034A87E /* NavigationCameraDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DFA8526168A300034A87E /* NavigationCameraDebugView.swift */; };
 		8A30113C25DDCC8A00CE192A /* NavigationCameraConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30113B25DDCC8A00CE192A /* NavigationCameraConstants.swift */; };
@@ -696,7 +701,6 @@
 		354A9BCA20EA9BDA00F03325 /* EventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetails.swift; sourceTree = "<group>"; };
 		355B469A22B902C9009CE634 /* SKUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKUTests.swift; sourceTree = "<group>"; };
 		355B469C22B9031E009CE634 /* SKUTestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKUTestable.swift; sourceTree = "<group>"; };
-		355ED36F1FAB724F00BCE1B8 /* BottomBannerViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomBannerViewLayout.swift; sourceTree = "<group>"; };
 		35726EE71F0856E900AFA1B6 /* DayStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayStyle.swift; sourceTree = "<group>"; };
 		3573EA70215A5A9F009899D7 /* RouteControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteControllerTests.swift; sourceTree = "<group>"; };
 		357F0DF01EB9D99F00A0B53C /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -764,6 +768,12 @@
 		8A1943A82685DC680066E2F8 /* NavigationGeocodedPlacemark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationGeocodedPlacemark.swift; sourceTree = "<group>"; };
 		8A2081C925E07CED00F9B8A6 /* NavigationMapViewIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationMapViewIdentifiers.swift; sourceTree = "<group>"; };
 		8A2081CA25E07CED00F9B8A6 /* RouteLineType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteLineType.swift; sourceTree = "<group>"; };
+		8A2354EA28877890003E42B4 /* BannerContainerViewDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerContainerViewDelegate.swift; sourceTree = "<group>"; };
+		8A2354EB28877890003E42B4 /* BannerContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerContainerView.swift; sourceTree = "<group>"; };
+		8A2354EC28877890003E42B4 /* BottomBannerViewControllerLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomBannerViewControllerLayout.swift; sourceTree = "<group>"; };
+		8A2354ED28877890003E42B4 /* BottomBannerViewControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomBannerViewControllerDelegate.swift; sourceTree = "<group>"; };
+		8A2354F2288778D6003E42B4 /* NavigationMapView+ContinuousAlternatives.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NavigationMapView+ContinuousAlternatives.swift"; sourceTree = "<group>"; };
+		8A2354F3288778D6003E42B4 /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		8A285E232637859800B11ECD /* OrnamentsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrnamentsController.swift; sourceTree = "<group>"; };
 		8A2DFA8526168A300034A87E /* NavigationCameraDebugView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationCameraDebugView.swift; sourceTree = "<group>"; };
 		8A30113B25DDCC8A00CE192A /* NavigationCameraConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCameraConstants.swift; sourceTree = "<group>"; };
@@ -1718,11 +1728,14 @@
 		8DFD94A52225AF5C00152F45 /* Banners */ = {
 			isa = PBXGroup;
 			children = (
+				8A2354EB28877890003E42B4 /* BannerContainerView.swift */,
+				8A2354EA28877890003E42B4 /* BannerContainerViewDelegate.swift */,
 				35F520BF1FB482A200FC9C37 /* NextBannerView.swift */,
 				8D63A7CF227A580A00520167 /* TopBannerViewController.swift */,
 				8A04DFBB275EBC1B00D87959 /* TopBannerViewControllerDelegate.swift */,
 				353610CD1FAB6A8F00FB1746 /* BottomBannerViewController.swift */,
-				355ED36F1FAB724F00BCE1B8 /* BottomBannerViewLayout.swift */,
+				8A2354ED28877890003E42B4 /* BottomBannerViewControllerDelegate.swift */,
+				8A2354EC28877890003E42B4 /* BottomBannerViewControllerLayout.swift */,
 				B493FB1C2767EDDB002AF455 /* InstructionsBannerViewDelegate.swift */,
 			);
 			name = Banners;
@@ -1846,9 +1859,11 @@
 		C51923B41EA55C5E002AF9E1 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				8A2354F3288778D6003E42B4 /* UIViewController.swift */,
 				8A99F18828821AA70034F5BD /* UILayoutGuide.swift */,
 				8A50A3D026EC0AA300894A8E /* StyleURI.swift */,
 				F46FF186260277F7007CC0E0 /* DateComponentsFormatter+NavigationAdditions.swift */,
+				8A2354F2288778D6003E42B4 /* NavigationMapView+ContinuousAlternatives.swift */,
 				8A41F63B25BF631500BD6FCF /* NavigationMapView+BuildingHighlighting.swift */,
 				8A41F63A25BF631500BD6FCF /* NavigationMapView+VanishingRouteLine.swift */,
 				8AA0385C27F3B5740007BD2D /* NavigationMapView+CLLocationManagerDelegate.swift */,
@@ -2611,6 +2626,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				351BEBF11E5BCC63006FE110 /* MapView.swift in Sources */,
+				8A2354EE28877890003E42B4 /* BannerContainerViewDelegate.swift in Sources */,
 				DA443DDE2278C90E00ED1307 /* CPTrip.swift in Sources */,
 				8A18569926320B8F00F8AE38 /* OverviewCameraOptions.swift in Sources */,
 				8AC40920279918930075248E /* NavigationViewDelegate.swift in Sources */,
@@ -2655,8 +2671,10 @@
 				16EF6C22211BA4B300AA580B /* CarPlayMapViewController.swift in Sources */,
 				8A41F63C25BF631500BD6FCF /* NavigationMapView+VanishingRouteLine.swift in Sources */,
 				8AD866F725CA1BF10019A638 /* NavigationCameraStateTransition.swift in Sources */,
+				8A2354F4288778D6003E42B4 /* NavigationMapView+ContinuousAlternatives.swift in Sources */,
 				16A509D7202BC0CA0011D788 /* ImageDownload.swift in Sources */,
 				8DB63A3A1FBBCA2200928389 /* RatingControl.swift in Sources */,
+				8A2354EF28877890003E42B4 /* BannerContainerView.swift in Sources */,
 				353EC9D71FB09708002EB0AB /* StepsViewController.swift in Sources */,
 				8A18568726320B5900F8AE38 /* FollowingCameraOptions.swift in Sources */,
 				8AE9081225FAA53300F37077 /* Collection.swift in Sources */,
@@ -2681,6 +2699,7 @@
 				359D1B281FFE70D30052FA42 /* NavigationView.swift in Sources */,
 				8AD866FF25CA1BF10019A638 /* NavigationViewportDataSource.swift in Sources */,
 				C5FFAC1520D96F5C009E7F98 /* CarPlayNavigationViewController.swift in Sources */,
+				8A2354F128877890003E42B4 /* BottomBannerViewControllerDelegate.swift in Sources */,
 				8AD2211727C43B06000734A5 /* LineView.swift in Sources */,
 				8DE879661FBB9980002F06C0 /* EndOfRouteViewController.swift in Sources */,
 				AE47A33422B1F6AE0096458C /* InstructionsCardContainerView.swift in Sources */,
@@ -2714,7 +2733,6 @@
 				8AD220AF27C09544000734A5 /* Date.swift in Sources */,
 				8A285E242637859800B11ECD /* OrnamentsController.swift in Sources */,
 				8A1943A92685DC680066E2F8 /* NavigationGeocodedPlacemark.swift in Sources */,
-				355ED3701FAB724F00BCE1B8 /* BottomBannerViewLayout.swift in Sources */,
 				8A0E0A52257AD9C300C2E924 /* NightStyle.swift in Sources */,
 				8A50A3C526EC09FB00894A8E /* FeedbackViewControllerType.swift in Sources */,
 				8AD220B127C097F3000734A5 /* HighlightedButton.swift in Sources */,
@@ -2745,6 +2763,7 @@
 				8A446645260A7B24008BA55E /* BoundingBox.swift in Sources */,
 				8AD866F625CA1BF10019A638 /* NavigationCamera.swift in Sources */,
 				B41299CF26D7101F004031A3 /* CLLocationCoordinate2D.swift in Sources */,
+				8A2354F5288778D6003E42B4 /* UIViewController.swift in Sources */,
 				8AD2210F27C434CD000734A5 /* TitleLabel.swift in Sources */,
 				8A50A3CB26EC09FB00894A8E /* FeedbackSubtypeCollectionViewCell.swift in Sources */,
 				8A50A3D326EC0AE100894A8E /* IdleTimerManager.swift in Sources */,
@@ -2756,6 +2775,7 @@
 				4316D95C24340555000DD8F8 /* Match.swift in Sources */,
 				8DEB4066220CE596008BAAB4 /* NavigationMapViewDelegate.swift in Sources */,
 				359D283C1F9DC14F00FDE9C9 /* UICollectionView.swift in Sources */,
+				8A2354F028877890003E42B4 /* BottomBannerViewControllerLayout.swift in Sources */,
 				B4E6712227BB0A56004EE9C1 /* SpriteInfoCache.swift in Sources */,
 				8A17635B25CC89D800737520 /* Expression.swift in Sources */,
 				8A04DFBC275EBC1B00D87959 /* TopBannerViewControllerDelegate.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -387,6 +387,9 @@ public extension NavigationServiceDelegate {
         return MapboxNavigationService.Default.shouldPreventReroutesWhenArrivingAtWaypoint
     }
     
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
     func navigationServiceDidChangeAuthorization(_ service: NavigationService, didChangeAuthorizationFor locationManager: CLLocationManager) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }

--- a/Sources/MapboxNavigation/BannerContainerView.swift
+++ b/Sources/MapboxNavigation/BannerContainerView.swift
@@ -68,7 +68,8 @@ open class BannerContainerView: UIView {
     
     var initialOffset: CGFloat = 0.0
     
-    weak var delegate: BannerContainerViewDelegate? {
+    // :nodoc:
+    public weak var delegate: BannerContainerViewDelegate? {
         didSet {
             delegate?.bannerContainerView(self, stateDidChangeTo: state)
         }

--- a/Sources/MapboxNavigation/BannerContainerView.swift
+++ b/Sources/MapboxNavigation/BannerContainerView.swift
@@ -1,0 +1,290 @@
+import UIKit
+
+// :nodoc:
+@objc(MBBannerContainerView)
+open class BannerContainerView: UIView {
+    
+    // :nodoc:
+    public enum `Type` {
+        case top
+        case bottom
+    }
+    
+    var type: BannerContainerView.`Type`
+    
+    // :nodoc:
+    public enum State {
+        case expanded
+        case collapsed
+    }
+    
+    var isExpandable: Bool = false {
+        didSet {
+            guard let superview = superview else { return }
+            setupConstraints(superview)
+        }
+    }
+    
+    var expansionOffset: CGFloat = 50.0
+    
+    var topSafeAreaInset: CGFloat = 0.0
+    
+    var bottomSafeAreaInset: CGFloat = 0.0
+    
+    open override func safeAreaInsetsDidChange() {
+        super.safeAreaInsetsDidChange()
+        
+        topSafeAreaInset = safeAreaInsets.top
+        bottomSafeAreaInset = safeAreaInsets.bottom
+    }
+    
+    // :nodoc:
+    public private(set) var state: State = .collapsed {
+        didSet {
+            delegate?.bannerContainerView(self, stateWillChangeTo: state)
+            
+            if oldValue == state { return }
+            
+            switch type {
+            case .top:
+                if state == .expanded {
+                    expansionConstraint.constant = 0.0
+                } else {
+                    expansionConstraint.constant = -expansionOffset
+                }
+            case .bottom:
+                if state == .expanded {
+                    expansionConstraint.constant = 0.0
+                } else {
+                    expansionConstraint.constant = expansionOffset
+                }
+            }
+            
+            delegate?.bannerContainerView(self, stateDidChangeTo: state)
+        }
+    }
+    
+    var expansionConstraint: NSLayoutConstraint!
+    
+    var initialOffset: CGFloat = 0.0
+    
+    weak var delegate: BannerContainerViewDelegate? {
+        didSet {
+            // TODO: Improve process of notifying users about state changes.
+            delegate?.bannerContainerView(self, stateDidChangeTo: state)
+        }
+    }
+    
+    // :nodoc:
+    public init(_ type: BannerContainerView.`Type`, frame: CGRect = .zero) {
+        self.type = type
+        
+        super.init(frame: frame)
+        
+        defer {
+            state = .collapsed
+        }
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    open override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        
+        guard let superview = superview else { return }
+        
+        setupConstraints(superview)
+    }
+    
+    // :nodoc:
+    public typealias CompletionHandler = (_ completed: Bool) -> Void
+    
+    func setupConstraints(_ superview: UIView) {
+        if expansionConstraint != nil {
+            NSLayoutConstraint.deactivate([expansionConstraint])
+        }
+        
+        switch type {
+        case .top:
+            expansionConstraint = topAnchor.constraint(equalTo: superview.topAnchor)
+        case .bottom:
+            expansionConstraint = bottomAnchor.constraint(equalTo: superview.bottomAnchor)
+        }
+        
+        if isExpandable {
+            if state == .expanded {
+                expansionConstraint.constant = 0.0
+            } else {
+                switch type {
+                case .top:
+                    expansionConstraint.constant = -expansionOffset
+                case .bottom:
+                    expansionConstraint.constant = expansionOffset
+                }
+            }
+            
+            let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(didPan))
+            addGestureRecognizer(panGestureRecognizer)
+        } else {
+            expansionConstraint.constant = 0.0
+        }
+        
+        expansionConstraint.isActive = true
+    }
+    
+    @objc func didPan(_ recognizer: UIPanGestureRecognizer) {
+        guard let view = recognizer.view else { return }
+        
+        if recognizer.state == .began {
+            initialOffset = expansionConstraint.constant
+        }
+        
+        let translation = recognizer.translation(in: view)
+        let currentOffset = initialOffset + translation.y
+        
+        switch type {
+        case .top:
+            if currentOffset < -expansionOffset {
+                expansionConstraint.constant = -expansionOffset
+            } else if currentOffset > expansionOffset {
+                expansionConstraint.constant = 0.0
+            } else {
+                expansionConstraint.constant = currentOffset
+            }
+        case .bottom:
+            if currentOffset < 0.0 {
+                expansionConstraint.constant = 0.0
+            } else if currentOffset > expansionOffset {
+                expansionConstraint.constant = expansionOffset
+            } else {
+                expansionConstraint.constant = currentOffset
+            }
+        }
+        
+        if recognizer.state == .ended {
+            let velocity = recognizer.velocity(in: view)
+            
+            switch type {
+            case .top:
+                if velocity.y >= 0.0 {
+                    state = .expanded
+                } else {
+                    state = .collapsed
+                }
+            case .bottom:
+                if velocity.y <= 0.0 {
+                    state = .expanded
+                } else {
+                    state = .collapsed
+                }
+            }
+            
+            UIView.animate(withDuration: 0.2,
+                           delay: 0.0,
+                           options: [.allowUserInteraction],
+                           animations: {
+                self.superview?.layoutIfNeeded()
+            }, completion: nil)
+        }
+        
+        let currentExpansionOffset = expansionConstraint.constant
+        let maximumExpansionOffset = expansionOffset
+        let expansionFranction = 1 - currentExpansionOffset / maximumExpansionOffset
+        
+        delegate?.bannerContainerView(self, didExpandTo: expansionFranction)
+    }
+    
+    // :nodoc:
+    public func show(animated: Bool = true,
+                     duration: TimeInterval = 0.2,
+                     animations: (() -> Void)? = nil,
+                     completion: CompletionHandler? = nil) {
+        guard isHidden else {
+            completion?(true)
+            return
+        }
+        
+        if let superview = superview, expansionConstraint == nil {
+            switch type {
+            case .top:
+                expansionConstraint = topAnchor.constraint(equalTo: superview.topAnchor)
+            case .bottom:
+                expansionConstraint = bottomAnchor.constraint(equalTo: superview.bottomAnchor)
+            }
+            
+            expansionConstraint.isActive = true
+        }
+        
+        layoutIfNeeded()
+        
+        if animated {
+            // TODO: Improve animation for devices with notch.
+            switch type {
+            case .top:
+                expansionConstraint.constant = -frame.height //+ self.topSafeAreaInset
+            case .bottom:
+                expansionConstraint.constant = frame.height //- self.bottomSafeAreaInset
+            }
+            
+            isHidden = false
+            superview?.layoutIfNeeded()
+            
+            UIView.animate(withDuration: duration,
+                           delay: 0.0,
+                           options: [],
+                           animations: {
+                animations?()
+                
+                if self.isExpandable {
+                    self.expansionConstraint.constant = self.expansionOffset
+                } else {
+                    self.expansionConstraint.constant = 0.0
+                }
+                
+                self.superview?.layoutIfNeeded()
+            }) { completed in
+                completion?(completed)
+            }
+        } else {
+            isHidden = false
+            completion?(true)
+        }
+    }
+    
+    // :nodoc:
+    public func hide(animated: Bool = true,
+                     duration: TimeInterval = 0.2,
+                     animations: (() -> Void)? = nil,
+                     completion: CompletionHandler? = nil) {
+        guard !isHidden else {
+            completion?(true)
+            return
+        }
+        
+        if animated {
+            UIView.animate(withDuration: duration,
+                           delay: 0.0,
+                           options: [],
+                           animations: {
+                animations?()
+                
+                switch self.type {
+                case .top:
+                    self.expansionConstraint.constant = -self.frame.height
+                case .bottom:
+                    self.expansionConstraint.constant = self.frame.height
+                }
+                
+                self.superview?.layoutIfNeeded()
+            }) { completed in
+                self.isHidden = true
+                completion?(completed)
+            }
+        } else {
+            isHidden = true
+            completion?(true)
+        }
+    }
+}

--- a/Sources/MapboxNavigation/BannerContainerView.swift
+++ b/Sources/MapboxNavigation/BannerContainerView.swift
@@ -70,7 +70,6 @@ open class BannerContainerView: UIView {
     
     weak var delegate: BannerContainerViewDelegate? {
         didSet {
-            // TODO: Improve process of notifying users about state changes.
             delegate?.bannerContainerView(self, stateDidChangeTo: state)
         }
     }
@@ -220,12 +219,11 @@ open class BannerContainerView: UIView {
         layoutIfNeeded()
         
         if animated {
-            // TODO: Improve animation for devices with notch.
             switch type {
             case .top:
-                expansionConstraint.constant = -frame.height //+ self.topSafeAreaInset
+                expansionConstraint.constant = -frame.height
             case .bottom:
-                expansionConstraint.constant = frame.height //- self.bottomSafeAreaInset
+                expansionConstraint.constant = frame.height
             }
             
             isHidden = false

--- a/Sources/MapboxNavigation/BannerContainerViewDelegate.swift
+++ b/Sources/MapboxNavigation/BannerContainerViewDelegate.swift
@@ -1,0 +1,33 @@
+import CoreGraphics
+import MapboxCoreNavigation
+
+// :nodoc:
+public protocol BannerContainerViewDelegate: AnyObject, UnimplementedLogging {
+    
+    func bannerContainerView(_ bannerContainerView: BannerContainerView,
+                             stateWillChangeTo state: BannerContainerView.State)
+    
+    func bannerContainerView(_ bannerContainerView: BannerContainerView,
+                             stateDidChangeTo state: BannerContainerView.State)
+    
+    func bannerContainerView(_ bannerContainerView: BannerContainerView,
+                             didExpandTo fraction: CGFloat)
+}
+
+extension BannerContainerViewDelegate {
+    
+    func bannerContainerView(_ bannerContainerView: BannerContainerView,
+                             stateWillChangeTo state: BannerContainerView.State) {
+        logUnimplemented(protocolType: BannerContainerViewDelegate.self, level: .debug)
+    }
+    
+    func bannerContainerView(_ bannerContainerView: BannerContainerView,
+                             stateDidChangeTo state: BannerContainerView.State) {
+        logUnimplemented(protocolType: BannerContainerViewDelegate.self, level: .debug)
+    }
+    
+    func bannerContainerView(_ bannerContainerView: BannerContainerView,
+                             didExpandTo fraction: CGFloat) {
+        logUnimplemented(protocolType: BannerContainerViewDelegate.self, level: .debug)
+    }
+}

--- a/Sources/MapboxNavigation/BannerContainerViewDelegate.swift
+++ b/Sources/MapboxNavigation/BannerContainerViewDelegate.swift
@@ -14,7 +14,8 @@ public protocol BannerContainerViewDelegate: AnyObject, UnimplementedLogging {
                              didExpandTo fraction: CGFloat)
 }
 
-extension BannerContainerViewDelegate {
+// :nodoc:
+public extension BannerContainerViewDelegate {
     
     func bannerContainerView(_ bannerContainerView: BannerContainerView,
                              stateWillChangeTo state: BannerContainerView.State) {

--- a/Sources/MapboxNavigation/BannerView.swift
+++ b/Sources/MapboxNavigation/BannerView.swift
@@ -1,12 +1,6 @@
 import UIKit
 
 // :nodoc:
-@objc(MBBannerContainerView)
-open class BannerContainerView: UIView {
-    
-}
-
-// :nodoc:
 @objc(MBTopBannerView)
 open class TopBannerView: UIView {
     

--- a/Sources/MapboxNavigation/BottomBannerViewController.swift
+++ b/Sources/MapboxNavigation/BottomBannerViewController.swift
@@ -4,17 +4,6 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 /**
- `BottomBannerViewControllerDelegate` provides a method for reacting to the user tapping on the "cancel" button in the `BottomBannerViewController`.
- */
-public protocol BottomBannerViewControllerDelegate: AnyObject {
-    /**
-     A method that is invoked when the user taps on the cancel button.
-     - parameter sender: The button that originated the tap event.
-     */
-    func didTapCancel(_ sender: Any)
-}
-
-/**
  A user interface element designed to display the estimated arrival time, distance, and time remaining, as well as give the user a control the cancel the navigation session.
  */
 @IBDesignable

--- a/Sources/MapboxNavigation/BottomBannerViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/BottomBannerViewControllerDelegate.swift
@@ -1,0 +1,10 @@
+/**
+ `BottomBannerViewControllerDelegate` provides a method for reacting to the user tapping on the "cancel" button in the `BottomBannerViewController`.
+ */
+public protocol BottomBannerViewControllerDelegate: AnyObject {
+    /**
+     A method that is invoked when the user taps on the cancel button.
+     - parameter sender: The button that originated the tap event.
+     */
+    func didTapCancel(_ sender: Any)
+}

--- a/Sources/MapboxNavigation/BottomBannerViewControllerLayout.swift
+++ b/Sources/MapboxNavigation/BottomBannerViewControllerLayout.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 extension BottomBannerViewController {
+    
     func setupRootViews() {
         let children = [bottomBannerView, bottomPaddingView]
         view.addSubviews(children)
@@ -10,34 +11,31 @@ extension BottomBannerViewController {
     func setupRootViewConstraints() {
         let constraints = [
             bottomBannerView.topAnchor.constraint(equalTo: view.topAnchor),
+            bottomBannerView.bottomAnchor.constraint(equalTo: bottomPaddingView.topAnchor),
             bottomBannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomBannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bottomBannerView.bottomAnchor.constraint(equalTo: bottomPaddingView.topAnchor),
             
             bottomPaddingView.topAnchor.constraint(equalTo: view.safeBottomAnchor),
+            bottomPaddingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             bottomPaddingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomPaddingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bottomPaddingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ]
         
         NSLayoutConstraint.activate(constraints)
     }
     
     func setupBottomBanner() {
-        let timeRemainingLabel = TimeRemainingLabel()
-        timeRemainingLabel.translatesAutoresizingMaskIntoConstraints = false
+        let timeRemainingLabel: TimeRemainingLabel = .forAutoLayout()
         timeRemainingLabel.font = .systemFont(ofSize: 28, weight: .medium)
         bottomBannerView.addSubview(timeRemainingLabel)
         self.timeRemainingLabel = timeRemainingLabel
         
-        let distanceRemainingLabel = DistanceRemainingLabel()
-        distanceRemainingLabel.translatesAutoresizingMaskIntoConstraints = false
+        let distanceRemainingLabel: DistanceRemainingLabel = .forAutoLayout()
         distanceRemainingLabel.font = .systemFont(ofSize: 18, weight: .medium)
         bottomBannerView.addSubview(distanceRemainingLabel)
         self.distanceRemainingLabel = distanceRemainingLabel
         
-        let arrivalTimeLabel = ArrivalTimeLabel()
-        arrivalTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        let arrivalTimeLabel: ArrivalTimeLabel = .forAutoLayout()
         bottomBannerView.addSubview(arrivalTimeLabel)
         self.arrivalTimeLabel = arrivalTimeLabel
         
@@ -47,18 +45,15 @@ extension BottomBannerViewController {
         bottomBannerView.addSubview(cancelButton)
         self.cancelButton = cancelButton
         
-        let verticalDivider = SeparatorView()
-        verticalDivider.translatesAutoresizingMaskIntoConstraints = false
+        let verticalDivider: SeparatorView = .forAutoLayout()
         bottomBannerView.addSubview(verticalDivider)
         self.verticalDividerView = verticalDivider
         
-        let horizontalDividerView = SeparatorView()
-        horizontalDividerView.translatesAutoresizingMaskIntoConstraints = false
+        let horizontalDividerView: SeparatorView = .forAutoLayout()
         bottomBannerView.addSubview(horizontalDividerView)
         self.horizontalDividerView = horizontalDividerView
         
-        let trailingSeparatorView = SeparatorView()
-        trailingSeparatorView.translatesAutoresizingMaskIntoConstraints = false
+        let trailingSeparatorView: SeparatorView = .forAutoLayout()
         bottomBannerView.addSubview(trailingSeparatorView)
         self.trailingSeparatorView = trailingSeparatorView
         

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -250,6 +250,7 @@ open class DayStyle: Style {
             
             TopBannerView.appearance(for: phoneTraitCollection).backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
             BottomBannerView.appearance(for: phoneTraitCollection).backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+            BottomPaddingView.appearance(for: phoneTraitCollection).backgroundColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
             InstructionsBannerView.appearance(for: phoneTraitCollection).backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
             
             ArrivalTimeLabel.appearance(for: phoneTraitCollection).normalFont = UIFont.systemFont(ofSize: 18.0, weight: .medium).adjustedFont

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -129,7 +129,7 @@ open class NavigationView: UIView {
         }
     }
     
-    var floatingButtons : [UIButton]? {
+    var floatingButtons: [UIButton]? {
         didSet {
             clearStackViews()
             setupStackViews()
@@ -153,9 +153,19 @@ open class NavigationView: UIView {
     
     lazy var speedLimitView: SpeedLimitView = .forAutoLayout(hidden: true)
     
-    lazy var topBannerContainerView: BannerContainerView = .forAutoLayout()
+    // :nodoc:
+    public lazy var topBannerContainerView: BannerContainerView = {
+        let topBannerContainerView = BannerContainerView(.top)
+        topBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
+        return topBannerContainerView
+    }()
     
-    lazy var bottomBannerContainerView: BannerContainerView = .forAutoLayout()
+    // :nodoc:
+    public lazy var bottomBannerContainerView: BannerContainerView = {
+        let bottomBannerContainerView = BannerContainerView(.bottom)
+        bottomBannerContainerView.translatesAutoresizingMaskIntoConstraints = false
+        return bottomBannerContainerView
+    }()
     
     func clearStackViews() {
         let oldFloatingButtons: [UIView] = floatingStackView.subviews

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -144,7 +144,8 @@ open class NavigationView: UIView {
         }
     }
     
-    lazy var wayNameView: WayNameView = {
+    // :nodoc:
+    public lazy var wayNameView: WayNameView = {
         let wayNameView: WayNameView = .forAutoLayout()
         wayNameView.containerView.isHidden = true
         wayNameView.containerView.clipsToBounds = true

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -112,7 +112,8 @@ open class NavigationView: UIView {
     
     // MARK: Overlay Views
     
-    lazy var floatingStackView: UIStackView = {
+    // :nodoc:
+    public lazy var floatingStackView: UIStackView = {
         let stackView = UIStackView(orientation: .vertical, autoLayout: true)
         stackView.distribution = .equalSpacing
         stackView.spacing = Constants.buttonSpacing

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -574,10 +574,10 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         ]
         
         subviewInits.append { [weak self] in
-            if let topBanner = self?.addTopBanner(navigationOptions),
-               let bottomBanner = self?.addBottomBanner(navigationOptions) {
-                self?.ornamentsController?.embedBanners(topBanner: topBanner,
-                                                        bottomBanner: bottomBanner)
+            if let topBannerViewController = self?.addTopBanner(navigationOptions),
+               let bottomBannerViewController = self?.addBottomBanner(navigationOptions) {
+                self?.ornamentsController?.embedBanners(topBannerViewController: topBannerViewController,
+                                                        bottomBannerViewController: bottomBannerViewController)
             }
         }
         

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -56,8 +56,9 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     var mapTileStore: TileStoreConfiguration.Location? {
         NavigationSettings.shared.tileStoreConfiguration.mapLocation
     }
-        
-    var navigationView: NavigationView {
+    
+    // :nodoc:
+    public var navigationView: NavigationView {
         return (view as! NavigationView)
     }
     

--- a/Sources/MapboxNavigation/NavigationViewLayout.swift
+++ b/Sources/MapboxNavigation/NavigationViewLayout.swift
@@ -62,12 +62,10 @@ extension NavigationView {
 
         let bottomBannerContainerViewTrailingConstraint = bottomBannerContainerView.trailingAnchor.constraint(equalTo: trailingAnchor)
         let bottomBannerContainerViewLeadingConstraint = bottomBannerContainerView.leadingAnchor.constraint(equalTo: leadingAnchor)
-        let bottomBannerContainerViewBottomConstraint = bottomBannerContainerView.bottomAnchor.constraint(equalTo: bottomAnchor)
 
         let bottomBannerConstraints = [
             bottomBannerContainerViewTrailingConstraint,
-            bottomBannerContainerViewLeadingConstraint,
-            bottomBannerContainerViewBottomConstraint
+            bottomBannerContainerViewLeadingConstraint
         ]
         
         layoutConstraints.append(contentsOf: bottomBannerConstraints)
@@ -199,12 +197,10 @@ extension NavigationView {
 
         let bottomBannerContainerViewTrailingConstraint = bottomBannerContainerView.trailingAnchor.constraint(equalTo: topBannerContainerView.trailingAnchor)
         let bottomBannerContainerViewLeadingConstraint = bottomBannerContainerView.leadingAnchor.constraint(equalTo: leadingAnchor)
-        let bottomBannerContainerViewBottomConstraint = bottomBannerContainerView.bottomAnchor.constraint(equalTo: bottomAnchor)
         
         let bottomBannerConstraints = [
             bottomBannerContainerViewTrailingConstraint,
-            bottomBannerContainerViewLeadingConstraint,
-            bottomBannerContainerViewBottomConstraint
+            bottomBannerContainerViewLeadingConstraint
         ]
         
         layoutConstraints.append(contentsOf: bottomBannerConstraints)

--- a/Sources/MapboxNavigation/NightStyle.swift
+++ b/Sources/MapboxNavigation/NightStyle.swift
@@ -81,6 +81,7 @@ open class NightStyle: DayStyle {
             
             TopBannerView.appearance(for: phoneTraitCollection).backgroundColor = backgroundColor
             BottomBannerView.appearance(for: phoneTraitCollection).backgroundColor = backgroundColor
+            BottomPaddingView.appearance(for: phoneTraitCollection).backgroundColor = backgroundColor
             InstructionsBannerView.appearance(for: phoneTraitCollection).backgroundColor = backgroundColor
             
             WayNameView.appearance(for: phoneTraitCollection).borderColor = #colorLiteral(red: 0.2802129388, green: 0.3988235593, blue: 0.5260632038, alpha: 1)

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -55,7 +55,7 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
                       bottomBannerViewController: ContainerViewController) {
         let topBannerContainerView = navigationViewData.navigationView.topBannerContainerView
         
-        embed(topBannerViewController, in: topBannerContainerView) { (parent, banner) -> [NSLayoutConstraint] in
+        navigationViewData.containerViewController.embed(topBannerViewController, in: topBannerContainerView) { (parent, banner) -> [NSLayoutConstraint] in
             banner.view.translatesAutoresizingMaskIntoConstraints = false
             return banner.view.constraintsForPinning(to: self.navigationViewData.navigationView.topBannerContainerView)
         }
@@ -64,7 +64,7 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
         
         let bottomBannerContainerView = navigationViewData.navigationView.bottomBannerContainerView
         
-        embed(bottomBannerViewController, in: bottomBannerContainerView) { (parent, banner) -> [NSLayoutConstraint] in
+        navigationViewData.containerViewController.embed(bottomBannerViewController, in: bottomBannerContainerView) { (parent, banner) -> [NSLayoutConstraint] in
             banner.view.translatesAutoresizingMaskIntoConstraints = false
             return banner.view.constraintsForPinning(to: self.navigationViewData.navigationView.bottomBannerContainerView)
         }
@@ -72,16 +72,6 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
         bottomBannerContainerView.backgroundColor = .clear
         
         navigationViewData.containerViewController.view.bringSubviewToFront(navigationViewData.navigationView.topBannerContainerView)
-    }
-    
-    private func embed(_ child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])?) {
-        child.willMove(toParent: navigationViewData.containerViewController)
-        navigationViewData.containerViewController.addChild(child)
-        container.addSubview(child.view)
-        if let childConstraints: [NSLayoutConstraint] = constraints?(navigationViewData.containerViewController, child) {
-            navigationViewData.containerViewController.view.addConstraints(childConstraints)
-        }
-        child.didMove(toParent: navigationViewData.containerViewController)
     }
     
     // MARK: Feedback Collection

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -51,23 +51,25 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
         updateMapViewOrnaments()
     }
     
-    func embedBanners(topBanner: ContainerViewController, bottomBanner: ContainerViewController) {
-        let topContainer = navigationViewData.navigationView.topBannerContainerView
+    func embedBanners(topBannerViewController: ContainerViewController,
+                      bottomBannerViewController: ContainerViewController) {
+        let topBannerContainerView = navigationViewData.navigationView.topBannerContainerView
         
-        embed(topBanner, in: topContainer) { (parent, banner) -> [NSLayoutConstraint] in
+        embed(topBannerViewController, in: topBannerContainerView) { (parent, banner) -> [NSLayoutConstraint] in
             banner.view.translatesAutoresizingMaskIntoConstraints = false
             return banner.view.constraintsForPinning(to: self.navigationViewData.navigationView.topBannerContainerView)
         }
         
-        topContainer.backgroundColor = .clear
+        topBannerContainerView.backgroundColor = .clear
         
-        let bottomContainer = navigationViewData.navigationView.bottomBannerContainerView
-        embed(bottomBanner, in: bottomContainer) { (parent, banner) -> [NSLayoutConstraint] in
+        let bottomBannerContainerView = navigationViewData.navigationView.bottomBannerContainerView
+        
+        embed(bottomBannerViewController, in: bottomBannerContainerView) { (parent, banner) -> [NSLayoutConstraint] in
             banner.view.translatesAutoresizingMaskIntoConstraints = false
             return banner.view.constraintsForPinning(to: self.navigationViewData.navigationView.bottomBannerContainerView)
         }
         
-        bottomContainer.backgroundColor = .clear
+        bottomBannerContainerView.backgroundColor = .clear
         
         navigationViewData.containerViewController.view.bringSubviewToFront(navigationViewData.navigationView.topBannerContainerView)
     }

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -426,15 +426,6 @@ extension TopBannerViewController: NavigationComponent {
         guard reason == .manual else { return }
         statusView.hide(delay: 0, animated: true)
     }
-    
-    private func embed(_ child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])? = nil) {
-        addChild(child)
-        container.addSubview(child.view)
-        if let childConstraints: [NSLayoutConstraint] = constraints?(self, child) {
-            view.addConstraints(childConstraints)
-        }
-        child.didMove(toParent: self)
-    }
 }
 
 // MARK: InstructionsBannerViewDelegate Conformance

--- a/Sources/MapboxNavigation/UIViewController.swift
+++ b/Sources/MapboxNavigation/UIViewController.swift
@@ -2,10 +2,16 @@ import UIKit
 
 extension UIViewController {
     
-    func embed(_ viewController: UIViewController, in view: UIView) {
+    func embed(_ viewController: UIViewController,
+               in view: UIView,
+               constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])? = nil) {
         viewController.view.frame = view.bounds
         view.addSubview(viewController.view)
         addChild(viewController)
+        
+        if let childConstraints = constraints?(self, viewController) {
+            self.view.addConstraints(childConstraints)
+        }
         
         viewController.didMove(toParent: self)
     }

--- a/Sources/MapboxNavigation/UIViewController.swift
+++ b/Sources/MapboxNavigation/UIViewController.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+extension UIViewController {
+    
+    func embed(_ viewController: UIViewController, in view: UIView) {
+        viewController.view.frame = view.bounds
+        view.addSubview(viewController.view)
+        addChild(viewController)
+        
+        viewController.didMove(toParent: self)
+    }
+}

--- a/Tests/MapboxNavigationTests/BottomBannerSnapshotTests.swift
+++ b/Tests/MapboxNavigationTests/BottomBannerSnapshotTests.swift
@@ -40,7 +40,7 @@ class BottomBannerSnapshotTests: TestCase {
         host.view.addSubview(container)
         constrain(container, to: host.view, side: .bottom)
         
-        host.embed(subject, child: subject, in: container) { (parent, banner) -> [NSLayoutConstraint] in
+        host.embed(subject, in: container) { (parent, banner) -> [NSLayoutConstraint] in
             banner.view.translatesAutoresizingMaskIntoConstraints = false
             return banner.view.constraintsForPinning(to: container)
         }

--- a/Tests/MapboxNavigationTests/BottomBannerSnapshotTests.swift
+++ b/Tests/MapboxNavigationTests/BottomBannerSnapshotTests.swift
@@ -21,7 +21,7 @@ class BottomBannerSnapshotTests: TestCase {
         host.view.addSubview(container)
         constrain(container, to: host.view, side: .bottom)
         
-        embed(parent: host, child: subject, in: container) { (parent, banner) -> [NSLayoutConstraint] in
+        host.embed(subject, in: container) { (parent, banner) -> [NSLayoutConstraint] in
             banner.view.translatesAutoresizingMaskIntoConstraints = false
             return banner.view.constraintsForPinning(to: container)
         }
@@ -40,7 +40,7 @@ class BottomBannerSnapshotTests: TestCase {
         host.view.addSubview(container)
         constrain(container, to: host.view, side: .bottom)
         
-        embed(parent: host, child: subject, in: container) { (parent, banner) -> [NSLayoutConstraint] in
+        host.embed(subject, child: subject, in: container) { (parent, banner) -> [NSLayoutConstraint] in
             banner.view.translatesAutoresizingMaskIntoConstraints = false
             return banner.view.constraintsForPinning(to: container)
         }

--- a/Tests/MapboxNavigationTests/InstructionsCardSnapshotTests.swift
+++ b/Tests/MapboxNavigationTests/InstructionsCardSnapshotTests.swift
@@ -30,7 +30,7 @@ class InstructionsCardSnapshotTests: TestCase {
         host.view.addSubview(container)
         constrain(container, to: host.view)
         
-        embed(parent: host, child: subject, in: container) { (parent, cards) -> [NSLayoutConstraint] in
+        host.embed(subject, in: container) { (parent, cards) -> [NSLayoutConstraint] in
             cards.view.translatesAutoresizingMaskIntoConstraints = false
             return cards.view.constraintsForPinning(to: container)
         }
@@ -51,7 +51,7 @@ class InstructionsCardSnapshotTests: TestCase {
         host.view.addSubview(container)
         constrain(container, to: host.view)
         
-        embed(parent: host, child: subject, in: container) { (parent, cards) -> [NSLayoutConstraint] in
+        host.embed(subject, in: container) { (parent, cards) -> [NSLayoutConstraint] in
             cards.view.translatesAutoresizingMaskIntoConstraints = false
             return cards.view.constraintsForPinning(to: container)
         }
@@ -74,7 +74,7 @@ class InstructionsCardSnapshotTests: TestCase {
         host.view.addSubview(container)
         constrain(container, to: host.view)
         
-        embed(parent: host, child: subject, in: container) { (parent, cards) -> [NSLayoutConstraint] in
+        host.embed(subject, in: container) { (parent, cards) -> [NSLayoutConstraint] in
             cards.view.translatesAutoresizingMaskIntoConstraints = false
             return cards.view.constraintsForPinning(to: container)
         }

--- a/Tests/MapboxNavigationTests/InstructionsCardViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/InstructionsCardViewControllerTests.swift
@@ -31,9 +31,8 @@ class InstructionsCardViewControllerTests: TestCase {
             hostViewController.view.addSubview(containerView)
             constrain(containerView, to: hostViewController.view)
             
-            embed(parent: hostViewController,
-                  child: instructionsCardViewController,
-                  in: containerView) { (parent, instructionsCard) -> [NSLayoutConstraint] in
+            hostViewController.embed(instructionsCardViewController,
+                                     in: containerView) { (parent, instructionsCard) -> [NSLayoutConstraint] in
                 instructionsCard.view.translatesAutoresizingMaskIntoConstraints = false
                 return instructionsCard.view.constraintsForPinning(to: containerView)
             }

--- a/Tests/MapboxNavigationTests/XCTestCase.swift
+++ b/Tests/MapboxNavigationTests/XCTestCase.swift
@@ -41,13 +41,4 @@ extension XCTestCase {
         ]
         NSLayoutConstraint.activate(constraints)
     }
-
-    func embed(parent:UIViewController, child: UIViewController, in container: UIView, constrainedBy constraints: ((UIViewController, UIViewController) -> [NSLayoutConstraint])?) {
-        parent.addChild(child)
-        container.addSubview(child.view)
-        if let childConstraints: [NSLayoutConstraint] = constraints?(parent, child) {
-            parent.view.addConstraints(childConstraints)
-        }
-        child.didMove(toParent: parent)
-    }
 }


### PR DESCRIPTION
### Description

PR brings several public API changes to banner container views presentation (and other related UI elements). Some of them include:
- `BannerContainerView.state` property that allows to check whether banner is either expanded or collapsed.
- `BannerContainerView.show(animated:duration:animations:completion:)` method that allows to fully present banner container.
- `BannerContainerView.hide(animated:duration:animations:completion:)` that allows to fully hide banner container.
- `BannerContainerViewDelegate` allows to get callbacks about state changes and fraction of expansion. Possibly will be extended in future to contain more useful methods.
- `NavigationView.wayNameView`, `NavigationView.topBannerContainerView`, `NavigationView.bottomBannerContainerView` and `NavigationView.navigationView` were made public.
- `BannerContainerView.type` (internal for now) allows to create either top or bottom banner container.

Example:

https://user-images.githubusercontent.com/1496498/179869405-c70de749-3e15-4ea6-afaa-b9436ec0359f.mov


