### PR TITLE
Custom mapping from numeric congestion value to congestion level with road class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fixed an issue where tapping on a route duration annotation that overlaps a different route would cause the wrong route to be passed into `NavigationMapViewDelegate.navigationMapView(_:didSelect:)` or `NavigationMapViewDelegate.navigationMapView(_:didSelect:)`. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
 * Fixed an issue where the shields in the instruction are using the style from last navigation session with the `NavigationMapView` injection used in the new session. ([#4197](https://github.com/mapbox/mapbox-navigation-ios/pull/4197))
 * Fixed an issue where the `NavigationMapView.localizeLabels()` method only localized map labels according to the user’s Preferred Language Order setting if the application also had a localization in the preferred language. ([#4205](https://github.com/mapbox/mapbox-navigation-ios/pull/4205))
+* Added `NavigationMapView.congestionMapping` to provide the customized mapping from `NumericCongestionLevel` and `MapboxStreetsRoadClass` to `CongestionLevel`. If provided, the route lines will display the associated colors of the `CongestionLevel` mapping result on the map view. ([#4179](https://github.com/mapbox/mapbox-navigation-ios/pull/4179))
 
 ### Banners and guidance instructions
 

--- a/Example/ViewController+FreeDrive.swift
+++ b/Example/ViewController+FreeDrive.swift
@@ -26,6 +26,20 @@ extension ViewController {
         subscribeForFreeDriveNotifications()
     }
     
+    func setupCongestionMapping() {
+        let congestionMapping: CongestionMapping = { (numericLevel, roadClass) in
+            switch roadClass {
+            case .motorway, .primary:
+                CongestionRange.setCongestionRanges(low: 0..<40, moderate: 40..<60, heavy: 60..<80, severe: 80..<101)
+            default:
+                CongestionRange.setCongestionRanges(low: 0..<15, moderate: 15..<30, heavy: 30..<45, severe: 45..<101)
+            }
+            return CongestionLevel.init(numericValue: numericLevel)
+        }
+        
+        navigationMapView.congestionMapping = congestionMapping
+    }
+    
     func subscribeForFreeDriveNotifications() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(didUpdatePassiveLocation),

--- a/Example/ViewController+FreeDrive.swift
+++ b/Example/ViewController+FreeDrive.swift
@@ -32,7 +32,7 @@ extension ViewController {
             case .motorway, .primary:
                 CongestionRange.setCongestionRanges(low: 0..<40, moderate: 40..<60, heavy: 60..<80, severe: 80..<101)
             default:
-                CongestionRange.setCongestionRanges(low: 0..<15, moderate: 15..<30, heavy: 30..<45, severe: 45..<101)
+                CongestionRange.setCongestionRanges(low: 0..<20, moderate: 20..<40, heavy: 40..<60, severe: 60..<101)
             }
             return CongestionLevel.init(numericValue: numericLevel)
         }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -177,6 +177,7 @@ class ViewController: UIViewController {
 
     private func configure(_ navigationMapView: NavigationMapView) {
         setupPassiveLocationProvider()
+        setupCongestionMapping()
         
         navigationMapView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -27,6 +27,8 @@ open class NavigationMapView: UIView {
      */
     public var roadClassesWithOverriddenCongestionLevels: Set<MapboxStreetsRoadClass>? = nil
     
+    public var congestionMapping: CongestionMapping? = nil
+    
     /**
      Controls whether to show congestion levels on alternative route lines. Defaults to `false`.
      
@@ -661,7 +663,9 @@ open class NavigationMapView: UIView {
             lineLayer?.lineCap = .constant(.round)
             
             if isMainRoute {
-                let congestionFeatures = route.congestionFeatures(legIndex: legIndex, roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels)
+                let congestionFeatures = route.congestionFeatures(legIndex: legIndex,
+                                                                  roadClassesWithOverriddenCongestionLevels: roadClassesWithOverriddenCongestionLevels,
+                                                                  congestionMapping: congestionMapping)
                 let gradientStops = routeLineCongestionGradient(route,
                                                                 congestionFeatures: congestionFeatures,
                                                                 isSoft: crossfadesCongestionSegments)

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -27,6 +27,10 @@ open class NavigationMapView: UIView {
      */
     public var roadClassesWithOverriddenCongestionLevels: Set<MapboxStreetsRoadClass>? = nil
     
+    /**
+     The closure to map the `NumericCongestionLevel` and `MapboxStreetsRoadClass` to `CongestionLevel`.
+     If provided, the route lines will display the associated colors of the `CongestionLevel` mapping result on the map view.
+     */
     public var congestionMapping: CongestionMapping? = nil
     
     /**

--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -83,7 +83,8 @@ extension Route {
     }
     
     func congestionFeatures(legIndex: Int? = nil,
-                            roadClassesWithOverriddenCongestionLevels: Set<MapboxStreetsRoadClass>? = nil) -> [Feature] {
+                            roadClassesWithOverriddenCongestionLevels: Set<MapboxStreetsRoadClass>? = nil,
+                            congestionMapping: CongestionMapping? = nil) -> [Feature] {
         guard let coordinates = shape?.coordinates, let shape = shape else { return [] }
         var features: [Feature] = []
         
@@ -91,7 +92,8 @@ extension Route {
             let legFeatures: [Feature]
             let currentLegAttribute = (legIndex != nil) ? index == legIndex : true
 
-            if let congestionLevels = leg.resolvedCongestionLevels, congestionLevels.count < coordinates.count + 2 {
+            if let congestionLevels = leg.resolvedCongestionLevels(congestionMapping: congestionMapping),
+                congestionLevels.count < coordinates.count + 2 {
                 // The last coordinate of the preceding step, is shared with the first coordinate of the next step, we don't need both.
                 let legCoordinates: [CLLocationCoordinate2D] = leg.steps.enumerated().reduce([]) { allCoordinates, current in
                     let index = current.offset


### PR DESCRIPTION
### Description
This Pr is to support the custom mapping from numeric congestion value to congestion level with road class with the `NavigationMapView.congestionMapping`.

### Implementation
`NavigationMapView.congestionMapping` is added as `CongestionMapping`, to map `NumericCongestionLevel` and `MapboxStreetsRoadClass` to congestion level. Developers could provide their own `CongestionRange` for different road class and convert the numeric congestion value to different level.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->