### PR TITLE
Incidents Options exposing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * A multi-leg route that crosses an international border can now have alternative routes. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Curvy roads are penalized slightly more consistently. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * You can now set `Waypoint.allowsSnappingToStaticallyClosedRoad` to `true` to allow the waypoint to snap to a road that is fully closed for long-term construction. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
+* Added `NavigationSettings.liveIncidentsOptions` to configure how incidents data is fetched. ([#4088](https://github.com/mapbox/mapbox-navigation-ios/pull/4088))
 
 ### Other changes
 

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		2B01E4B6274671550002A5F7 /* MapboxRoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B3274671540002A5F7 /* MapboxRoutingProvider.swift */; };
 		2B01E4B7274671550002A5F7 /* RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B4274671540002A5F7 /* RoutingProvider.swift */; };
 		2B01E4B8274671550002A5F7 /* Directions+RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */; };
+		2B02397728B37E2200C348D0 /* IncidentsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B02397628B37E2200C348D0 /* IncidentsOptions.swift */; };
 		2B07444124B4832400615E87 /* TokenTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B07444024B4832400615E87 /* TokenTestViewController.swift */; };
 		2B27557F2860B01A002D1CAD /* HistoryRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B27557E2860B01A002D1CAD /* HistoryRecorder.swift */; };
 		2B28AD7D284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28AD7C284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift */; };
@@ -609,6 +610,7 @@
 		2B01E4B3274671540002A5F7 /* MapboxRoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapboxRoutingProvider.swift; sourceTree = "<group>"; };
 		2B01E4B4274671540002A5F7 /* RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutingProvider.swift; sourceTree = "<group>"; };
 		2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Directions+RoutingProvider.swift"; sourceTree = "<group>"; };
+		2B02397628B37E2200C348D0 /* IncidentsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncidentsOptions.swift; sourceTree = "<group>"; };
 		2B07444024B4832400615E87 /* TokenTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenTestViewController.swift; sourceTree = "<group>"; };
 		2B27557E2860B01A002D1CAD /* HistoryRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryRecorder.swift; sourceTree = "<group>"; };
 		2B28AD7C284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlternativeRouteDetectionStrategy.swift; sourceTree = "<group>"; };
@@ -2033,6 +2035,7 @@
 				353E68FB1EF0B7F8007B2AE5 /* NavigationLocationManager.swift */,
 				C5E7A31B1F4F6828001CB015 /* NavigationRouteOptions.swift */,
 				35375EC01F31FA86004CE727 /* NavigationSettings.swift */,
+				2B02397628B37E2200C348D0 /* IncidentsOptions.swift */,
 				351174F31EF1C0530065E248 /* ReplayLocationManager.swift */,
 				C5ADFBF91DDCC9580011824B /* LegacyRouteController.swift */,
 				8D2AA744211CDD4000EB7F72 /* NavigationService.swift */,
@@ -2968,6 +2971,7 @@
 				118D883426F8CA0700B2ED7B /* FeedbackEvent.swift in Sources */,
 				E2C623A726CBFCE1005769FA /* OnMainQueue.swift in Sources */,
 				C5C94C1C1DDCD2340097296A /* LegacyRouteController.swift in Sources */,
+				2B02397728B37E2200C348D0 /* IncidentsOptions.swift in Sources */,
 				3A8187C924BDAE9C00708F19 /* URLSession.swift in Sources */,
 				2B27557F2860B01A002D1CAD /* HistoryRecorder.swift in Sources */,
 				359574A81F28CC5A00838209 /* CLLocation.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/IncidentsOptions.swift
+++ b/Sources/MapboxCoreNavigation/IncidentsOptions.swift
@@ -2,11 +2,15 @@
 import Foundation
 
 /**
- Electronic Horizon supports live incidents on a most probable path. To enable live incidents `IncidentsOptions` should be provided to `NavigationSettings` before starting navigation. If both `graph` and `apiUrl` are empty, live incidents are disabled (by default).
+ Configures how Electronic Horizon supports live incidents on a most probable path.
+ 
+ To enable live incidents `IncidentsOptions` should be provided to `NavigationSettings` before starting navigation.
  */
 public struct IncidentsOptions {
     /**
      Incidents provider graph name.
+     
+     If empty - incidents will be disabled.
      */
     public var graph: String
     /**

--- a/Sources/MapboxCoreNavigation/IncidentsOptions.swift
+++ b/Sources/MapboxCoreNavigation/IncidentsOptions.swift
@@ -12,7 +12,7 @@ public struct IncidentsOptions {
     /**
      LTS incidents service API url.
      
-     If empty line is supplied will use a default url.
+     If `nil` is supplied will use a default url.
      */
-    public var apiURL: URL
+    public var apiURL: URL?
 }

