### PR TITLE
Only set initial maneuver avoidance radius when driving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Location tracking
 
+* Fixed an error when rerouting the user with `NavigationRouteOptions.profileIdentifier` set to `ProfileIdentifier.walking` or `ProfileIdentifier.cycling`. ([#4024](https://github.com/mapbox/mapbox-navigation-ios/pull/4024))
 * Fixed an issue where the user’s location continued to be snapped to a roadway even after the user’s course deviated significantly from that roadway, for example because the user was actually on a parallel road. ([#4012](https://github.com/mapbox/mapbox-navigation-ios/pull/4012))
 
 ### Other changes

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -398,7 +398,7 @@ extension InternalRouter where Self: Router {
         let options = progress.reroutingOptions(from: origin)
         
         // https://github.com/mapbox/mapbox-navigation-ios/issues/3966
-        if isRerouting && options.profileIdentifier != .walking && options.profileIdentifier != .cycling {
+        if isRerouting && (options.profileIdentifier == .automobile || options.profileIdentifier == .automobileAvoidingTraffic) {
             options.initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius * origin.speed
         }
         

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -397,7 +397,8 @@ extension InternalRouter where Self: Router {
         routeTask?.cancel()
         let options = progress.reroutingOptions(from: origin)
         
-        if isRerouting {
+        // https://github.com/mapbox/mapbox-navigation-ios/issues/3966
+        if isRerouting && options.profileIdentifier != .walking && options.profileIdentifier != .cycling {
             options.initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius * origin.speed
         }
         


### PR DESCRIPTION
Only set the initial maneuver avoidance radius when driving; avoid setting it with the cycling and walking profiles, which don’t support the `avoid_maneuver_radius` query parameter yet.

Fixes #3966.

/cc @mandeepsandhu