### PR TITLE
Remove arrow if the route line is removed after arrival

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Each alternative route shown during turn-by-turn navigation is now annotated with the amount of time it saves or adds to the trip. To hide these annotations, set the `NavigationMapView.showsRelativeDurationOnContinuousAlternativeRoutes` property to `false`. ([#3956](https://github.com/mapbox/mapbox-navigation-ios/pull/3956))
 * Fixed the issue where the route line endpoint is ahead of user location indicator on short straight-line route step when `NavigationViewController.routeLineTracksTraversal` enabled in active navigation. ([#3992](https://github.com/mapbox/mapbox-navigation-ios/pull/3992))
 * Added the ability to provide duration and completion handler while visualizing routes using `NavigationMapView.showcase(_:animated:duration:completion:)`. ([#4022](https://github.com/mapbox/mapbox-navigation-ios/pull/4022))
-* Fixed the issue where the route line is removed after arrival but arrow is remained. ([#4040](https://github.com/mapbox/mapbox-navigation-ios/pull/4040))
+* Fixed an issue where the maneuver arrow is not removed after arriving to the final destination. ([#4040](https://github.com/mapbox/mapbox-navigation-ios/pull/4040))
 
 ### CarPlay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Each alternative route shown during turn-by-turn navigation is now annotated with the amount of time it saves or adds to the trip. To hide these annotations, set the `NavigationMapView.showsRelativeDurationOnContinuousAlternativeRoutes` property to `false`. ([#3956](https://github.com/mapbox/mapbox-navigation-ios/pull/3956))
 * Fixed the issue where the route line endpoint is ahead of user location indicator on short straight-line route step when `NavigationViewController.routeLineTracksTraversal` enabled in active navigation. ([#3992](https://github.com/mapbox/mapbox-navigation-ios/pull/3992))
 * Added the ability to provide duration and completion handler while visualizing routes using `NavigationMapView.showcase(_:animated:duration:completion:)`. ([#4022](https://github.com/mapbox/mapbox-navigation-ios/pull/4022))
+* Fixed the issue where the route line is removed after arrival but arrow is remained. ([#4040](https://github.com/mapbox/mapbox-navigation-ios/pull/4040))
 
 ### CarPlay
 

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -864,10 +864,14 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         let legIndex = progress.legIndex
         let nextStep = progress.currentLegProgress.stepIndex + 1
         
-        navigationMapView?.addArrow(route: progress.route, legIndex: legIndex, stepIndex: nextStep)
         navigationMapView?.updateRouteLine(routeProgress: progress,
                                            coordinate: navigationService.router.location?.coordinate,
                                            shouldRedraw: true)
+        if navigationMapView?.routes != nil {
+            navigationMapView?.addArrow(route: progress.route, legIndex: legIndex, stepIndex: nextStep)
+        } else {
+            navigationMapView?.removeArrow()
+        }
         navigationMapView?.showWaypoints(on: progress.route, legIndex: legIndex)
     }
     

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -63,6 +63,7 @@ extension NavigationMapView {
         guard !routeProgress.routeIsComplete else {
             removeRoutes()
             removeContinuousAlternativesRoutes()
+            removeArrow()
             return
         }
         

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -46,7 +46,8 @@ extension NavigationMapView {
             let currentLegProgress = router.routeProgress.currentLegProgress
             let nextStepIndex = currentLegProgress.stepIndex + 1
             
-            if nextStepIndex <= currentLegProgress.leg.steps.count {
+            if nextStepIndex <= currentLegProgress.leg.steps.count,
+               navigationMapView.routes != nil {
                 navigationMapView.addArrow(route: router.route, legIndex: router.routeProgress.legIndex, stepIndex: nextStepIndex)
             }
             

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -106,7 +106,8 @@ extension NavigationMapView {
         }
         
         private func updateMapOverlays(for routeProgress: RouteProgress) {
-            if routeProgress.currentLegProgress.followOnStep != nil {
+            if routeProgress.currentLegProgress.followOnStep != nil,
+               navigationMapView.routes != nil {
                 navigationMapView.addArrow(route: routeProgress.route,
                                            legIndex: routeProgress.legIndex,
                                            stepIndex: routeProgress.currentLegProgress.stepIndex + 1)


### PR DESCRIPTION
### Description
This Pr is to fix #4035 by removing arrow when the route line is removed after arrival. 

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
![arrivalArrow](https://user-images.githubusercontent.com/48976398/181838652-3f1fd293-48aa-45f9-af19-a9e3dc1f5077.png)

<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->