### PR TITLE
Add shape index parameter to route refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Routing
 
 * Route refreshing now respects current user progress on a leg to reduce update size and improve updating longer routes. ([#4111](https://github.com/mapbox/mapbox-navigation-ios/pull/4111))
-* Added `RoutingProvider.refreshRoute(indexedRouteResponse:fromLegAtIndex:currentRouteShapeIndex:currentLegShapeIndex:completionHandler:)` to request a refresh starting from specified shape index. Updated `RouteLegProgress` and `RouteProgress` initializers to include shape indices, and added `RouteProgress.refreshRoute(with:at:legIndex:legShapeIndex:)` to apply partial route refresh. ([#4111](https://github.com/mapbox/mapbox-navigation-ios/pull/4111))
+* Added `RoutingProvider.refreshRoute(indexedRouteResponse:fromLegAtIndex:routeShapeIndex:legShapeIndex:completionHandler:)` to request a refresh starting from specified shape index. Updated `RouteLegProgress` and `RouteProgress` initializers to include shape indices, and added `RouteProgress.refreshRoute(with:at:legIndex:legShapeIndex:)` to apply partial route refresh. ([#4111](https://github.com/mapbox/mapbox-navigation-ios/pull/4111))
 
 ### Banners and guidance instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
 * Fixed an issue where tapping on a route duration annotation that overlaps a different route would cause the wrong route to be passed into `NavigationMapViewDelegate.navigationMapView(_:didSelect:)` or `NavigationMapViewDelegate.navigationMapView(_:didSelect:)`. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
 
+### Routing
+
+* Route refreshing now respects current user progress on a leg to reduce update size and improve updating longer routes. ([#4111](https://github.com/mapbox/mapbox-navigation-ios/pull/4111))
+* Added `RoutingProvider.refreshRoute(indexedRouteResponse:fromLegAtIndex:currentRouteShapeIndex:currentLegShapeIndex:completionHandler:)` to request a refresh starting from specified shape index. Updated `RouteLegProgress` and `RouteProgress` initializers to include shape indices, and added `RouteProgress.refreshRoute(with:at:legIndex:legShapeIndex:)` to apply partial route refresh. ([#4111](https://github.com/mapbox/mapbox-navigation-ios/pull/4111))
+
 ### Banners and guidance instructions
 
 * Added replacement for `VisualInstruction.maneuverImageSet(side:)` method to generate a maneuver image on iOS 13 and above. ([#4161](https://github.com/mapbox/mapbox-navigation-ios/pull/4161))

--- a/Sources/MapboxCoreNavigation/Directions+RoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/Directions+RoutingProvider.swift
@@ -32,7 +32,7 @@ extension Directions: RoutingProvider {
         return calculate(options, completionHandler: completionHandler)
     }
     
-    @discardableResult public func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, completionHandler: @escaping RouteCompletionHandler) -> NavigationProviderRequest? {
+    @discardableResult public func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, currentRouteShapeIndex: Int?, completionHandler: @escaping RouteCompletionHandler) -> NavigationProviderRequest? {
         guard case let .route(routeOptions) = indexedRouteResponse.routeResponse.options else {
             preconditionFailure("Invalid route data passed for refreshing. Expected `RouteResponse` containing `.route` `ResponseOptions` but got `.match`.")
         }

--- a/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
@@ -368,7 +368,7 @@ public class MapboxRoutingProvider: RoutingProvider {
                                                  routeIndex: routeIndex,
                                                  legIndex: startLegIndex,
                                                  routingProfile: routeOptions.profileIdentifier.nativeProfile,
-                                                 currentRouteGeometryIndex: currentRouteShapeIndex as? NSNumber)
+                                                 currentRouteGeometryIndex: currentRouteShapeIndex.map { NSNumber(value: $0) })
 
         requestId = router.getRouteRefresh(for: refreshOptions, callback: { [weak self] result, _ in
             guard let self = self else { return }

--- a/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
@@ -322,6 +322,7 @@ public class MapboxRoutingProvider: RoutingProvider {
      */
     @discardableResult public func refreshRoute(indexedRouteResponse: IndexedRouteResponse,
                                                 fromLegAtIndex startLegIndex: UInt32 = 0,
+                                                currentRouteShapeIndex: Int? = nil,
                                                 completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
         guard case let .route(routeOptions) = indexedRouteResponse.routeResponse.options else {
             preconditionFailure("Invalid route data passed for refreshing. Expected `RouteResponse` containing `.route` `ResponseOptions` but got `.match`.")
@@ -344,8 +345,8 @@ public class MapboxRoutingProvider: RoutingProvider {
                                                  routeIndex: routeIndex,
                                                  legIndex: startLegIndex,
                                                  routingProfile: routeOptions.profileIdentifier.nativeProfile,
-                                                 currentRouteGeometryIndex: nil)
-        
+                                                 currentRouteGeometryIndex: currentRouteShapeIndex as? NSNumber)
+
         requestId = router.getRouteRefresh(for: refreshOptions, callback: { [weak self] result, _ in
             guard let self = self else { return }
             

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -389,7 +389,8 @@ open class RouteController: NSObject {
                with: snappedLocation,
                rawLocation: rawLocation,
                upcomingRouteAlerts: status.upcomingRouteAlerts,
-               mapMatchingResult: MapMatchingResult(status: status))
+               mapMatchingResult: MapMatchingResult(status: status),
+               routeShapeIndex: Int(status.geometryIndex))
         
         updateIndexes(status: status, progress: routeProgress)
         updateRouteLegProgress(status: status)
@@ -520,6 +521,8 @@ open class RouteController: NSObject {
             preconditionFailure("Route legs used for navigation must have destinations")
         }
         let remainingVoiceInstructions = legProgress.currentStepProgress.remainingSpokenInstructions ?? []
+
+        legProgress.shapeIndex = Int(status.shapeIndex)
         
         // We are at least at the "You will arrive" instruction
         if legProgress.remainingSteps.count <= 2 && remainingVoiceInstructions.count <= 2 {
@@ -543,9 +546,10 @@ open class RouteController: NSObject {
         }
     }
     
-    private func update(progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation, upcomingRouteAlerts routeAlerts: [UpcomingRouteAlert], mapMatchingResult: MapMatchingResult) {
+    private func update(progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation, upcomingRouteAlerts routeAlerts: [UpcomingRouteAlert], mapMatchingResult: MapMatchingResult, routeShapeIndex: Int) {
         progress.updateDistanceTraveled(with: location)
         progress.upcomingRouteAlerts = routeAlerts.map { RouteAlert($0) }
+        progress.currentRouteShapeIndex = routeShapeIndex
         
         //Fire the delegate method
         delegate?.router(self, didUpdate: progress, with: location, rawLocation: rawLocation)

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -549,7 +549,7 @@ open class RouteController: NSObject {
     private func update(progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation, upcomingRouteAlerts routeAlerts: [UpcomingRouteAlert], mapMatchingResult: MapMatchingResult, routeShapeIndex: Int) {
         progress.updateDistanceTraveled(with: location)
         progress.upcomingRouteAlerts = routeAlerts.map { RouteAlert($0) }
-        progress.currentRouteShapeIndex = routeShapeIndex
+        progress.shapeIndex = routeShapeIndex
         
         //Fire the delegate method
         delegate?.router(self, didUpdate: progress, with: location, rawLocation: rawLocation)

--- a/Sources/MapboxCoreNavigation/RouteLegProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteLegProgress.swift
@@ -186,6 +186,7 @@ open class RouteLegProgress: Codable {
 
      - parameter leg: Leg on a `Route`.
      - parameter stepIndex: Current step the user is on.
+     - parameter shapeIndex: Index relative to leg shape, representing the point the user is currently located at.
      */
     public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0, shapeIndex: Int = 0) {
         precondition(leg.steps.indices.contains(stepIndex), "It's not possible to set the stepIndex: \(stepIndex) when it's higher than steps count \(leg.steps.count) or not included.")

--- a/Sources/MapboxCoreNavigation/RouteLegProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteLegProgress.swift
@@ -175,6 +175,11 @@ open class RouteLegProgress: Codable {
             return speedLimit
         }
     }
+
+    /**
+     Index relative to leg shape, representing the point the user is currently located at.
+     */
+    public internal(set) var shapeIndex: Int?
     
     /**
      Intializes a new `RouteLegProgress`.
@@ -247,5 +252,6 @@ open class RouteLegProgress: Codable {
         case stepIndex
         case userHasArrivedAtWaypoint
         case currentStepProgress
+        case shapeIndex
     }
 }

--- a/Sources/MapboxCoreNavigation/RouteLegProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteLegProgress.swift
@@ -179,7 +179,7 @@ open class RouteLegProgress: Codable {
     /**
      Index relative to leg shape, representing the point the user is currently located at.
      */
-    public internal(set) var shapeIndex: Int?
+    public internal(set) var shapeIndex: Int
     
     /**
      Intializes a new `RouteLegProgress`.
@@ -187,11 +187,12 @@ open class RouteLegProgress: Codable {
      - parameter leg: Leg on a `Route`.
      - parameter stepIndex: Current step the user is on.
      */
-    public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0) {
+    public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0, shapeIndex: Int = 0) {
         precondition(leg.steps.indices.contains(stepIndex), "It's not possible to set the stepIndex: \(stepIndex) when it's higher than steps count \(leg.steps.count) or not included.")
         
         self.leg = leg
         self.stepIndex = stepIndex
+        self.shapeIndex = shapeIndex
         
         currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
     }

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -15,15 +15,15 @@ open class RouteProgress: Codable {
      - parameter route: The route to follow.
      - parameter options: The route options that were attached to the route request.
      - parameter legIndex: Zero-based index indicating the current leg the user is on.
-     - parameter currentRouteShapeIndex: Index relative to route shape, representing the point the user is currently located at.
-     - parameter currentLegShapeIndex: Index relative to leg shape, representing the point the user is currently located at.
+     - parameter routeShapeIndex: Index relative to route shape, representing the point the user is currently located at.
+     - parameter legShapeIndex: Index relative to leg shape, representing the point the user is currently located at.
      */
-    public init(route: Route, options: RouteOptions, legIndex: Int = 0, spokenInstructionIndex: Int = 0, currentRouteShapeIndex: Int = 0, currentLegShapeIndex: Int = 0) {
+    public init(route: Route, options: RouteOptions, legIndex: Int = 0, spokenInstructionIndex: Int = 0, routeShapeIndex: Int = 0, legShapeIndex: Int = 0) {
         self.route = route
         self.routeOptions = options
         self.legIndex = legIndex
-        self.currentRouteShapeIndex = currentRouteShapeIndex
-        self.currentLegProgress = RouteLegProgress(leg: route.legs[legIndex], stepIndex: 0, spokenInstructionIndex: spokenInstructionIndex, shapeIndex: currentLegShapeIndex)
+        self.shapeIndex = routeShapeIndex
+        self.currentLegProgress = RouteLegProgress(leg: route.legs[legIndex], stepIndex: 0, spokenInstructionIndex: spokenInstructionIndex, shapeIndex: legShapeIndex)
 
         self.calculateLegsCongestion()
     }
@@ -167,7 +167,7 @@ open class RouteProgress: Codable {
     /**
      Index relative to route shape, representing the point the user is currently located at.
      */
-    public internal(set) var currentRouteShapeIndex: Int
+    public internal(set) var shapeIndex: Int
 
     /**
      Increments the progress according to new location specified.
@@ -371,7 +371,7 @@ open class RouteProgress: Codable {
         case routeOptions
         case legIndex
         case currentLegProgress
-        case currentRouteShapeIndex
+        case shapeIndex
     }
         
     required public init(from decoder: Decoder) throws {
@@ -382,7 +382,7 @@ open class RouteProgress: Codable {
         self.routeOptions = try container.decode(RouteOptions.self, forKey: .routeOptions)
         self.legIndex = try container.decode(Int.self, forKey: .legIndex)
         self.currentLegProgress = try container.decode(RouteLegProgress.self, forKey: .currentLegProgress)
-        self.currentRouteShapeIndex = try container.decode(Int.self, forKey: .currentRouteShapeIndex)
+        self.shapeIndex = try container.decode(Int.self, forKey: .shapeIndex)
         
         calculateLegsCongestion()
     }
@@ -394,6 +394,6 @@ open class RouteProgress: Codable {
         try container.encode(routeOptions, forKey: .routeOptions)
         try container.encode(legIndex, forKey: .legIndex)
         try container.encode(currentLegProgress, forKey: .currentLegProgress)
-        try container.encode(currentRouteShapeIndex, forKey: .currentRouteShapeIndex)
+        try container.encode(shapeIndex, forKey: .shapeIndex)
     }
 }

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -150,7 +150,12 @@ open class RouteProgress: Codable {
         calculateLegsCongestion()
         updateDistanceTraveled(with: location)
     }
-    
+
+    /**
+     Index relative to route shape, representing the point the user is currently located at.
+     */
+    public internal(set) var currentRouteShapeIndex: Int?
+
     /**
      Increments the progress according to new location specified.
      - parameter location: Updated user location.
@@ -353,6 +358,7 @@ open class RouteProgress: Codable {
         case routeOptions
         case legIndex
         case currentLegProgress
+        case currentRouteShapeIndex
     }
         
     required public init(from decoder: Decoder) throws {
@@ -363,6 +369,7 @@ open class RouteProgress: Codable {
         self.routeOptions = try container.decode(RouteOptions.self, forKey: .routeOptions)
         self.legIndex = try container.decode(Int.self, forKey: .legIndex)
         self.currentLegProgress = try container.decode(RouteLegProgress.self, forKey: .currentLegProgress)
+        self.currentRouteShapeIndex = try container.decodeIfPresent(Int.self, forKey: .currentRouteShapeIndex)
         
         calculateLegsCongestion()
     }
@@ -374,5 +381,6 @@ open class RouteProgress: Codable {
         try container.encode(routeOptions, forKey: .routeOptions)
         try container.encode(legIndex, forKey: .legIndex)
         try container.encode(currentLegProgress, forKey: .currentLegProgress)
+        try container.encode(currentRouteShapeIndex, forKey: .currentRouteShapeIndex)
     }
 }

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -16,11 +16,12 @@ open class RouteProgress: Codable {
      - parameter options: The route options that were attached to the route request.
      - parameter legIndex: Zero-based index indicating the current leg the user is on.
      */
-    public init(route: Route, options: RouteOptions, legIndex: Int = 0, spokenInstructionIndex: Int = 0) {
+    public init(route: Route, options: RouteOptions, legIndex: Int = 0, spokenInstructionIndex: Int = 0, currentRouteShapeIndex: Int = 0, currentLegShapeIndex: Int = 0) {
         self.route = route
         self.routeOptions = options
         self.legIndex = legIndex
-        self.currentLegProgress = RouteLegProgress(leg: route.legs[legIndex], stepIndex: 0, spokenInstructionIndex: spokenInstructionIndex)
+        self.currentRouteShapeIndex = currentRouteShapeIndex
+        self.currentLegProgress = RouteLegProgress(leg: route.legs[legIndex], stepIndex: 0, spokenInstructionIndex: spokenInstructionIndex, shapeIndex: currentLegShapeIndex)
 
         self.calculateLegsCongestion()
     }
@@ -144,6 +145,16 @@ open class RouteProgress: Codable {
     public func refreshRoute(with refreshedRoute: RouteRefreshSource, at location: CLLocation) {
         route.refreshLegAttributes(from: refreshedRoute)
         route.refreshLegIncidents(from: refreshedRoute)
+        commonRefreshRoute(at: location)
+    }
+
+    public func refreshRoute(with refreshedRoute: RouteRefreshSource, at location: CLLocation, legIndex: Int, legShapeIndex: Int) {
+        route.refreshLegAttributes(from: refreshedRoute, legIndex: legIndex, legShapeIndex: legShapeIndex)
+        route.refreshLegIncidents(from: refreshedRoute, legIndex: legIndex, legShapeIndex: legShapeIndex)
+        commonRefreshRoute(at: location)
+    }
+
+    private func commonRefreshRoute(at location: CLLocation) {
         currentLegProgress = RouteLegProgress(leg: route.legs[legIndex],
                                               stepIndex: currentLegProgress.stepIndex,
                                               spokenInstructionIndex: currentLegProgress.currentStepProgress.spokenInstructionIndex)
@@ -154,7 +165,7 @@ open class RouteProgress: Codable {
     /**
      Index relative to route shape, representing the point the user is currently located at.
      */
-    public internal(set) var currentRouteShapeIndex: Int?
+    public internal(set) var currentRouteShapeIndex: Int
 
     /**
      Increments the progress according to new location specified.
@@ -369,7 +380,7 @@ open class RouteProgress: Codable {
         self.routeOptions = try container.decode(RouteOptions.self, forKey: .routeOptions)
         self.legIndex = try container.decode(Int.self, forKey: .legIndex)
         self.currentLegProgress = try container.decode(RouteLegProgress.self, forKey: .currentLegProgress)
-        self.currentRouteShapeIndex = try container.decodeIfPresent(Int.self, forKey: .currentRouteShapeIndex)
+        self.currentRouteShapeIndex = try container.decode(Int.self, forKey: .currentRouteShapeIndex)
         
         calculateLegsCongestion()
     }

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -15,6 +15,8 @@ open class RouteProgress: Codable {
      - parameter route: The route to follow.
      - parameter options: The route options that were attached to the route request.
      - parameter legIndex: Zero-based index indicating the current leg the user is on.
+     - parameter currentRouteShapeIndex: Index relative to route shape, representing the point the user is currently located at.
+     - parameter currentLegShapeIndex: Index relative to leg shape, representing the point the user is currently located at.
      */
     public init(route: Route, options: RouteOptions, legIndex: Int = 0, spokenInstructionIndex: Int = 0, currentRouteShapeIndex: Int = 0, currentLegShapeIndex: Int = 0) {
         self.route = route

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -282,7 +282,7 @@ extension InternalRouter where Self: Router {
     
     func refreshAndCheckForFasterRoute(from location: CLLocation, routeProgress: RouteProgress) {
         if refreshesRoute {
-            refreshRoute(from: location, legIndex: routeProgress.legIndex) { [weak self] in
+            refreshRoute(from: location, legIndex: routeProgress.legIndex, shapeIndex: routeProgress.currentRouteShapeIndex) { [weak self] in
                 self?.checkForFasterRoute(from: location, routeProgress: routeProgress)
             }
         } else {
@@ -290,7 +290,7 @@ extension InternalRouter where Self: Router {
         }
     }
     
-    func refreshRoute(from location: CLLocation, legIndex: Int, completion: @escaping ()->()) {
+    func refreshRoute(from location: CLLocation, legIndex: Int, shapeIndex: Int?, completion: @escaping ()->()) {
         guard refreshesRoute else {
             completion()
             return
@@ -313,7 +313,8 @@ extension InternalRouter where Self: Router {
         }
         isRefreshing = true
         resolvedRoutingProvider.refreshRoute(indexedRouteResponse: indexedRouteResponse,
-                                             fromLegAtIndex: UInt32(legIndex)) { [weak self] session, result in
+                                             fromLegAtIndex: UInt32(legIndex),
+                                             currentRouteShapeIndex: shapeIndex) { [weak self] session, result in
             defer {
                 self?.isRefreshing = false
                 self?.lastRouteRefresh = nil

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -282,7 +282,7 @@ extension InternalRouter where Self: Router {
     
     func refreshAndCheckForFasterRoute(from location: CLLocation, routeProgress: RouteProgress) {
         if refreshesRoute {
-            refreshRoute(from: location, legIndex: routeProgress.legIndex, routeShapeIndex: routeProgress.currentRouteShapeIndex, legShapeIndex: routeProgress.currentLegProgress.shapeIndex) { [weak self] in
+            refreshRoute(from: location, legIndex: routeProgress.legIndex, routeShapeIndex: routeProgress.shapeIndex, legShapeIndex: routeProgress.currentLegProgress.shapeIndex) { [weak self] in
                 self?.checkForFasterRoute(from: location, routeProgress: routeProgress)
             }
         } else {

--- a/Sources/MapboxCoreNavigation/RoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/RoutingProvider.swift
@@ -51,7 +51,12 @@ public protocol RoutingProvider {
      */
     @discardableResult func refreshRoute(indexedRouteResponse: IndexedRouteResponse,
                                          fromLegAtIndex: UInt32,
-                                         currentRouteShapeIndex: Int?,
+                                         completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest?
+
+    @discardableResult func refreshRoute(indexedRouteResponse: IndexedRouteResponse,
+                                         fromLegAtIndex: UInt32,
+                                         currentRouteShapeIndex: Int,
+                                         currentLegShapeIndex: Int,
                                          completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest?
 }
 

--- a/Sources/MapboxCoreNavigation/RoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/RoutingProvider.swift
@@ -42,10 +42,10 @@ public protocol RoutingProvider {
                                             completionHandler: @escaping Directions.MatchCompletionHandler) -> NavigationProviderRequest?
     
     /**
-     Begins asynchronously refreshing the route with the given identifier, optionally starting from an arbitrary leg along the route.
+     Begins asynchronously refreshing the route with the given identifier, starting from an arbitrary leg along the route.
      
      - parameter indexedRouteResponse: The `RouteResponse` and selected `routeIndex` in it to be refreshed.
-     - parameter fromLegAtIndex: The index of the leg in the route at which to begin refreshing. The response will omit any leg before this index and refresh any leg from this index to the end of the route. If this argument is omitted, the entire route is refreshed.
+     - parameter fromLegAtIndex: The index of the leg in the route at which to begin refreshing. The response will omit any leg before this index and refresh any leg from this index to the end of the route. If this argument is `0`, the entire route is refreshed.
      - parameter completionHandler: The closure (block) to call with updated `RouteResponse` data. Order of `routes` remain unchanged comparing to original `indexedRouteResponse`. This closure is executed on the application’s main thread.
      - returns: Related request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel corresponding task using this handle.
      */
@@ -53,6 +53,16 @@ public protocol RoutingProvider {
                                          fromLegAtIndex: UInt32,
                                          completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest?
 
+    /**
+     Begins asynchronously refreshing the route with the given identifier, starting from an arbitrary leg and shape index along the route.
+
+     - parameter indexedRouteResponse: The `RouteResponse` and selected `routeIndex` in it to be refreshed.
+     - parameter fromLegAtIndex: The index of the leg in the route at which to begin refreshing. The response will omit any leg before this index and refresh any leg from this index to the end of the route.
+     - parameter currentRouteShapeIndex: Index relative to route shape, representing the point the user is currently located at.
+     - parameter currentRouteShapeIndex: Index relative to `fromLegAtIndex` leg shape, representing the point the user is currently located at.
+     - parameter completionHandler: The closure (block) to call with updated `RouteResponse` data. Order of `routes` remain unchanged comparing to original `indexedRouteResponse`. This closure is executed on the application’s main thread.
+     - returns: Related request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel corresponding task using this handle.
+     */
     @discardableResult func refreshRoute(indexedRouteResponse: IndexedRouteResponse,
                                          fromLegAtIndex: UInt32,
                                          currentRouteShapeIndex: Int,

--- a/Sources/MapboxCoreNavigation/RoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/RoutingProvider.swift
@@ -51,6 +51,7 @@ public protocol RoutingProvider {
      */
     @discardableResult func refreshRoute(indexedRouteResponse: IndexedRouteResponse,
                                          fromLegAtIndex: UInt32,
+                                         currentRouteShapeIndex: Int?,
                                          completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest?
 }
 

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -359,6 +359,7 @@ class CustomRoutingProviderStub: RoutingProvider {
     var routeStub: (() -> Void)?
     var matchStub: (() -> Void)?
     var refreshStub: (() -> Void)?
+    var refreshByIndexStub: (() -> Void)?
     
     func calculateRoutes(options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
         routeStub?()
@@ -377,6 +378,11 @@ class CustomRoutingProviderStub: RoutingProvider {
     
     func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
         refreshStub?()
+        return nil
+    }
+    
+    func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, currentRouteShapeIndex: Int, currentLegShapeIndex: Int, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        refreshByIndexStub?()
         return nil
     }
 }

--- a/Tests/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -115,9 +115,9 @@ class RouteProgressTests: TestCase {
         return RouteLeg(steps: steps, name: "", distance: 0, expectedTravelTime: 0, profileIdentifier: .automobile)
     }
     
-    func routeLegProgress(options: RouteOptions, routeCoordinates: [CLLocationCoordinate2D]) -> RouteLegProgress {
+    func routeLegProgress(options: RouteOptions, routeCoordinates: [CLLocationCoordinate2D], shapeIndex: Int = 0) -> RouteLegProgress {
         let leg = routeLeg(options: options, routeCoordinates: routeCoordinates)
-        return RouteLegProgress(leg: leg)
+        return RouteLegProgress(leg: leg, shapeIndex: shapeIndex)
     }
     
     func testRemainingWaypointsAlongLeg() {
@@ -289,7 +289,10 @@ class RouteProgressTests: TestCase {
     }
     
     func testRouteProggressCodable() {
-        let routeProgress = RouteProgress(route: route, options: routeOptions)
+        let routeProgress = RouteProgress(route: route,
+                                          options: routeOptions,
+                                          currentRouteShapeIndex: 37,
+                                          currentLegShapeIndex: 13)
         
         let encoder = JSONEncoder()
         encoder.userInfo[.options] = routeOptions
@@ -311,6 +314,8 @@ class RouteProgressTests: TestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.leg.source, decoded.currentLegProgress.leg.source)
         XCTAssertEqual(routeProgress.congestionTravelTimesSegmentsByStep.count, decoded.congestionTravelTimesSegmentsByStep.count)
         XCTAssertEqual(routeProgress.congestionTimesPerStep, decoded.congestionTimesPerStep)
+        XCTAssertEqual(routeProgress.currentRouteShapeIndex, decoded.currentRouteShapeIndex)
+        XCTAssertEqual(routeProgress.currentLegProgress.shapeIndex, decoded.currentLegProgress.shapeIndex)
     }
     
     func testRouteLegProgressCodable() {
@@ -324,7 +329,7 @@ class RouteProgressTests: TestCase {
             CLLocationCoordinate2D(latitude: 12, longitude: 18),
         ]
         let options = RouteOptions(coordinates: [coordinates.first!, coordinates.last!])
-        let legProgress = routeLegProgress(options: options, routeCoordinates: coordinates)
+        let legProgress = routeLegProgress(options: options, routeCoordinates: coordinates, shapeIndex: 11)
         
         let data = try! JSONEncoder().encode(legProgress)
         let decoded = try! JSONDecoder().decode(RouteLegProgress.self, from: data)
@@ -334,6 +339,7 @@ class RouteProgressTests: TestCase {
         XCTAssertEqual(legProgress.userHasArrivedAtWaypoint, decoded.userHasArrivedAtWaypoint)
         XCTAssertEqual(legProgress.currentStepProgress.step, decoded.currentStepProgress.step)
         XCTAssertEqual(legProgress.currentStepProgress.distanceTraveled, decoded.currentStepProgress.distanceTraveled)
+        XCTAssertEqual(legProgress.shapeIndex, decoded.shapeIndex)
     }
     
     func testRouteStepProgressCodable() {

--- a/Tests/MapboxCoreNavigationTests/RouteProgressTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteProgressTests.swift
@@ -291,8 +291,8 @@ class RouteProgressTests: TestCase {
     func testRouteProggressCodable() {
         let routeProgress = RouteProgress(route: route,
                                           options: routeOptions,
-                                          currentRouteShapeIndex: 37,
-                                          currentLegShapeIndex: 13)
+                                          routeShapeIndex: 37,
+                                          legShapeIndex: 13)
         
         let encoder = JSONEncoder()
         encoder.userInfo[.options] = routeOptions
@@ -314,7 +314,7 @@ class RouteProgressTests: TestCase {
         XCTAssertEqual(routeProgress.currentLegProgress.leg.source, decoded.currentLegProgress.leg.source)
         XCTAssertEqual(routeProgress.congestionTravelTimesSegmentsByStep.count, decoded.congestionTravelTimesSegmentsByStep.count)
         XCTAssertEqual(routeProgress.congestionTimesPerStep, decoded.congestionTimesPerStep)
-        XCTAssertEqual(routeProgress.currentRouteShapeIndex, decoded.currentRouteShapeIndex)
+        XCTAssertEqual(routeProgress.shapeIndex, decoded.shapeIndex)
         XCTAssertEqual(routeProgress.currentLegProgress.shapeIndex, decoded.currentLegProgress.shapeIndex)
     }
     


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->
Covers integrating `current_route_geometry_index` Route Refresh API parameter.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
- [x] Test if annotations are refreshed according to the specified index
- [x] Add implementation to Directions+RoutingProvider

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->

Depends on https://github.com/mapbox/mapbox-directions-swift/pull/733