### PR TITLE
Remove the targetCoordinates mapping after reroute with the dependency upgrade

### DIFF
--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -930,15 +930,6 @@ extension RouteController: ReroutingControllerDelegate {
     }
     
     func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions, routeOrigin: RouterOrigin) {
-        // The response and options after reroute lost waypoint targetCoordinate.
-        if response.waypoints?.count == routeProgress.routeOptions.waypoints.count,
-           options.waypoints.count == routeProgress.routeOptions.waypoints.count {
-            for (index, previousWayoint) in routeProgress.routeOptions.waypoints.enumerated() {
-                response.waypoints?[index].targetCoordinate = previousWayoint.targetCoordinate
-                options.waypoints[index].targetCoordinate = previousWayoint.targetCoordinate
-            }
-        }
-        
         let indexedRouteResponse = IndexedRouteResponse(routeResponse: response,
                                                         routeIndex: 0,
                                                         responseOrigin: routeOrigin)


### PR DESCRIPTION
### Description
#4034 introduced the mapping of `targetCoordinate` in `RouteController` after rerouting event to fix the failure of building highlighting issue due to the loss of `targetCoordinate` after rerouting event. But the dependency upgrade of #4085 fixed the loss of `targetCoordinate` from root. So this PR is to remove the previously introduced fix in SDK side.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->