### PR TITLE
Fill Incident properties from IncidentInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Added `ResumeButton.borderWidth`, `ResumeButton.cornerRadius` and `ResumeButton.borderColor` properties that allow `ResumeButton`'s style modification. ([#3996](https://github.com/mapbox/mapbox-navigation-ios/pull/3996))
 * Fixed a crash when dismissing `NavigationViewController`. ([#4029](https://github.com/mapbox/mapbox-navigation-ios/pull/4029))
 * Fixed an issue where `StyleManager` was not applying style on iPad. ([#4039](https://github.com/mapbox/mapbox-navigation-ios/pull/4039))
+* Added filling of `Incident` properties `countryCodeAlpha3`, `countryCode`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, `affectedRoadNames` when receiving `RoadObject` via Electronic Horizon. ([#4045](https://github.com/mapbox/mapbox-navigation-ios/pull/4045))
 
 ## v2.6.0
 

--- a/Sources/MapboxCoreNavigation/Incident.swift
+++ b/Sources/MapboxCoreNavigation/Incident.swift
@@ -33,7 +33,7 @@ extension Incident {
         @unknown default:
             fatalError("Unknown IncidentInfo type.")
         }
-        
+
         self.init(identifier: incidentInfo.id,
                   type: incidentType,
                   description: incidentInfo.description ?? "",
@@ -45,7 +45,15 @@ extension Incident {
                   subtypeDescription: incidentInfo.subTypeDescription,
                   alertCodes: Set(incidentInfo.alertcCodes.map { $0.intValue }),
                   lanesBlocked: BlockedLanes(descriptions: incidentInfo.lanesBlocked),
-                  shapeIndexRange: -1 ..< -1)
+                  shapeIndexRange: -1 ..< -1,
+                  countryCodeAlpha3: incidentInfo.iso_3166_1_alpha3,
+                  countryCode: incidentInfo.iso_3166_1_alpha2,
+                  roadIsClosed: incidentInfo.isRoadClosed,
+                  longDescription: incidentInfo.longDescription,
+                  numberOfBlockedLanes: incidentInfo.numLanesBlocked?.intValue,
+                  congestionLevel: incidentInfo.congestion?.value?.intValue,
+                  affectedRoadNames: incidentInfo.affectedRoadNames
+        )
     }
 }
 


### PR DESCRIPTION
### Description
Some `Incident` properties were not filled when received in `RoadObject` via electronic horizon.
This PR sets the corresponding properties during the construction of the `Incident` object.

### Implementation

`countryCodeAlpha3`, `countryCode`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, and `affectedRoadNames` properties were filled.

There are also `lanesClearDesc` and `openLR` properties that don't have a pair in the `Incident` object and its Directions API counterpart.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->