### PR TITLE
Duplicate departure events fix

### DIFF
--- a/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
@@ -511,6 +511,10 @@ open class NavigationEventsManager {
         sessionState.arrivalTimestamp = nil
     }
     
+    func arriveAtDestination() {
+        sessionState.arrivalTimestamp = nil
+    }
+    
     func record(_ locations: [CLLocation]) {
         locations.forEach(sessionState.pastLocations.push(_:))
     }

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -660,7 +660,11 @@ extension MapboxNavigationService: RouterDelegate {
     
     public func router(_ router: Router, didArriveAt waypoint: Waypoint) -> Bool {
         //Notify the events manager that we've arrived at a waypoint
-        eventsManager.arriveAtWaypoint()
+        if router.routeProgress.remainingWaypoints.count <= 1 {
+            eventsManager.arriveAtDestination()
+        } else {
+            eventsManager.arriveAtWaypoint()
+        }
         
         let shouldAutomaticallyAdvance =  delegate?.navigationService(self, didArriveAt: waypoint) ?? Default.didArriveAtWaypoint
         if !shouldAutomaticallyAdvance {


### PR DESCRIPTION
### Description
SDK generated departure events after arriving at each waypoint which is excessive for the final waypoint.
Since it's not a user-facing change I guess we don't need a CHANGELOG entry?

### Implementation
This PR adds a check to detect arriving at different waypoints.