### PR TITLE
Add custom `NavigationViewController` transitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed `MapView` rendering issues that occur after the application returns to the foreground. ([#1402](https://github.com/mapbox/mapbox-maps-ios/pull/1402))
 * Each alternative route shown during turn-by-turn navigation is now annotated with the amount of time it saves or adds to the trip. To hide these annotations, set the `NavigationMapView.showsRelativeDurationOnContinuousAlternativeRoutes` property to `false`. ([#3956](https://github.com/mapbox/mapbox-navigation-ios/pull/3956))
 * Fixed the issue where the route line endpoint is ahead of user location indicator on short straight-line route step when `NavigationViewController.routeLineTracksTraversal` enabled in active navigation. ([#3992](https://github.com/mapbox/mapbox-navigation-ios/pull/3992))
+* Added the ability to provide duration and completion handler while visualizing routes using `NavigationMapView.showcase(_:animated:duration:completion:)`. ([#4022](https://github.com/mapbox/mapbox-navigation-ios/pull/4022))
 
 ### CarPlay
 

--- a/MapboxNavigation-SPM.xcodeproj/project.pbxproj
+++ b/MapboxNavigation-SPM.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		8A092F9C25DEE81900CA7CF5 /* ViewController+FreeDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A092F9A25DEE81900CA7CF5 /* ViewController+FreeDrive.swift */; };
 		8A0D5DB625DF2A86006F0919 /* StyledFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */; };
 		8A0D5DB725DF2A86006F0919 /* StyledFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */; };
+		8A2818BF2889C9E6000F90A7 /* DismissalAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2818BE2889C9E6000F90A7 /* DismissalAnimator.swift */; };
+		8A2818C12889C9FC000F90A7 /* PresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2818C02889C9FC000F90A7 /* PresentationAnimator.swift */; };
 		8A506B7C285A53A0008A6082 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 8A506B7B285A53A0008A6082 /* SnapshotTesting */; };
 		8A506BC8285A83BF008A6082 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A506BC7285A83BF008A6082 /* AppDelegate.swift */; };
 		8A506BCA285A83BF008A6082 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A506BC9285A83BF008A6082 /* SceneDelegate.swift */; };
@@ -93,6 +95,8 @@
 		43E69517233D297B0019BF6E /* cover.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = cover.md; path = docs/cover.md; sourceTree = "<group>"; };
 		8A092F9A25DEE81900CA7CF5 /* ViewController+FreeDrive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ViewController+FreeDrive.swift"; path = "Example/ViewController+FreeDrive.swift"; sourceTree = "<group>"; };
 		8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StyledFeature.swift; path = Example/StyledFeature.swift; sourceTree = "<group>"; };
+		8A2818BE2889C9E6000F90A7 /* DismissalAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissalAnimator.swift; sourceTree = "<group>"; };
+		8A2818C02889C9FC000F90A7 /* PresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationAnimator.swift; sourceTree = "<group>"; };
 		8A506BC5285A83BF008A6082 /* NavigationViewExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NavigationViewExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A506BC7285A83BF008A6082 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A506BC9285A83BF008A6082 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -238,9 +242,19 @@
 			name = Example;
 			sourceTree = "<group>";
 		};
+		8A2818BD2889C9C0000F90A7 /* Transitions */ = {
+			isa = PBXGroup;
+			children = (
+				8A2818BE2889C9E6000F90A7 /* DismissalAnimator.swift */,
+				8A2818C02889C9FC000F90A7 /* PresentationAnimator.swift */,
+			);
+			path = Transitions;
+			sourceTree = "<group>";
+		};
 		8A506BC6285A83BF008A6082 /* NavigationViewExample */ = {
 			isa = PBXGroup;
 			children = (
+				8A2818BD2889C9C0000F90A7 /* Transitions */,
 				8A506BC7285A83BF008A6082 /* AppDelegate.swift */,
 				8A506BC9285A83BF008A6082 /* SceneDelegate.swift */,
 				8A506BCB285A83BF008A6082 /* ViewController.swift */,
@@ -701,6 +715,8 @@
 			files = (
 				8A506BCC285A83BF008A6082 /* ViewController.swift in Sources */,
 				8A506BC8285A83BF008A6082 /* AppDelegate.swift in Sources */,
+				8A2818C12889C9FC000F90A7 /* PresentationAnimator.swift in Sources */,
+				8A2818BF2889C9E6000F90A7 /* DismissalAnimator.swift in Sources */,
 				8A506BCA285A83BF008A6082 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxNavigation-SPM.xcodeproj/project.pbxproj
+++ b/MapboxNavigation-SPM.xcodeproj/project.pbxproj
@@ -18,6 +18,13 @@
 		8A0D5DB625DF2A86006F0919 /* StyledFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */; };
 		8A0D5DB725DF2A86006F0919 /* StyledFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */; };
 		8A506B7C285A53A0008A6082 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 8A506B7B285A53A0008A6082 /* SnapshotTesting */; };
