### PR TITLE
Fix the intersections property loss after route refresh.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Added the `NavigationViewController(for:routeIndex:navigationOptions:)` initializer to start turn-by-turn navigation using map matching response. ([#4127](https://github.com/mapbox/mapbox-navigation-ios/pull/4127))
 * Fixed an issue where continuous alternative route lines and their corresponding callouts were misplaced on long routes. ([#4176](https://github.com/mapbox/mapbox-navigation-ios/pull/4176))
 * Added `ReplayLocationManager(history:)` and `MapboxNavigationService(history:customRoutingProvider:credentials:eventsManagerType:routerType:customActivityType:)` for replaying trips recorded by a history file. ([#4194](https://github.com/mapbox/mapbox-navigation-ios/pull/4194))
+* Fixed an issue where after route refresh, the `RouteStepProgress.userDistanceToUpcomingIntersection`, `RouteStepProgress.intersectionsIncludingUpcomingManeuverIntersection`, `RouteStepProgress.intersectionDistances` and `RouteStepProgress.intersectionIndex` are all set to default values. ([#4193](https://github.com/mapbox/mapbox-navigation-ios/pull/4193))
 
 ### Map
 

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -398,44 +398,13 @@ open class RouteController: NSObject {
         updateSpokenInstructionProgress(status: status, willReRoute: isRerouting)
         updateVisualInstructionProgress(status: status)
         updateRoadName(status: status)
-        updateDistanceToIntersection(from: snappedLocation)
+        routeProgress.updateDistanceToIntersection(from: snappedLocation)
         
         rerouteAfterArrivalIfNeeded(snappedLocation, status: status)
         
         if status.routeState != .complete {
             // Check for faster route proactively (if reroutesProactively is enabled)
             refreshAndCheckForFasterRoute(from: snappedLocation, routeProgress: routeProgress)
-        }
-    }
-    
-    func updateDistanceToIntersection(from location: CLLocation) {
-        guard var intersections = routeProgress.currentLegProgress.currentStepProgress.step.intersections else { return }
-        
-        // The intersections array does not include the upcoming maneuver intersection.
-        if let upcomingStep = routeProgress.currentLegProgress.upcomingStep,
-           let upcomingIntersection = upcomingStep.intersections?.first {
-            intersections += [upcomingIntersection]
-        }
-        
-        routeProgress.currentLegProgress.currentStepProgress.intersectionsIncludingUpcomingManeuverIntersection = intersections
-        
-        if let shape = routeProgress.currentLegProgress.currentStepProgress.step.shape,
-           let upcomingIntersection = routeProgress.currentLegProgress.currentStepProgress.upcomingIntersection {
-            routeProgress.currentLegProgress.currentStepProgress.userDistanceToUpcomingIntersection = shape.distance(from: location.coordinate, to: upcomingIntersection.location)
-        }
-        
-        updateIntersectionDistances()
-    }
-    
-    func updateIntersectionDistances() {
-        if routeProgress.currentLegProgress.currentStepProgress.intersectionDistances == nil {
-            routeProgress.currentLegProgress.currentStepProgress.intersectionDistances = [CLLocationDistance]()
-            
-            if let shape = routeProgress.currentLegProgress.currentStep.shape,
-               let intersections = routeProgress.currentLegProgress.currentStep.intersections {
-                let distances: [CLLocationDistance] = intersections.compactMap { shape.distance(from: shape.coordinates.first, to: $0.location) }
-                routeProgress.currentLegProgress.currentStepProgress.intersectionDistances = distances
-            }
         }
     }
     

--- a/Sources/MapboxCoreNavigation/RouteLegProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteLegProgress.swift
@@ -188,14 +188,14 @@ open class RouteLegProgress: Codable {
      - parameter stepIndex: Current step the user is on.
      - parameter shapeIndex: Index relative to leg shape, representing the point the user is currently located at.
      */
-    public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0, shapeIndex: Int = 0) {
+    public init(leg: RouteLeg, stepIndex: Int = 0, spokenInstructionIndex: Int = 0, shapeIndex: Int = 0, intersectionIndex: Int = 0) {
         precondition(leg.steps.indices.contains(stepIndex), "It's not possible to set the stepIndex: \(stepIndex) when it's higher than steps count \(leg.steps.count) or not included.")
         
         self.leg = leg
         self.stepIndex = stepIndex
         self.shapeIndex = shapeIndex
         
-        currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex)
+        currentStepProgress = RouteStepProgress(step: leg.steps[stepIndex], spokenInstructionIndex: spokenInstructionIndex, intersectionIndex: intersectionIndex)
     }
 
     typealias StepIndexDistance = (index: Int, distance: CLLocationDistance)

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -157,13 +157,14 @@ open class RouteProgress: Codable {
     }
 
     private func commonRefreshRoute(at location: CLLocation) {
+        let intersectionIndex = currentLegProgress.currentStepProgress.intersectionIndex
         currentLegProgress = RouteLegProgress(leg: route.legs[legIndex],
                                               stepIndex: currentLegProgress.stepIndex,
                                               spokenInstructionIndex: currentLegProgress.currentStepProgress.spokenInstructionIndex)
         calculateLegsCongestion()
         updateDistanceTraveled(with: location)
+        currentLegProgress.currentStepProgress.intersectionIndex = intersectionIndex
         updateDistanceToIntersection(from: location)
-        updateIntersectionIndex()
     }
 
     /**
@@ -220,12 +221,6 @@ open class RouteProgress: Codable {
             let distances: [CLLocationDistance] = intersections.compactMap { shape.distance(from: shape.coordinates.first, to: $0.location) }
             currentLegProgress.currentStepProgress.intersectionDistances = distances
         }
-    }
-    
-    func updateIntersectionIndex() {
-        guard let distances = currentLegProgress.currentStepProgress.intersectionDistances else { return }
-        let upcomingIntersectionIndex = distances.firstIndex { $0 > currentLegProgress.currentStepProgress.distanceTraveled } ?? distances.endIndex
-        currentLegProgress.currentStepProgress.intersectionIndex = upcomingIntersectionIndex > 0 ? distances.index(before: upcomingIntersectionIndex) : 0
     }
     
     // MARK: Leg Statistics

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -157,13 +157,12 @@ open class RouteProgress: Codable {
     }
 
     private func commonRefreshRoute(at location: CLLocation) {
-        let intersectionIndex = currentLegProgress.currentStepProgress.intersectionIndex
         currentLegProgress = RouteLegProgress(leg: route.legs[legIndex],
                                               stepIndex: currentLegProgress.stepIndex,
-                                              spokenInstructionIndex: currentLegProgress.currentStepProgress.spokenInstructionIndex)
+                                              spokenInstructionIndex: currentLegProgress.currentStepProgress.spokenInstructionIndex,
+                                              intersectionIndex: currentLegProgress.currentStepProgress.intersectionIndex)
         calculateLegsCongestion()
         updateDistanceTraveled(with: location)
-        currentLegProgress.currentStepProgress.intersectionIndex = intersectionIndex
         updateDistanceToIntersection(from: location)
     }
 

--- a/Sources/MapboxCoreNavigation/RouteProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteProgress.swift
@@ -195,41 +195,37 @@ open class RouteProgress: Codable {
      - parameter location: Updated user location.
      */
     func updateDistanceToIntersection(from location: CLLocation) {
-        let stepProgress = currentLegProgress.currentStepProgress
-        guard var intersections = stepProgress.step.intersections else { return }
+        guard var intersections = currentLegProgress.currentStepProgress.step.intersections else { return }
         
         // The intersections array does not include the upcoming maneuver intersection.
         if let upcomingIntersection = currentLegProgress.upcomingStep?.intersections?.first {
             intersections += [upcomingIntersection]
         }
-        stepProgress.intersectionsIncludingUpcomingManeuverIntersection = intersections
+        currentLegProgress.currentStepProgress.intersectionsIncludingUpcomingManeuverIntersection = intersections
         
-        if let shape = stepProgress.step.shape,
-           let upcomingIntersection = stepProgress.upcomingIntersection {
-            stepProgress.userDistanceToUpcomingIntersection = shape.distance(from: location.coordinate, to: upcomingIntersection.location)
+        if let shape = currentLegProgress.currentStep.shape,
+           let upcomingIntersection = currentLegProgress.currentStepProgress.upcomingIntersection {
+            currentLegProgress.currentStepProgress.userDistanceToUpcomingIntersection = shape.distance(from: location.coordinate, to: upcomingIntersection.location)
         }
         
         updateIntersectionDistances()
     }
     
     func updateIntersectionDistances() {
-        let stepProgress = currentLegProgress.currentStepProgress
-        guard stepProgress.intersectionDistances == nil else { return }
+        guard currentLegProgress.currentStepProgress.intersectionDistances == nil else { return }
         
-        stepProgress.intersectionDistances = [CLLocationDistance]()
-        if let shape = stepProgress.step.shape,
-           let intersections = stepProgress.step.intersections {
+        currentLegProgress.currentStepProgress.intersectionDistances = [CLLocationDistance]()
+        if let shape = currentLegProgress.currentStep.shape,
+           let intersections = currentLegProgress.currentStep.intersections {
             let distances: [CLLocationDistance] = intersections.compactMap { shape.distance(from: shape.coordinates.first, to: $0.location) }
-            stepProgress.intersectionDistances = distances
+            currentLegProgress.currentStepProgress.intersectionDistances = distances
         }
     }
     
     func updateIntersectionIndex() {
-        let stepProgress = currentLegProgress.currentStepProgress
-        if let distances = stepProgress.intersectionDistances {
-            let upcomingIntersectionIndex = distances.firstIndex { $0 > stepProgress.distanceTraveled } ?? distances.endIndex
-            stepProgress.intersectionIndex = upcomingIntersectionIndex > 0 ? distances.index(before: upcomingIntersectionIndex) : 0
-        }
+        guard let distances = currentLegProgress.currentStepProgress.intersectionDistances else { return }
+        let upcomingIntersectionIndex = distances.firstIndex { $0 > currentLegProgress.currentStepProgress.distanceTraveled } ?? distances.endIndex
+        currentLegProgress.currentStepProgress.intersectionIndex = upcomingIntersectionIndex > 0 ? distances.index(before: upcomingIntersectionIndex) : 0
     }
     
     // MARK: Leg Statistics

--- a/Sources/MapboxCoreNavigation/RouteStepProgress.swift
+++ b/Sources/MapboxCoreNavigation/RouteStepProgress.swift
@@ -12,11 +12,11 @@ open class RouteStepProgress: Codable {
 
      - parameter step: Step on a `RouteLeg`.
      */
-    public init(step: RouteStep, spokenInstructionIndex: Int = 0) {
+    public init(step: RouteStep, spokenInstructionIndex: Int = 0, intersectionIndex: Int = 0) {
         self.step = step
         self.userDistanceToManeuverLocation = step.distance
-        self.intersectionIndex = 0
         self.spokenInstructionIndex = spokenInstructionIndex
+        self.intersectionIndex = intersectionIndex
     }
     
     // MARK: Step Stats


### PR DESCRIPTION
### Description
This Pr is to fix the issue that after route refresh, the step intersections related properties will be set to default values. This Pr is to update the step intersections related properties with the updated location.

### Implementation

- Move the `RouteController.updateDistanceToIntersection(from:)` and `RouteController.updateIntersectionDistances()` to `RouteProgress`, and call them after the route refresh event.
- Also call the  `RouteProgress.updateIntersectionIndex()` in route refresh event to update the `RouteStepProgress.intersectionIndex`. Because it's updated by navigator status.



### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->