### PR TITLE
Convert MatchOptions to RouteOptions on the fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.8.1
+
+* Fixed an issue where creating a `RouteController` with the result of `RouteResponse(matching:options:credentials:)` would cause route progress and guidance instructions to remain stuck at the beginning of the route. ([#4186](https://github.com/mapbox/mapbox-navigation-ios/pull/4186))
+
 ## v2.8.0
 
 ### Packaging

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -268,10 +268,8 @@ open class RouteController: NSObject {
     private func updateNavigator(with indexedRouteResponse: IndexedRouteResponse,
                                  fromLegIndex legIndex: Int,
                                  completion: ((Result<(RouteInfo?, [AlternativeRoute]), Error>) -> Void)?) {
-        guard case .route(let routeOptions) = indexedRouteResponse.routeResponse.options else {
-            completion?(.failure(RouteControllerError.internalError))
-            return
-        }
+        let routeOptions = indexedRouteResponse.validatedRouteOptions
+        
         let encoder = JSONEncoder()
         encoder.userInfo[.options] = routeOptions
         guard let newMainRoute = indexedRouteResponse.currentRoute,

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -63,6 +63,15 @@ public struct IndexedRouteResponse {
         self.routeIndex = routeIndex
         self.responseOrigin = responseOrigin
     }
+    
+    internal var validatedRouteOptions: RouteOptions {
+        switch routeResponse.options {
+        case let .match(matchOptions):
+            return RouteOptions(matchOptions: matchOptions)
+        case let .route(options):
+            return options
+        }
+    }
 }
 
 /**

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -696,13 +696,21 @@ extension CarPlayManager: CPMapTemplateDelegate {
                             using routeChoice: CPRouteChoice) {
         guard let interfaceController = interfaceController,
               let carPlayMapViewController = carPlayMapViewController else {
-                  return
-              }
+            return
+        }
         
-        guard let routeResponse = routeChoice.routeResponseFromUserInfo,
-              let routeOptions = routeResponse.options as? RouteOptions else {
-                  preconditionFailure("CPRouteChoice should contain `RouteResponseUserInfo` struct.")
-              }
+        guard let routeResponse = routeChoice.routeResponseFromUserInfo else {
+            preconditionFailure("CPRouteChoice should contain `RouteResponseUserInfo` struct.")
+        }
+        
+        var routeOptions = routeResponse.options as? RouteOptions
+        if routeOptions == nil,
+           let matchOptions = routeResponse.options as? MatchOptions {
+            routeOptions = RouteOptions(matchOptions: matchOptions)
+        }
+        guard let routeOptions = routeOptions else {
+            preconditionFailure("Options in user info should be either a RouteOptions or a MatchOptions.")
+        }
 
         mapTemplate.hideTripPreviews()
         


### PR DESCRIPTION
Backported a small part of #4127 to the release-v2.8 branch to fix #4126, which is a regression introduced in #3824.

If the current route response contains a MatchOptions, convert it to a RouteOptions before attempting to update the navigator with it instead of reporting an internal error or, in CarPlay, tripping a precondition failure.

/cc @mapbox/navigation-ios