### PR TITLE
Disable Metal based tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -700,14 +700,15 @@ workflows:
           requires:
             - "Get old API logs"
             - "Get new API logs"
-  test-host-workflow:
-    jobs:
-      - spm-test-host-job:
-          name: "swift test; Xcode 13.4.1; iOS 15.5"
-          xcode: "13.4.1"
-          iOS: "15.5"
-          device: "iPhone 13"
-          context: Slack Orb
+  # FIXME: Temporarily disabled, failing tests that are executed with MapboxNavigationTestHost should be fixed.
+  # test-host-workflow:
+  #   jobs:
+  #     - spm-test-host-job:
+  #         name: "swift test; Xcode 13.4.1; iOS 15.5"
+  #         xcode: "13.4.1"
+  #         iOS: "15.5"
+  #         device: "iPhone 13"
+  #         context: Slack Orb
   main-workflow:
       jobs:
         - build-job:


### PR DESCRIPTION
### Description

Temporarily disable tests that are based on Metal renderer and `MapboxNavigationTestHost` application.