### PR TITLE
Add delegate methods for tapping route duration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Map
 
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
+* Fixed an issue where users tap on the route duration bubble, the wrong route or continuous alternative route is selected. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
 
 ### Banners and guidance instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Map
 
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
-* Fixed an issue where users tap on the route duration bubble, the wrong route or continuous alternative route is selected. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
+* Fixed an issue where tapping on a route duration annotation that overlaps a different route would cause the wrong route to be passed into `NavigationMapViewDelegate.navigationMapView(_:didSelect:)` or `NavigationMapViewDelegate.navigationMapView(_:didSelect:)`. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
 
 ### Banners and guidance instructions
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -744,7 +744,8 @@ extension ViewController: NavigationMapViewDelegate {
     }
 
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
-        guard let index = routes?.firstIndex(where: { $0 === route }) else { return }
+        guard let index = routes?.firstIndex(where: { $0 === route }),
+              index != indexedRouteResponse?.routeIndex else { return }
         indexedRouteResponse?.routeIndex = index
     }
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1323,6 +1323,7 @@ open class NavigationMapView: UIView {
             "text": .string(labelText),
             "imageName": .string(imageName),
             "sortOrder": .number(Double(isSelected ? index : -index)),
+            "routeIndex": .number(Double(index))
         ]
         
         return feature
@@ -2122,7 +2123,7 @@ open class NavigationMapView: UIView {
             return
         }
         
-        routeFromTappedPoint(point: tapPoint)  { [weak self] (routeFoundByPoint) in
+        route(at: tapPoint)  { [weak self] (routeFoundByPoint) in
             guard !routeFoundByPoint, let self = self else { return }
             if let routes = self.routes(closeTo: tapPoint),
                let selectedRoute = routes.first {
@@ -2134,7 +2135,7 @@ open class NavigationMapView: UIView {
         }
     }
     
-    func routeFromTappedPoint(point: CGPoint, completion: @escaping (Bool) -> Void) {
+    func route(at point: CGPoint, completion: @escaping (Bool) -> Void) {
         let group = DispatchGroup()
         var routeFoundByPoint: Bool = false
         let layerIds: [String] = [
@@ -2167,10 +2168,9 @@ open class NavigationMapView: UIView {
     func routeIndexFromMapQuery(with options: RenderedQueryOptions, at point: CGPoint, completion: @escaping (Int?) -> Void) {
         mapView.mapboxMap.queryRenderedFeatures(with: [point], options: options) { result in
             if case .success(let queriedFeatures) = result,
-               let indexValue = queriedFeatures.first?.feature.properties?["sortOrder"] as? JSONValue,
-               case .number(let number) = indexValue {
-                let routeIndex = abs(Int(number))
-                completion(routeIndex)
+               let indexValue = queriedFeatures.first?.feature.properties?["routeIndex"] as? JSONValue,
+               case .number(let routeIndex) = indexValue {
+                completion(Int(routeIndex))
             } else {
                 completion(nil)
             }


### PR DESCRIPTION
### Description
This PR is to fix #3847 by adding the ability for users to detect the taps on duration annotations for routes and continuous alternative routes.

### Implementation
When users tapped the `NavigationMapView`, the `NavigationMapView` will check whether duration annotations for routes and continuous alternative routes have been tapped. If users tapped duration annotations, it will notify the `NavigationMapViewDelegate.navigationMapView(_: didTap:)` about the taps. If not, it will check the taps on Waypoints, the closest route and the closest continuous alternative route.

The `NavigationMapViewDelegate.navigationMapView(_: didTap:)` provides the route or continuous alternative route whose duration annotation has been tapped.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->