### PR TITLE
Add routing profile switcher to example application

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -100,7 +100,7 @@ class ViewController: UIViewController {
     
     weak var activeNavigationViewController: NavigationViewController?
     
-    var profileIdentifier: ProfileIdentifier? = .automobileAvoidingTraffic
+    var profileIdentifier: ProfileIdentifier = .automobileAvoidingTraffic
 
     // MARK: - Initializer methods
     
@@ -273,7 +273,19 @@ class ViewController: UIViewController {
     }
     
     private func presentActionsAlertController() {
-        let alertController = UIAlertController(title: "Start Navigation", message: "Select the navigation type", preferredStyle: .actionSheet)
+        var title: String?
+        switch profileIdentifier {
+        case .automobile, .automobileAvoidingTraffic:
+            title = "Start Driving"
+        case .cycling:
+            title = "Start Cycling"
+        case .walking:
+            title = "Start Walking"
+        default:
+            title = "Start Navigation"
+        }
+        
+        let alertController = UIAlertController(title: title, message: "Select the navigation type", preferredStyle: .actionSheet)
         
         let basic: ActionHandler = { _ in self.startBasicNavigation() }
         let day: ActionHandler = { _ in self.startNavigation(styles: [DayStyle()]) }
@@ -450,9 +462,10 @@ class ViewController: UIViewController {
         let toggleDayNightStyle: ActionHandler = { _ in self.toggleDayNightStyle() }
         let requestFollowCamera: ActionHandler = { _ in self.requestFollowCamera() }
         let requestIdleCamera: ActionHandler = { _ in self.requestIdleCamera() }
+        let requestAutoDirections: ActionHandler = { _ in self.requestAutoDirections() }
+        let requestAutoAvoidingTrafficDirections: ActionHandler = { _ in self.requestAutoAvoidingTrafficDirections() }
         let requestCyclingDirections: ActionHandler = { _ in self.requestCyclingDirections() }
         let requestWalkingDirections: ActionHandler = { _ in self.requestWalkingDirections() }
-        let requestAutoDirections: ActionHandler = { _ in self.requestAutoDirections() }
         let turnOnHistoryRecording: ActionHandler = { _ in self.turnOnHistoryRecording() }
         let turnOffHistoryRecording: ActionHandler = { _ in self.turnOffHistoryRecording() }
         
@@ -460,9 +473,10 @@ class ViewController: UIViewController {
             ("Toggle Day/Night Style", .default, toggleDayNightStyle),
             ("Request Following Camera", .default, requestFollowCamera),
             ("Request Idle Camera", .default, requestIdleCamera),
+            ("Request Auto Directions", .default, requestAutoDirections),
+            ("Request Auto Avoiding Traffic Directions", .default, requestAutoAvoidingTrafficDirections),
             ("Request Cycling Directions", .default, requestCyclingDirections),
             ("Request Walking Directions", .default, requestWalkingDirections),
-            ("Request Automobile Directions", .default, requestAutoDirections),
             ("Turn On History Recording", .default, turnOnHistoryRecording),
             ("Turn Off History Recording", .default, turnOffHistoryRecording),
             ("Cancel", .cancel, nil),
@@ -496,6 +510,11 @@ class ViewController: UIViewController {
     }
     
     func requestAutoDirections() {
+        profileIdentifier = .automobile
+        requestRoute()
+    }
+    
+    func requestAutoAvoidingTrafficDirections() {
         profileIdentifier = .automobileAvoidingTraffic
         requestRoute()
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -101,6 +101,10 @@ class ViewController: UIViewController {
     weak var activeNavigationViewController: NavigationViewController?
     
     var profileIdentifier: ProfileIdentifier = .automobileAvoidingTraffic
+    let drivingProfileText = NSLocalizedString("Start Driving", comment: "")
+    let drivingAvoidingTrafficProfileText = NSLocalizedString("Start Driving Avoiding Traffic", comment: "")
+    let cyclingProfileText = NSLocalizedString("Start Cycling", comment: "")
+    let walkingProfileText = NSLocalizedString("Start Walking", comment: "")
 
     // MARK: - Initializer methods
     
@@ -275,14 +279,16 @@ class ViewController: UIViewController {
     private func presentActionsAlertController() {
         var title: String?
         switch profileIdentifier {
-        case .automobile, .automobileAvoidingTraffic:
-            title = "Start Driving"
+        case .automobile:
+            title = drivingProfileText
+        case .automobileAvoidingTraffic:
+            title = drivingAvoidingTrafficProfileText
         case .cycling:
-            title = "Start Cycling"
+            title = cyclingProfileText
         case .walking:
-            title = "Start Walking"
+            title = walkingProfileText
         default:
-            title = "Start Navigation"
+            title = NSLocalizedString("Start Navigation", comment: "")
         }
         
         let alertController = UIAlertController(title: title, message: "Select the navigation type", preferredStyle: .actionSheet)
@@ -511,25 +517,25 @@ class ViewController: UIViewController {
     
     func requestAutoDirections() {
         profileIdentifier = .automobile
-        startButton.setTitle("Start Driving", for: .normal)
+        startButton.setTitle(drivingProfileText, for: .normal)
         requestRoute()
     }
     
     func requestAutoAvoidingTrafficDirections() {
         profileIdentifier = .automobileAvoidingTraffic
-        startButton.setTitle("Start Driving", for: .normal)
+        startButton.setTitle(drivingAvoidingTrafficProfileText, for: .normal)
         requestRoute()
     }
     
     func requestCyclingDirections() {
         profileIdentifier = .cycling
-        startButton.setTitle("Start Cycling", for: .normal)
+        startButton.setTitle(cyclingProfileText, for: .normal)
         requestRoute()
     }
 
     func requestWalkingDirections() {
         profileIdentifier = .walking
-        startButton.setTitle("Start Walking", for: .normal)
+        startButton.setTitle(walkingProfileText, for: .normal)
         requestRoute()
     }
     

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -511,21 +511,25 @@ class ViewController: UIViewController {
     
     func requestAutoDirections() {
         profileIdentifier = .automobile
+        startButton.setTitle("Start Driving", for: .normal)
         requestRoute()
     }
     
     func requestAutoAvoidingTrafficDirections() {
         profileIdentifier = .automobileAvoidingTraffic
+        startButton.setTitle("Start Driving", for: .normal)
         requestRoute()
     }
     
     func requestCyclingDirections() {
         profileIdentifier = .cycling
+        startButton.setTitle("Start Cycling", for: .normal)
         requestRoute()
     }
 
     func requestWalkingDirections() {
         profileIdentifier = .walking
+        startButton.setTitle("Start Walking", for: .normal)
         requestRoute()
     }
     

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -99,6 +99,8 @@ class ViewController: UIViewController {
     }
     
     weak var activeNavigationViewController: NavigationViewController?
+    
+    var profileIdentifier: ProfileIdentifier? = .automobileAvoidingTraffic
 
     // MARK: - Initializer methods
     
@@ -448,6 +450,9 @@ class ViewController: UIViewController {
         let toggleDayNightStyle: ActionHandler = { _ in self.toggleDayNightStyle() }
         let requestFollowCamera: ActionHandler = { _ in self.requestFollowCamera() }
         let requestIdleCamera: ActionHandler = { _ in self.requestIdleCamera() }
+        let requestCyclingDirections: ActionHandler = { _ in self.requestCyclingDirections() }
+        let requestWalkingDirections: ActionHandler = { _ in self.requestWalkingDirections() }
+        let requestAutoDirections: ActionHandler = { _ in self.requestAutoDirections() }
         let turnOnHistoryRecording: ActionHandler = { _ in self.turnOnHistoryRecording() }
         let turnOffHistoryRecording: ActionHandler = { _ in self.turnOffHistoryRecording() }
         
@@ -455,6 +460,9 @@ class ViewController: UIViewController {
             ("Toggle Day/Night Style", .default, toggleDayNightStyle),
             ("Request Following Camera", .default, requestFollowCamera),
             ("Request Idle Camera", .default, requestIdleCamera),
+            ("Request Cycling Directions", .default, requestCyclingDirections),
+            ("Request Walking Directions", .default, requestWalkingDirections),
+            ("Request Automobile Directions", .default, requestAutoDirections),
             ("Turn On History Recording", .default, turnOnHistoryRecording),
             ("Turn Off History Recording", .default, turnOffHistoryRecording),
             ("Cancel", .cancel, nil),
@@ -486,7 +494,22 @@ class ViewController: UIViewController {
     func requestIdleCamera() {
         navigationMapView.navigationCamera.stop()
     }
+    
+    func requestAutoDirections() {
+        profileIdentifier = .automobileAvoidingTraffic
+        requestRoute()
+    }
+    
+    func requestCyclingDirections() {
+        profileIdentifier = .cycling
+        requestRoute()
+    }
 
+    func requestWalkingDirections() {
+        profileIdentifier = .walking
+        requestRoute()
+    }
+    
     func turnOnHistoryRecording() {
         PassiveLocationManager.startRecordingHistory()
     }
@@ -519,7 +542,7 @@ class ViewController: UIViewController {
         }
         waypoints.insert(userWaypoint, at: 0)
 
-        let navigationRouteOptions = NavigationRouteOptions(waypoints: waypoints)
+        let navigationRouteOptions = NavigationRouteOptions(waypoints: waypoints, profileIdentifier: profileIdentifier)
         
         // Get periodic updates regarding changes in estimated arrival time and traffic congestion segments along the route line.
         RouteControllerProactiveReroutingInterval = 30


### PR DESCRIPTION
This PR fixes #4023 by adding three new actions to the gear button in the Example application to switch the routing profile between `.automobileAvoidingTraffic`, `.cycling`, and `.walking`. Users can switch the routing profile before or after a long press.

https://user-images.githubusercontent.com/43434254/183699638-da58775e-8c34-4f97-be2b-22a4a67c2f56.mp4


