### PR TITLE
Fix the building highlighting loss after out of map boundary and rerouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fixed the issue where the route line endpoint is ahead of user location indicator on short straight-line route step when `NavigationViewController.routeLineTracksTraversal` enabled in active navigation. ([#3992](https://github.com/mapbox/mapbox-navigation-ios/pull/3992))
 * Added the ability to provide duration and completion handler while visualizing routes using `NavigationMapView.showcase(_:animated:duration:completion:)`. ([#4022](https://github.com/mapbox/mapbox-navigation-ios/pull/4022))
 * Fixed an issue where the maneuver arrow is not removed after arriving to the final destination. ([#4040](https://github.com/mapbox/mapbox-navigation-ios/pull/4040))
+* Fixed an issue where the destination building is not highlighted after rerouting. ([#4034](https://github.com/mapbox/mapbox-navigation-ios/pull/4034))
 * Fixed an issue where the incorrect destination building is highlighted after panning the correct building off screen. ([#4034](https://github.com/mapbox/mapbox-navigation-ios/pull/4034))
 
 ### CarPlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Fixed the issue where the route line endpoint is ahead of user location indicator on short straight-line route step when `NavigationViewController.routeLineTracksTraversal` enabled in active navigation. ([#3992](https://github.com/mapbox/mapbox-navigation-ios/pull/3992))
 * Added the ability to provide duration and completion handler while visualizing routes using `NavigationMapView.showcase(_:animated:duration:completion:)`. ([#4022](https://github.com/mapbox/mapbox-navigation-ios/pull/4022))
 * Fixed an issue where the maneuver arrow is not removed after arriving to the final destination. ([#4040](https://github.com/mapbox/mapbox-navigation-ios/pull/4040))
-* Fixed the issue of unexpected building highlighted when the coordinate is out of map boundary. ([#4034](https://github.com/mapbox/mapbox-navigation-ios/pull/4034))
+* Fixed an issue where the incorrect destination building is highlighted after panning the correct building off screen. ([#4034](https://github.com/mapbox/mapbox-navigation-ios/pull/4034))
 
 ### CarPlay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fixed the issue where the route line endpoint is ahead of user location indicator on short straight-line route step when `NavigationViewController.routeLineTracksTraversal` enabled in active navigation. ([#3992](https://github.com/mapbox/mapbox-navigation-ios/pull/3992))
 * Added the ability to provide duration and completion handler while visualizing routes using `NavigationMapView.showcase(_:animated:duration:completion:)`. ([#4022](https://github.com/mapbox/mapbox-navigation-ios/pull/4022))
 * Fixed an issue where the maneuver arrow is not removed after arriving to the final destination. ([#4040](https://github.com/mapbox/mapbox-navigation-ios/pull/4040))
+* Fixed the issue of unexpected building highlighted when the coordinate is out of map boundary. ([#4034](https://github.com/mapbox/mapbox-navigation-ios/pull/4034))
 
 ### CarPlay
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		B4319F2F27A35EA8005A706E /* SpriteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4319F2E27A35EA8005A706E /* SpriteRepository.swift */; };
 		B44177F82649B08400781319 /* UserLocationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44177F72649B08400781319 /* UserLocationStyle.swift */; };
 		B443A48B27BB0CB8000AF101 /* sprite-info.json in Resources */ = {isa = PBXBuildFile; fileRef = B443A48A27BB0CB8000AF101 /* sprite-info.json */; };
+		B44E1A802891DD350093743C /* CLLocationCoordinate2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44E1A7F2891DD350093743C /* CLLocationCoordinate2D.swift */; };
 		B456A8C12620C9C300FD86D8 /* MMEEventsManager+Spy.h in Headers */ = {isa = PBXBuildFile; fileRef = B456A8B82620C9C000FD86D8 /* MMEEventsManager+Spy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B456A8D22620C9C700FD86D8 /* MMEEventsManager+Spy.m in Sources */ = {isa = PBXBuildFile; fileRef = B456A8B72620C9C000FD86D8 /* MMEEventsManager+Spy.m */; };
 		B456A8EC2620D26B00FD86D8 /* LeakTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456A8EB2620D26A00FD86D8 /* LeakTest.swift */; };
@@ -932,6 +933,7 @@
 		B4319F2E27A35EA8005A706E /* SpriteRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteRepository.swift; sourceTree = "<group>"; };
 		B44177F72649B08400781319 /* UserLocationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLocationStyle.swift; sourceTree = "<group>"; };
 		B443A48A27BB0CB8000AF101 /* sprite-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "sprite-info.json"; sourceTree = "<group>"; };
+		B44E1A7F2891DD350093743C /* CLLocationCoordinate2D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocationCoordinate2D.swift; sourceTree = "<group>"; };
 		B456A8B72620C9C000FD86D8 /* MMEEventsManager+Spy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "MMEEventsManager+Spy.m"; path = "include/MMEEventsManager+Spy.m"; sourceTree = "<group>"; };
 		B456A8B82620C9C000FD86D8 /* MMEEventsManager+Spy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "MMEEventsManager+Spy.h"; path = "include/MMEEventsManager+Spy.h"; sourceTree = "<group>"; };
 		B456A8EB2620D26A00FD86D8 /* LeakTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeakTest.swift; sourceTree = "<group>"; };
@@ -1963,6 +1965,7 @@
 				3A8187C824BDAE9C00708F19 /* URLSession.swift */,
 				11D1F89F2696048D0053A93F /* Dictionary+DeepMerge.swift */,
 				8AC85EA328628E4F003F8FC8 /* UIDevice.swift */,
+				B44E1A7F2891DD350093743C /* CLLocationCoordinate2D.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -3026,6 +3029,7 @@
 				35C77F621FE8219900338416 /* NavigationSettings.swift in Sources */,
 				41B901EB271048BD007F9F78 /* HistoryRecording.swift in Sources */,
 				DA5F44C825F07AB700F573EC /* MapboxStreetsRoadClass.swift in Sources */,
+				B44E1A802891DD350093743C /* CLLocationCoordinate2D.swift in Sources */,
 				2B5A4AC728099FA900170A2B /* AlternativeRoute.swift in Sources */,
 				2E50E0C0264E35CA009D3848 /* RoadObjectMatcher.swift in Sources */,
 				C51DF8661F38C31C006C6A15 /* Locale.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/CLLocationCoordinate2D.swift
+++ b/Sources/MapboxCoreNavigation/CLLocationCoordinate2D.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CoreLocation
+
+extension CLLocationCoordinate2D: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(latitude)
+        hasher.combine(longitude)
+    }
+    
+    static func == (lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
+        return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
+    }
+}

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -930,6 +930,15 @@ extension RouteController: ReroutingControllerDelegate {
     }
     
     func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions, routeOrigin: RouterOrigin) {
+        // The response and options after reroute lost waypoint targetCoordinate.
+        if response.waypoints?.count == routeProgress.routeOptions.waypoints.count,
+           options.waypoints.count == routeProgress.routeOptions.waypoints.count {
+            for (index, previousWayoint) in routeProgress.routeOptions.waypoints.enumerated() {
+                response.waypoints?[index].targetCoordinate = previousWayoint.targetCoordinate
+                options.waypoints[index].targetCoordinate = previousWayoint.targetCoordinate
+            }
+        }
+        
         let indexedRouteResponse = IndexedRouteResponse(routeResponse: response,
                                                         routeIndex: 0,
                                                         responseOrigin: routeOrigin)

--- a/Sources/MapboxNavigation/BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/BuildingHighlighting.swift
@@ -49,8 +49,9 @@ extension BuildingHighlighting {
         
         // In case if not all buildings were found and user is within allowed destination
         // threshold - attempt to highlight buildings based on destination coordinate.
+        let destination = progress.currentLeg.destination
         if !buildingWasFound, passedApproachingDestinationThreshold,
-           let currentLegWaypoint = progress.currentLeg.destination?.targetCoordinate {
+           let currentLegWaypoint = destination?.targetCoordinate ?? destination?.coordinate {
             navigationMapView.highlightBuildings(at: [currentLegWaypoint],
                                                  in3D: waypointStyle == .extrudedBuilding ? true : false,
                                                  completion: { found in

--- a/Sources/MapboxNavigation/BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/BuildingHighlighting.swift
@@ -49,9 +49,8 @@ extension BuildingHighlighting {
         
         // In case if not all buildings were found and user is within allowed destination
         // threshold - attempt to highlight buildings based on destination coordinate.
-        let destination = progress.currentLeg.destination
         if !buildingWasFound, passedApproachingDestinationThreshold,
-           let currentLegWaypoint = destination?.targetCoordinate ?? destination?.coordinate {
+           let currentLegWaypoint = progress.currentLeg.destination?.targetCoordinate {
             navigationMapView.highlightBuildings(at: [currentLegWaypoint],
                                                  in3D: waypointStyle == .extrudedBuilding ? true : false,
                                                  completion: { found in

--- a/Sources/MapboxNavigation/CGPoint.swift
+++ b/Sources/MapboxNavigation/CGPoint.swift
@@ -7,4 +7,7 @@ extension CGPoint {
     public func distance(to: CGPoint) -> CGFloat {
         return sqrt((self.x - to.x) * (self.x - to.x) + (self.y - to.y) * (self.y - to.y))
     }
+    
+    // `MapView.mapboxMap.point(for:)` will return the point if the coordinate is outside of the `MapView` bounds.
+    static let pointOutOfMapViewBounds = CGPoint(x: -1.0, y: -1.0)
 }

--- a/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
@@ -23,7 +23,7 @@ extension NavigationMapView {
                                    in3D extrudesBuildings: Bool = true,
                                    extrudeAll: Bool = false,
                                    completion: ((_ foundAllBuildings: Bool) -> Void)? = nil) {
-        highlightBuildings = highlightBuildings.filter{ coordinates.contains($0.key) }
+        highlightedBuildingIdentifiersByCoordinate = highlightedBuildingIdentifiersByCoordinate.filter{ coordinates.contains($0.key) }
         let group = DispatchGroup()
         let identifiers = mapView.mapboxMap.style.allLayerIdentifiers
             .compactMap({ $0.id })
@@ -50,7 +50,7 @@ extension NavigationMapView {
                 
                 if case .success(let queriedFeatures) = result {
                     if let identifier = queriedFeatures.first?.feature.featureIdentifier {
-                        self.highlightBuildings[coordinate] = identifier
+                        self.highlightedBuildingIdentifiersByCoordinate[coordinate] = identifier
                     }
                 }
             })
@@ -58,11 +58,11 @@ extension NavigationMapView {
 
         group.notify(queue: DispatchQueue.main) { [weak self] in
             guard let self = self else { return }
-            self.addBuildingsLayer(with: Set(self.highlightBuildings.values),
+            self.addBuildingsLayer(with: Set(self.highlightedBuildingIdentifiersByCoordinate.values),
                                    in3D: extrudesBuildings,
                                    extrudeAll: extrudeAll,
                                    layerPosition: layerPosition)
-            completion?(self.highlightBuildings.keys.count == coordinates.count)
+            completion?(self.highlightedBuildingIdentifiersByCoordinate.keys.count == coordinates.count)
         }
     }
     
@@ -70,7 +70,7 @@ extension NavigationMapView {
      Removes the highlight from all buildings highlighted by `highlightBuildings(at:in3D:completion:)`.
      */
     public func unhighlightBuildings() {
-        highlightBuildings.removeAll()
+        highlightedBuildingIdentifiersByCoordinate.removeAll()
         let identifier = NavigationMapView.LayerIdentifier.buildingExtrusionLayer
         
         do {

--- a/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
@@ -92,18 +92,15 @@ extension NavigationMapView {
             highlightedBuildingsLayer.source = "composite"
             highlightedBuildingsLayer.sourceLayer = "building"
             
-            let extrudeExpression: Expression = Exp(.eq) {
-                Exp(.get) {
-                    "extrude"
-                }
-                "true"
-            }
-            
             if extrudeAll {
-                highlightedBuildingsLayer.filter = extrudeExpression
+                highlightedBuildingsLayer.filter = Exp(.eq) {
+                    Exp(.get) {
+                        "extrude"
+                    }
+                    "true"
+                }
             } else {
                 highlightedBuildingsLayer.filter = Exp(.all) {
-                    extrudeExpression
                     Exp(.inExpression) {
                         Exp(.id)
                         Exp(.literal) {

--- a/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
@@ -32,7 +32,7 @@ extension NavigationMapView {
         
         for coordinate in coordinates {
             let screenCoordinate = mapView.mapboxMap.point(for: coordinate)
-            if screenCoordinate == CGPoint(x: -1.0, y: -1.0) {
+            if screenCoordinate == .pointOutOfMapViewBounds {
                 continue
             }
             

--- a/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+BuildingHighlighting.swift
@@ -30,10 +30,13 @@ extension NavigationMapView {
             .filter({ $0.contains("building") })
         let layerPosition = identifiers.last.map { LayerPosition.above($0) }
         
-        coordinates.forEach { coordinate in
-            group.enter()
-            
+        for coordinate in coordinates {
             let screenCoordinate = mapView.mapboxMap.point(for: coordinate)
+            if screenCoordinate == CGPoint(x: -1.0, y: -1.0) {
+                continue
+            }
+            
+            group.enter()
             let options = RenderedQueryOptions(layerIds: identifiers, filter: nil)
             
             mapView.mapboxMap.queryRenderedFeatures(with: screenCoordinate,

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -896,6 +896,11 @@ open class NavigationMapView: UIView {
      */
     var mostRecentUserCourseViewLocation: CLLocation?
     
+    /**
+     The coordinates and corresponding identifiers for highlight buildings.
+     */
+    var highlightBuildings = [CLLocationCoordinate2D: Int64]()
+    
     func setupUserLocation() {
         if !isAuthorized() { return }
         

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -899,7 +899,7 @@ open class NavigationMapView: UIView {
     /**
      The coordinates and corresponding identifiers for highlight buildings.
      */
-    var highlightBuildings = [CLLocationCoordinate2D: Int64]()
+    var highlightedBuildingIdentifiersByCoordinate = [CLLocationCoordinate2D: Int64]()
     
     func setupUserLocation() {
         if !isAuthorized() { return }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1022,7 +1022,7 @@ open class NavigationMapView: UIView {
               animated: Bool = false) {
         // If the point is outside of the bounds of `MapView` - hide user course view.
         let point = mapView.mapboxMap.point(for: location.coordinate)
-        if point.x == -1.0 && point.y == -1.0 {
+        if point == .pointOutOfMapViewBounds {
             userCourseView.isHidden = true
             return
         } else {

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -529,17 +529,6 @@ extension NavigationViewControllerTests: NavigationViewControllerDelegate, Style
     }
 }
 
-extension CLLocationCoordinate2D: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(latitude)
-        hasher.combine(longitude)
-    }
-    
-    static func == (lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
-        return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
-    }
-}
-
 extension NavigationViewControllerTests {
     fileprivate func location(at coordinate: CLLocationCoordinate2D) -> CLLocation {
         return CLLocation(coordinate: coordinate,


### PR DESCRIPTION
### Description
This PR is to fix the building highlighting issues.

### Implementation
- [x] When the building coordinate is out of the map boundary, the map query won't work for this case. Added `NavigationMapView.highlightBuildings` to remember the past query result to provide the valid identifier of the building coordinate.
- [x] According to [test comment](https://github.com/mapbox/mapbox-maps-ios/issues/1488#issuecomment-1197372757),  when not extrude all buildings, don't apply the `extrusion` check for the building identifier. But a building may have multiple identifiers, the identifier from map query result may has `extrusion: false`
- [x] fixed #4033 , when the coordinate is out of map boundary and screen coordinate as `CGPoint(x: -1.0, y: -1.0)`, don't do the map query, because it will give an unmatched result. 
- [x] fixed an issue where the destination building is not highlighted after rerouting

### Screenshots or Gifs
![rerouting](https://user-images.githubusercontent.com/48976398/181641272-5aef34b9-af57-4ad3-9eeb-ad9f720b2b3e.gif)



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->