### PR TITLE
Simulation teleport fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Fixed an issue where `StyleManager` was not applying style on iPad. ([#4039](https://github.com/mapbox/mapbox-navigation-ios/pull/4039))
 * Added filling of `Incident` properties `countryCodeAlpha3`, `countryCode`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, `affectedRoadNames` when receiving `RoadObject` via Electronic Horizon. ([#4045](https://github.com/mapbox/mapbox-navigation-ios/pull/4045))
 * Fixes bearing calculation error during tunnel dead reckoning.
+* Fixed and issue where simulation `inTunnels` or `onPoorGPS` could teleport user puck to the route origin. ([#4058](https://github.com/mapbox/mapbox-navigation-ios/pull/4058))
 
 ## v2.6.0
 

--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -59,6 +59,9 @@ open class SimulatedLocationManager: NavigationLocationManager {
         self.currentSpeed = currentSpeed
         self.currentDistance = currentDistance
         self.route = route
+        if currentDistance != 0 {
+            self.remainingRouteShape = route.shape?.trimmed(from: currentDistance, to: LocationDistance.infinity)
+        }
 
         restartTimer()
         


### PR DESCRIPTION
### Description
Engaging route simulation by `inTunnels` or `onPoorGPS` may jump the user puck to the beginning of the route. This PR fixes the issue.

### Implementation
Added skipping the traversed distance of the shape when simulation is starting.