+		8A506BC8285A83BF008A6082 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A506BC7285A83BF008A6082 /* AppDelegate.swift */; };
+		8A506BCA285A83BF008A6082 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A506BC9285A83BF008A6082 /* SceneDelegate.swift */; };
+		8A506BCC285A83BF008A6082 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A506BCB285A83BF008A6082 /* ViewController.swift */; };
+		8A506BCF285A83BF008A6082 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A506BCD285A83BF008A6082 /* Main.storyboard */; };
+		8A506BD1285A83C0008A6082 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8A506BD0285A83C0008A6082 /* Assets.xcassets */; };
+		8A506BD4285A83C0008A6082 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A506BD2285A83C0008A6082 /* LaunchScreen.storyboard */; };
+		8A506BDA285A843E008A6082 /* MapboxNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = 8A506BD9285A843E008A6082 /* MapboxNavigation */; };
 		8A8EDF1C284ABE55009DE805 /* route.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A8EDF1B284ABE55009DE805 /* route.json */; };
 		8AC81F5A284832E000662395 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC81F59284832E000662395 /* AppDelegate.swift */; };
 		8AC81F5C284832E000662395 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC81F5B284832E000662395 /* SceneDelegate.swift */; };
@@ -86,6 +93,14 @@
 		43E69517233D297B0019BF6E /* cover.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = cover.md; path = docs/cover.md; sourceTree = "<group>"; };
 		8A092F9A25DEE81900CA7CF5 /* ViewController+FreeDrive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ViewController+FreeDrive.swift"; path = "Example/ViewController+FreeDrive.swift"; sourceTree = "<group>"; };
 		8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StyledFeature.swift; path = Example/StyledFeature.swift; sourceTree = "<group>"; };
+		8A506BC5285A83BF008A6082 /* NavigationViewExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NavigationViewExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A506BC7285A83BF008A6082 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8A506BC9285A83BF008A6082 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		8A506BCB285A83BF008A6082 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		8A506BCE285A83BF008A6082 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		8A506BD0285A83C0008A6082 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		8A506BD3285A83C0008A6082 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8A506BD5285A83C0008A6082 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A8EDF11284A8DB8009DE805 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		8A8EDF1B284ABE55009DE805 /* route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = route.json; sourceTree = "<group>"; };
 		8AC81F57284832E000662395 /* MapboxNavigationTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MapboxNavigationTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,6 +168,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8A506BC2285A83BF008A6082 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A506BDA285A843E008A6082 /* MapboxNavigation in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8AC81F54284832E000662395 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -213,6 +236,20 @@
 				8A0D5DB525DF2A86006F0919 /* StyledFeature.swift */,
 			);
 			name = Example;
+			sourceTree = "<group>";
+		};
+		8A506BC6285A83BF008A6082 /* NavigationViewExample */ = {
+			isa = PBXGroup;
+			children = (
+				8A506BC7285A83BF008A6082 /* AppDelegate.swift */,
+				8A506BC9285A83BF008A6082 /* SceneDelegate.swift */,
+				8A506BCB285A83BF008A6082 /* ViewController.swift */,
+				8A506BCD285A83BF008A6082 /* Main.storyboard */,
+				8A506BD0285A83C0008A6082 /* Assets.xcassets */,
+				8A506BD2285A83C0008A6082 /* LaunchScreen.storyboard */,
+				8A506BD5285A83C0008A6082 /* Info.plist */,
+			);
+			path = NavigationViewExample;
 			sourceTree = "<group>";
 		};
 		8AC81F58284832E000662395 /* MapboxNavigationTestHost */ = {
@@ -290,6 +327,7 @@
 				DA1A1AFC25E085D40097BBD7 /*  */,
 				8AC81F58284832E000662395 /* MapboxNavigationTestHost */,
 				8AC81F70284832F400662395 /* MapboxNavigationTests */,
+				8A506BC6285A83BF008A6082 /* NavigationViewExample */,
 				C5ADFBCA1DDCC7840011824B /* Products */,
 				A9E2B43473B53369153F54C6 /* Frameworks */,
 			);
