### PR TITLE
Constraint the following distance after current maneuver for camera.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Fixed an issue where `StyleManager` was not applying style on iPad. ([#4039](https://github.com/mapbox/mapbox-navigation-ios/pull/4039))
 * Added filling of `Incident` properties `countryCodeAlpha3`, `countryCode`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, `affectedRoadNames` when receiving `RoadObject` via Electronic Horizon. ([#4045](https://github.com/mapbox/mapbox-navigation-ios/pull/4045))
 * Fixed and issue where simulation `inTunnels` or `onPoorGPS` could teleport user puck to the route origin. ([#4058](https://github.com/mapbox/mapbox-navigation-ios/pull/4058))
+* Fixed and inssue where the user location indicator moves out of view when approaching complex intersections. ([#4070](https://github.com/mapbox/mapbox-navigation-ios/pull/4070))
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@
 * Fixed a crash when dismissing `NavigationViewController`. ([#4029](https://github.com/mapbox/mapbox-navigation-ios/pull/4029))
 * Fixed an issue where `StyleManager` was not applying style on iPad. ([#4039](https://github.com/mapbox/mapbox-navigation-ios/pull/4039))
 * Added filling of `Incident` properties `countryCodeAlpha3`, `countryCode`, `roadIsClosed`, `longDescription`, `numberOfBlockedLanes`, `congestionLevel`, `affectedRoadNames` when receiving `RoadObject` via Electronic Horizon. ([#4045](https://github.com/mapbox/mapbox-navigation-ios/pull/4045))
-* Fixed and issue where simulation `inTunnels` or `onPoorGPS` could teleport user puck to the route origin. ([#4058](https://github.com/mapbox/mapbox-navigation-ios/pull/4058))
-* Fixed and inssue where the user location indicator moves out of view when approaching complex intersections. ([#4070](https://github.com/mapbox/mapbox-navigation-ios/pull/4070))
+* Fixed an issue where simulation `inTunnels` or `onPoorGPS` could teleport user puck to the route origin. ([#4058](https://github.com/mapbox/mapbox-navigation-ios/pull/4058))
+* Fixed an issue where the user location indicator moves out of view when approaching complex intersections. ([#4070](https://github.com/mapbox/mapbox-navigation-ios/pull/4070))
 
 ## v2.6.0
 


### PR DESCRIPTION
### Description
This Pr is to fix the overlooking issue when approaching complex intersections and the user location indicator may be out of view frame.

### Implementation
When approaching complex intersections, we have the `GeometryFramingAfterManeuver` to provide the distance to extend current camera view.

- After current step, if the next step distance is smaller than `GeometryFramingAfterManeuver.distanceToFrameAfterManeuver`, the next step will be included. Other wise, the trimmed next step within the `distanceToFrameAfterManeuver` will be included. And further following steps won't be included.
- After next step, if the total distance included is smaller than the `GeometryFramingAfterManeuver.distanceToCoalesceCompoundManeuvers`, the whole step or the trimmed step will be included until the total distance reach the `GeometryFramingAfterManeuver.distanceToCoalesceCompoundManeuvers` limit.

### Screenshots or Gifs
Test in location at  `53.965999, 27.654109` to the location `53.962892, 27.660161` through the roundabout.
Before the fix, the overlooking distance is too long when approaching complex intersections, it will cause the user location indicator moving out of view.
![pre](https://user-images.githubusercontent.com/48976398/184028483-505c5818-8fa4-496e-952f-ab8d72fa09d0.gif)

After the fix, constraint the total overlooking distance for next step to `GeometryFramingAfterManeuver.distanceToFrameAfterManeuver`, and the total distance for following steps to  `GeometryFramingAfterManeuver.distanceToCoalesceCompoundManeuvers`, the user location indicator won't be too far from the camera center.
![after](https://user-images.githubusercontent.com/48976398/184028627-ba18599d-5d9b-4e8a-9968-4cddae944190.gif)

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->