### PR TITLE
Implement a function for breaking through mute of the speech synthesizer.

### DIFF
--- a/Sources/MapboxNavigation/MultiplexedSpeechSynthesizer.swift
+++ b/Sources/MapboxNavigation/MultiplexedSpeechSynthesizer.swift
@@ -108,6 +108,11 @@ open class MultiplexedSpeechSynthesizer: SpeechSynthesizing {
         currentLegProgress = legProgress
         speechSynthesizers.first?.speak(instruction, during: legProgress, locale: locale)
     }
+
+    public func forceSpeak(_ instruction: SpokenInstruction, during legProgress: RouteLegProgress, locale: Locale? = nil) {
+        currentLegProgress = legProgress
+        speechSynthesizers.first?.forceSpeak(instruction, during: legProgress, locale: locale)
+    }
     
     public func stopSpeaking() {
         speechSynthesizers.forEach { $0.stopSpeaking() }

--- a/Sources/MapboxNavigation/SpeechSynthesizing.swift
+++ b/Sources/MapboxNavigation/SpeechSynthesizing.swift
@@ -5,7 +5,7 @@ import MapboxCoreNavigation
 /**
  Protocol for implementing speech synthesizer to be used in `RouteVoiceController`.
  */
-public protocol SpeechSynthesizing: AnyObject {
+public protocol SpeechSynthesizing: AnyObject, UnimplementedLogging {
     
     /// A delegate that will be notified about significant events related to spoken instructions.
     var delegate: SpeechSynthesizingDelegate? { get set }
@@ -38,11 +38,30 @@ public protocol SpeechSynthesizing: AnyObject {
     ///
     /// This method is not guaranteed to be synchronous or asynchronous. When vocalizing is finished, `voiceController(_ voiceController: SpeechSynthesizing, didSpeak instruction: SpokenInstruction, with error: SpeechError?)` should be called.
     func speak(_ instruction: SpokenInstruction, during legProgress: RouteLegProgress, locale: Locale?)
+
+    /// A request to vocalize the instruction, breaking through the mute of the speech synthesizer if muted
+    /// - parameter instruction: an instruction to be vocalized
+    /// - parameter legProgress: current leg progress, corresponding to the instruction
+    /// - parameter locale: A locale to be used for vocalizing the instruction. If `nil` is passed - `SpeechSynthesizing.locale` will be used as 'default'.
+    ///
+    /// This method is not guaranteed to be synchronous or asynchronous. When vocalizing is finished, `voiceController(_ voiceController: SpeechSynthesizing, didSpeak instruction: SpokenInstruction, with error: SpeechError?)` should be called.
+    func forceSpeak(_ instruction: SpokenInstruction, during legProgress: RouteLegProgress, locale: Locale?)
     
     /// Tells synthesizer to stop current vocalization in a graceful manner
     func stopSpeaking()
     /// Tells synthesizer to stop current vocalization immediately
     func interruptSpeaking()
+}
+
+extension SpeechSynthesizing {
+
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    public func forceSpeak(_ instruction: SpokenInstruction, during legProgress: RouteLegProgress, locale: Locale?) {
+        logUnimplemented(protocolType: SpeechSynthesizing.self, level: .debug)
+        speak(instruction, during: legProgress, locale: locale)
+    }
 }
 
 /**

--- a/Sources/MapboxNavigation/SystemSpeechSynthesizer.swift
+++ b/Sources/MapboxNavigation/SystemSpeechSynthesizer.swift
@@ -64,7 +64,10 @@ open class SystemSpeechSynthesizer: NSObject, SpeechSynthesizing {
                                         with: nil)
             return
         }
-        
+        forceSpeak(instruction, during: legProgress, locale: locale)
+    }
+    
+    open func forceSpeak(_ instruction: SpokenInstruction, during legProgress: RouteLegProgress, locale: Locale? = nil) {
         guard let locale = locale ?? self.locale else {
             self.delegate?.speechSynthesizer(self,
                                              encounteredError: SpeechError.undefinedSpeechLocale(instruction: instruction))


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->

Implement `SpeechSynthesizing.forceSpeak(instruction:during:locale:)` for breaking through mute of the speech synthesizer.

I am using the `SystemSpeechSyntesizer` for providing additional spoken instructions in my app, but want some important instructions to break through the mute toggle that is in the UI. The `forceSpeak(..)` function will bypass the mute check and proceed to speak the instruction regardless.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

I've made the forceSpeak(..) function optional to implement in the `SpeechSynthesizing` protocol since I do not have a proper implementation for `MapboxSpeechSynthesizer`. That instead uses volume of an `AVAudioPlayer` to mute instructions.

So when `forceSpeak(..)` isn't implemented, it forwards the call to the regular `speak(..)` function while using `UnimplementedLogging.logUnimplemented(..)` to log a warning in console.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

See code.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->