### PR TITLE
Fix the route line layer position issue after rerouting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fixed an issue where the maneuver arrow on the route line overlapped labels for points of interest. ([#4030](https://github.com/mapbox/mapbox-navigation-ios/pull/4030))
 * Fixed an issue where `NavigationMapView` injected with `NavigationOptions` isn't visible in active navigation. ([#4049](https://github.com/mapbox/mapbox-navigation-ios/pull/4049)) 
 * Fixed the crash caused by showing a route that doesn't contain coordinates. ([#4046](https://github.com/mapbox/mapbox-navigation-ios/pull/4046))
+* Fixed an issue where the route line layer is above poi label. ([#4062](https://github.com/mapbox/mapbox-navigation-ios/pull/4062))
 
 ### CarPlay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Added `customActivityType` to `MapboxNavigationService` initialization to allow overriding default activity type for location updates during this navigation session. Changed default activity type from `automotiveNavigation` to `otherNavigation` for `.automobile` and `.automobileAvoidingTraffic` profiles.  ([#4068](https://github.com/mapbox/mapbox-navigation-ios/pull/4068))
 * Added `NavigationSettings.navigatorPredictionInterval` to control how far ahead Navigator will predict user current position. ([#4072](https://github.com/mapbox/mapbox-navigation-ios/pull/4072))
 
+### Map
+
+* Fixed an issue where the route line layer appears above point of interest labels. ([#4062](https://github.com/mapbox/mapbox-navigation-ios/pull/4062))
+
 ## 2.7.0
 
 ### Packaging
@@ -30,7 +34,6 @@
 * Fixed an issue where the maneuver arrow on the route line overlapped labels for points of interest. ([#4030](https://github.com/mapbox/mapbox-navigation-ios/pull/4030))
 * Fixed an issue where `NavigationMapView` injected with `NavigationOptions` isn't visible in active navigation. ([#4049](https://github.com/mapbox/mapbox-navigation-ios/pull/4049)) 
 * Fixed the crash caused by showing a route that doesn't contain coordinates. ([#4046](https://github.com/mapbox/mapbox-navigation-ios/pull/4046))
-* Fixed an issue where the route line layer appears above point of interest labels. ([#4062](https://github.com/mapbox/mapbox-navigation-ios/pull/4062))
 
 ### CarPlay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * Fixed an issue where the maneuver arrow on the route line overlapped labels for points of interest. ([#4030](https://github.com/mapbox/mapbox-navigation-ios/pull/4030))
 * Fixed an issue where `NavigationMapView` injected with `NavigationOptions` isn't visible in active navigation. ([#4049](https://github.com/mapbox/mapbox-navigation-ios/pull/4049)) 
 * Fixed the crash caused by showing a route that doesn't contain coordinates. ([#4046](https://github.com/mapbox/mapbox-navigation-ios/pull/4046))
-* Fixed an issue where the route line layer is above poi label. ([#4062](https://github.com/mapbox/mapbox-navigation-ios/pull/4062))
+* Fixed an issue where the route line layer appears above point of interest labels. ([#4062](https://github.com/mapbox/mapbox-navigation-ios/pull/4062))
 
 ### CarPlay
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -99,6 +99,15 @@ extension AppDelegate: CarPlayManagerDelegate {
         
         // Example of building highlighting in 3D.
         navigationViewController.waypointStyle = .extrudedBuilding
+        
+        guard let navigationMapView = navigationViewController.navigationMapView else { return }
+        // Provide the custom layer position for route line in active navigation.
+        let route = navigationViewController.navigationService.route
+        if navigationMapView.mapView.mapboxMap.style.layerExists(withId: "road-intersection") {
+            navigationMapView.show([route], layerPosition: .below("road-intersection") ,legIndex: 0)
+        } else {
+            navigationMapView.show([route], legIndex: 0)
+        }
     }
     
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager,

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -136,8 +136,6 @@ class CustomViewController: UIViewController {
         
         if routeProgress.legIndex != currentLegIndex {
             navigationMapView.showWaypoints(on: routeProgress.route, legIndex: routeProgress.legIndex)
-            navigationMapView.show([routeProgress.route], legIndex: routeProgress.legIndex)
-            currentLegIndex = routeProgress.legIndex
         }
         
         // Update the top banner with progress updates
@@ -150,7 +148,8 @@ class CustomViewController: UIViewController {
         // Update the main route line during active navigation when `NavigationMapView.routeLineTracksTraversal` set to `true`
         // and route progress change, by calling `NavigationMapView.updateRouteLine(routeProgress:coordinate:shouldRedraw:)`
         // without redrawing the main route.
-        navigationMapView.updateRouteLine(routeProgress: routeProgress, coordinate: location.coordinate)
+        navigationMapView.updateRouteLine(routeProgress: routeProgress, coordinate: location.coordinate, shouldRedraw: routeProgress.legIndex != currentLegIndex)
+        currentLegIndex = routeProgress.legIndex
     }
     
     @objc func updateInstructionsBanner(notification: NSNotification) {

--- a/Example/CustomViewController.swift
+++ b/Example/CustomViewController.swift
@@ -67,11 +67,16 @@ class CustomViewController: UIViewController {
         navigationService.start()
         
         navigationMapView.mapView.mapboxMap.onNext(event: .styleLoaded, handler: { [weak self] _ in
-            guard let route = self?.navigationService.route else { return }
+            guard let self = self else { return }
             // By setting the `NavigationMapView.routeLineTracksTraversal` to `true`, it would allow the main route shown with
             // traversed part disappearing effect in a standalone `NavigationMapView` during active navigation.
-            self?.navigationMapView.routeLineTracksTraversal = true
-            self?.navigationMapView.show([route], legIndex: 0)
+            self.navigationMapView.routeLineTracksTraversal = true
+            if self.navigationMapView.mapView.mapboxMap.style.layerExists(withId: "road-intersection") {
+                // Provide the custom layer position for route line in active navigation.
+                self.navigationMapView.show([self.navigationService.route], layerPosition: .below("road-intersection") ,legIndex: 0)
+            } else {
+                self.navigationMapView.show([self.navigationService.route], legIndex: 0)
+            }
         })
         
         // By default `NavigationViewportDataSource` tracks location changes from `PassiveLocationManager`, to consume

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -775,11 +775,10 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         
         if legIndex != currentLegIndexMapped {
             navigationMapView?.showWaypoints(on: routeProgress.route, legIndex: legIndex)
-            navigationMapView?.show([routeProgress.route], legIndex: legIndex)
-            currentLegIndexMapped = legIndex
         }
         
-        navigationMapView?.updateRouteLine(routeProgress: routeProgress, coordinate: location.coordinate)
+        navigationMapView?.updateRouteLine(routeProgress: routeProgress, coordinate: location.coordinate, shouldRedraw: legIndex != currentLegIndexMapped)
+        currentLegIndexMapped = legIndex
     }
     
     private func checkTunnelState(at location: CLLocation, along progress: RouteProgress) {

--- a/Sources/MapboxNavigation/NavigationMapView+ContinuousAlternatives.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+ContinuousAlternatives.swift
@@ -22,10 +22,7 @@ extension NavigationMapView {
         
         showContinuousAlternativeRoutesDurations()
         
-        guard let routes = self.routes,
-              !routes.isEmpty else { return }
-        
-        applyRoutesDisplay()
+        updateRouteLineWithRouteLineTracksTraversal()
     }
     
     func removeContinuousAlternativesRoutesLayers() {

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -445,7 +445,7 @@ extension NavigationMapView {
     func routeLineRestrictionsGradient(_ restrictionFeatures: [Turf.Feature]) -> [Double: UIColor] {
         // If there's no restricted feature, hide the restricted route line layer.
         guard restrictionFeatures.count > 0 else {
-            let gradientStops: [Double: UIColor] = [0.0: traversedRouteColor]
+            let gradientStops: [Double: UIColor] = [0.0: .defaultTraversedRouteColor]
             return gradientStops
         }
         

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -56,7 +56,7 @@ extension NavigationMapView {
      */
     public func updateRouteLine(routeProgress: RouteProgress, coordinate: CLLocationCoordinate2D?, shouldRedraw: Bool = false) {
         if shouldRedraw {
-            show([routeProgress.route], legIndex: routeProgress.legIndex)
+            show([routeProgress.route], layerPosition: customRouteLineLayerPosition, legIndex: routeProgress.legIndex)
         }
         
         guard routeLineTracksTraversal && routes != nil else { return }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1803,6 +1803,11 @@ open class NavigationMapView: UIView {
                    layerInfo.type.rawValue != "symbol",
                    let sourceLayer = mapView.mapboxMap.style.layerProperty(for: layerInfo.id, property: "source-layer").value as? String,
                    !sourceLayer.isEmpty {
+                    if layerInfo.type.rawValue == "circle",
+                       let isPersistentCircle = try? mapView.mapboxMap.style.isPersistentLayer(id: layerInfo.id),
+                       !isPersistentCircle {
+                        continue
+                    }
                     targetLayer = layerInfo.id
                 }
             } else if isAboveRoadLayer {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -487,7 +487,7 @@ open class NavigationMapView: UIView {
                     arrowSymbolLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     arrowSymbolCasingLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     
-                    let layerPosition = layerPosition(for: NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer, route: route)
+                    let layerPosition = layerPosition(for: NavigationMapView.LayerIdentifier.arrowSymbolLayer, route: route)
                     try mapView.mapboxMap.style.addPersistentLayer(arrowSymbolLayer, layerPosition: layerPosition)
                     try mapView.mapboxMap.style.addPersistentLayer(arrowSymbolCasingLayer,
                                                                    layerPosition: .below(NavigationMapView.LayerIdentifier.arrowSymbolLayer))
@@ -1787,11 +1787,14 @@ open class NavigationMapView: UIView {
             }
         }
         
+        var foundAboveLayer: Bool = false
         for layerInfo in mapView.mapboxMap.style.allLayerIdentifiers.reversed() {
             if lowerLayers.contains(layerInfo.id) {
                 // find the topmost layer that should be below the layerIdentifier.
-                layerPosition = .above(layerInfo.id)
-                break
+                if !foundAboveLayer {
+                    layerPosition = .above(layerInfo.id)
+                    foundAboveLayer = true
+                }
             } else if upperLayers.contains(layerInfo.id) {
                 // find the bottommost layer that should be above the layerIdentifier.
                 layerPosition = .below(layerInfo.id)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -140,6 +140,11 @@ open class NavigationMapView: UIView {
      */
     var pendingCoordinateForRouteLine: CLLocationCoordinate2D?
     
+    /**
+     A custom route line layer position.
+     */
+    var customRouteLineLayerPosition: MapboxMaps.LayerPosition? = nil
+    
     var showsRoute: Bool {
         get {
             guard let mainRouteLayerIdentifier = routes?.first?.identifier(.route(isMainRoute: true)),
@@ -163,7 +168,7 @@ open class NavigationMapView: UIView {
     func updateRouteLineWithRouteLineTracksTraversal() {
         if let routes = self.routes {
             let offset = fractionTraveled
-            show(routes, legIndex: currentLegIndex)
+            show(routes, layerPosition: customRouteLineLayerPosition, legIndex: currentLegIndex)
             if let route = routes.first, routeLineTracksTraversal {
                 updateRouteLineOffset(along: route, offset: offset)
             }
@@ -212,9 +217,9 @@ open class NavigationMapView: UIView {
         
         switch routesPresentationStyle {
         case .single:
-            show([activeRoute])
+            show([activeRoute], layerPosition: customRouteLineLayerPosition)
         case .all:
-            show(routes)
+            show(routes, layerPosition: customRouteLineLayerPosition)
         }
         
         showWaypoints(on: activeRoute)
@@ -256,6 +261,7 @@ open class NavigationMapView: UIView {
         
         self.routes = routes
         currentLegIndex = legIndex
+        customRouteLineLayerPosition = layerPosition
         
         applyRoutesDisplay(layerPosition: layerPosition)
     }
@@ -528,7 +534,7 @@ open class NavigationMapView: UIView {
     func removeLineGradientStops() {
         fractionTraveled = 0.0
         if let routes = self.routes {
-            show(routes, legIndex: currentLegIndex)
+            show(routes, layerPosition: customRouteLineLayerPosition, legIndex: currentLegIndex)
         }
         
         routePoints = nil
@@ -1793,7 +1799,7 @@ open class NavigationMapView: UIView {
                 // find the topmost non symbol layer for layerIdentifier in lowermostSymbolLayers.
                 if targetLayer == nil,
                    layerInfo.type.rawValue != "symbol",
-                   !layerInfo.id.contains("copy"),
+                   !layerInfo.id.contains("label"),
                    let sourceLayer = mapView.mapboxMap.style.layerProperty(for: layerInfo.id, property: "source-layer").value as? String,
                    !sourceLayer.isEmpty {
                     targetLayer = layerInfo.id

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1799,7 +1799,6 @@ open class NavigationMapView: UIView {
                 // find the topmost non symbol layer for layerIdentifier in lowermostSymbolLayers.
                 if targetLayer == nil,
                    layerInfo.type.rawValue != "symbol",
-                   !layerInfo.id.contains("label"),
                    let sourceLayer = mapView.mapboxMap.style.layerProperty(for: layerInfo.id, property: "source-layer").value as? String,
                    !sourceLayer.isEmpty {
                     targetLayer = layerInfo.id

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -487,8 +487,7 @@ open class NavigationMapView: UIView {
                     arrowSymbolLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     arrowSymbolCasingLayer.source = NavigationMapView.SourceIdentifier.arrowSymbolSource
                     
-                    let layerPosition = layerPosition(for: NavigationMapView.LayerIdentifier.arrowSymbolLayer, route: route)
-                    try mapView.mapboxMap.style.addPersistentLayer(arrowSymbolLayer, layerPosition: layerPosition)
+                    try mapView.mapboxMap.style.addPersistentLayer(arrowSymbolLayer, layerPosition: .above(NavigationMapView.LayerIdentifier.arrowLayer))
                     try mapView.mapboxMap.style.addPersistentLayer(arrowSymbolCasingLayer,
                                                                    layerPosition: .below(NavigationMapView.LayerIdentifier.arrowSymbolLayer))
                 }

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -252,6 +252,7 @@ open class NavigationMapView: UIView {
                      layerPosition: MapboxMaps.LayerPosition? = nil,
                      legIndex: Int? = nil) {
         removeRoutes()
+        removeContinuousAlternativesRoutesLayers()
         
         self.routes = routes
         currentLegIndex = legIndex
@@ -685,7 +686,7 @@ open class NavigationMapView: UIView {
                 // In case if custom layer position was set - use it, otherwise in case if the route
                 // is the main one place it above `MapView.mainRouteLineParentLayerIdentifier`. All
                 // other alternative routes will be placed below it.
-                if let belowLayerIdentifier = parentLayerIndentifier {
+                if let belowLayerIdentifier = parentLayerIndentifier, mapView.mapboxMap.style.layerExists(withId: belowLayerIdentifier) {
                     layerPosition = .below(belowLayerIdentifier)
                 } else {
                     layerPosition = self.layerPosition(for: layerIdentifier, route: route, customLayerPosition: customLayerPosition)
@@ -760,7 +761,7 @@ open class NavigationMapView: UIView {
         if let lineLayer = lineLayer {
             do {
                 var layerPosition: MapboxMaps.LayerPosition? = nil
-                if let parentLayerIndentifier = parentLayerIndentifier {
+                if let parentLayerIndentifier = parentLayerIndentifier, mapView.mapboxMap.style.layerExists(withId: parentLayerIndentifier) {
                     layerPosition = .below(parentLayerIndentifier)
                 } else {
                     layerPosition = self.layerPosition(for: layerIdentifier, route: route)
@@ -1792,6 +1793,7 @@ open class NavigationMapView: UIView {
                 // find the topmost non symbol layer for layerIdentifier in lowermostSymbolLayers.
                 if targetLayer == nil,
                    layerInfo.type.rawValue != "symbol",
+                   !layerInfo.id.contains("copy"),
                    let sourceLayer = mapView.mapboxMap.style.layerProperty(for: layerInfo.id, property: "source-layer").value as? String,
                    !sourceLayer.isEmpty {
                     targetLayer = layerInfo.id

--- a/Sources/MapboxNavigation/RouteLineController.swift
+++ b/Sources/MapboxNavigation/RouteLineController.swift
@@ -90,8 +90,6 @@ extension NavigationMapView {
             navigationMapView.updatePreferredFrameRate(for: progress)
             if currentLegIndexMapped != legIndex {
                 navigationMapView.showWaypoints(on: route, legIndex: legIndex)
-                navigationMapView.show([route], legIndex: legIndex)
-                currentLegIndexMapped = legIndex
             }
             
             if currentStepIndexMapped != stepIndex {
@@ -103,7 +101,8 @@ extension NavigationMapView {
                 navigationMapView.showVoiceInstructionsOnMap(route: route)
             }
             
-            navigationMapView.updateRouteLine(routeProgress: progress, coordinate: location.coordinate)
+            navigationMapView.updateRouteLine(routeProgress: progress, coordinate: location.coordinate, shouldRedraw: currentLegIndexMapped != legIndex)
+            currentLegIndexMapped = legIndex
         }
         
         private func updateMapOverlays(for routeProgress: RouteProgress) {

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -621,6 +621,18 @@ class NavigationMapViewTests: TestCase {
             "source": "composite",
             "source-layer": "road-exit"
         ]
+        let poiLabelLayer: [String: String] = [
+            "id": "poi-label",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "poi"
+        ]
+        let poiLabelCircleLayer: [String: String] = [
+            "id": "poi-label copy",
+            "type": "circle",
+            "source": "composite",
+            "source-layer": "poi"
+        ]
         
         let styleJSONObject: [String: Any] = [
             "version": 8,
@@ -641,7 +653,9 @@ class NavigationMapViewTests: TestCase {
             "layers": [
                 buildingLayer,
                 roadLabelLayer,
-                roadExitLayer
+                roadExitLayer,
+                poiLabelLayer,
+                poiLabelCircleLayer
             ]
         ]
         
@@ -676,6 +690,8 @@ class NavigationMapViewTests: TestCase {
             NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer,
             NavigationMapView.LayerIdentifier.arrowSymbolLayer,
             roadExitLayer["id"]!,
+            poiLabelLayer["id"]!,
+            poiLabelCircleLayer["id"]!,
             NavigationMapView.LayerIdentifier.waypointCircleLayer,
             NavigationMapView.LayerIdentifier.waypointSymbolLayer
         ]
@@ -684,6 +700,7 @@ class NavigationMapViewTests: TestCase {
         navigationMapView.removeWaypoints()
         navigationMapView.addArrow(route: multilegRoute, legIndex: 0, stepIndex: 0)
         navigationMapView.showsRestrictedAreasOnRoute = false
+        navigationMapView.show(continuousAlternatives: [])
         
         allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
         expectedLayerSequence = [
@@ -695,7 +712,9 @@ class NavigationMapViewTests: TestCase {
             NavigationMapView.LayerIdentifier.arrowLayer,
             NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer,
             NavigationMapView.LayerIdentifier.arrowSymbolLayer,
-            roadExitLayer["id"]!
+            roadExitLayer["id"]!,
+            poiLabelLayer["id"]!,
+            poiLabelCircleLayer["id"]!
         ]
         XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to add layers in sequence.")
     }

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -633,12 +633,6 @@ class NavigationMapViewTests: TestCase {
             "source": "composite",
             "source-layer": "poi"
         ]
-        let poiLabelCircleLayer: [String: String] = [
-            "id": "poi-label copy",
-            "type": "circle",
-            "source": "composite",
-            "source-layer": "poi"
-        ]
         
         let styleJSONObject: [String: Any] = [
             "version": 8,
@@ -661,8 +655,7 @@ class NavigationMapViewTests: TestCase {
                 roadTrafficLayer,
                 roadLabelLayer,
                 roadExitLayer,
-                poiLabelLayer,
-                poiLabelCircleLayer
+                poiLabelLayer
             ]
         ]
         
@@ -699,7 +692,6 @@ class NavigationMapViewTests: TestCase {
             NavigationMapView.LayerIdentifier.arrowSymbolLayer,
             roadExitLayer["id"]!,
             poiLabelLayer["id"]!,
-            poiLabelCircleLayer["id"]!,
             NavigationMapView.LayerIdentifier.waypointCircleLayer,
             NavigationMapView.LayerIdentifier.waypointSymbolLayer
         ]
@@ -722,8 +714,7 @@ class NavigationMapViewTests: TestCase {
             NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer,
             NavigationMapView.LayerIdentifier.arrowSymbolLayer,
             roadExitLayer["id"]!,
-            poiLabelLayer["id"]!,
-            poiLabelCircleLayer["id"]!
+            poiLabelLayer["id"]!
         ]
         allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
         XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to apply custom layer position for route line.")

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -633,6 +633,12 @@ class NavigationMapViewTests: TestCase {
             "source": "composite",
             "source-layer": "poi"
         ]
+        let poiLabelCircleLayer: [String: String] = [
+            "id": "poi-label copy",
+            "type": "circle",
+            "source": "composite",
+            "source-layer": "poi"
+        ]
         
         let styleJSONObject: [String: Any] = [
             "version": 8,
@@ -655,7 +661,8 @@ class NavigationMapViewTests: TestCase {
                 roadTrafficLayer,
                 roadLabelLayer,
                 roadExitLayer,
-                poiLabelLayer
+                poiLabelLayer,
+                poiLabelCircleLayer
             ]
         ]
         
@@ -682,9 +689,6 @@ class NavigationMapViewTests: TestCase {
         var expectedLayerSequence = [
             buildingLayer["id"]!,
             roadTrafficLayer["id"]!,
-            multilegRoute.identifier(.routeCasing(isMainRoute: true)),
-            multilegRoute.identifier(.route(isMainRoute: true)),
-            multilegRoute.identifier(.restrictedRouteAreaRoute),
             roadLabelLayer["id"]!,
             NavigationMapView.LayerIdentifier.arrowStrokeLayer,
             NavigationMapView.LayerIdentifier.arrowLayer,
@@ -692,10 +696,14 @@ class NavigationMapViewTests: TestCase {
             NavigationMapView.LayerIdentifier.arrowSymbolLayer,
             roadExitLayer["id"]!,
             poiLabelLayer["id"]!,
+            poiLabelCircleLayer["id"]!,
             NavigationMapView.LayerIdentifier.waypointCircleLayer,
-            NavigationMapView.LayerIdentifier.waypointSymbolLayer
+            NavigationMapView.LayerIdentifier.waypointSymbolLayer,
+            multilegRoute.identifier(.routeCasing(isMainRoute: true)),
+            multilegRoute.identifier(.route(isMainRoute: true)),
+            multilegRoute.identifier(.restrictedRouteAreaRoute)
         ]
-        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to add layers in sequence.")
+        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to add route line layers at topmost when copy layer existed.")
         
         // When custom layer position for route line provided, use the custom layer position.
         let customRouteLineLayerPosition = MapboxMaps.LayerPosition.below("road-traffic")
@@ -714,7 +722,8 @@ class NavigationMapViewTests: TestCase {
             NavigationMapView.LayerIdentifier.arrowSymbolCasingLayer,
             NavigationMapView.LayerIdentifier.arrowSymbolLayer,
             roadExitLayer["id"]!,
-            poiLabelLayer["id"]!
+            poiLabelLayer["id"]!,
+            poiLabelCircleLayer["id"]!
         ]
         allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
         XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to apply custom layer position for route line.")

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -689,6 +689,9 @@ class NavigationMapViewTests: TestCase {
         var expectedLayerSequence = [
             buildingLayer["id"]!,
             roadTrafficLayer["id"]!,
+            multilegRoute.identifier(.routeCasing(isMainRoute: true)),
+            multilegRoute.identifier(.route(isMainRoute: true)),
+            multilegRoute.identifier(.restrictedRouteAreaRoute),
             roadLabelLayer["id"]!,
             NavigationMapView.LayerIdentifier.arrowStrokeLayer,
             NavigationMapView.LayerIdentifier.arrowLayer,
@@ -698,12 +701,9 @@ class NavigationMapViewTests: TestCase {
             poiLabelLayer["id"]!,
             poiLabelCircleLayer["id"]!,
             NavigationMapView.LayerIdentifier.waypointCircleLayer,
-            NavigationMapView.LayerIdentifier.waypointSymbolLayer,
-            multilegRoute.identifier(.routeCasing(isMainRoute: true)),
-            multilegRoute.identifier(.route(isMainRoute: true)),
-            multilegRoute.identifier(.restrictedRouteAreaRoute)
+            NavigationMapView.LayerIdentifier.waypointSymbolLayer
         ]
-        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to add route line layers at topmost when copy layer existed.")
+        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to add route line layers below bottommost symbol layer.")
         
         // When custom layer position for route line provided, use the custom layer position.
         let customRouteLineLayerPosition = MapboxMaps.LayerPosition.below("road-traffic")
@@ -731,6 +731,6 @@ class NavigationMapViewTests: TestCase {
         navigationMapView.addArrow(route: multilegRoute, legIndex: 0, stepIndex: 0)
         navigationMapView.show(continuousAlternatives: [])
         allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
-        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to keep layer positions.")
+        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to keep layer positions in active navigation.")
     }
 }

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -609,6 +609,12 @@ class NavigationMapViewTests: TestCase {
             "source": "composite",
             "source-layer": "building"
         ]
+        let roadTrafficLayer: [String: String] = [
+            "id": "road-traffic",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "road"
+        ]
         let roadLabelLayer: [String: String] = [
             "id": "road-label",
             "type": "symbol",
@@ -652,6 +658,7 @@ class NavigationMapViewTests: TestCase {
             ],
             "layers": [
                 buildingLayer,
+                roadTrafficLayer,
                 roadLabelLayer,
                 roadExitLayer,
                 poiLabelLayer,
@@ -681,6 +688,7 @@ class NavigationMapViewTests: TestCase {
         var allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
         var expectedLayerSequence = [
             buildingLayer["id"]!,
+            roadTrafficLayer["id"]!,
             multilegRoute.identifier(.routeCasing(isMainRoute: true)),
             multilegRoute.identifier(.route(isMainRoute: true)),
             multilegRoute.identifier(.restrictedRouteAreaRoute),
@@ -697,16 +705,17 @@ class NavigationMapViewTests: TestCase {
         ]
         XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to add layers in sequence.")
         
+        // When custom layer position for route line provided, use the custom layer position.
+        let customRouteLineLayerPosition = MapboxMaps.LayerPosition.below("road-traffic")
+        navigationMapView.show([multilegRoute], layerPosition: customRouteLineLayerPosition)
         navigationMapView.removeWaypoints()
-        navigationMapView.addArrow(route: multilegRoute, legIndex: 0, stepIndex: 0)
         navigationMapView.showsRestrictedAreasOnRoute = false
-        navigationMapView.show(continuousAlternatives: [])
         
-        allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
         expectedLayerSequence = [
             buildingLayer["id"]!,
             multilegRoute.identifier(.routeCasing(isMainRoute: true)),
             multilegRoute.identifier(.route(isMainRoute: true)),
+            roadTrafficLayer["id"]!,
             roadLabelLayer["id"]!,
             NavigationMapView.LayerIdentifier.arrowStrokeLayer,
             NavigationMapView.LayerIdentifier.arrowLayer,
@@ -716,6 +725,12 @@ class NavigationMapViewTests: TestCase {
             poiLabelLayer["id"]!,
             poiLabelCircleLayer["id"]!
         ]
-        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to add layers in sequence.")
+        allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
+        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to apply custom layer position for route line.")
+        
+        navigationMapView.addArrow(route: multilegRoute, legIndex: 0, stepIndex: 0)
+        navigationMapView.show(continuousAlternatives: [])
+        allLayerIds = navigationMapView.mapView.mapboxMap.style.allLayerIdentifiers.map({ $0.id })
+        XCTAssertEqual(allLayerIds, expectedLayerSequence, "Failed to keep layer positions.")
     }
 }


### PR DESCRIPTION
### Description
This Pr is to fix the issue of route line layer position issue after rerouting. 

### Implementation
1. When finding the topmost non-symbol layer for route line, explicit check whether the layer is the `label` layer .  During style loading, some `label` layers exist above symbol layers, such as `poi label copy` as a `circle layer` but above the symbol layer of `poi label`. So it will cause the `NavigationMapView.layerPosition(for:route:customLayerPosition:)` found the wrong topmost non-symbol layer, especially for route line.
2. When adding casing layer and alternative route layer, check whether the parent layer added to the style already.
3. When adding route line layers, remove all the continuous alternative route layers first.
4. Added test for the custom layer position of route line and the non-symbol label layer .

### Use cases
Call `NavigationMapView.show(_:layerPosition:legIndex:)` to provide custom layer position for route line in both CarPlay and mobile. 
During active navigation, when alternative routes update, call `NavigationMapView.show(continuousAlternatives:)`. When `reroute`, `refresh`, `routeProgress` update, call `NavigationMapView.updateRouteLine(routeProgress:coordinate:shouldRedraw:)`. They will keep the custom layer position for route line in both mobile and CarPlay.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
6. Update progress status on the project board.
7. Request a review from the team, if not a draft.
8. Add targeted milestone, when applicable.
9. Create ticket tracking addition of public documentation pages entry, when applicable.
10. Update Changelog.
11. Rebase onto main from the branch before merge.
-->