@@ -304,6 +342,7 @@
 				C53F2F0720EBC95600D9798F /* Example.app */,
 				8AC81F57284832E000662395 /* MapboxNavigationTestHost.app */,
 				8AC81F6F284832F400662395 /* MapboxNavigationTests.xctest */,
+				8A506BC5285A83BF008A6082 /* NavigationViewExample.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -332,6 +371,27 @@
 			productReference = 358D14631E5E3B7700ADE590 /* Example.app */;
 			productType = "com.apple.product-type.application";
 		};
+		8A506BC4285A83BF008A6082 /* NavigationViewExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A506BD8285A83C0008A6082 /* Build configuration list for PBXNativeTarget "NavigationViewExample" */;
+			buildPhases = (
+				8A506BC1285A83BF008A6082 /* Sources */,
+				8A506BC2285A83BF008A6082 /* Frameworks */,
+				8A506BC3285A83BF008A6082 /* Resources */,
+				8A506BDB285A846F008A6082 /* Apply Mapbox Access Token */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NavigationViewExample;
+			packageProductDependencies = (
+				8A506BD9285A843E008A6082 /* MapboxNavigation */,
+			);
+			productName = NavigationViewExample;
+			productReference = 8A506BC5285A83BF008A6082 /* NavigationViewExample.app */;
+			productType = "com.apple.product-type.application";
+		};
 		8AC81F56284832E000662395 /* MapboxNavigationTestHost */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8AC81F6A284832E200662395 /* Build configuration list for PBXNativeTarget "MapboxNavigationTestHost" */;
@@ -339,7 +399,7 @@
 				8AC81F53284832E000662395 /* Sources */,
 				8AC81F54284832E000662395 /* Frameworks */,
 				8AC81F55284832E000662395 /* Resources */,
-				8AB31424284837EC00348E52 /* Apply Mapbox Token */,
+				8AB31424284837EC00348E52 /* Apply Mapbox Access Token */,
 			);
 			buildRules = (
 			);
@@ -405,7 +465,7 @@
 				KnownAssetTags = (
 					New,
 				);
-				LastSwiftUpdateCheck = 1330;
+				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1340;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
@@ -414,6 +474,9 @@
 						DevelopmentTeam = GJZR2MEM28;
 						LastSwiftMigration = 1030;
 						ProvisioningStyle = Automatic;
+					};
+					8A506BC4285A83BF008A6082 = {
+						CreatedOnToolsVersion = 13.4.1;
 					};
 					8AC81F56284832E000662395 = {
 						CreatedOnToolsVersion = 13.3.1;
@@ -480,6 +543,7 @@
 				C53F2EDE20EBC95600D9798F /* Example-CarPlay */,
 				8AC81F56284832E000662395 /* MapboxNavigationTestHost */,
 				8AC81F6E284832F400662395 /* MapboxNavigationTests */,
+				8A506BC4285A83BF008A6082 /* NavigationViewExample */,
 			);
 		};
 /* End PBXProject section */
@@ -495,6 +559,16 @@
 				35002D611E5F6ADB0090E733 /* Assets.xcassets in Resources */,
 				DA303C9F21B76B5C00F921DC /* LaunchScreen.storyboard in Resources */,
 				DA303CA421B76CB000F921DC /* Localizable.stringsdict in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A506BC3285A83BF008A6082 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A506BD4285A83C0008A6082 /* LaunchScreen.storyboard in Resources */,
+				8A506BD1285A83C0008A6082 /* Assets.xcassets in Resources */,
+				8A506BCF285A83BF008A6082 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -535,7 +609,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		8AB31424284837EC00348E52 /* Apply Mapbox Token */ = {
+		8A506BDB285A846F008A6082 /* Apply Mapbox Access Token */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -545,7 +619,26 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
-			name = "Apply Mapbox Token";
+			name = "Apply Mapbox Access Token";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This Run Script build phase helps to keep the navigation SDK’s developers from exposing their own access tokens during development. See <https://www.mapbox.com/help/ios-private-access-token/> for more information. If you are developing an application privately, you may add the MGLMapboxAccessToken key directly to your Info.plist file and delete this build phase.\n\ntoken_file=~/.mapbox\ntoken_file2=~/mapbox\ntoken=\"$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MBXAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://www.mapbox.com/account/access-tokens/'\n  echo \"warning: Get an access token from <https://www.mapbox.com/account/access-tokens/>, then create a new file at $token_file or $token_file2 that contains the access token.\"\nfi\n";
+		};
+		8AB31424284837EC00348E52 /* Apply Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Apply Mapbox Access Token";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -599,6 +692,16 @@
 				8A0D5DB625DF2A86006F0919 /* StyledFeature.swift in Sources */,
 				B4FC994927D19E3A00FB6D4A /* ViewController+StyleManager.swift in Sources */,
 				358D14661E5E3B7700ADE590 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A506BC1285A83BF008A6082 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A506BCC285A83BF008A6082 /* ViewController.swift in Sources */,
