### PR TITLE
Fix the issue of invisible exit views from night mode to day mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
 * Fixed an issue where tapping on a route duration annotation that overlaps a different route would cause the wrong route to be passed into `NavigationMapViewDelegate.navigationMapView(_:didSelect:)` or `NavigationMapViewDelegate.navigationMapView(_:didSelect:)`. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
+* Fixed an issue where the exit views in the instruction banner are invisible after style change in a new navigation session. ([#4197](https://github.com/mapbox/mapbox-navigation-ios/pull/4197))
 
 ### Routing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
 * Fixed an issue where tapping on a route duration annotation that overlaps a different route would cause the wrong route to be passed into `NavigationMapViewDelegate.navigationMapView(_:didSelect:)` or `NavigationMapViewDelegate.navigationMapView(_:didSelect:)`. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
-* Fixed an issue where the exit views in the instruction banner are invisible after style change in a new navigation session. ([#4197](https://github.com/mapbox/mapbox-navigation-ios/pull/4197))
+* Fixed an issue where the shields in the instruction are using the style from last navigation session with the `NavigationMapView` injection used in the new session. ([#4197](https://github.com/mapbox/mapbox-navigation-ios/pull/4197))
 
 ### Routing
 

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -402,12 +402,12 @@ extension CarPlayMapViewController: StyleManagerDelegate {
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         let mapboxMapStyle = navigationMapView.mapView.mapboxMap.style
+        let styleURI = StyleURI(url: style.mapStyleURL)
         if mapboxMapStyle.uri?.rawValue != style.mapStyleURL.absoluteString {
-            let styleURI = StyleURI(url: style.mapStyleURL)
             mapboxMapStyle.uri = styleURI
-            // Update the sprite repository of wayNameView when map style changes.
-            wayNameView?.label.updateStyle(styleURI: styleURI, idiom: .carPlay)
         }
+        
+        wayNameView?.label.updateStyle(styleURI: styleURI, idiom: .carPlay)
     }
     
     public func styleManagerDidRefreshAppearance(_ styleManager: StyleManager) {

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -1032,13 +1032,12 @@ extension CarPlayNavigationViewController: StyleManagerDelegate {
     
     public func styleManager(_ styleManager: StyleManager, didApply style: Style) {
         let mapboxMapStyle = navigationMapView?.mapView.mapboxMap.style
+        let styleURI = StyleURI(url: style.mapStyleURL)
         if mapboxMapStyle?.uri?.rawValue != style.mapStyleURL.absoluteString {
-            let styleURI = StyleURI(url: style.mapStyleURL)
             mapboxMapStyle?.uri = styleURI
-            // Update the sprite repository of wayNameView when map style changes.
-            wayNameView?.label.updateStyle(styleURI: styleURI, idiom: .carPlay)
         }
         
+        wayNameView?.label.updateStyle(styleURI: styleURI, idiom: .carPlay)
         updateMapTemplateStyle()
         updateManeuvers(navigationService.routeProgress)
     }

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -1202,13 +1202,12 @@ extension NavigationViewController: StyleManagerDelegate {
     }
     
     private func updateMapStyle(_ style: Style) {
+        let styleURI = StyleURI(url: style.mapStyleURL)
         if navigationMapView?.mapView.mapboxMap.style.uri?.rawValue != style.mapStyleURL.absoluteString {
-            let styleURI = StyleURI(url: style.mapStyleURL)
             navigationMapView?.mapView.mapboxMap.style.uri = styleURI
-            // Update the sprite repository of wayNameView when map style changes.
-            ornamentsController?.updateStyle(styleURI: styleURI)
         }
         
+        ornamentsController?.updateStyle(styleURI: styleURI)
         currentStatusBarStyle = style.statusBarStyle ?? .default
         setNeedsStatusBarAppearanceUpdate()
     }

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTests.swift
@@ -485,6 +485,46 @@ class NavigationViewControllerTests: TestCase {
                        floatingButton,
                        "Unexpected floating button.")
     }
+    
+    func testShieldStyleWithNavigationMapViewInjection() {
+        let nightStyleURI: StyleURI = .navigationNight
+        let dayStyleURI: StyleURI = .navigationDay
+        
+        let spriteRepository = SpriteRepository.shared
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 1.0
+        spriteRepository.sessionConfiguration = config
+        
+        let styleLoadedExpectation = XCTestExpectation(description: "Style updated expectation.")
+        spriteRepository.updateStyle(styleURI: nightStyleURI) { _ in
+            styleLoadedExpectation.fulfill()
+        }
+        wait(for: [styleLoadedExpectation], timeout: 2.0)
+        XCTAssertEqual(spriteRepository.userInterfaceIdiomStyles[.phone],
+                       nightStyleURI,
+                       "Failed to update the style of SpriteRepository singleton to Night style.")
+        
+        class CustomNavigationMapView: NavigationMapView { }
+        let injected = CustomNavigationMapView()
+        injected.mapView.mapboxMap.style.uri = dayStyleURI
+        
+        let navService = MapboxNavigationService(indexedRouteResponse: initialRouteResponse,
+                                                 customRoutingProvider: nil,
+                                                 credentials: Fixture.credentials)
+        let navOptions = NavigationOptions(styles: [DayStyle()],
+                                           navigationService: navService,
+                                           navigationMapView: injected)
+        let subject = NavigationViewController(for: initialRouteResponse, navigationOptions: navOptions)
+        _ = subject.view // trigger view load
+        
+        XCTAssert(subject.navigationMapView == injected, "NavigtionMapView not injected properly.")
+        XCTAssertEqual(injected.mapView.mapboxMap.style.uri?.rawValue,
+                       subject.styleManager.currentStyle?.mapStyleURL.absoluteString,
+                       "Failed to apply the style to NavigationViewController.")
+        XCTAssertEqual(spriteRepository.userInterfaceIdiomStyles[.phone],
+                       dayStyleURI,
+                       "Failed to update the style of SpriteRepository singleton with the injected NavigationMapView.")
+    }
 }
 
 extension NavigationViewControllerTests: NavigationViewControllerDelegate, StyleManagerDelegate {


### PR DESCRIPTION
### Description
This Pr is to fix the issue that when two continuous active navigation using different styles, the exit views in the second session may be invisible.

### Implementation
https://github.com/mapbox/mapbox-navigation-ios/pull/3930 introduced the function to record the platform related style.
If there're two active active navigation sessions, If the second active navigation session is using the customized `NavigationMapView` in its `NavigationOptions` which has the same style as in the `NavigationOptions` , and hasn't change its style from the start, the shields may use the style from the previous active navigation session on current platform.  It would lead to the invisible Exit Views on the instruction label of the second active navigation session. 

The root cause is that we only update the shield when the style is changed during current navigation session as in https://github.com/mapbox/mapbox-navigation-ios/blob/b1bccccc17bfb3bbbf54397c4e94e405752852da/Sources/MapboxNavigation/NavigationViewController.swift#L1073-L1078


### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->