### PR TITLE
RouteOptions activityType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## main
+
+### Location Tracking
+
+* Exposed `RouteOptions.activityType` for subclassing which controls the location manager's activity type. Changed it's default value from `automotiveNavigation` to `otherNavigation`. ([#4068](https://github.com/mapbox/mapbox-navigation-ios/pull/4068))
+
 ## 2.7.0
 
 ### Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Location Tracking
 
-* Exposed `RouteOptions.activityType` for subclassing which controls the location manager's activity type. Changed it's default value from `automotiveNavigation` to `otherNavigation`. ([#4068](https://github.com/mapbox/mapbox-navigation-ios/pull/4068))
+* Added `customActivityType` to `MapboxNavigationService` initialization to allow overriding default activity type for location updates during this navigation session. Changed default activity type from `automotiveNavigation` to `otherNavigation` for `.automobile` and `.automobileAvoidingTraffic` profiles.  ([#4068](https://github.com/mapbox/mapbox-navigation-ios/pull/4068))
 
 ## 2.7.0
 

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -317,7 +317,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
+    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -350,7 +350,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:)")
+    @available(*, deprecated, renamed: "init(routeResponse:routeIndex:routeOptions:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -382,6 +382,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
+     - parameter customActivityType: Custom `CLActivityType` to be used for location updates. If not specified, SDK will pick it automatically for current navigation profile.
      */
     required public init(routeResponse: RouteResponse,
                          routeIndex: Int,
@@ -391,7 +392,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                          locationSource: NavigationLocationManager? = nil,
                          eventsManagerType: NavigationEventsManager.Type? = nil,
                          simulating simulationMode: SimulationMode? = nil,
-                         routerType: Router.Type? = nil) {
+                         routerType: Router.Type? = nil,
+                         customActivityType: CLActivityType? = nil) {
         nativeLocationSource = locationSource ?? NavigationLocationManager()
         self.credentials = credentials
         self.simulationMode = simulationMode ?? .inTunnels
@@ -416,7 +418,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         let eventType = eventsManagerType ?? NavigationEventsManager.self
         _eventsManager = eventType.init(activeNavigationDataSource: self,
                                         accessToken: self.credentials.accessToken)
-        locationManager.activityType = routeOptions.activityType
+        locationManager.activityType = customActivityType ?? routeOptions.activityType
         bootstrapEvents()
         
         router.delegate = self

--- a/Sources/MapboxCoreNavigation/RouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/RouteOptions.swift
@@ -7,7 +7,7 @@ extension RouteOptions {
      
      SDK configures this value judging by `profileIdentifier`. You can subclass and override this property if needed.
      */
-    open var activityType: CLActivityType {
+    @objc open var activityType: CLActivityType {
         switch self.profileIdentifier {
         case .cycling, .walking:
             return .fitness

--- a/Sources/MapboxCoreNavigation/RouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/RouteOptions.swift
@@ -2,12 +2,17 @@ import CoreLocation
 import MapboxDirections
 
 extension RouteOptions {
-    internal var activityType: CLActivityType {
+    /**
+     The type of user activity associated with the location updates.
+     
+     SDK configures this value judging by `profileIdentifier`. You can subclass and override this property if needed.
+     */
+    open var activityType: CLActivityType {
         switch self.profileIdentifier {
         case .cycling, .walking:
             return .fitness
         default:
-            return .automotiveNavigation
+            return .otherNavigation
         }
     }
     

--- a/Sources/MapboxCoreNavigation/RouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/RouteOptions.swift
@@ -2,12 +2,7 @@ import CoreLocation
 import MapboxDirections
 
 extension RouteOptions {
-    /**
-     The type of user activity associated with the location updates.
-     
-     SDK configures this value judging by `profileIdentifier`. You can subclass and override this property if needed.
-     */
-    @objc open var activityType: CLActivityType {
+    internal var activityType: CLActivityType {
         switch self.profileIdentifier {
         case .cycling, .walking:
             return .fitness


### PR DESCRIPTION
### Description
We found that `otherNavigation` activity type produces better GPS data in comparison to `automotiveNavigation` we used previously, with just marginally bigger battery consumptions. So we've decided to update the default value and expose a clear path for customizing it by anyone who still prefers `automotiveNavigation` or any other type.

### Implementation
Exposed `RouteOptions.activityType` `open`; changed default value to `otherNavigation`