+				8A506BC8285A83BF008A6082 /* AppDelegate.swift in Sources */,
+				8A506BCA285A83BF008A6082 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -685,6 +788,22 @@
 			name = Main.storyboard;
 			sourceTree = "<group>";
 		};
+		8A506BCD285A83BF008A6082 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				8A506BCE285A83BF008A6082 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		8A506BD2285A83C0008A6082 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				8A506BD3285A83C0008A6082 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
 		8AC81F5F284832E000662395 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -765,6 +884,84 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Example/Example-Swift-BridgingHeader.h";
+			};
+			name = Release;
+		};
+		8A506BD6285A83C0008A6082 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = NavigationViewExample/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Get user location";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "Get user location";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Get user location";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.NavigationViewExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8A506BD7285A83C0008A6082 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = NavigationViewExample/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Get user location";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "Get user location";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Get user location";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.NavigationViewExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -1103,6 +1300,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		8A506BD8285A83C0008A6082 /* Build configuration list for PBXNativeTarget "NavigationViewExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A506BD6285A83C0008A6082 /* Debug */,
+				8A506BD7285A83C0008A6082 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		8AC81F6A284832E200662395 /* Build configuration list for PBXNativeTarget "MapboxNavigationTestHost" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1165,6 +1371,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8A8EDF0E284A8305009DE805 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
+		};
+		8A506BD9285A843E008A6082 /* MapboxNavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MapboxNavigation;
 		};
 		8AC81F78284833D100662395 /* MapboxNavigation */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/NavigationViewExample/AppDelegate.swift
+++ b/NavigationViewExample/AppDelegate.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+}

--- a/NavigationViewExample/Base.lproj/LaunchScreen.storyboard
+++ b/NavigationViewExample/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/NavigationViewExample/Base.lproj/Main.storyboard
+++ b/NavigationViewExample/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/NavigationViewExample/Info.plist
+++ b/NavigationViewExample/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MBXAccessToken</key>
+	<string>PASTE MAPBOX ACCESS TOKEN HERE</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>location</string>
+	</array>
+</dict>
+</plist>

--- a/NavigationViewExample/SceneDelegate.swift
+++ b/NavigationViewExample/SceneDelegate.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+}

