### PR TITLE
Make `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.9.0
+
+### Map
+
+* `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
+
 ## v2.8.0
 
 ### Packaging

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -351,7 +351,10 @@ open class NavigationMapView: UIView {
         removeLineGradientStops()
     }
     
-    func removeAlternativeRoutes() {
+    /**
+     Removes all alternative routes that are currently shown on a map.
+     */
+    public func removeAlternativeRoutes() {
         var sourceIdentifiers = Set<String>()
         var layerIdentifiers = Set<String>()
         routes?.dropFirst().forEach {
@@ -1338,7 +1341,7 @@ open class NavigationMapView: UIView {
     /**
      Removes all visible continuous alternative routes duration callouts.
      */
-    func removeContinuousAlternativeRoutesDurations() {
+    public func removeContinuousAlternativeRoutesDurations() {
         let style = mapView.mapboxMap.style
         style.removeLayers([NavigationMapView.LayerIdentifier.continuousAlternativeRoutesDurationAnnotationsLayer])
         style.removeSources([NavigationMapView.SourceIdentifier.continuousAlternativeRoutesDurationAnnotationsSource])


### PR DESCRIPTION
### Description

Make `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` public.

Both methods are useful when removing specific parts of currently presented routes and annotations.