### PR TITLE
Use `MapView.safeAreaInsets` as a viewport padding in free-drive navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.8.0
 
 ### Packaging
+
 * MapboxNavigation now requires [MapboxMaps v10.8._x_](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.8.0-beta.1). ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * MapboxCoreNavigation now requires [MapboxNavigationNative v112._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/112.0.0). ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * MapboxCoreNavigation now requires [MapboxDirections v2.7.0-beta.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.7.0-beta.1). ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
@@ -23,6 +24,7 @@
 * Fixed an issue where some roads were shown as restricted on the route line even if public access is allowed for “local traffic only”. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 
 ### Guidance Instructions
+
 * Fixed an issue where the top banner and current road name label represented Mexican state highways with generic shields. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Fixed an issue where the route would instruct the user to make a “U-turn” toward the passenger side wherever the user should actually make two successive turns toward the passenger side or take an exit ramp that curves 180°. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * `JunctionView` now appears after passing some toll booths or electronic toll collection points in Japan. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
@@ -40,6 +42,10 @@
 * Curvy roads are penalized slightly more consistently. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * You can now set `Waypoint.allowsSnappingToStaticallyClosedRoad` to `true` to allow the waypoint to snap to a road that is fully closed for long-term construction. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Added `NavigationSettings.liveIncidentsOptions` to configure how incidents data is fetched. ([#4088](https://github.com/mapbox/mapbox-navigation-ios/pull/4088))
+
+### CarPlay
+
+* Fixed an issue where navigation camera viewport padding was not taking into account `MapView` safe area insets on CarPlay. ([#4098](https://github.com/mapbox/mapbox-navigation-ios/pull/4098))
 
 ### Other changes
 

--- a/Sources/MapboxNavigation/NavigationViewportDataSource.swift
+++ b/Sources/MapboxNavigation/NavigationViewportDataSource.swift
@@ -192,8 +192,8 @@ public class NavigationViewportDataSource: ViewportDataSource {
             }
             
             if followingCameraOptions.paddingUpdatesAllowed || followingMobileCamera.padding == nil {
-                followingMobileCamera.padding = .zero
-                followingCarPlayCamera.padding = .zero
+                followingMobileCamera.padding = mapView.safeAreaInsets
+                followingCarPlayCamera.padding = mapView.safeAreaInsets
             }
             
             return


### PR DESCRIPTION
### Description

PR fixes an issue where navigation viewport padding was always set to `.zero` during free-drive navigation.