--- a/NavigationViewExample/Transitions/DismissalAnimator.swift
+++ b/NavigationViewExample/Transitions/DismissalAnimator.swift
@@ -26,10 +26,17 @@ class DismissalAnimator: NSObject, UIViewControllerAnimatedTransitioning {
                                                                          completion: { _ in
             transitionContext.containerView.addSubview(toViewController.view)
             
+            // `NavigationMapView` should be transfered back from `NavigationViewController` to `ViewController`.
             toViewController.navigationView.navigationMapView = fromViewController.navigationView.navigationMapView
             
+            // To receive gesture events delegate should be re-assigned back to `ViewController`.
+            toViewController.navigationView.navigationMapView.delegate = toViewController
+            
+            // Use default puck style.
             toViewController.navigationView.navigationMapView.userLocationStyle = .puck2D()
             
+            // Show routes that were originally requested and remove the ones that were added during
+            // active navigation (along with waypoints, continuous alternatives, route durations etc).
             if let routes = toViewController.routes {
                 let cameraOptions = CameraOptions(bearing: 0.0, pitch: 0.0)
                 toViewController.navigationView.navigationMapView.showcase(routes,

--- a/NavigationViewExample/Transitions/DismissalAnimator.swift
+++ b/NavigationViewExample/Transitions/DismissalAnimator.swift
@@ -1,0 +1,44 @@
+import UIKit
+import MapboxMaps
+import MapboxNavigation
+
+class DismissalAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+    
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return 0.0
+    }
+    
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard let fromViewController = transitionContext.viewController(forKey: .from) as? NavigationViewController,
+              let toViewController = transitionContext.viewController(forKey: .to) as? ViewController else {
+            transitionContext.completeTransition(false)
+            return
+        }
+        
+        // Hide top and bottom banner containers.
+        fromViewController.navigationView.topBannerContainerView.hide(duration: 1.0)
+        fromViewController.navigationView.bottomBannerContainerView.hide(duration: 1.0,
+                                                                         animations: {
+            fromViewController.navigationView.wayNameView.alpha = 0.0
+            fromViewController.navigationView.floatingStackView.alpha = 0.0
+            fromViewController.navigationView.speedLimitView.alpha = 0.0
+        },
+                                                                         completion: { _ in
+            transitionContext.containerView.addSubview(toViewController.view)
+            
+            toViewController.navigationView.navigationMapView = fromViewController.navigationView.navigationMapView
+            
+            toViewController.navigationView.navigationMapView.userLocationStyle = .puck2D()
+            
+            if let routes = toViewController.routes {
+                let cameraOptions = CameraOptions(bearing: 0.0, pitch: 0.0)
+                toViewController.navigationView.navigationMapView.showcase(routes,
+                                                                           routesPresentationStyle: .all(shouldFit: true, cameraOptions: cameraOptions),
+                                                                           animated: true,
+                                                                           duration: 1.0) { _ in
+                    transitionContext.completeTransition(true)
+                }
+            }
+        })
+    }
+}

--- a/NavigationViewExample/Transitions/PresentationAnimator.swift
+++ b/NavigationViewExample/Transitions/PresentationAnimator.swift
@@ -1,0 +1,54 @@
+import UIKit
+import MapboxNavigation
+
+class PresentationAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+    
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return 0.0
+    }
+    
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard let fromViewController = transitionContext.viewController(forKey: .from) as? ViewController,
+              let toViewController = transitionContext.viewController(forKey: .to) as? NavigationViewController else {
+            transitionContext.completeTransition(false)
+            return
+        }
+        
+        // Replace already exisiting `NavigationMapView` from `NavigationViewController` with `NavigationMapView`
+        // that was used in `PreviewViewController`.
+        toViewController.navigationView.navigationMapView = fromViewController.navigationView.navigationMapView
+        
+        // Switch navigation camera to active navigation mode.
+        toViewController.navigationMapView?.navigationCamera.viewportDataSource = NavigationViewportDataSource(toViewController.navigationView.navigationMapView.mapView,
+                                                                                                               viewportDataSourceType: .active)
+        toViewController.navigationMapView?.navigationCamera.follow()
+        
+        // Change user location style to show view that represents user’s location and course on the map.
+        toViewController.navigationMapView?.userLocationStyle = .courseView()
+        
+        // Render part of the route that has been traversed with full transparency, to give the illusion of a disappearing route.
+        // FIXME: After `NavigationViewController` dismissal route is not correctly updated.
+        // toViewController.routeLineTracksTraversal = true
+        
+        // Hide top and bottom container views before animating their presentation.
+        toViewController.navigationView.bottomBannerContainerView.hide(animated: false)
+        toViewController.navigationView.topBannerContainerView.hide(animated: false)
+        
+        // Hide `WayNameView`, `FloatingStackView` and `SpeedLimitView` to smoothly present them.
+        toViewController.navigationView.wayNameView.alpha = 0.0
+        toViewController.navigationView.floatingStackView.alpha = 0.0
+        toViewController.navigationView.speedLimitView.alpha = 0.0
+        
+        // Animate top and bottom banner views presentation.
+        toViewController.navigationView.bottomBannerContainerView.show(duration: 1.0,
+                                                                       animations: {
+            toViewController.navigationView.wayNameView.alpha = 1.0
+            toViewController.navigationView.floatingStackView.alpha = 1.0
+            toViewController.navigationView.speedLimitView.alpha = 1.0
+        })
+        toViewController.navigationView.topBannerContainerView.show(duration: 1.0)
+        
+        transitionContext.containerView.addSubview(toViewController.view)
+        transitionContext.completeTransition(true)
+    }
+}

--- a/NavigationViewExample/Transitions/PresentationAnimator.swift
+++ b/NavigationViewExample/Transitions/PresentationAnimator.swift
@@ -15,7 +15,7 @@ class PresentationAnimator: NSObject, UIViewControllerAnimatedTransitioning {
         }
         
         // Replace already exisiting `NavigationMapView` from `NavigationViewController` with `NavigationMapView`
-        // that was used in `PreviewViewController`.
+        // that was used in `ViewController`.
         toViewController.navigationView.navigationMapView = fromViewController.navigationView.navigationMapView
         
         // Switch navigation camera to active navigation mode.

