### PR TITLE
Remove redundant iOS 11 availability macros

### DIFF
--- a/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
+++ b/Sources/MapboxNavigation/Feedback/FeedbackSubtypeViewController.swift
@@ -55,7 +55,7 @@ class FeedbackSubtypeViewController: FeedbackViewController {
     override func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         var availableWidth = collectionView.bounds.width
         
-        if #available(iOS 11.0, *), let keyWindow = UIApplication.shared.keyWindow {
+        if let keyWindow = UIApplication.shared.keyWindow {
             availableWidth = keyWindow.safeAreaLayoutGuide.layoutFrame.size.width
         }
         

--- a/Sources/MapboxNavigation/NSAttributedString.swift
+++ b/Sources/MapboxNavigation/NSAttributedString.swift
@@ -10,7 +10,7 @@ extension NSMutableAttributedString {
             
             let sanitizedAttachment = NSTextAttachment()
             let maximumHeight = maximumImageSize.height
-            if #available(iOS 11.0, *), let image = attachment.image, image.size.height > maximumHeight {
+            if let image = attachment.image, image.size.height > maximumHeight {
                 // Scale down any oversized images.
                 let size = CGSize(width: image.size.width * maximumHeight / image.size.height, height: maximumHeight)
                 let resizedImage = UIGraphicsImageRenderer(size: size, format: imageRendererFormat).image { (context) in

--- a/Sources/MapboxNavigation/UIView.swift
+++ b/Sources/MapboxNavigation/UIView.swift
@@ -115,71 +115,43 @@ extension UIView {
     // MARK: Anchors Access
     
     var safeArea: UIEdgeInsets {
-        guard #available(iOS 11.0, *) else { return .zero }
         return safeAreaInsets
     }
     
     var safeTopAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.topAnchor
-        }
-        return topAnchor
+        return safeAreaLayoutGuide.topAnchor
     }
     
     var safeLeadingAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.leadingAnchor
-        }
-        return leadingAnchor
+        return safeAreaLayoutGuide.leadingAnchor
     }
     
     var safeBottomAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.bottomAnchor
-        }
-        return bottomAnchor
+        return safeAreaLayoutGuide.bottomAnchor
     }
     
     var safeRightAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.rightAnchor
-        }
-        return rightAnchor
+        return safeAreaLayoutGuide.rightAnchor
     }
     
     var safeTrailingAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.trailingAnchor
-        }
-        return trailingAnchor
+        return safeAreaLayoutGuide.trailingAnchor
     }
     
     var safeWidthAnchor: NSLayoutDimension {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.widthAnchor
-        }
-        return widthAnchor
+        return safeAreaLayoutGuide.widthAnchor
     }
     
     var safeHeightAnchor: NSLayoutDimension {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.heightAnchor
-        }
-        return heightAnchor
+        return safeAreaLayoutGuide.heightAnchor
     }
     
     var safeCenterXAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.centerXAnchor
-        }
-        return centerXAnchor
+        return safeAreaLayoutGuide.centerXAnchor
     }
     
     var safeCenterYAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11.0, *) {
-            return safeAreaLayoutGuide.centerYAnchor
-        }
-        return centerYAnchor
+        return safeAreaLayoutGuide.centerYAnchor
     }
 }
 


### PR DESCRIPTION
The minimum deployment target for MapboxNavigation and the Example application is iOS 11.0, so there’s no longer any need to guard for iOS 11 API availability.

/cc @mapbox/navigation-ios