### PR TITLE
Fix crash that occurs while rotating device and applying `NavigationView` constraints at the same time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * Fixed a “dereference error” when passing certain OpenLR identifiers into the `RoadObjectMatcher.matchOpenLR(location:identifier:)` method. ([#4110](https://github.com/mapbox/mapbox-navigation-ios/pull/4110))
 * Fixed an issue where the `RoadObjectMatcher.matchOpenLR(location:identifier:)` method sometimes returned the wrong parallel roadway. ([#4110](https://github.com/mapbox/mapbox-navigation-ios/pull/4110))
 * Removed the `Hashable`-conforming extension for `CLLocationCoordinate2D` in `MapboxCoreNavigation` to fix a compiler error in applications that define their own `Hashable` conformance for this type. ([#4109](https://github.com/mapbox/mapbox-navigation-ios/pull/4109))
+* Fixed the crash that sometimes occurs when orientation of the view controller that contains `NavigationView` is being changed and `NavigationView`'s parent view is being deallocated at the same time. ([#4118](https://github.com/mapbox/mapbox-navigation-ios/pull/4118))
 
 ## v2.7.2
 

--- a/Sources/MapboxNavigation/NavigationViewLayout.swift
+++ b/Sources/MapboxNavigation/NavigationViewLayout.swift
@@ -3,6 +3,11 @@ import UIKit
 extension NavigationView {
     
     func setupConstraints() {
+        // There are some race conditions when superview of the `NavigationView` no longer exists
+        // (e.g. when device orientation changes and `NavigationView` is being removed at the same time).
+        // Do not apply layout constraints in such cases.
+        if superview == nil { return }
+        
         NSLayoutConstraint.deactivate(regularConstraints)
         regularConstraints = []
         setupRegularConstraints(&regularConstraints)

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -47,6 +47,9 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
     }
     
     @objc func orientationDidChange(_ notification: Notification) {
+        // There are some race conditions when superview of the `NavigationView` no longer exists.
+        // Do not apply layout constraints in such cases.
+        if navigationViewData.navigationView.superview == nil { return }
         navigationViewData.navigationView.setupConstraints()
         updateMapViewOrnaments()
     }

--- a/Sources/MapboxNavigation/OrnamentsController.swift
+++ b/Sources/MapboxNavigation/OrnamentsController.swift
@@ -47,9 +47,6 @@ class OrnamentsController: NavigationComponent, NavigationComponentDelegate {
     }
     
     @objc func orientationDidChange(_ notification: Notification) {
-        // There are some race conditions when superview of the `NavigationView` no longer exists.
-        // Do not apply layout constraints in such cases.
-        if navigationViewData.navigationView.superview == nil { return }
         navigationViewData.navigationView.setupConstraints()
         updateMapViewOrnaments()
     }


### PR DESCRIPTION
### Description

Closing #4117.

PR fixes crash that sometimes occurs when orientation of the view controller that contains `NavigationView` is being changed and `NavigationView`'s parent view is being deallocated at the same time.