--- a/NavigationViewExample/ViewController.swift
+++ b/NavigationViewExample/ViewController.swift
@@ -1,0 +1,148 @@
+import UIKit
+import CoreLocation
+import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
+
+class ViewController: UIViewController {
+    
+    var navigationView: NavigationView!
+    
+    var navigationRouteOptions: NavigationRouteOptions!
+    
+    var currentRouteIndex = 0 {
+        didSet {
+            guard let currentRoute = currentRoute else { return }
+            
+            var routes = [currentRoute]
+            routes.append(contentsOf: self.routes!.filter {
+                $0 != currentRoute
+            })
+            
+            navigationView.navigationMapView.showcase(routes,
+                                                      routesPresentationStyle: .all(),
+                                                      animated: true) { _ in
+                guard let routeResponse = self.routeResponse else { return }
+                
+                let navigationService = MapboxNavigationService(routeResponse: routeResponse,
+                                                                routeIndex: self.currentRouteIndex,
+                                                                routeOptions: self.navigationRouteOptions,
+                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                credentials: NavigationSettings.shared.directions.credentials,
+                                                                simulating: .always)
+                
+                let navigationOptions = NavigationOptions(navigationService: navigationService)
+                let navigationViewController = NavigationViewController(for: routeResponse,
+                                                                        routeIndex: self.currentRouteIndex,
+                                                                        routeOptions: self.navigationRouteOptions,
+                                                                        navigationOptions: navigationOptions)
+                navigationViewController.modalPresentationStyle = .fullScreen
+                navigationViewController.transitioningDelegate = self
+                navigationViewController.delegate = self
+                
+                self.present(navigationViewController, animated: true)
+            }
+        }
+    }
+    
+    var currentRoute: Route? {
+        return routes?[currentRouteIndex]
+    }
+    
+    var routes: [Route]? {
+        return routeResponse?.routes
+    }
+    
+    var routeResponse: RouteResponse? {
+        didSet {
+            guard currentRoute != nil else {
+                navigationView.navigationMapView.removeRoutes()
+                return
+            }
+            currentRouteIndex = 0
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        navigationView = NavigationView(frame: view.bounds)
+        navigationView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(navigationView)
+        
+        NSLayoutConstraint.activate([
+            navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationView.topAnchor.constraint(equalTo: view.topAnchor),
+            navigationView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        navigationView.floatingButtons = nil
+        
+        let navigationViewportDataSource = NavigationViewportDataSource(navigationView.navigationMapView.mapView,
+                                                                        viewportDataSourceType: .raw)
+        navigationView.navigationMapView.navigationCamera.viewportDataSource = navigationViewportDataSource
+        navigationView.navigationMapView.navigationCamera.follow()
+        
+        navigationView.navigationMapView.delegate = self
+        
+        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
+        navigationView.navigationMapView.addGestureRecognizer(gesture)
+    }
+    
+    @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        let location = navigationView.navigationMapView.mapView.mapboxMap.coordinate(for: gesture.location(in: navigationView.navigationMapView.mapView))
+        
+        requestRoute(destination: location)
+    }
+    
+    func requestRoute(destination: CLLocationCoordinate2D) {
+        guard let origin = navigationView.navigationMapView.mapView.location.latestLocation?.coordinate else { return }
+        
+        let navigationRouteOptions = NavigationRouteOptions(coordinates: [
+            origin,
+            destination
+        ])
+        
+        Directions.shared.calculate(navigationRouteOptions) { [weak self] (_, result) in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let response):
+                guard let self = self else { return }
+                
+                self.navigationRouteOptions = navigationRouteOptions
+                self.routeResponse = response
+            }
+        }
+    }
+}
+
+extension ViewController: NavigationMapViewDelegate {
+    
+    func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
+        currentRouteIndex = routes?.firstIndex(of: route) ?? 0
+    }
+}
+
+extension ViewController: UIViewControllerTransitioningDelegate {
+
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return DismissalAnimator()
+    }
+
+    public func animationController(forPresented presented: UIViewController,
+                                    presenting: UIViewController,
+                                    source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return PresentationAnimator()
+    }
+}
+
+extension ViewController: NavigationViewControllerDelegate {
+
+    public func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController,
+                                                   byCanceling canceled: Bool) {
+        navigationViewController.dismiss(animated: true)
+    }
+}

