### PR TITLE
Support the offline mode for shields in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Improved the pronunciation of junction names in Japanese in Japan. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * At a fork or exit on an expressway in Japan, spoken instructions now mention the junction name and side of the road but no longer mention the expressway name or number that the user would stay on. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
 * Fixed confusing instructions to take the roundabout in the Russian localization. ([#4085](https://github.com/mapbox/mapbox-navigation-ios/pull/4085))
+* Fixed the crashes occured in guidance instructions during offline navigation. ([#4147](https://github.com/mapbox/mapbox-navigation-ios/pull/4147))
 
 ### Routing
 

--- a/Sources/MapboxNavigation/ImageDownloader.swift
+++ b/Sources/MapboxNavigation/ImageDownloader.swift
@@ -3,6 +3,7 @@ import MapboxDirections
 import UIKit
 
 typealias ImageDownloadCompletionBlock = (UIImage?, Data?, Error?) -> Void
+typealias ImageDownloadCompletionHandler = (DownloadError?) -> Void
 
 protocol ReentrantImageDownloader {
     func downloadImage(with url: URL, completion: ImageDownloadCompletionBlock?) -> Void

--- a/Sources/MapboxNavigation/InstructionPresenter.swift
+++ b/Sources/MapboxNavigation/InstructionPresenter.swift
@@ -183,7 +183,10 @@ class InstructionPresenter {
                 if let legacyIcon = repository.legacyCache.image(forKey: representation.legacyCacheKey) {
                     return legacyAttributedString(for: legacyIcon, dataSource: dataSource)
                 } else if representation.legacyCacheKey != nil {
-                    spriteRepository.updateRepresentation(for: representation, completion: onImageDownload)
+                    spriteRepository.updateRepresentation(for: representation) { (error) in
+                        guard error == nil else { return }
+                        onImageDownload()
+                    }
                     return nil
                 }
             }
@@ -199,7 +202,10 @@ class InstructionPresenter {
         // Return nothing in the meantime, triggering downstream behavior (generic shield or text).
         // Update the SpriteRepository with the ImageRepresentation only when it has valid shield or legacy shield.
         if representation.shield != nil || representation.legacyCacheKey != nil {
-            spriteRepository.updateRepresentation(for: representation, completion: onImageDownload)
+            spriteRepository.updateRepresentation(for: representation) { (error) in
+                guard error == nil else { return }
+                onImageDownload()
+            }
         }
         return nil
     }

--- a/Sources/MapboxNavigation/SpriteRepository.swift
+++ b/Sources/MapboxNavigation/SpriteRepository.swift
@@ -34,7 +34,7 @@ class SpriteRepository {
         imageDownloader = ImageDownloader(sessionConfiguration: sessionConfiguration)
     }
     
-    func updateStyle(styleURI: StyleURI?, completion: @escaping (DownloadError?) -> Void) {
+    func updateStyle(styleURI: StyleURI?, completion: @escaping ImageDownloadCompletionHandler) {
         // If no valid StyleURI provided, use the default Day style.
         let newStyleURI = styleURI ?? self.styleURI
         guard newStyleURI != self.styleURI || getSpriteImage() == nil else {
@@ -51,7 +51,8 @@ class SpriteRepository {
         updateSprite(completion: completion)
     }
 
-    func updateRepresentation(for representation: VisualInstruction.Component.ImageRepresentation? = nil, completion: @escaping (DownloadError?) -> Void) {
+    func updateRepresentation(for representation: VisualInstruction.Component.ImageRepresentation? = nil,
+                              completion: @escaping ImageDownloadCompletionHandler) {
         let dispatchGroup = DispatchGroup()
         var downloadError: DownloadError? = nil
 
@@ -74,7 +75,7 @@ class SpriteRepository {
         }
     }
     
-    func updateSprite(completion: @escaping (DownloadError?) -> Void) {
+    func updateSprite(completion: @escaping ImageDownloadCompletionHandler) {
         guard let styleID = styleID,
               let infoRequestURL = spriteURL(isImage: false, styleID: styleID),
               let spriteRequestURL = spriteURL(isImage: true, styleID: styleID) else {
@@ -102,7 +103,8 @@ class SpriteRepository {
         }
     }
     
-    func updateLegacy(representation: VisualInstruction.Component.ImageRepresentation? = nil, completion: @escaping (DownloadError?) -> Void) {
+    func updateLegacy(representation: VisualInstruction.Component.ImageRepresentation? = nil,
+                      completion: @escaping ImageDownloadCompletionHandler) {
         guard let cacheKey = representation?.legacyCacheKey else {
             completion(.clientError)
             return

--- a/Sources/MapboxNavigation/SpriteRepository.swift
+++ b/Sources/MapboxNavigation/SpriteRepository.swift
@@ -12,18 +12,26 @@ class SpriteRepository {
     let infoCache =  SpriteInfoCache()
     let baseURL: URL = URL(string: "https://api.mapbox.com/styles/v1")!
     var styleURI: StyleURI = .navigationDay
-    fileprivate(set) var imageDownloader: ReentrantImageDownloader = ImageDownloader()
+    fileprivate(set) var imageDownloader: ReentrantImageDownloader
     
     static let shared = SpriteRepository.init()
+    
+    private let requestTimeOut: TimeInterval = 10
     
     var styleID: String? {
         styleURI.rawValue.components(separatedBy: "styles")[safe: 1]
     }
     
-    var sessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.default {
+    var sessionConfiguration: URLSessionConfiguration {
         didSet {
             imageDownloader = ImageDownloader(sessionConfiguration: sessionConfiguration)
         }
+    }
+    
+    init() {
+        sessionConfiguration = URLSessionConfiguration.default
+        sessionConfiguration.timeoutIntervalForRequest = self.requestTimeOut
+        imageDownloader = ImageDownloader(sessionConfiguration: sessionConfiguration)
     }
     
     func updateStyle(styleURI: StyleURI?, completion: @escaping (DownloadError?) -> Void) {

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -341,6 +341,7 @@ open class TopBannerViewController: UIViewController {
             }
             
             self.view.isUserInteractionEnabled = true
+            self.instructionsBannerView.update(for: self.currentInstruction)
             self.delegate?.topBanner(self, didDismissStepsController: steps)
             completion?()
         }

--- a/Sources/MapboxNavigation/WayNameLabel.swift
+++ b/Sources/MapboxNavigation/WayNameLabel.swift
@@ -22,7 +22,7 @@ open class WayNameLabel: StylableLabel {
     
     // When the map style changes, update the sprite repository and the label.
     func updateStyle(styleURI: StyleURI?) {
-        spriteRepository.updateStyle(styleURI: styleURI) { [weak self] (_) in
+        spriteRepository.updateStyle(styleURI: styleURI) { [weak self] _ in
             guard let self = self,
                   let roadName = self.text else { return }
             
@@ -33,7 +33,7 @@ open class WayNameLabel: StylableLabel {
     func updateRoad(roadName: String, representation: VisualInstruction.Component.ImageRepresentation? = nil) {
         // When the imageRepresentation of road shield changes, update the sprite repository and the label.
         if representation != self.representation {
-            spriteRepository.updateRepresentation(for: representation) { [weak self] (_) in
+            spriteRepository.updateRepresentation(for: representation) { [weak self] _ in
                 guard let self = self else { return }
                 self.representation = representation
                 self.setup(with: roadName)

--- a/Sources/MapboxNavigation/WayNameLabel.swift
+++ b/Sources/MapboxNavigation/WayNameLabel.swift
@@ -22,7 +22,7 @@ open class WayNameLabel: StylableLabel {
     
     // When the map style changes, update the sprite repository and the label.
     func updateStyle(styleURI: StyleURI?) {
-        spriteRepository.updateStyle(styleURI: styleURI) { [weak self] in
+        spriteRepository.updateStyle(styleURI: styleURI) { [weak self] (_) in
             guard let self = self,
                   let roadName = self.text else { return }
             
@@ -33,7 +33,7 @@ open class WayNameLabel: StylableLabel {
     func updateRoad(roadName: String, representation: VisualInstruction.Component.ImageRepresentation? = nil) {
         // When the imageRepresentation of road shield changes, update the sprite repository and the label.
         if representation != self.representation {
-            spriteRepository.updateRepresentation(for: representation) { [weak self] in
+            spriteRepository.updateRepresentation(for: representation) { [weak self] (_) in
                 guard let self = self else { return }
                 self.representation = representation
                 self.setup(with: roadName)

--- a/Tests/MapboxNavigationTests/SpriteRepositoryTests.swift
+++ b/Tests/MapboxNavigationTests/SpriteRepositoryTests.swift
@@ -156,7 +156,7 @@ class SpriteRepositoryTests: TestCase {
         XCTAssertNil(repository.legacyCache.image(forKey: cacheKey))
         
         let expectation = expectation(description: "Image Downloaded.")
-        repository.updateRepresentation(for: representation) {
+        repository.updateRepresentation(for: representation) { _ in
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 3.0)
@@ -182,7 +182,7 @@ class SpriteRepositoryTests: TestCase {
         let styleURI = StyleURI.navigationNight
         
         let expectation = expectation(description: "Style updated.")
-        repository.updateStyle(styleURI: styleURI) {
+        repository.updateStyle(styleURI: styleURI) { _ in
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 3.0)
@@ -202,7 +202,7 @@ class SpriteRepositoryTests: TestCase {
         var dataKey = "us-interstate-3" + "-\(styleID)"
         
         var downloadExpectation = expectation(description: "Representation updated.")
-        repository.updateRepresentation(for: representation) {
+        repository.updateRepresentation(for: representation) { _ in
             downloadExpectation.fulfill()
         }
         wait(for: [downloadExpectation], timeout: 3.0)


### PR DESCRIPTION
### Description
This PR is to fix #4141 to support the shields in offline navigation.

### Implementation
Add the time out constraint to shields request, and the error handling in  `InstructionPresenter` to avoid the nonstop shield request if it has an error. Use generic shields for offline navigation.

When switching from offline mode to online mode, the preview process by swiping top banner or opening `StepsViewController` will both trigger the downloading process of shields. And it will replace the generic shields with Mapbox designed shields or legacy shields. 

### Screenshots or Gifs
Build a route from San Francisco to San Diego, turn off the network connection, start with simulation and open the `StepsViewController` for preview. The shields in the guidance instruction will be generic shields.
![offline](https://user-images.githubusercontent.com/48976398/190023929-b3d5e512-50c5-4114-8850-02ddb69b362c.gif)


Turn on the network and open the `StepsViewController` for preview. The shields in the guidance instruction will start downloading again and appear as Mapbox designed shields or legacy shields. It will also update the current instruction banner view.
![online](https://user-images.githubusercontent.com/48976398/190024015-e92dd1e3-bf23-4f32-bb00-10317f348206.gif)




<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->