--- a/Sources/MapboxCoreNavigation/IncidentsOptions.swift
+++ b/Sources/MapboxCoreNavigation/IncidentsOptions.swift
@@ -1,0 +1,18 @@
+
+import Foundation
+
+/**
+ Electronic Horizon supports live incidents on a most probable path. To enable live incidents `IncidentsOptions` should be provided to `NavigationSettings` before starting navigation. If both `graph` and `apiUrl` are empty, live incidents are disabled (by default).
+ */
+public struct IncidentsOptions {
+    /**
+     Incidents provider graph name.
+     */
+    public var graph: String
+    /**
+     LTS incidents service API url.
+     
+     If empty line is supplied will use a default url.
+     */
+    public var apiURL: URL
+}

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -104,7 +104,7 @@ class NativeHandlersFactory {
     static var navigatorConfig: NavigatorConfig {
         var nativeIncidentsOptions: MapboxNavigationNative.IncidentsOptions?
         if let incidentsOptions = NavigationSettings.shared.liveIncidentsOptions,
-           !incidentsOptions.graph.isEmpty || incidentsOptions.apiURL != nil {
+           !incidentsOptions.graph.isEmpty {
             nativeIncidentsOptions = .init(graph: incidentsOptions.graph,
                                            apiUrl: incidentsOptions.apiURL?.absoluteString ?? "")
         }

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -104,10 +104,9 @@ class NativeHandlersFactory {
     static var navigatorConfig: NavigatorConfig {
         var nativeIncidentsOptions: MapboxNavigationNative.IncidentsOptions?
         if let incidentsOptions = NavigationSettings.shared.liveIncidentsOptions,
-           !incidentsOptions.graph.isEmpty,
-           !incidentsOptions.apiURL.absoluteString.isEmpty {
+           !incidentsOptions.graph.isEmpty || incidentsOptions.apiURL != nil {
             nativeIncidentsOptions = .init(graph: incidentsOptions.graph,
-                                           apiUrl: incidentsOptions.apiURL.absoluteString)
+                                           apiUrl: incidentsOptions.apiURL?.absoluteString ?? "")
         }
         return NavigatorConfig(voiceInstructionThreshold: nil,
                                electronicHorizonOptions: nil,

--- a/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
+++ b/Sources/MapboxCoreNavigation/NativeHandlersFactory.swift
@@ -102,6 +102,13 @@ class NativeHandlersFactory {
     }()
     
     static var navigatorConfig: NavigatorConfig {
+        var nativeIncidentsOptions: MapboxNavigationNative.IncidentsOptions?
+        if let incidentsOptions = NavigationSettings.shared.liveIncidentsOptions,
+           !incidentsOptions.graph.isEmpty,
+           !incidentsOptions.apiURL.absoluteString.isEmpty {
+            nativeIncidentsOptions = .init(graph: incidentsOptions.graph,
+                                           apiUrl: incidentsOptions.apiURL.absoluteString)
+        }
         return NavigatorConfig(voiceInstructionThreshold: nil,
                                electronicHorizonOptions: nil,
                                polling: NavigationSettings.shared.navigatorPredictionInterval.map {
@@ -109,7 +116,7 @@ class NativeHandlersFactory {
                                                   unconditionalPatience: nil,
                                                   unconditionalInterval: nil)
                                 },
-                               incidentsOptions: nil,
+                               incidentsOptions: nativeIncidentsOptions,
                                noSignalSimulationEnabled: nil,
                                avoidManeuverSeconds: NSNumber(value: RerouteController.DefaultManeuverAvoidanceRadius),
                                useSensors: NSNumber(booleanLiteral: NavigationSettings.shared.utilizeSensorData))

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -14,7 +14,7 @@ public typealias RoutingProviderSource = MapboxRoutingProvider.Source
  To customize the user experience during a particular turn-by-turn navigation session, use the `NavigationOptions` class
  when initializing a `NavigationViewController`.
 
- To customize some global defaults use `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
+ To customize some global defaults use `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
  */
 public class NavigationSettings {
     
@@ -40,7 +40,8 @@ public class NavigationSettings {
                   routingProviderSource: .hybrid,
                   alternativeRouteDetectionStrategy: .init(),
                   utilizeSensorData: false,
-                  navigatorPredictionInterval: nil)
+                  navigatorPredictionInterval: nil,
+                  liveIncidentsOptions: nil)
         }
 
         var directions: Directions
@@ -49,6 +50,7 @@ public class NavigationSettings {
         var alternativeRouteDetectionStrategy: AlternativeRouteDetectionStrategy?
         var utilizeSensorData: Bool
         var navigatorPredictionInterval: TimeInterval?
+        var liveIncidentsOptions: IncidentsOptions?
     }
 
     /// Protects access to `_state`.
@@ -72,7 +74,7 @@ public class NavigationSettings {
     /**
      Default `Directions` instance. By default, `Directions.shared` is used.
 
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
      */
     public var directions: Directions {
         state.directions
@@ -81,14 +83,14 @@ public class NavigationSettings {
     /**
      Global `TileStoreConfiguration` instance.
 
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
      */
     public var tileStoreConfiguration: TileStoreConfiguration {
         state.tileStoreConfiguration
     }
 
     /**
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
      */
     public var routingProviderSource: RoutingProviderSource {
         state.routingProviderSource
@@ -97,7 +99,7 @@ public class NavigationSettings {
     /**
      Configuration on how `AlternativeRoute`s will be detected during navigation process.
      
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
      
      If set to `nil`, the detection is turned off.
      */
@@ -123,10 +125,21 @@ public class NavigationSettings {
      
      If not specified (`nilled`), default value will be used.
      
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
      */
     public var navigatorPredictionInterval: TimeInterval? {
         state.navigatorPredictionInterval
+    }
+    
+    /**
+     Configuration on how live incidents on a most probable path are detected.
+     
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+     
+     If set to `nil`, live incidents are turned off (by default).
+     */
+    public var liveIncidentsOptions: IncidentsOptions? {
+        state.liveIncidentsOptions
     }
     
     /**
@@ -146,25 +159,28 @@ public class NavigationSettings {
        - alternativeRouteDetectionStrategy: Configures how `AlternativeRoute`s will be detected during navigation process.
        - utilizeSensorData: Enables using sensors data to improve positioning.
        - navigatorPredictionInterval: Defines approximate navigator prediction between location ticks.
+       - liveIncidentsOptions: Configures Electronic Horizon live incidents.
      */
     public func initialize(directions: Directions,
                            tileStoreConfiguration: TileStoreConfiguration,
                            routingProviderSource: RoutingProviderSource = .hybrid,
                            alternativeRouteDetectionStrategy: AlternativeRouteDetectionStrategy? = .init(),
                            utilizeSensorData: Bool = false,
-                           navigatorPredictionInterval: TimeInterval? = nil) {
+                           navigatorPredictionInterval: TimeInterval? = nil,
+                           liveIncidentsOptions: IncidentsOptions? = nil) {
         lock.lock(); defer {
             lock.unlock()
         }
         if _state != nil {
-            Log.warning("Warning: Using NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:) after corresponding variables was initialized. Possible reasons: Initialize called more than once, or the following properties was accessed before initialization: `tileStoreConfiguration`, `directions`, `routingProviderSource`, `alternativeRouteDetectionStrategy`, `utilizeSensorData`, `navigatorPredictionInterval`. This might result in an undefined behaviour.", category: .settings)
+            Log.warning("Warning: Using NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:) after corresponding variables was initialized. Possible reasons: Initialize called more than once, or the following properties was accessed before initialization: `tileStoreConfiguration`, `directions`, `routingProviderSource`, `alternativeRouteDetectionStrategy`, `utilizeSensorData`, `navigatorPredictionInterval`, `liveIncidentsOptions`. This might result in an undefined behaviour.", category: .settings)
         }
         _state = .init(directions: directions,
                        tileStoreConfiguration: tileStoreConfiguration,
                        routingProviderSource: routingProviderSource,
                        alternativeRouteDetectionStrategy: alternativeRouteDetectionStrategy,
                        utilizeSensorData: utilizeSensorData,
-                       navigatorPredictionInterval: navigatorPredictionInterval)
+                       navigatorPredictionInterval: navigatorPredictionInterval,
+                       liveIncidentsOptions: liveIncidentsOptions)
     }
     
     /**


### PR DESCRIPTION
### Description
We need to expose public configuration for Navigator's incidents options. This is required by customers and Android already has such ability.

### Implementation
Added NavigationSettings.liveIncidentsOptions and forwarded this configuration to NavigatorConfig.