--- a/NavigationViewExample/ViewController.swift
+++ b/NavigationViewExample/ViewController.swift
@@ -37,9 +37,14 @@ class ViewController: UIViewController {
                                                                         routeOptions: self.navigationRouteOptions,
                                                                         navigationOptions: navigationOptions)
                 navigationViewController.modalPresentationStyle = .fullScreen
-                navigationViewController.transitioningDelegate = self
                 navigationViewController.delegate = self
                 
+                // `ViewController` should assign `transitioningDelegate` to `self` for
+                // `PresentationAnimator` and `DismissalAnimator` to work correctly.
+                navigationViewController.transitioningDelegate = self
+                
+                // `NavigationViewController` should be presented with animation for
+                // `PresentationAnimator` to work correctly.
                 self.present(navigationViewController, animated: true)
             }
         }
@@ -83,11 +88,11 @@ class ViewController: UIViewController {
                                                                         viewportDataSourceType: .raw)
         navigationView.navigationMapView.navigationCamera.viewportDataSource = navigationViewportDataSource
         navigationView.navigationMapView.navigationCamera.follow()
-        
         navigationView.navigationMapView.delegate = self
         
-        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
-        navigationView.navigationMapView.addGestureRecognizer(gesture)
+        let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self,
+                                                                      action: #selector(handleLongPress(_:)))
+        navigationView.navigationMapView.addGestureRecognizer(longPressGestureRecognizer)
     }
     
     @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
@@ -143,6 +148,8 @@ extension ViewController: NavigationViewControllerDelegate {
 
     public func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController,
                                                    byCanceling canceled: Bool) {
+        // `NavigationViewController` should be dismissed with animation for
+        // `DismissalAnimator` to work correctly.
         navigationViewController.dismiss(animated: true)
     }
 }

--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -14,9 +14,11 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     private var navigationMapView: NavigationMapView {
         return navigationViewData.navigationView.navigationMapView
     }
+    
     private var router: Router {
         navigationViewData.router
     }
+    
     private var topBannerContainerView: BannerContainerView {
         return navigationViewData.navigationView.topBannerContainerView
     }
@@ -29,10 +31,9 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     
     init(_ navigationViewData: NavigationViewData) {
         self.navigationViewData = navigationViewData
-        
     }
     
-    private func resumeNotifications() {
+    func resumeNotifications() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(orientationDidChange(_:)),
                                                name: UIDevice.orientationDidChangeNotification,
@@ -43,7 +44,7 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
                                                object: navigationMapView.navigationCamera)
     }
 
