### PR TITLE
Navigation prediction interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Location Tracking
 
 * Added `customActivityType` to `MapboxNavigationService` initialization to allow overriding default activity type for location updates during this navigation session. Changed default activity type from `automotiveNavigation` to `otherNavigation` for `.automobile` and `.automobileAvoidingTraffic` profiles.  ([#4068](https://github.com/mapbox/mapbox-navigation-ios/pull/4068))
+* Added `NavigationSettings.navigatorPredictionInterval` to control how far ahead Navigator will predict user current position. ([#4072](https://github.com/mapbox/mapbox-navigation-ios/pull/4072))
 
 ## 2.7.0
 

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -104,7 +104,11 @@ class NativeHandlersFactory {
     static var navigatorConfig: NavigatorConfig {
         return NavigatorConfig(voiceInstructionThreshold: nil,
                                electronicHorizonOptions: nil,
-                               polling: nil,
+                               polling: NavigationSettings.shared.navigatorPredictionInterval.map {
+                                    PollingConfig(lookAhead: NSNumber(value: $0),
+                                                  unconditionalPatience: nil,
+                                                  unconditionalInterval: nil)
+                                },
                                incidentsOptions: nil,
                                noSignalSimulationEnabled: nil,
                                avoidManeuverSeconds: NSNumber(value: RerouteController.DefaultManeuverAvoidanceRadius),

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -119,7 +119,9 @@ public class NavigationSettings {
     /**
      Defines approximate navigator prediction between location ticks.
      
-     If not specified, default value will be used.
+     Due to discrete location updates, Navigator always operates data "in the past" so it has to make prediction about user's current real position. This interval controls how far ahead Navigator will try to predict user location.
+     
+     If not specified (`nilled`), default value will be used.
      
      You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
      */

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -14,7 +14,7 @@ public typealias RoutingProviderSource = MapboxRoutingProvider.Source
  To customize the user experience during a particular turn-by-turn navigation session, use the `NavigationOptions` class
  when initializing a `NavigationViewController`.
 
- To customize some global defaults use `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:)` method.
+ To customize some global defaults use `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
  */
 public class NavigationSettings {
     
@@ -39,7 +39,8 @@ public class NavigationSettings {
                   tileStoreConfiguration: .default,
                   routingProviderSource: .hybrid,
                   alternativeRouteDetectionStrategy: .init(),
-                  utilizeSensorData: false)
+                  utilizeSensorData: false,
+                  navigatorPredictionInterval: nil)
         }
 
         var directions: Directions
@@ -47,6 +48,7 @@ public class NavigationSettings {
         var routingProviderSource: RoutingProviderSource
         var alternativeRouteDetectionStrategy: AlternativeRouteDetectionStrategy?
         var utilizeSensorData: Bool
+        var navigatorPredictionInterval: TimeInterval?
     }
 
     /// Protects access to `_state`.
@@ -70,7 +72,7 @@ public class NavigationSettings {
     /**
      Default `Directions` instance. By default, `Directions.shared` is used.
 
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
      */
     public var directions: Directions {
         state.directions
@@ -79,15 +81,14 @@ public class NavigationSettings {
     /**
      Global `TileStoreConfiguration` instance.
 
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
      */
     public var tileStoreConfiguration: TileStoreConfiguration {
         state.tileStoreConfiguration
     }
 
     /**
-     Default `routingProviderSource` used for rerouting during navigation. By default, `.hybrid` is used.
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
      */
     public var routingProviderSource: RoutingProviderSource {
         state.routingProviderSource
@@ -96,7 +97,7 @@ public class NavigationSettings {
     /**
      Configuration on how `AlternativeRoute`s will be detected during navigation process.
      
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
      
      If set to `nil`, the detection is turned off.
      */
@@ -116,6 +117,17 @@ public class NavigationSettings {
     }
     
     /**
+     Defines approximate navigator prediction between location ticks.
+     
+     If not specified, default value will be used.
+     
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
+     */
+    public var navigatorPredictionInterval: TimeInterval? {
+        state.navigatorPredictionInterval
+    }
+    
+    /**
      Initializes the settings with custom instances of globally used types.
 
      If you don't provide custom values, they will be initialized with the defaults.
@@ -131,23 +143,26 @@ public class NavigationSettings {
        - routingProviderSource: Configures the type of routing to be used by various SDK objects when providing route calculations. Use this value to configure usage of onlive vs. offline data for routing.
        - alternativeRouteDetectionStrategy: Configures how `AlternativeRoute`s will be detected during navigation process.
        - utilizeSensorData: Enables using sensors data to improve positioning.
+       - navigatorPredictionInterval: Defines approximate navigator prediction between location ticks.
      */
     public func initialize(directions: Directions,
                            tileStoreConfiguration: TileStoreConfiguration,
                            routingProviderSource: RoutingProviderSource = .hybrid,
                            alternativeRouteDetectionStrategy: AlternativeRouteDetectionStrategy? = .init(),
-                           utilizeSensorData: Bool = false) {
+                           utilizeSensorData: Bool = false,
+                           navigatorPredictionInterval: TimeInterval? = nil) {
         lock.lock(); defer {
             lock.unlock()
         }
         if _state != nil {
-            Log.warning("Warning: Using NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:) after corresponding variables was initialized. Possible reasons: Initialize called more than once, or the following properties was accessed before initialization: `tileStoreConfiguration`, `directions`, `routingProviderSource`, `alternativeRouteDetectionStrategy`, `utilizeSensorData`. This might result in an undefined behaviour.", category: .settings)
+            Log.warning("Warning: Using NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:) after corresponding variables was initialized. Possible reasons: Initialize called more than once, or the following properties was accessed before initialization: `tileStoreConfiguration`, `directions`, `routingProviderSource`, `alternativeRouteDetectionStrategy`, `utilizeSensorData`, `navigatorPredictionInterval`. This might result in an undefined behaviour.", category: .settings)
         }
         _state = .init(directions: directions,
                        tileStoreConfiguration: tileStoreConfiguration,
                        routingProviderSource: routingProviderSource,
                        alternativeRouteDetectionStrategy: alternativeRouteDetectionStrategy,
-                       utilizeSensorData: utilizeSensorData)
+                       utilizeSensorData: utilizeSensorData,
+                       navigatorPredictionInterval: navigatorPredictionInterval)
     }
     
     /**


### PR DESCRIPTION
### Description
Due to discrete location updates, Navigator always operates data "in the past" so it has to make prediction about user's current real position. NN allows to configure this interval at initialization, so we expose it to users. 

### Implementation
Added `NavigationSettings.navigatorPredictionInterval` to configure Navigator at init.