### PR TITLE
Switch to night style when Dark Mode is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Added the `NavigationViewControllerDelegate.navigationViewController(_:didSelect:)` and `NavigationViewControllerDelegate.navigationViewController(_:didSelect:)` methods that allow selection of the waypoint and continuous alternative. ([#4175](https://github.com/mapbox/mapbox-navigation-ios/pull/4175))
 * MapboxMobileEvents dependency is replaced with CoreTelemetry (part of MapboxCommon). ([#4011](https://github.com/mapbox/mapbox-navigation-ios/pull/4011))
 * Deprecated `NavigationEventsManager.init(activeNavigationDataSource:passiveNavigationDataSource:accessToken:mobileEventsManager:)` in favour of `NavigationEventsManager.init(activeNavigationDataSource:passiveNavigationDataSource:accessToken:)`. ([#4011](https://github.com/mapbox/mapbox-navigation-ios/pull/4011))
+* Added `NavigationViewController.usesNightStyleInDarkMode` property to control whether night style is used in dark mode. ([#4143](https://github.com/mapbox/mapbox-navigation-ios/pull/4143))
 
 ## v2.8.1
 

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -447,13 +447,11 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         if #available(iOS 12.0, *) {
             if self.traitCollection.userInterfaceStyle == .dark {
-                print("!!! Dark mode enabled")
-                print("!!! style manager: \(String(describing: styleManager))")
-                styleManager?.applyStyle(type: .night)
+                styleManager.applyStyle(type: .night)
             }
         } else {
             // Fallback on earlier versions
-            styleManager?.applyStyle(type: .day)
+            return
         }
     }
     
@@ -465,6 +463,19 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         }
         
         notifyUserAboutLowVolumeIfNeeded()
+    }
+    
+    override open func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        if #available(iOS 12.0, *) {
+            if newCollection.userInterfaceStyle == .dark {
+                styleManager.applyStyle(type: .night)
+            } else {
+                styleManager.applyStyle(type: .day)
+            }
+        } else {
+            // Fallback on earlier versions
+            return
+        }
     }
     
     func notifyUserAboutLowVolumeIfNeeded() {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -444,6 +444,17 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         setupNavigationService()
         setupVoiceController()
         setupNavigationCamera()
+        
+        if #available(iOS 12.0, *) {
+            if self.traitCollection.userInterfaceStyle == .dark {
+                print("!!! Dark mode enabled")
+                print("!!! style manager: \(String(describing: styleManager))")
+                styleManager?.applyStyle(type: .night)
+            }
+        } else {
+            // Fallback on earlier versions
+            styleManager?.applyStyle(type: .day)
+        }
     }
     
     open override func viewWillAppear(_ animated: Bool) {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -466,15 +466,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
     
     override open func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
-        if #available(iOS 12.0, *) {
-            if newCollection.userInterfaceStyle == .dark {
-                styleManager.applyStyle(type: .night)
-            } else {
-                styleManager.applyStyle(type: .day)
-            }
-        } else {
-            // Fallback on earlier versions
-            return
+        if usesNightStyleInDarkMode {
+            transitionStyle(to: newCollection)
         }
     }
     
@@ -813,6 +806,11 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
      */
     public var waypointStyle: WaypointStyle = .annotation
     
+    /**
+     Allows to control whether night style is used in dark mode or not.
+     */
+    public var usesNightStyleInDarkMode = true
+    
     var approachingDestinationThreshold: CLLocationDistance = DefaultApproachingDestinationThresholdDistance
     var passedApproachingDestinationThreshold: Bool = false
     var currentLeg: RouteLeg?
@@ -840,6 +838,19 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     open override var preferredStatusBarStyle: UIStatusBarStyle {
         get {
             return currentStatusBarStyle
+        }
+    }
+    
+    func transitionStyle(to newCollection: UITraitCollection) {
+        if #available(iOS 12.0, *) {
+            if newCollection.userInterfaceStyle == .dark {
+                styleManager.applyStyle(type: .night)
+            } else {
+                styleManager.applyStyle(type: .day)
+            }
+        } else {
+            // Fallback on earlier versions
+            return
         }
     }
 }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -445,13 +445,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         setupVoiceController()
         setupNavigationCamera()
         
-        if #available(iOS 12.0, *) {
-            if self.traitCollection.userInterfaceStyle == .dark {
-                styleManager.applyStyle(type: .night)
-            }
-        } else {
-            // Fallback on earlier versions
-            return
+        if usesNightStyleInDarkMode && self.traitCollection.userInterfaceStyle == .dark {
+            styleManager.applyStyle(type: .night)
         }
     }
     
@@ -842,15 +837,10 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     }
     
     func transitionStyle(to newCollection: UITraitCollection) {
-        if #available(iOS 12.0, *) {
-            if newCollection.userInterfaceStyle == .dark {
-                styleManager.applyStyle(type: .night)
-            } else {
-                styleManager.applyStyle(type: .day)
-            }
+        if newCollection.userInterfaceStyle == .dark {
+            styleManager.applyStyle(type: .night)
         } else {
-            // Fallback on earlier versions
-            return
+            styleManager.applyStyle(type: .day)
         }
     }
 }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -804,7 +804,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     /**
      Allows to control whether night style is used in dark mode or not.
      */
-    public var usesNightStyleInDarkMode = true
+    public var usesNightStyleInDarkMode = false
     
     var approachingDestinationThreshold: CLLocationDistance = DefaultApproachingDestinationThresholdDistance
     var passedApproachingDestinationThreshold: Bool = false

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -802,9 +802,9 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
     public var waypointStyle: WaypointStyle = .annotation
     
     /**
-     Allows to control whether night style is used in dark mode or not.
+     Controls whether night style will be used whenever dark mode is enabled. Defaults to `false`.
      */
-    public var usesNightStyleInDarkMode = false
+    public var usesNightStyleInDarkMode: Bool = false
     
     var approachingDestinationThreshold: CLLocationDistance = DefaultApproachingDestinationThresholdDistance
     var passedApproachingDestinationThreshold: Bool = false


### PR DESCRIPTION
### Description
This PR fixes #2223 by defaulting to night style for NavigationViewController regardless of the time of day and switching to between day/night styles whenever light/dark mode is enabled.