### PR TITLE
Status polling config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Curvy roads are penalized slightly more consistently. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * You can now set `Waypoint.allowsSnappingToStaticallyClosedRoad` to `true` to allow the waypoint to snap to a road that is fully closed for long-term construction. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Added `NavigationSettings.liveIncidentsOptions` to configure how incidents data is fetched. ([#4088](https://github.com/mapbox/mapbox-navigation-ios/pull/4088))
+* Added `NavigationSettings.statusPollingConfig` to configure navigator status polling options. ([#4135](https://github.com/mapbox/mapbox-navigation-ios/pull/4135))
 * Fixed incorrect duration calculations and route refreshing when an arrival step’s geometry contained only one coordinate. Normally, an arrival step’s geometry is expected to be a zero-length `LineString`; that is, with two coincident coordinates. ([#4110](https://github.com/mapbox/mapbox-navigation-ios/pull/4110))
 
 ### CarPlay

--- a/Sources/MapboxCoreNavigation/NavigationSettings.swift
+++ b/Sources/MapboxCoreNavigation/NavigationSettings.swift
@@ -4,6 +4,33 @@ import MapboxDirections
 /// Defines source of routing engine (online or offline) to be used for requests.
 public typealias RoutingProviderSource = MapboxRoutingProvider.Source
 
+/// Configures Navigator status polling options.
+public struct StatusPollingConfig {
+    /**
+     If new location is not provided during `unconditionalPollingPatience` - status will be polled unconditionally.
+     
+     If `nil` - default value will be used.
+     */
+    public var unconditionalPollingPatience: TimeInterval?
+    /**
+     Interval of unconditional status polling.
+     
+     If `nil` - default value will be used.
+     */
+    public var unconditionalPollingInterval: TimeInterval?
+    
+    /**
+     Creates new `StatusPollingConfig`.
+     
+     - parameter unconditionalPollingPatience: patience time before unconditional status polling.
+     - parameter unconditionalPollingInterval: unconditional polling interval.
+     */
+    public init(unconditionalPollingPatience: TimeInterval? = nil, unconditionalPollingInterval: TimeInterval? = nil) {
+        self.unconditionalPollingPatience = unconditionalPollingPatience
+        self.unconditionalPollingInterval = unconditionalPollingInterval
+    }
+}
+
 /**
  Global settings that are used across the SDK for altering navigation behavior.
 
@@ -14,7 +41,7 @@ public typealias RoutingProviderSource = MapboxRoutingProvider.Source
  To customize the user experience during a particular turn-by-turn navigation session, use the `NavigationOptions` class
  when initializing a `NavigationViewController`.
 
- To customize some global defaults use `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+ To customize some global defaults use `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
  */
 public class NavigationSettings {
     
@@ -41,7 +68,8 @@ public class NavigationSettings {
                   alternativeRouteDetectionStrategy: .init(),
                   utilizeSensorData: false,
                   navigatorPredictionInterval: nil,
-                  liveIncidentsOptions: nil)
+                  liveIncidentsOptions: nil,
+                  statusPollingConfig: nil)
         }
 
         var directions: Directions
@@ -51,6 +79,7 @@ public class NavigationSettings {
         var utilizeSensorData: Bool
         var navigatorPredictionInterval: TimeInterval?
         var liveIncidentsOptions: IncidentsOptions?
+        var statusPollingConfig: StatusPollingConfig?
     }
 
     /// Protects access to `_state`.
@@ -74,7 +103,7 @@ public class NavigationSettings {
     /**
      Default `Directions` instance. By default, `Directions.shared` is used.
 
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
      */
     public var directions: Directions {
         state.directions
@@ -83,14 +112,14 @@ public class NavigationSettings {
     /**
      Global `TileStoreConfiguration` instance.
 
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
      */
     public var tileStoreConfiguration: TileStoreConfiguration {
         state.tileStoreConfiguration
     }
 
     /**
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
      */
     public var routingProviderSource: RoutingProviderSource {
         state.routingProviderSource
@@ -99,7 +128,7 @@ public class NavigationSettings {
     /**
      Configuration on how `AlternativeRoute`s will be detected during navigation process.
      
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
      
      If set to `nil`, the detection is turned off.
      */
@@ -125,7 +154,7 @@ public class NavigationSettings {
      
      If not specified (`nilled`), default value will be used.
      
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
      */
     public var navigatorPredictionInterval: TimeInterval? {
         state.navigatorPredictionInterval
@@ -134,12 +163,23 @@ public class NavigationSettings {
     /**
      Configuration on how live incidents on a most probable path are detected.
      
-     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:)` method.
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
      
      If set to `nil`, live incidents are turned off (by default).
      */
     public var liveIncidentsOptions: IncidentsOptions? {
         state.liveIncidentsOptions
+    }
+    
+    /**
+     Configuration on how navigator status is polled.
+     
+     You can override this property by using `NavigationSettings.initialize(directions:tileStoreConfiguration:navigationRouterType:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:)` method.
+     
+     If set to `nil`, default settings will be applied
+     */
+    public var statusPollingConfig: StatusPollingConfig? {
+        state.statusPollingConfig
     }
     
     /**
@@ -167,12 +207,13 @@ public class NavigationSettings {
                            alternativeRouteDetectionStrategy: AlternativeRouteDetectionStrategy? = .init(),
                            utilizeSensorData: Bool = false,
                            navigatorPredictionInterval: TimeInterval? = nil,
-                           liveIncidentsOptions: IncidentsOptions? = nil) {
+                           liveIncidentsOptions: IncidentsOptions? = nil,
+                           statusPollingConfig: StatusPollingConfig? = nil) {
         lock.lock(); defer {
             lock.unlock()
         }
         if _state != nil {
-            Log.warning("Warning: Using NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:) after corresponding variables was initialized. Possible reasons: Initialize called more than once, or the following properties was accessed before initialization: `tileStoreConfiguration`, `directions`, `routingProviderSource`, `alternativeRouteDetectionStrategy`, `utilizeSensorData`, `navigatorPredictionInterval`, `liveIncidentsOptions`. This might result in an undefined behaviour.", category: .settings)
+            Log.warning("Warning: Using NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:utilizeSensorData:navigatorPredictionInterval:liveIncidentsOptions:statusPollingConfig:) after corresponding variables was initialized. Possible reasons: Initialize called more than once, or the following properties was accessed before initialization: `tileStoreConfiguration`, `directions`, `routingProviderSource`, `alternativeRouteDetectionStrategy`, `utilizeSensorData`, `navigatorPredictionInterval`, `liveIncidentsOptions`, `statusPollingConfig`. This might result in an undefined behaviour.", category: .settings)
         }
         _state = .init(directions: directions,
                        tileStoreConfiguration: tileStoreConfiguration,
@@ -180,7 +221,8 @@ public class NavigationSettings {
                        alternativeRouteDetectionStrategy: alternativeRouteDetectionStrategy,
                        utilizeSensorData: utilizeSensorData,
                        navigatorPredictionInterval: navigatorPredictionInterval,
-                       liveIncidentsOptions: liveIncidentsOptions)
+                       liveIncidentsOptions: liveIncidentsOptions,
+                       statusPollingConfig: statusPollingConfig)
     }
     
     /**


### PR DESCRIPTION
### Description
Some use-cases require customizing `NN.PollingConfig`. That is also configurable on Android.

### Implementation
Exposed `StatusPollingConfig` through `NavigationSettings` to provide configuration.