### PR TITLE
Update the check for `circleLayer` for default route line position

### DIFF
--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1861,10 +1861,11 @@ open class NavigationMapView: UIView {
                    let sourceLayer = mapView.mapboxMap.style.layerProperty(for: layerInfo.id, property: "source-layer").value as? String,
                    !sourceLayer.isEmpty {
                     if layerInfo.type.rawValue == "circle",
-                       let isPersistentCircle = try? mapView.mapboxMap.style.isPersistentLayer(id: layerInfo.id),
-                       let pitchAlignment = mapView.mapboxMap.style.layerProperty(for: layerInfo.id, property: "circle-pitch-alignment").value as? String,
-                       isPersistentCircle || (pitchAlignment == "viewport") {
-                        continue
+                       let isPersistentCircle = try? mapView.mapboxMap.style.isPersistentLayer(id: layerInfo.id) {
+                        let pitchAlignment = mapView.mapboxMap.style.layerProperty(for: layerInfo.id, property: "circle-pitch-alignment").value as? String
+                        if isPersistentCircle || (pitchAlignment != "map") {
+                            continue
+                        }
                     }
                     targetLayer = layerInfo.id
                 }

--- a/Tests/MapboxNavigationTests/RouteLineLayerPositionTests.swift
+++ b/Tests/MapboxNavigationTests/RouteLineLayerPositionTests.swift
@@ -268,8 +268,7 @@ class RouteLineLayerPositionTests: TestCase {
         let circleMapLayer = "circleMapLayer"
         addCircleLayerInRuntime(mapView: navigationMapView.mapView,
                                 circleLabelId: circleLabelLayer,
-                                isPersistent: true,
-                                circlePitchAlignment: .viewport)
+                                isPersistent: true)
         addCircleLayerInRuntime(mapView: navigationMapView.mapView,
                                 circleLabelId: circleMapLayer,
                                 isPersistent: false,
@@ -326,7 +325,7 @@ class RouteLineLayerPositionTests: TestCase {
     func addCircleLayerInRuntime(mapView: MapView,
                                  circleLabelId: String,
                                  isPersistent: Bool,
-                                 circlePitchAlignment: CirclePitchAlignment,
+                                 circlePitchAlignment: CirclePitchAlignment? = nil,
                                  layerPosition: MapboxMaps.LayerPosition? = nil) {
         do {
             if !mapView.mapboxMap.style.sourceExists(withId: circleLabelId) {
@@ -344,7 +343,9 @@ class RouteLineLayerPositionTests: TestCase {
             circleLabelLayer.circleColor = .constant(.init(UIColor.black))
             circleLabelLayer.circleOpacity = .constant(.init(1))
             circleLabelLayer.circleRadius = .constant(.init(10))
-            circleLabelLayer.circlePitchAlignment = .constant(circlePitchAlignment)
+            if let circlePitchAlignment = circlePitchAlignment {
+                circleLabelLayer.circlePitchAlignment = .constant(circlePitchAlignment)
+            }
             
             if isPersistent {
                 try mapView.mapboxMap.style.addPersistentLayer(circleLabelLayer, layerPosition: layerPosition)


### PR DESCRIPTION
### Description
#4084 introduced the check for circle layer when adding route line without custom layer position. But when no custom `circlePitchAlignment` property set for circle layer, the property will be `nil` and take the `viewport` as the pitch alignment for labeling.

### Implementation
This PR is to update the check from #4084 of the `pitchAlignment == "viewport"` to `pitchAlignment != "map"`. Because when circle layer has `circlePitchAlignment = nil` value, it will default choose the `viewport` for pitch alignment for label, such as the waypoint circle layer added in `NavigationMapView`. So the route line should skip this circle layer as well. 

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->