### PR TITLE
Send telemetry events to detect Drop-In usage

### DIFF
--- a/Sources/MapboxCoreNavigation/Feedback/EventConstants.swift
+++ b/Sources/MapboxCoreNavigation/Feedback/EventConstants.swift
@@ -19,6 +19,8 @@ enum EventType: String {
     case carplayDisconnect = "navigation.carplay.disconnect"
     case routeRetrieval = "mobile.performance_trace"
     case freeDrive = "navigation.freeDrive"
+    case dropInConnect = "navigation.dropin.connect"
+    case dropInDisconnect = "navigation.dropin.disconnect"
 }
 
 // :nodoc:

--- a/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
@@ -365,6 +365,17 @@ open class NavigationEventsManager {
         
         return event
     }
+    
+    public func sendDropInConnectEvent() {
+        // send using navigationservice.eventsmanager
+        let attributes = eventAttributes(type: .dropInConnect)
+        eventsAPI.sendImmediateEvent(with: attributes)
+    }
+    
+    public func sendDropInDisconnectEvent() {
+        let attributes = eventAttributes(type: .dropInDisconnect)
+        eventsAPI.sendImmediateEvent(with: attributes)
+    }
 
     public func sendCarPlayConnectEvent() {
         let attributes = eventAttributes(type: .carplayConnect)

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -584,6 +584,7 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         } else {
             dismiss(animated: true, completion: nil)
         }
+        navigationService.eventsManager.sendDropInDisconnectEvent()
     }
     
     // MARK: Customizing Views and Child View Controllers
@@ -695,6 +696,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         
         arrivalController?.destination = route?.legs.last?.destination
         reportButton.isHidden = !showsReportFeedback
+        
+        navigationService.eventsManager.sendDropInConnectEvent()
     }
     
     func addTopBanner(_ navigationOptions: NavigationOptions?) -> ContainerViewController {


### PR DESCRIPTION
### Description
This PR adds support to determine drop-in UI usage by sending telemetry events when `NavigationViewController`'s controllers are setup, and `NavigationViewController` is disconnected (similar to detecting CarPlay connect/disconnect).