### PR TITLE
Add the update version workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,6 +662,34 @@ jobs:
                 notify_success: true
       - notify-build-finished
 
+  update-version-job:
+    parameters:
+      xcode:
+        type: string
+        default: "12.5.1"
+    macos:
+      xcode: << parameters.xcode >>
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *restore-cache-gems
+      - *restore-cache-podmaster
+      - *install-gems
+      - *prepare-netrc-file
+      - *add-github-to-known-hosts
+      - install-mbx-ci
+      - run:
+          name: Update version
+          command: |
+            export GITHUB_WRITER_TOKEN=$(mbx-ci github writer public token)
+            git remote set-url origin "https://x-access-token:$GITHUB_WRITER_TOKEN@github.com/mapbox/mapbox-navigation-ios"
+            git config --global user.email no-reply@mapbox.com && git config --global user.name mapbox-ci
+            VERSION=$( echo << pipeline.git.branch >> | sed 's/^trigger-update-version-//' )
+            ./scripts/update-version.sh $VERSION
+      - *save-cache-podmaster
+      - *save-cache-gems
+
 workflows:
   extended-workflow:
     jobs:
@@ -770,3 +798,9 @@ workflows:
             filters:
               branches:
                 only: main
+  update-version-workflow:
+    jobs:
+      - update-version-job:
+          filters:
+            branches:
+              only: /^trigger-update-version-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,7 +666,7 @@ jobs:
     parameters:
       xcode:
         type: string
-        default: "12.5.1"
+        default: "13.4.1"
     macos:
       xcode: << parameters.xcode >>
     environment:


### PR DESCRIPTION
This workflow will be used by the Release train app in the **Update version** stage.

**update-version-workflow** runs the **scripts/update-version.sh** script. It's necessary to execute this script on the Circle CI because the Release train app instance running on the Linux machine and the script needs MacOS.

You can read more about this step in the Release train app doc.