-    private func suspendNotifications() {
+    func suspendNotifications() {
         NotificationCenter.default.removeObserver(self,
                                                   name: UIDevice.orientationDidChangeNotification,
                                                   object: nil)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -2145,7 +2145,8 @@ open class NavigationMapView: UIView {
     
     func fitCamera(to routes: [Route],
                    routesPresentationStyle: RoutesPresentationStyle = .all(),
-                   animated: Bool = false) {
+                   animated: Bool = false,
+                   duration: TimeInterval = 1.0) {
         let geometry: Geometry
         let customCameraOptions: MapboxMaps.CameraOptions?
         
@@ -2164,7 +2165,7 @@ open class NavigationMapView: UIView {
                                                          padding: customCameraOptions?.padding ?? edgeInsets,
                                                          bearing: bearing,
                                                          pitch: customCameraOptions?.pitch) {
-            mapView?.camera.ease(to: cameraOptions, duration: animated ? 1.0 : 0.0)
+            mapView?.camera.ease(to: cameraOptions, duration: animated ? duration : 0.0)
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -238,13 +238,7 @@ open class NavigationView: UIView {
         
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         navigationMapView.mapView.ornaments.options.compass.visibility = .hidden
-        
-        NSLayoutConstraint.activate([
-            navigationMapView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            navigationMapView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            navigationMapView.topAnchor.constraint(equalTo: topAnchor),
-            navigationMapView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
+        navigationMapView.pinTo(parentView: self)
         
         resumeButton.isHidden = true
     }

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -73,16 +73,9 @@ open class NavigationView: UIView {
             insertSubview(navigationMapView, at: 0)
             
             navigationMapView.isHidden = false
-            navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             navigationMapView.translatesAutoresizingMaskIntoConstraints = false
             navigationMapView.delegate = delegate
-            
-            NSLayoutConstraint.activate([
-                navigationMapView.leadingAnchor.constraint(equalTo: leadingAnchor),
-                navigationMapView.trailingAnchor.constraint(equalTo: trailingAnchor),
-                navigationMapView.topAnchor.constraint(equalTo: topAnchor),
-                navigationMapView.bottomAnchor.constraint(equalTo: bottomAnchor)
-            ])
+            navigationMapView.pinTo(parentView: self)
         }
     }
     
@@ -159,7 +152,8 @@ open class NavigationView: UIView {
         return wayNameView
     }()
     
-    lazy var speedLimitView: SpeedLimitView = .forAutoLayout(hidden: true)
+    // :nodoc:
+    public lazy var speedLimitView: SpeedLimitView = .forAutoLayout(hidden: true)
     
     // :nodoc:
     public lazy var topBannerContainerView: BannerContainerView = {
@@ -243,8 +237,14 @@ open class NavigationView: UIView {
         addSubviews(children)
         
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        navigationMapView.mapView.ornaments.compassView.isHidden = true
-        navigationMapView.mapView.ornaments.scaleBarView.isHidden = true
+        navigationMapView.mapView.ornaments.options.compass.visibility = .hidden
+        
+        NSLayoutConstraint.activate([
+            navigationMapView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            navigationMapView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            navigationMapView.topAnchor.constraint(equalTo: topAnchor),
+            navigationMapView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
         
         resumeButton.isHidden = true
     }

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -76,6 +76,13 @@ open class NavigationView: UIView {
             navigationMapView.translatesAutoresizingMaskIntoConstraints = false
             navigationMapView.delegate = delegate
             navigationMapView.pinTo(parentView: self)
+            
+            // FIXME: Provide a reliable way of notifying dependants (e.g. `CameraController`,
+            // `ArrivalController` might need to re-subscribe to notifications that are sent from
+            // injected `NavigationMapView` instance).
+            if oldValue != navigationMapView {
+                delegate?.navigationView(self, didReplace: navigationMapView)
+            }
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -741,9 +741,21 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
 }
 
+// MARK: - NavigationViewDelegate methods
+
 extension NavigationViewController: NavigationViewDelegate {
-    func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton) {
+    
+    func navigationView(_ view: NavigationView, didTap cancelButton: CancelButton) {
         handleCancelAction()
+    }
+    
+    func navigationView(_ navigationView: NavigationView, didReplace navigationMapView: NavigationMapView) {
+        cameraController?.navigationViewData.navigationView.navigationMapView = navigationMapView
+        
+        // `CameraController` is subscribing for a certain changes in `NavigationMapView`.
+        // In case if `NavigationMapView` is injected re-subscription should be performed.
+        cameraController?.suspendNotifications()
+        cameraController?.resumeNotifications()
     }
 }
 

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -45,12 +45,21 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
     
     func setupNavigationCamera() {
+        // By default `NavigationCamera` in active guidance navigation should be set to `NavigationCameraState.following` state.
+        if let navigationMapView = navigationMapView {
+            navigationMapView.navigationCamera.viewportDataSource = NavigationViewportDataSource(navigationMapView.mapView,
+                                                                                                 viewportDataSourceType: .active)
+            navigationMapView.navigationCamera.follow()
+        }
+        
+        // In case if `NavigationMapView` instance was injected - do not set initial camera options.
+        if let _ = navigationOptions?.navigationMapView {
+            return
+        }
+        
         if let centerCoordinate = navigationService.routeProgress.route.shape?.coordinates.first {
             navigationMapView?.setInitialCamera(centerCoordinate)
         }
-        
-        // By default `NavigationCamera` in active guidance navigation should be set to `NavigationCameraState.following` state.
-        navigationMapView?.navigationCamera.follow()
     }
     
     var mapTileStore: TileStoreConfiguration.Location? {

--- a/Sources/MapboxNavigation/NavigationViewDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewDelegate.swift
@@ -2,5 +2,7 @@ import Foundation
 
 protocol NavigationViewDelegate: NavigationMapViewDelegate, InstructionsBannerViewDelegate {
     
-    func navigationView(_ view: NavigationView, didTapCancelButton: CancelButton)
+    func navigationView(_ navigationView: NavigationView, didTap cancelButton: CancelButton)
+    
+    func navigationView(_ navigationView: NavigationView, didReplace navigationMapView: NavigationMapView)
 }


### PR DESCRIPTION
### Description

- Added presentation and dismissal transitions for `NavigationViewController` (application side).
- Added `NavigationViewExample` that showcases transitions.
- Added the ability to inject `NavigationMapView` to `NavigationViewController` without blinking effects (requires change in public API).

Example:

https://user-images.githubusercontent.com/1496498/180327408-78c141d7-730a-422d-822d-376beac5e931.mov


