### PR TITLE
Use matched location from NN to calculate RouteProgress.distanceTraveled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 * Fixed an error when rerouting the user with `NavigationRouteOptions.profileIdentifier` set to `ProfileIdentifier.walking` or `ProfileIdentifier.cycling`. ([#4024](https://github.com/mapbox/mapbox-navigation-ios/pull/4024))
 * Fixed an issue where the user’s location continued to be snapped to a roadway even after the user’s course deviated significantly from that roadway, for example because the user was actually on a parallel road. ([#4012](https://github.com/mapbox/mapbox-navigation-ios/pull/4012))
+* Fixed an issue when `RouteController` didn't update `RouteProgress.distanceTraveled` property during simulation. ([#4043](https://github.com/mapbox/mapbox-navigation-ios/pull/4043))
 
 ### Other changes
 

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -433,7 +433,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
     }
     
     private func update(progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
-        progress.updateDistanceTraveled(with: rawLocation)
+        progress.updateDistanceTraveled(with: location)
         
         //Fire the delegate method
         delegate?.router(self, didUpdate: progress, with: location, rawLocation: rawLocation)

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -518,7 +518,7 @@ open class RouteController: NSObject {
     }
     
     private func update(progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation, upcomingRouteAlerts routeAlerts: [UpcomingRouteAlert], mapMatchingResult: MapMatchingResult) {
-        progress.updateDistanceTraveled(with: rawLocation)
+        progress.updateDistanceTraveled(with: location)
         progress.upcomingRouteAlerts = routeAlerts.map { RouteAlert($0) }
         
         //Fire the delegate method


### PR DESCRIPTION
### Description
When the device doesn't provide location updates (simulator, bad network, tunnels), NavigationNative's simulation kicks in. This resolves in situations when the raw location from the device may be outdated, while matched location is usable. Since UI is updated based on the location (puck, route line) we should keep the other info updated.

Fixes #4042. 

### Implementation
This PR changes the location used to calculate `RouteProgress`'s `distanceTraveled`, `distanceRemaining`, `durationRemaining`, `fractionTraveled` properties from raw to matched one. This could potentially affect some subsystems using `RouteProgress`.