### PR TITLE
Only clear Sprite cache when style changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Banners and guidance instructions
 
 * Added the `WayNameView.cornerRadius` property for customizing how the current road name is labeled. ([#4004](https://github.com/mapbox/mapbox-navigation-ios/pull/4004))
+* Reduced memory footprint while downloading road shield images. ([#4020](https://github.com/mapbox/mapbox-navigation-ios/pull/4020))
 
 ### Other changes
 
@@ -27,7 +28,6 @@
 * Added `NavigationSettings.utilizeSensorData` toggle to allow navigator to use additional device sensors data for better positioning. ([#3973](https://github.com/mapbox/mapbox-navigation-ios/pull/3973))
 * Fixed the issue of restricted layer over the whole route after the removal of continuous alternative route with a small portion of restricted road class at start. ([#4009](https://github.com/mapbox/mapbox-navigation-ios/pull/4009))
 * Added `ResumeButton.borderWidth`, `ResumeButton.cornerRadius` and `ResumeButton.borderColor` properties that allow `ResumeButton`'s style modification. ([#3996](https://github.com/mapbox/mapbox-navigation-ios/pull/3996))
-* Reduced the downloading of road shield images. ([#4020](https://github.com/mapbox/mapbox-navigation-ios/pull/4020))
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Added `NavigationSettings.utilizeSensorData` toggle to allow navigator to use additional device sensors data for better positioning. ([#3973](https://github.com/mapbox/mapbox-navigation-ios/pull/3973))
 * Fixed the issue of restricted layer over the whole route after the removal of continuous alternative route with a small portion of restricted road class at start. ([#4009](https://github.com/mapbox/mapbox-navigation-ios/pull/4009))
 * Added `ResumeButton.borderWidth`, `ResumeButton.cornerRadius` and `ResumeButton.borderColor` properties that allow `ResumeButton`'s style modification. ([#3996](https://github.com/mapbox/mapbox-navigation-ios/pull/3996))
+* Reduced the downloading of road shield images. ([#4020](https://github.com/mapbox/mapbox-navigation-ios/pull/4020))
 
 ## v2.6.0
 

--- a/Sources/MapboxNavigation/SpriteRepository.swift
+++ b/Sources/MapboxNavigation/SpriteRepository.swift
@@ -33,7 +33,14 @@ class SpriteRepository {
             completion()
             return
         }
-        updateSprite(styleURI: newStyleURI, completion: completion)
+        
+        spriteCache.clearMemory()
+        infoCache.clearMemory()
+        
+        // Update the styleURI just after the Sprite memory reset. When the connection is poor, the next round of style update
+        // or the representation update could use the correct ones.
+        self.styleURI = newStyleURI
+        updateSprite(completion: completion)
     }
 
     func updateRepresentation(for representation: VisualInstruction.Component.ImageRepresentation? = nil, completion: @escaping CompletionHandler) {
@@ -41,7 +48,7 @@ class SpriteRepository {
 
         if getSpriteImage() == nil {
             dispatchGroup.enter()
-            updateSprite(styleURI: styleURI) {
+            updateSprite() {
                 dispatchGroup.leave()
             }
         }
@@ -56,13 +63,7 @@ class SpriteRepository {
         }
     }
     
-    func updateSprite(styleURI: StyleURI, completion: @escaping CompletionHandler) {
-        spriteCache.clearMemory()
-        infoCache.clearMemory()
-        
-        // Update the styleURI just after the Sprite memory reset. When the connection is poor, the next round of style update
-        // or the representation update could use the correct ones.
-        self.styleURI = styleURI
+    func updateSprite(completion: @escaping CompletionHandler) {
         guard let styleID = styleID,
               let infoRequestURL = spriteURL(isImage: false, styleID: styleID),
               let spriteRequestURL = spriteURL(isImage: true, styleID: styleID) else {


### PR DESCRIPTION
### Description
This PR is to reduce the memory loss of the Sprite. 

### Implementation
Previously, when the Sprite image or metadata not ready to use, the Sprite cache will be cleared.  Because the Sprite only depends on style, this PR is to reduce the memory loss by only allowing style change to clear the Sprite cache.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->