### PR TITLE
Replace symbolSet with symbolImage in CarPlay maneuver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
 
+### Guidance Instructions
+
+* Added `VisualInstruction.maneuverImage(side:userInterfaceStyle:)` to generate maneuver image for iOS 13 and above versions. ([#4161](https://github.com/mapbox/mapbox-navigation-ios/pull/4161))
+
 ### Other changes
 
 * Additional parameters were added to `FloatingButton.rounded(image:selectedImage:size:type:imageEdgeInsets:cornerRadius)` to be able to provide button type, button image edge insets and corner radius. ([#4060](https://github.com/mapbox/mapbox-navigation-ios/pull/4060), [#4157](https://github.com/mapbox/mapbox-navigation-ios/pull/4157))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
 
-### Guidance Instructions
+### Banners and guidance instructions
 
-* Added `VisualInstruction.maneuverImage(side:userInterfaceStyle:)` to generate maneuver image for iOS 13 and above versions. ([#4161](https://github.com/mapbox/mapbox-navigation-ios/pull/4161))
+* Added replacement for `VisualInstruction.maneuverImageSet(side:)` method to generate a maneuver image on iOS 13 and above. ([#4161](https://github.com/mapbox/mapbox-navigation-ios/pull/4161))
 
 ### Other changes
 

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -889,7 +889,13 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         primaryManeuver.instructionVariants = [text]
         
         // Add maneuver arrow
-        primaryManeuver.symbolSet = visualInstruction.primaryInstruction.maneuverImageSet(side: visualInstruction.drivingSide)
+        if #available(iOS 13.0, *) {
+            let userInterfaceStyle = traitCollection.userInterfaceStyle
+            primaryManeuver.symbolImage = visualInstruction.primaryInstruction.maneuverImage(side: visualInstruction.drivingSide,
+                                                                                             userInterfaceStyle: userInterfaceStyle)
+        } else {
+            primaryManeuver.symbolSet = visualInstruction.primaryInstruction.maneuverImageSet(side: visualInstruction.drivingSide)
+        }
         
         // Estimating the width of Apple's maneuver view
         let bounds: () -> (CGRect) = {

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -117,8 +117,8 @@ extension VisualInstruction {
      - returns: A `UIImage` representing the maneuver.
      */
     @available(iOS 13.0, *)
-    public func maneuverImage(side: DrivingSide, userInterfaceStyle: UIUserInterfaceStyle) -> UIImage? {
-        var color: UIColor
+    func maneuverImage(side: DrivingSide, userInterfaceStyle: UIUserInterfaceStyle) -> UIImage? {
+        let color: UIColor
         switch userInterfaceStyle {
         case .unspecified:
             color = .black

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -108,6 +108,33 @@ extension VisualInstruction {
         return CPImageSet(lightContentImage: maneuverIcons[1], darkContentImage: maneuverIcons[0])
     }
     
+    /**
+     Returns a `UIImage` representing the maneuver.
+     
+     - parameter side: Driving side of the road cars and traffic flow.
+     - parameter userInterfaceStyle: The `UIUserInterfaceStyle` that the maneuver will be displayed in.
+     
+     - returns: A `UIImage` representing the maneuver.
+     */
+    @available(iOS 13.0, *)
+    public func maneuverImage(side: DrivingSide, userInterfaceStyle: UIUserInterfaceStyle) -> UIImage? {
+        var color: UIColor
+        switch userInterfaceStyle {
+        case .unspecified:
+            color = .black
+        case .light:
+            color = .black
+        case .dark:
+            color = .white
+        @unknown default:
+            Log.error("Error occured with unknown UIUserInterfaceStyle.", category: .navigationUI)
+            return nil
+        }
+        return maneuverViewImage(drivingSide: side,
+                                 color: color,
+                                 size: CGSize(width: 30, height: 30))
+    }
+    
     /// Returns whether the `VisualInstruction`’s maneuver image should be flipped according to the driving side.
     public func shouldFlipImage(side: DrivingSide) -> Bool {
         switch maneuverType ?? .turn {


### PR DESCRIPTION
### Description
This PR is to fix #3977 by replacing `CPManeuver.symbolSet` with `CPManeuver. symbolImage` to generate maneuver for CarPlay during active navigation.

### Implementation
This Pr add the public API `VisualInstruction.maneuverImage(side:userInterfaceStyle:)` to replace the `VisualInstruction.maneuverImageSet(side:)` for iOS 13 and above.  It will generate the maneuver image for CarPlay during active navigation.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->