### PR TITLE
Add traversed route line layer to customize `traversedRouteColor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Fixed an issue where the map would cut off a continuous alternative route to appear as if it began after the deviation point. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Fixed an issue where the callout annotating a continuous alternative route appeared far away from the route and contained an inaccurate travel time. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Fixed an issue where some roads were shown as restricted on the route line even if public access is allowed for “local traffic only”. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
-* Fixed an issue where the part of the route that has been traversed couldn't be customized through `NavigationMapView.traversedRouteColor`. ([#4106](https://github.com/mapbox/mapbox-navigation-ios/pull/4106))
+* Fixed an issue where the `NavigationMapView.traversedRouteColor` property had no effect on the traversed part of the route line. ([#4106](https://github.com/mapbox/mapbox-navigation-ios/pull/4106))
 
 ### Guidance Instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fixed an issue where the map would cut off a continuous alternative route to appear as if it began after the deviation point. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Fixed an issue where the callout annotating a continuous alternative route appeared far away from the route and contained an inaccurate travel time. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Fixed an issue where some roads were shown as restricted on the route line even if public access is allowed for “local traffic only”. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
+* Fixed an issue where the part of the route that has been traversed couldn't be customized through `NavigationMapView.traversedRouteColor`. ([#4106](https://github.com/mapbox/mapbox-navigation-ios/pull/4106))
 
 ### Guidance Instructions
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -367,14 +367,6 @@ open class NavigationMapView: UIView {
         mapView.mapboxMap.style.removeSources(sourceIdentifiers)
     }
     
-    func removeRestrictedRouteArea() {
-        guard let sourceIdentifier = routes?.first?.identifier(.restrictedRouteAreaSource),
-              let layerIdentifier = routes?.first?.identifier(.restrictedRouteAreaRoute) else { return }
-        
-        mapView.mapboxMap.style.removeLayers(Set([layerIdentifier]))
-        mapView.mapboxMap.style.removeSources(Set([sourceIdentifier]))
-    }
-    
     /**
      Shows the step arrow given the current `RouteProgress`.
      

--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -142,6 +142,8 @@ extension Route {
             return "\(identifier).\(isMainRoute ? "main" : "alternative").route_line"
         case .routeCasing(isMainRoute: let isMainRoute):
             return "\(identifier).\(isMainRoute ? "main" : "alternative").route_line_casing"
+        case .traversedRoute:
+            return "\(identifier).traversed_route"
         case .restrictedRouteAreaSource:
             return "\(identifier).restricted_area_source"
         case .restrictedRouteAreaRoute:

--- a/Sources/MapboxNavigation/RouteLineType.swift
+++ b/Sources/MapboxNavigation/RouteLineType.swift
@@ -8,6 +8,8 @@ enum RouteLineType {
     
     case routeCasing(isMainRoute: Bool)
     
+    case traversedRoute
+    
     case restrictedRouteAreaSource
     
     case restrictedRouteAreaRoute

--- a/Tests/MapboxNavigationTests/RouteLineLayerPositionTests.swift
+++ b/Tests/MapboxNavigationTests/RouteLineLayerPositionTests.swift
@@ -298,12 +298,12 @@ class RouteLineLayerPositionTests: TestCase {
         navigationMapView.showWaypoints(on: multilegRoute)
         navigationMapView.show([multilegRoute])
         navigationMapView.showsRestrictedAreasOnRoute = true
+        navigationMapView.routeLineTracksTraversal = false
         
         expectedLayerSequence = [
             buildingLayer["id"]!,
             roadTrafficLayer["id"]!,
             circleMapLayer,
-            multilegRoute.identifier(.traversedRoute),
             multilegRoute.identifier(.routeCasing(isMainRoute: true)),
             multilegRoute.identifier(.route(isMainRoute: true)),
             multilegRoute.identifier(.restrictedRouteAreaRoute),

--- a/Tests/MapboxNavigationTests/RouteLineLayerPositionTests.swift
+++ b/Tests/MapboxNavigationTests/RouteLineLayerPositionTests.swift
@@ -238,9 +238,11 @@ class RouteLineLayerPositionTests: TestCase {
         navigationMapView.show([multilegRoute], layerPosition: customRouteLineLayerPosition)
         navigationMapView.removeWaypoints()
         navigationMapView.showsRestrictedAreasOnRoute = false
+        navigationMapView.routeLineTracksTraversal = true
         
         expectedLayerSequence = [
             buildingLayer["id"]!,
+            multilegRoute.identifier(.traversedRoute),
             multilegRoute.identifier(.routeCasing(isMainRoute: true)),
             multilegRoute.identifier(.route(isMainRoute: true)),
             roadTrafficLayer["id"]!,
@@ -301,6 +303,7 @@ class RouteLineLayerPositionTests: TestCase {
             buildingLayer["id"]!,
             roadTrafficLayer["id"]!,
             circleMapLayer,
+            multilegRoute.identifier(.traversedRoute),
             multilegRoute.identifier(.routeCasing(isMainRoute: true)),
             multilegRoute.identifier(.route(isMainRoute: true)),
             multilegRoute.identifier(.restrictedRouteAreaRoute),


### PR DESCRIPTION
### Description
This Pr is to fix #4105 by adding a traversed route line layer below main route casing layer with `traversedRouteColor`, to support the color customization for the traversed part of main route line. 

### Implementation
When `routeLineTracksTraversal` is on, add a traversed route line layer below main route casing layer, but above the alternative route layer. The traversed layer should have the same source and width as the main route casing layer, with it's color as `traversedRouteColor`.

So when the user location is updated, the main route line and route casing layer are both updated and trimmed, the below traversed layer will show up. By default, it would be transparent. But the customer could change the `NavigationMapView.traversedRouteColor` to show the traversed part with the designed color.

### Screenshots or Gifs
when we turn on the `routeLineTracksTraversal` and have color for the route line as below:
```
navigationViewController.routeLineTracksTraversal = true
navigationViewController.navigationMapView?.traversedRouteColor = .black
navigationViewController.navigationMapView?.trafficUnknownColor = .red
navigationViewController.navigationMapView?.trafficLowColor = .red
```
The traversed part will be displayed as below in the color of `traversedRouteColor`.

![customColor](https://user-images.githubusercontent.com/48976398/186766528-9f4ac071-b75a-4521-ae07-d64c421ddfd1.png)

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->