### PR TITLE
RouteOptions customization on reroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * You can now set `Waypoint.allowsSnappingToStaticallyClosedRoad` to `true` to allow the waypoint to snap to a road that is fully closed for long-term construction. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Added `NavigationSettings.liveIncidentsOptions` to configure how incidents data is fetched. ([#4088](https://github.com/mapbox/mapbox-navigation-ios/pull/4088))
 * Added `NavigationSettings.statusPollingConfig` to configure navigator status polling options. ([#4135](https://github.com/mapbox/mapbox-navigation-ios/pull/4135))
+* Added `RouterDelegate.router(_:willModify:)`, `NavigationServiceDelegate.navigationService(_:willModify:)` and `NavigationViewControllerDelegate.navigationViewController(_:willModify:)` methods to allow `RouteOptions` customization on reroutes. ([#4102](https://github.com/mapbox/mapbox-navigation-ios/pull/4102))
 * Fixed incorrect duration calculations and route refreshing when an arrival step’s geometry contained only one coordinate. Normally, an arrival step’s geometry is expected to be a zero-length `LineString`; that is, with two coincident coordinates. ([#4110](https://github.com/mapbox/mapbox-navigation-ios/pull/4110))
 
 ### CarPlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * You can now set `Waypoint.allowsSnappingToStaticallyClosedRoad` to `true` to allow the waypoint to snap to a road that is fully closed for long-term construction. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Added `NavigationSettings.liveIncidentsOptions` to configure how incidents data is fetched. ([#4088](https://github.com/mapbox/mapbox-navigation-ios/pull/4088))
 * Added `NavigationSettings.statusPollingConfig` to configure navigator status polling options. ([#4135](https://github.com/mapbox/mapbox-navigation-ios/pull/4135))
-* Added `RouterDelegate.router(_:willModify:)`, `NavigationServiceDelegate.navigationService(_:willModify:)` and `NavigationViewControllerDelegate.navigationViewController(_:willModify:)` methods to allow `RouteOptions` customization on reroutes. ([#4102](https://github.com/mapbox/mapbox-navigation-ios/pull/4102))
+* Added `RouterDelegate.router(_:modifiedOptionsForReroute:)`, `NavigationServiceDelegate.navigationService(_:modifiedOptionsForReroute:)` and `NavigationViewControllerDelegate.navigationViewController(_:modifiedOptionsForReroute:)` methods to allow `RouteOptions` customization on reroutes. ([#4102](https://github.com/mapbox/mapbox-navigation-ios/pull/4102))
 * Fixed incorrect duration calculations and route refreshing when an arrival step’s geometry contained only one coordinate. Normally, an arrival step’s geometry is expected to be a zero-length `LineString`; that is, with two coincident coordinates. ([#4110](https://github.com/mapbox/mapbox-navigation-ios/pull/4110))
 
 ### CarPlay

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		2B01E4B7274671550002A5F7 /* RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B4274671540002A5F7 /* RoutingProvider.swift */; };
 		2B01E4B8274671550002A5F7 /* Directions+RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */; };
 		2B02397728B37E2200C348D0 /* IncidentsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B02397628B37E2200C348D0 /* IncidentsOptions.swift */; };
+		2B02397928B6508700C348D0 /* DefaultRerouteControllerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B02397828B6508700C348D0 /* DefaultRerouteControllerInterface.swift */; };
 		2B07444124B4832400615E87 /* TokenTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B07444024B4832400615E87 /* TokenTestViewController.swift */; };
 		2B27557F2860B01A002D1CAD /* HistoryRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B27557E2860B01A002D1CAD /* HistoryRecorder.swift */; };
 		2B28AD7D284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B28AD7C284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift */; };
@@ -609,6 +610,7 @@
 		2B01E4B4274671540002A5F7 /* RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutingProvider.swift; sourceTree = "<group>"; };
 		2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Directions+RoutingProvider.swift"; sourceTree = "<group>"; };
 		2B02397628B37E2200C348D0 /* IncidentsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncidentsOptions.swift; sourceTree = "<group>"; };
+		2B02397828B6508700C348D0 /* DefaultRerouteControllerInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultRerouteControllerInterface.swift; sourceTree = "<group>"; };
 		2B07444024B4832400615E87 /* TokenTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenTestViewController.swift; sourceTree = "<group>"; };
 		2B27557E2860B01A002D1CAD /* HistoryRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryRecorder.swift; sourceTree = "<group>"; };
 		2B28AD7C284F68A1001CD1FB /* AlternativeRouteDetectionStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlternativeRouteDetectionStrategy.swift; sourceTree = "<group>"; };
@@ -2017,6 +2019,7 @@
 				2BF398C0274BDEA8000C9A72 /* Directions.swift */,
 				2B01E4B5274671550002A5F7 /* Directions+RoutingProvider.swift */,
 				351BEC0B1E5BCC72006FE110 /* DistanceFormatter.swift */,
+				2B02397828B6508700C348D0 /* DefaultRerouteControllerInterface.swift */,
 				B417913A2624F9EA001E0348 /* MBXInfo.plist */,
 				C5ADFBCD1DDCC7840011824B /* Info.plist */,
 				C5ADFBCC1DDCC7840011824B /* MapboxCoreNavigation.h */,
@@ -3013,6 +3016,7 @@
 				C5C94C1D1DDCD2370097296A /* RouteProgress.swift in Sources */,
 				2BBED93B267A3AB900F90032 /* BillingHandler.swift in Sources */,
 				2BE701352535948100F46E4E /* RestStop.swift in Sources */,
+				2B02397928B6508700C348D0 /* DefaultRerouteControllerInterface.swift in Sources */,
 				2B01E4B6274671550002A5F7 /* MapboxRoutingProvider.swift in Sources */,
 				2B28E22127EB48C60029E4C1 /* RerouteControllerDelegate.swift in Sources */,
 				8D4CF9C621349FFB009C3FEE /* NavigationServiceDelegate.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/DefaultRerouteControllerInterface.swift
+++ b/Sources/MapboxCoreNavigation/DefaultRerouteControllerInterface.swift
@@ -1,0 +1,23 @@
+import Foundation
+@_implementationOnly import MapboxNavigationNative_Private
+
+class DefaultRerouteControllerInterface: RerouteControllerInterface {
+    typealias RequestConfiguration = (String) -> String
+    
+    let nativeInterface: RerouteControllerInterface
+    var requestConfig: RequestConfiguration?
+    
+    init(nativeInterface: RerouteControllerInterface,
+         requestConfig: RequestConfiguration? = nil) {
+        self.nativeInterface = nativeInterface
+        self.requestConfig = requestConfig
+    }
+    
+    func reroute(forUrl url: String, callback: @escaping RerouteCallback) {
+        nativeInterface.reroute(forUrl: requestConfig?(url) ?? url, callback: callback)
+    }
+    
+    func cancel() {
+        nativeInterface.cancel()
+    }
+}

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -611,6 +611,10 @@ extension MapboxNavigationService: RouterDelegate {
         delegate?.navigationService(self, willRerouteFrom: location)
     }
     
+    public func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions {
+        return delegate?.navigationService(self, willModify: options) ?? options
+    }
+    
     public func router(_ router: Router, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
         //notify the events manager that the route has changed
         eventsManager.reportReroute(progress: router.routeProgress, proactive: proactive)

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -611,8 +611,8 @@ extension MapboxNavigationService: RouterDelegate {
         delegate?.navigationService(self, willRerouteFrom: location)
     }
     
-    public func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions {
-        return delegate?.navigationService(self, willModify: options) ?? options
+    public func router(_ router: Router, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions {
+        return delegate?.navigationService(self, modifiedOptionsForReroute: options) ?? options
     }
     
     public func router(_ router: Router, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -32,12 +32,25 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately before the navigation service calculates a new route.
      
-     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:didRerouteAlong:)` is called.
+     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:willModify:)` is called.
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
      */
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation)
+    
+    /**
+     When reroute is happening, navigation service suggests to customize the `RouteOptions` used to calculate new route.
+     
+     This method is called after `navigationService(_:willRerouteFrom:)` is called, and before `navigationService(_:didRerouteAlong:)` is called. This method is not called on proactive rerouting.
+     
+     Default implementation does no modifications.
+     
+     - parameter service: The navigation service that will calculate a new route.
+     - parameter options: Original `RouteOptions`.
+     - returns: Modified `RouteOptions`.
+     */
+    func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions
     
     /**
      Called when navigation service has detected a change in alternative routes list.
@@ -103,7 +116,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the navigation service receives a new route.
      
-     This method is called after `navigationService(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationService(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter route: The new route.
@@ -276,6 +289,11 @@ public extension NavigationServiceDelegate {
      */
     func navigationService(_ service: NavigationService, willRerouteFrom location: CLLocation) {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
+    }
+    
+    func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions {
+        logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
+        return options
     }
     
     /**

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -32,7 +32,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately before the navigation service calculates a new route.
      
-     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:willModify:)` is called.
+     This method is called after `navigationService(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationService(_:modifiedOptionsForReroute:)` is called.
      
      - parameter service: The navigation service that will calculate a new route.
      - parameter location: The user’s current location.
@@ -50,7 +50,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
      - parameter options: Original `RouteOptions`.
      - returns: Modified `RouteOptions`.
      */
-    func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions
+    func navigationService(_ service: NavigationService, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions
     
     /**
      Called when navigation service has detected a change in alternative routes list.
@@ -116,7 +116,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the navigation service receives a new route.
      
-     This method is called after `navigationService(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationService(_:modifiedOptionsForReroute:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter route: The new route.
@@ -126,7 +126,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the navigation service fails to receive a new route.
      
-     This method is called after `navigationService(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationService(_:modifiedOptionsForReroute:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -291,7 +291,7 @@ public extension NavigationServiceDelegate {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
     }
     
-    func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions {
+    func navigationService(_ service: NavigationService, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions {
         logUnimplemented(protocolType: NavigationServiceDelegate.self, level: .debug)
         return options
     }

--- a/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
+++ b/Sources/MapboxCoreNavigation/NavigationServiceDelegate.swift
@@ -126,7 +126,7 @@ public protocol NavigationServiceDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the navigation service fails to receive a new route.
      
-     This method is called after `navigationService(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationService(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter service: The navigation service that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -50,13 +50,13 @@ class RerouteController {
             }
 
             defaultRerouteController.requestConfig = { [weak delegate] in
-               guard let delegate = delegate,
-                     let url = URL(string: $0),
-                     let options = RouteOptions(url: url) else {
-                   return $0
-               }
+                guard let delegate = delegate,
+                      let url = URL(string: $0),
+                      let options = RouteOptions(url: url) else {
+                    return $0
+                }
                 return NavigationSettings.shared.directions.url(forCalculating: delegate.rerouteControllerWillModify(options: options)).absoluteString
-           }
+            }
         }
     }
 

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -42,7 +42,23 @@ class RerouteController {
 
     // MARK: Reporting Data
     
-    weak var delegate: ReroutingControllerDelegate?
+    weak var delegate: ReroutingControllerDelegate? {
+        didSet {
+            guard delegate != nil else {
+                defaultRerouteController.requestConfig = nil
+                return
+            }
+
+            defaultRerouteController.requestConfig = { [weak delegate] in
+               guard let delegate = delegate,
+                     let url = URL(string: $0),
+                     let options = RouteOptions(url: url) else {
+                   return $0
+               }
+                return NavigationSettings.shared.directions.url(forCalculating: delegate.rerouteControllerWillModify(options: options)).absoluteString
+           }
+        }
+    }
 
     func userIsOnRoute() -> Bool {
         return !rerouteDetector.isReroute()
@@ -54,7 +70,7 @@ class RerouteController {
 
     // MARK: Internal State Management
     
-    private let defaultRerouteController: RerouteControllerInterface
+    private let defaultRerouteController: DefaultRerouteControllerInterface
     private let rerouteDetector: RerouteDetectorInterface
     
     private var reroutingRequest: NavigationProviderRequest?
@@ -67,20 +83,23 @@ class RerouteController {
         reroutesProactively = true
         isCancelled = false
         config.setAvoidManeuverSecondsForSeconds(NSNumber(value: Self.DefaultManeuverAvoidanceRadius))
-        customRoutingProvider = nil
+        if customRoutingProvider != nil {
+            customRoutingProvider = nil
+        }
     }
 
     required init(_ navigator: MapboxNavigationNative.Navigator, config: ConfigHandle) {
         self.navigator = navigator
         self.config = config
-        self.defaultRerouteController = navigator.getRerouteController()
+        self.defaultRerouteController = DefaultRerouteControllerInterface(nativeInterface: navigator.getRerouteController())
+        self.navigator?.setRerouteControllerForController(defaultRerouteController)
         self.rerouteDetector = navigator.getRerouteDetector()
         self.navigator?.addRerouteObserver(for: self)
     }
 
     deinit {
         self.navigator?.removeRerouteObserver(for: self)
-        self.navigator?.setRerouteControllerForController(defaultRerouteController)
+        self.navigator?.setRerouteControllerForController(defaultRerouteController.nativeInterface)
     }
 }
 

--- a/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RerouteControllerDelegate.swift
@@ -13,6 +13,7 @@ protocol ReroutingControllerDelegate: AnyObject {
     func rerouteControllerDidRecieveReroute(_ rerouteController: RerouteController, response: RouteResponse, options: RouteOptions, routeOrigin: RouterOrigin)
     func rerouteControllerDidCancelReroute(_ rerouteController: RerouteController)
     func rerouteControllerDidFailToReroute(_ rerouteController: RerouteController, with error: DirectionsError)
+    func rerouteControllerWillModify(options: RouteOptions) -> RouteOptions
 }
 
 /**

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -965,6 +965,10 @@ extension RouteController: ReroutingControllerDelegate {
         announceReroutingError(with: error)
         self.isRerouting = false
     }
+    
+    func rerouteControllerWillModify(options: RouteOptions) -> RouteOptions {
+        return delegate?.router(self, willModify: options) ?? options
+    }
 }
 
 extension RouteController {

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -967,7 +967,7 @@ extension RouteController: ReroutingControllerDelegate {
     }
     
     func rerouteControllerWillModify(options: RouteOptions) -> RouteOptions {
-        return delegate?.router(self, willModify: options) ?? options
+        return delegate?.router(self, modifiedOptionsForReroute: options) ?? options
     }
 }
 

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -28,7 +28,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately before the router calculates a new route.
 
-     This method is called after `router(_:shouldRerouteFrom:)` is called, and before `router(_:willModify:)` is called.
+     This method is called after `router(_:shouldRerouteFrom:)` is called, and before `router(_:modifiedOptionsForReroute:)` is called.
      
      - parameter router: The router that will calculate a new route.
      - parameter location: The user’s current location.
@@ -46,7 +46,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
      - parameter options: Original `RouteOptions`.
      - returns: Modified `RouteOptions`.
      */
-    func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions
+    func router(_ router: Router, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -62,7 +62,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the router receives a new route.
      
-     This method is called after `router(_:willModify:)` method is called.
+     This method is called after `router(_:modifiedOptionsForReroute:)` method is called.
      
      - parameter router: The router that has calculated a new route.
      - parameter route: The new route.
@@ -132,7 +132,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the router fails to receive a new route.
      
-     This method is called after `router(_:willModify:)`.
+     This method is called after `router(_:modifiedOptionsForReroute:)`.
      
      - parameter router: The router that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -233,7 +233,7 @@ public extension RouterDelegate {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
     }
     
-    func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions {
+    func router(_ router: Router, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
         return options
     }

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -28,12 +28,25 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately before the router calculates a new route.
 
-     This method is called after `router(_:shouldRerouteFrom:)` is called, and before `router(_:didRerouteAlong:)` is called.
+     This method is called after `router(_:shouldRerouteFrom:)` is called, and before `router(_:willModify:)` is called.
      
      - parameter router: The router that will calculate a new route.
      - parameter location: The user’s current location.
      */
     func router(_ router: Router, willRerouteFrom location: CLLocation)
+    
+    /**
+     When reroute is happening, router suggests to customize the `RouteOptions` used to calculate new route.
+     
+     This method is called after `router(_:willRerouteFrom:)` is called, and before `router(_:didRerouteAlong:)` is called. This method is not called on proactive rerouting.
+     
+     Default implementation does no modifications.
+     
+     - parameter router: The router that will calculate a new route.
+     - parameter options: Original `RouteOptions`.
+     - returns: Modified `RouteOptions`.
+     */
+    func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions
     
     /**
      Called when a location has been identified as unqualified to navigate on.
@@ -49,7 +62,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called immediately after the router receives a new route.
      
-     This method is called after `router(_:willRerouteFrom:)` method is called.
+     This method is called after `router(_:willModify:)` method is called.
      
      - parameter router: The router that has calculated a new route.
      - parameter route: The new route.
@@ -218,6 +231,11 @@ public extension RouterDelegate {
     
     func router(_ router: Router, willRerouteFrom location: CLLocation) {
         logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
+    }
+    
+    func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions {
+        logUnimplemented(protocolType: RouterDelegate.self, level: .debug)
+        return options
     }
     
     func router(_ router: Router, shouldDiscard location: CLLocation) -> Bool {

--- a/Sources/MapboxCoreNavigation/RouterDelegate.swift
+++ b/Sources/MapboxCoreNavigation/RouterDelegate.swift
@@ -132,7 +132,7 @@ public protocol RouterDelegate: AnyObject, UnimplementedLogging {
     /**
      Called when the router fails to receive a new route.
      
-     This method is called after `router(_:willRerouteFrom:)`.
+     This method is called after `router(_:willModify:)`.
      
      - parameter router: The router that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -777,8 +777,8 @@ extension NavigationViewController: NavigationServiceDelegate {
         delegate?.navigationViewController(self, willRerouteFrom: location)
     }
     
-    public func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions {
-        return delegate?.navigationViewController(self, willModify: options) ?? options
+    public func navigationService(_ service: NavigationService, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions {
+        return delegate?.navigationViewController(self, modifiedOptionsForReroute: options) ?? options
     }
     
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -777,6 +777,10 @@ extension NavigationViewController: NavigationServiceDelegate {
         delegate?.navigationViewController(self, willRerouteFrom: location)
     }
     
+    public func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions {
+        return delegate?.navigationViewController(self, willModify: options) ?? options
+    }
+    
     public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
         for component in navigationComponents {
             component.navigationService(service, didRerouteAlong: route, at: location, proactive: proactive)

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -96,7 +96,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      
      - note: Multiple method calls will not interrupt the first ongoing request.
      
-     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:didRerouteAlong:)` is called.
+     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:willModify:)` is called.
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
      - parameter location: The user’s current location.
@@ -104,9 +104,22 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?)
     
     /**
+     When reroute is happening, navigation view controller suggests to customize the `RouteOptions` used to calculate new route.
+     
+     This method is called after `navigationViewController(_:willRerouteFrom:)` is called, and before `navigationViewController(_:didRerouteAlong:)` is called. This method is not called on proactive rerouting.
+     
+     Default implementation does no modifications.
+     
+     - parameter navigationViewController: The navigation view controller that will calculate a new route.
+     - parameter options: Original `RouteOptions`.
+     - returns: Modified `RouteOptions`.
+     */
+    func navigationViewController(_ navigationViewController: NavigationViewController, willModify options: RouteOptions) -> RouteOptions
+    
+    /**
      Called immediately after the navigation view controller receives a new route.
      
-     This method is called after `navigationViewController(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationViewController(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter route: The new route.
@@ -345,6 +358,11 @@ public extension NavigationViewControllerDelegate {
      */
     func navigationViewController(_ navigationViewController: NavigationViewController, willRerouteFrom location: CLLocation?) {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+    }
+    
+    func navigationViewController(_ navigationViewController: NavigationViewController, willModify options: RouteOptions) -> RouteOptions {
+        logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
+        return options
     }
     
     /**

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -96,7 +96,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      
      - note: Multiple method calls will not interrupt the first ongoing request.
      
-     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:willModify:)` is called.
+     This method is called after `navigationViewController(_:shouldRerouteFrom:)` is called, simultaneously with the `Notification.Name.routeControllerWillReroute` notification being posted, and before `navigationViewController(_:modifiedOptionsForReroute:)` is called.
      
      - parameter navigationViewController: The navigation view controller that will calculate a new route.
      - parameter location: The user’s current location.
@@ -114,12 +114,12 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
      - parameter options: Original `RouteOptions`.
      - returns: Modified `RouteOptions`.
      */
-    func navigationViewController(_ navigationViewController: NavigationViewController, willModify options: RouteOptions) -> RouteOptions
+    func navigationViewController(_ navigationViewController: NavigationViewController, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions
     
     /**
      Called immediately after the navigation view controller receives a new route.
      
-     This method is called after `navigationViewController(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
+     This method is called after `navigationViewController(_:modifiedOptionsForReroute:)` and simultaneously with the `Notification.Name.routeControllerDidReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter route: The new route.
@@ -179,7 +179,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called when the navigation view controller fails to receive a new route.
      
-     This method is called after `navigationViewController(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationViewController(_:modifiedOptionsForReroute:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.
@@ -360,7 +360,7 @@ public extension NavigationViewControllerDelegate {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
     }
     
-    func navigationViewController(_ navigationViewController: NavigationViewController, willModify options: RouteOptions) -> RouteOptions {
+    func navigationViewController(_ navigationViewController: NavigationViewController, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions {
         logUnimplemented(protocolType: NavigationViewControllerDelegate.self,  level: .debug)
         return options
     }

--- a/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/NavigationViewControllerDelegate.swift
@@ -179,7 +179,7 @@ public protocol NavigationViewControllerDelegate: VisualInstructionDelegate {
     /**
      Called when the navigation view controller fails to receive a new route.
      
-     This method is called after `navigationViewController(_:willRerouteFrom:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
+     This method is called after `navigationViewController(_:willModify:)` and simultaneously with the `Notification.Name.routeControllerDidFailToReroute` notification being posted.
      
      - parameter navigationViewController: The navigation view controller that has calculated a new route.
      - parameter error: An error raised during the process of obtaining a new route.

--- a/Sources/TestHelper/NavigationServiceTestDoubles.swift
+++ b/Sources/TestHelper/NavigationServiceTestDoubles.swift
@@ -32,6 +32,11 @@ public class NavigationServiceDelegateSpy: NavigationServiceDelegate {
         recentMessages.append(#function)
     }
     
+    public func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions {
+        recentMessages.append(#function)
+        return options
+    }
+    
     public func navigationService(_ service: NavigationService, shouldDiscard location: CLLocation) -> Bool {
         recentMessages.append(#function)
         return false

--- a/Sources/TestHelper/NavigationServiceTestDoubles.swift
+++ b/Sources/TestHelper/NavigationServiceTestDoubles.swift
@@ -32,7 +32,7 @@ public class NavigationServiceDelegateSpy: NavigationServiceDelegate {
         recentMessages.append(#function)
     }
     
-    public func navigationService(_ service: NavigationService, willModify options: RouteOptions) -> RouteOptions {
+    public func navigationService(_ service: NavigationService, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions {
         recentMessages.append(#function)
         return options
     }

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -7,7 +7,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onDidRefresh: ((RouteProgress) -> Void)?
     public var onShouldRerouteFrom: ((CLLocation) -> Bool)?
     public var onWillRerouteFrom: ((CLLocation) -> Void)?
-    public var onWillModify: ((RouteOptions) -> RouteOptions)?
+    public var onModifiedOptionsForReroute: ((RouteOptions) -> RouteOptions)?
     public var onShouldDiscard: ((CLLocation) -> Bool)?
     public var onDidRerouteAlong: (((route: Route, location: CLLocation?, proactive: Bool)) -> Void)?
     public var onDidFailToRerouteWith: ((Error) -> Void)?
@@ -42,8 +42,8 @@ public final class RouterDelegateSpy: RouterDelegate {
         onWillRerouteFrom?(location)
     }
     
-    public func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions {
-        return onWillModify?(options) ?? options
+    public func router(_ router: Router, modifiedOptionsForReroute options: RouteOptions) -> RouteOptions {
+        return onModifiedOptionsForReroute?(options) ?? options
     }
     
     public func router(_ router: Router,

--- a/Sources/TestHelper/RouterDelegateSpy.swift
+++ b/Sources/TestHelper/RouterDelegateSpy.swift
@@ -7,6 +7,7 @@ public final class RouterDelegateSpy: RouterDelegate {
     public var onDidRefresh: ((RouteProgress) -> Void)?
     public var onShouldRerouteFrom: ((CLLocation) -> Bool)?
     public var onWillRerouteFrom: ((CLLocation) -> Void)?
+    public var onWillModify: ((RouteOptions) -> RouteOptions)?
     public var onShouldDiscard: ((CLLocation) -> Bool)?
     public var onDidRerouteAlong: (((route: Route, location: CLLocation?, proactive: Bool)) -> Void)?
     public var onDidFailToRerouteWith: ((Error) -> Void)?
@@ -39,6 +40,10 @@ public final class RouterDelegateSpy: RouterDelegate {
     public func router(_ router: Router,
                        willRerouteFrom location: CLLocation) {
         onWillRerouteFrom?(location)
+    }
+    
+    public func router(_ router: Router, willModify options: RouteOptions) -> RouteOptions {
+        return onWillModify?(options) ?? options
     }
     
     public func router(_ router: Router,

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -799,7 +799,7 @@ class NavigationServiceTests: TestCase {
         router.reroute(from: firstLoction,
                        along: router.routeProgress)
 
-        wait(for: [finishExpectation], timeout: locationManager.expectedReplayTime)
+        wait(for: [finishExpectation], timeout: locationManager.expectedReplayTime + 5)
         locationManager.stopUpdatingLocation()
         
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:willModify:)"))

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -763,7 +763,7 @@ class NavigationServiceTests: TestCase {
     }
 
     func testReroutingUpdatesRouteOptions() {
-        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: .default, routingProviderSource: .offline)
+        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: .default, routingProviderSource: .online)
         
         let trace = Fixture.generateTrace(for: initialRouteResponse.routes!.first!).shiftedToPresent()
         guard let firstLoction = trace.first,

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -779,16 +779,25 @@ class NavigationServiceTests: TestCase {
                                               locationSource: locationManager)
         service.delegate = delegate
         let router = service.router
-
-        let didFailtToRerouteExpectation = expectation(forNotification: .routeControllerDidFailToReroute,
-                                                       object: router)
+        
+        let finishExpectation = expectation(description: "Reroute should finish either way.")
+        NotificationCenter.default.addObserver(forName: .routeControllerDidFailToReroute,
+                                               object: nil,
+                                               queue: .main) { _ in
+            finishExpectation.fulfill()
+        }
+        NotificationCenter.default.addObserver(forName: .routeControllerDidReroute,
+                                               object: nil,
+                                               queue: .main) { _ in
+            finishExpectation.fulfill()
+        }
         
         service.start()
         
         router.reroute(from: firstLoction,
                        along: router.routeProgress)
 
-        wait(for: [didFailtToRerouteExpectation], timeout: locationManager.expectedReplayTime)
+        wait(for: [finishExpectation], timeout: locationManager.expectedReplayTime)
         locationManager.stopUpdatingLocation()
         
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:willModify:)"))

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -781,12 +781,14 @@ class NavigationServiceTests: TestCase {
         let router = service.router
         
         let finishExpectation = expectation(description: "Reroute should finish either way.")
-        NotificationCenter.default.addObserver(forName: .routeControllerDidFailToReroute,
+        finishExpectation.assertForOverFulfill = false
+        
+        let failObserver = NotificationCenter.default.addObserver(forName: .routeControllerDidFailToReroute,
                                                object: nil,
                                                queue: .main) { _ in
             finishExpectation.fulfill()
         }
-        NotificationCenter.default.addObserver(forName: .routeControllerDidReroute,
+        let rerouteObserver = NotificationCenter.default.addObserver(forName: .routeControllerDidReroute,
                                                object: nil,
                                                queue: .main) { _ in
             finishExpectation.fulfill()
@@ -801,6 +803,9 @@ class NavigationServiceTests: TestCase {
         locationManager.stopUpdatingLocation()
         
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:willModify:)"))
+        
+        NotificationCenter.default.removeObserver(failObserver)
+        NotificationCenter.default.removeObserver(rerouteObserver)
     }
     
     func testUnimplementedLogging() {

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -801,7 +801,7 @@ class NavigationServiceTests: TestCase {
         router.reroute(from: firstLoction,
                        along: router.routeProgress)
 
-        wait(for: [finishExpectation], timeout: locationManager.expectedReplayTime + 5)
+        _ = XCTWaiter.wait(for: [finishExpectation], timeout: locationManager.expectedReplayTime + 5)
         locationManager.stopUpdatingLocation()
         
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:willModify:)"))

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -763,6 +763,8 @@ class NavigationServiceTests: TestCase {
     }
 
     func testReroutingUpdatesRouteOptions() {
+        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: .default, routingProviderSource: .offline)
+        
         let trace = Fixture.generateTrace(for: initialRouteResponse.routes!.first!).shiftedToPresent()
         guard let firstLoction = trace.first,
               let lastLocation = trace.last,

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -505,7 +505,7 @@ class NavigationServiceTests: TestCase {
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:didRerouteAlong:at:proactive:)"))
 
         // MARK: Custom routing provider should not trigger RouteOptions customization
-        XCTAssertFalse(delegate.recentMessages.contains("navigationService(_:willModify:)"))
+        XCTAssertFalse(delegate.recentMessages.contains("navigationService(_:modifiedOptionsForReroute:)"))
         
         // MARK: On the next call to `locationManager(_, didUpdateLocations:)`
         navigationService.locationManager!(navigationService.locationManager, didUpdateLocations: [testLocation])
@@ -758,7 +758,7 @@ class NavigationServiceTests: TestCase {
         wait(for: [rerouteTriggeredExpectation, didRerouteExpectation], timeout: locationManager.expectedReplayTime)
         locationManager.stopUpdatingLocation()
         
-        XCTAssertFalse(delegate.recentMessages.contains("navigationService(_:willModify:)"))
+        XCTAssertFalse(delegate.recentMessages.contains("navigationService(_:modifiedOptionsForReroute:)"))
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:didRerouteAlong:at:proactive:)"))
     }
 
@@ -804,7 +804,7 @@ class NavigationServiceTests: TestCase {
         _ = XCTWaiter.wait(for: [finishExpectation], timeout: locationManager.expectedReplayTime + 5)
         locationManager.stopUpdatingLocation()
         
-        XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:willModify:)"))
+        XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:modifiedOptionsForReroute:)"))
         
         NotificationCenter.default.removeObserver(failObserver)
         NotificationCenter.default.removeObserver(rerouteObserver)

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -780,6 +780,8 @@ class NavigationServiceTests: TestCase {
                                               credentials: Fixture.credentials,
                                               locationSource: locationManager)
         let router = service.router
+        (router as? RouteController)?.rerouteController.resetToDefaultSettings()
+        
         let routerSpy = RouterDelegateSpy()
         let modifyExpectation = expectation(description: "Reroute should request options editing.")
         modifyExpectation.assertForOverFulfill = false

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -220,6 +220,50 @@ class RouteControllerTests: TestCase {
         
         wait(for: [alternativesExpectation], timeout: 2)
     }
+    
+    func testCustomRoutingProvider() {
+        let routingProviderStub = CustomRoutingProviderStub()
+        let routeExpectation = XCTestExpectation(description: "Route calculation should be called")
+        
+        routingProviderStub.routeStub = {
+            routeExpectation.fulfill()
+        }
+        
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
+            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
+        ]
+        
+        let options = NavigationRouteOptions(coordinates: coordinates)
+        let route = Fixture.route(from: "route-for-off-route", options: options)
+        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+        let routeResponse = RouteResponse(httpResponse: nil,
+                                          routes: [route],
+                                          options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
+                                          credentials: .mocked)
+        
+        let offRouteLocation = CLLocationCoordinate2D(latitude: coordinates[1].latitude,
+                                                      longitude: -coordinates[1].longitude)
+        let offRouteReplayLocation = Fixture.generateCoordinates(between: coordinates[0],
+                                                                 and: offRouteLocation,
+                                                                 count: 100).map {
+            CLLocation(coordinate: $0)
+        }.shiftedToPresent()
+        
+        let routeController = RouteController(alongRouteAtIndex: 0,
+                                              in: routeResponse,
+                                              options: options,
+                                              customRoutingProvider: routingProviderStub,
+                                              dataSource: self)
+        
+        let locationManager = ReplayLocationManager(locations: offRouteReplayLocation)
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+        
+        locationManager.speedMultiplier = 50
+        locationManager.startUpdatingLocation()
+        wait(for: [routeExpectation], timeout: locationManager.expectedReplayTime)
+    }
 }
 
 extension RouteControllerTests: RouterDataSource {
@@ -229,5 +273,26 @@ extension RouteControllerTests: RouterDataSource {
     
     var locationManagerType: NavigationLocationManager.Type {
         return NavigationLocationManager.self
+    }
+}
+
+class CustomRoutingProviderStub: RoutingProvider {
+    var routeStub: (() -> Void)?
+    var matchStub: (() -> Void)?
+    var refreshStub: (() -> Void)?
+    
+    func calculateRoutes(options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        routeStub?()
+        return nil
+    }
+    
+    func calculateRoutes(options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> NavigationProviderRequest? {
+        matchStub?()
+        return nil
+    }
+    
+    func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        refreshStub?()
+        return nil
     }
 }

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -264,6 +264,53 @@ class RouteControllerTests: TestCase {
         locationManager.startUpdatingLocation()
         wait(for: [routeExpectation], timeout: locationManager.expectedReplayTime)
     }
+    
+    func testReroutingUpdatesRouteOptions() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
+            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
+        ]
+        
+        let options = NavigationRouteOptions(coordinates: coordinates)
+        let route = Fixture.route(from: "route-for-off-route", options: options)
+        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+        let routeResponse = RouteResponse(httpResponse: nil,
+                                          routes: [route],
+                                          options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
+                                          credentials: .mocked)
+        
+        let offRouteLocation = CLLocationCoordinate2D(latitude: coordinates[1].latitude,
+                                                      longitude: -coordinates[1].longitude)
+        let offRouteReplayLocation = Fixture.generateCoordinates(between: coordinates[0],
+                                                                 and: offRouteLocation,
+                                                                 count: 100).map {
+            CLLocation(coordinate: $0)
+        }.shiftedToPresent()
+        
+        let routeController = RouteController(alongRouteAtIndex: 0,
+                                              in: routeResponse,
+                                              options: options,
+                                              customRoutingProvider: nil,
+                                              dataSource: self)
+        
+        let routerDelegateSpy = RouterDelegateSpy()
+        let modifyExpectation = expectation(description: "Reroute should request options editing.")
+        modifyExpectation.assertForOverFulfill = false
+        
+        routerDelegateSpy.onModifiedOptionsForReroute = { options in
+            modifyExpectation.fulfill()
+            return options
+        }
+        routeController.delegate = routerDelegateSpy
+        
+        let locationManager = ReplayLocationManager(locations: offRouteReplayLocation)
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+        
+        locationManager.speedMultiplier = 50
+        locationManager.startUpdatingLocation()
+        wait(for: [modifyExpectation], timeout: locationManager.expectedReplayTime)
+    }
 }
 
 extension RouteControllerTests: RouterDataSource {


### PR DESCRIPTION
### Description
Resolves #4032 
Adding possibility to modify route options on each reroute. This does not cover proactive reroute since it's idea is to find "same but faster" route, at which point it will loose it's purpose if we modify route search criteria (a.k.a. RouteOptions). It also does not cover custom routing provider use case since it is already covering that step.

### Implementation
Added default reroute controller interface wrapper to chime in route options customization.  Reworked controller setup accordingly. Added delegate methods to forward the change. Unit tests updated