### PR TITLE
Fix arrival feedback pop-up to not occupy too much of the map in landscape mode

### DIFF
--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -56,10 +56,30 @@ class ArrivalController: NavigationComponentDelegate {
         navigationViewData.navigationView.endOfRouteHideConstraint?.isActive = false
         navigationViewData.navigationView.endOfRouteShowConstraint?.isActive = true
 
+        let leftInset = navigationMapView.navigationCamera.viewportDataSource.followingMobileCamera.padding?.left
+        let rightInset = navigationMapView.navigationCamera.viewportDataSource.followingMobileCamera.padding?.right
+        
         navigationMapView.navigationCamera.stop()
         
-        if (navigationViewData.navigationView.endOfRouteHeightConstraint?.constant) != nil {
+        if let height = navigationViewData.navigationView.endOfRouteHeightConstraint?.constant {
             self.navigationViewData.navigationView.floatingStackView.alpha = 0.0
+            var cameraOptions = CameraOptions(cameraState: navigationMapView.mapView.cameraState)
+            // Since `padding` is not an animatable property `zoom` is increased to cover up abrupt camera change.
+            if let zoom = cameraOptions.zoom {
+                cameraOptions.zoom = zoom + 1.0
+            }
+            
+            cameraOptions.padding = UIEdgeInsets(top: topBannerContainerView.bounds.height,
+                                                 left: leftInset ?? 20,
+                                                 bottom: height + 20,
+                                                 right: rightInset ?? 20)
+            cameraOptions.center = destination?.coordinate
+            cameraOptions.pitch = 0
+            navigationMapView.mapView.camera.ease(to: cameraOptions, duration: duration) { (animatingPosition) in
+                if animatingPosition == .end {
+                    completion?(true)
+                }
+            }
         }
     }
     

--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -21,11 +21,6 @@ class ArrivalController: NavigationComponentDelegate {
     var destination: Waypoint?
     var showsEndOfRoute: Bool = true
     
-    var endOfRouteIsActive: Bool {
-        let show = navigationViewData.navigationView.endOfRouteShowConstraint
-        return navigationViewData.navigationView.endOfRouteView != nil && show?.isActive ?? false
-    }
-    
     private lazy var endOfRouteViewController: EndOfRouteViewController = {
         let storyboard = UIStoryboard(name: "Navigation", bundle: .mapboxNavigation)
         let viewController = storyboard.instantiateViewController(withIdentifier: "EndOfRouteViewController") as! EndOfRouteViewController
@@ -51,10 +46,6 @@ class ArrivalController: NavigationComponentDelegate {
         
         embedEndOfRoute(into: viewController, onDismiss: onDismiss)
         endOfRouteViewController.destination = destination
-        navigationViewData.navigationView.endOfRouteView?.isHidden = false
-        
-        navigationViewData.navigationView.endOfRouteHideConstraint?.isActive = false
-        navigationViewData.navigationView.endOfRouteShowConstraint?.isActive = true
 
         let leftInset = navigationMapView.navigationCamera.viewportDataSource.followingMobileCamera.padding?.left
         let rightInset = navigationMapView.navigationCamera.viewportDataSource.followingMobileCamera.padding?.right
@@ -95,7 +86,7 @@ class ArrivalController: NavigationComponentDelegate {
         let endOfRoute = endOfRouteViewController
         viewController.addChild(endOfRoute)
         navigationViewData.navigationView.endOfRouteView = endOfRoute.view
-        navigationViewData.navigationView.constrainEndOfRoute()
+        navigationViewData.navigationView.showEndOfRoute()
         endOfRoute.didMove(toParent: viewController)
 
         endOfRoute.dismissHandler = { [weak self] (stars, comment) in

--- a/Sources/MapboxNavigation/ArrivalController.swift
+++ b/Sources/MapboxNavigation/ArrivalController.swift
@@ -58,24 +58,8 @@ class ArrivalController: NavigationComponentDelegate {
 
         navigationMapView.navigationCamera.stop()
         
-        if let height = navigationViewData.navigationView.endOfRouteHeightConstraint?.constant {
+        if (navigationViewData.navigationView.endOfRouteHeightConstraint?.constant) != nil {
             self.navigationViewData.navigationView.floatingStackView.alpha = 0.0
-            var cameraOptions = CameraOptions(cameraState: navigationMapView.mapView.cameraState)
-            // Since `padding` is not an animatable property `zoom` is increased to cover up abrupt camera change.
-            if let zoom = cameraOptions.zoom {
-                cameraOptions.zoom = zoom + 1.0
-            }
-            cameraOptions.padding = UIEdgeInsets(top: topBannerContainerView.bounds.height,
-                                                 left: 20,
-                                                 bottom: height + 20,
-                                                 right: 20)
-            cameraOptions.center = destination?.coordinate
-            cameraOptions.pitch = 0
-            navigationMapView.mapView.camera.ease(to: cameraOptions, duration: duration) { (animatingPosition) in
-                if animatingPosition == .end {
-                    completion?(true)
-                }
-            }
         }
     }
     

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -39,7 +39,7 @@ import MapboxCoreNavigation
 @IBDesignable
 open class NavigationView: UIView {
     
-    private enum Constants {
+    enum Constants {
         static let endOfRouteHeight: CGFloat = 260.0
         static let buttonSpacing: CGFloat = 8.0
     }
@@ -85,13 +85,13 @@ open class NavigationView: UIView {
     
     lazy var endOfRouteShowConstraint: NSLayoutConstraint? = endOfRouteView?.bottomAnchor.constraint(equalTo: bottomAnchor)
     
-    lazy var endOfRouteHideConstraint: NSLayoutConstraint? = endOfRouteView?.topAnchor.constraint(equalTo: bottomAnchor)
-    
     lazy var endOfRouteHeightConstraint: NSLayoutConstraint? = endOfRouteView?.heightAnchor.constraint(equalToConstant: Constants.endOfRouteHeight)
     
     var topBannerContainerViewLayoutConstraints: [NSLayoutConstraint] = []
     
     var bottomBannerContainerViewLayoutConstraints: [NSLayoutConstraint] = []
+    
+    var endOfRouteViewLayoutConstraints: [NSLayoutConstraint] = []
     
     var endOfRouteView: UIView? {
         didSet {
@@ -105,13 +105,9 @@ open class NavigationView: UIView {
         }
     }
     
-    func constrainEndOfRoute() {
-        endOfRouteHideConstraint?.isActive = true
-        
-        endOfRouteView?.leadingAnchor.constraint(equalTo: bottomBannerContainerView.leadingAnchor).isActive = true
-        endOfRouteView?.trailingAnchor.constraint(equalTo: bottomBannerContainerView.trailingAnchor).isActive = true
-        
-        endOfRouteHeightConstraint?.isActive = true
+    func showEndOfRoute() {
+        endOfRouteView?.isHidden = false
+        setupEndOfRouteConstraints()
     }
     
     // MARK: Overlay Views

--- a/Sources/MapboxNavigation/NavigationView.swift
+++ b/Sources/MapboxNavigation/NavigationView.swift
@@ -108,8 +108,8 @@ open class NavigationView: UIView {
     func constrainEndOfRoute() {
         endOfRouteHideConstraint?.isActive = true
         
-        endOfRouteView?.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        endOfRouteView?.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        endOfRouteView?.leadingAnchor.constraint(equalTo: bottomBannerContainerView.leadingAnchor).isActive = true
+        endOfRouteView?.trailingAnchor.constraint(equalTo: bottomBannerContainerView.trailingAnchor).isActive = true
         
         endOfRouteHeightConstraint?.isActive = true
     }

--- a/Sources/MapboxNavigation/NavigationViewLayout.swift
+++ b/Sources/MapboxNavigation/NavigationViewLayout.swift
@@ -374,4 +374,25 @@ extension NavigationView {
         
         NSLayoutConstraint.activate(bottomBannerContainerViewLayoutConstraints)
     }
+    
+    func setupEndOfRouteConstraints() {
+        guard let endOfRouteView = endOfRouteView,
+              let endOfRouteShowConstraint = endOfRouteShowConstraint,
+              let endOfRouteHeightConstraint = endOfRouteHeightConstraint else { return }
+        
+        NSLayoutConstraint.deactivate(endOfRouteViewLayoutConstraints)
+                                
+        let endOfRouteLeadingConstraint  = endOfRouteView.leadingAnchor.constraint(equalTo: bottomBannerContainerView.leadingAnchor)
+        
+        let endOfRouteTrailingConstraint  = endOfRouteView.trailingAnchor.constraint(equalTo: bottomBannerContainerView.trailingAnchor)
+        
+        endOfRouteViewLayoutConstraints = [
+            endOfRouteShowConstraint,
+            endOfRouteHeightConstraint,
+            endOfRouteLeadingConstraint,
+            endOfRouteTrailingConstraint
+        ]
+        
+        NSLayoutConstraint.activate(endOfRouteViewLayoutConstraints)
+    }
 }

--- a/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_72" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -68,13 +68,13 @@
                                 <rect key="frame" x="0.0" y="92" width="375" height="54"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rate your trip" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W5U-cV-cDO" customClass="EndOfRouteStaticLabel" customModule="MapboxNavigation">
-                                        <rect key="frame" x="144" y="0.0" width="87.5" height="17"/>
+                                        <rect key="frame" x="143.66666666666666" y="0.0" width="87.666666666666657" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.25098039220000001" green="0.36078431370000003" blue="0.47843137250000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Izy-1z-tcx" customClass="RatingControl" customModule="MapboxNavigation">
-                                        <rect key="frame" x="107.5" y="22" width="160" height="32"/>
+                                        <rect key="frame" x="107.66666666666669" y="22" width="160" height="32"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="160" placeholder="YES" id="GdR-Sf-yUf"/>
                                             <constraint firstAttribute="height" constant="32" placeholder="YES" id="UUo-I9-X6b"/>
@@ -120,11 +120,11 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ekW-06-trL" userLabel="Safe Area Mask" customClass="EndOfRouteContentView" customModule="MapboxNavigation">
-                                <rect key="frame" x="0.0" y="350" width="375" height="50"/>
+                                <rect key="frame" x="0.0" y="346" width="375" height="54"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D6B-Ff-n7b" userLabel="End Navigation Button Container">
-                                <rect key="frame" x="0.0" y="350" width="375" height="50"/>
+                                <rect key="frame" x="0.0" y="346" width="375" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5f2-dT-la4" customClass="EndOfRouteButton" customModule="MapboxNavigation">
                                         <rect key="frame" x="136" y="10" width="103" height="30"/>
@@ -149,16 +149,16 @@
                             <constraint firstItem="TEs-GQ-xWN" firstAttribute="top" secondItem="evE-dd-pMr" secondAttribute="bottom" constant="65" id="6IH-iM-ln5"/>
                             <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="P8U-kf-mkb" secondAttribute="top" constant="10" id="GFJ-yQ-Cye"/>
                             <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="D6B-Ff-n7b" secondAttribute="trailing" id="Ljt-Gw-pXu"/>
-                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="Qjw-oe-dVe"/>
+                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="Qjw-oe-dVe"/>
                             <constraint firstItem="ekW-06-trL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="TeT-ls-Ns4"/>
                             <constraint firstItem="ekW-06-trL" firstAttribute="trailing" secondItem="P8U-kf-mkb" secondAttribute="trailing" id="UUM-FL-FrV"/>
                             <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="TEs-GQ-xWN" secondAttribute="trailing" id="Vg9-Xi-JtV"/>
                             <constraint firstItem="unQ-4I-UPo" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="WJ9-OZ-x1y"/>
                             <constraint firstAttribute="bottom" secondItem="ekW-06-trL" secondAttribute="bottom" id="f1v-ju-qen"/>
                             <constraint firstItem="unQ-4I-UPo" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" id="gVo-YH-zU7"/>
-                            <constraint firstItem="evE-dd-pMr" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="k0v-jB-TbO"/>
-                            <constraint firstItem="TEs-GQ-xWN" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="lxR-dT-lxi"/>
-                            <constraint firstItem="4jh-bR-wXL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="muP-uc-2iF"/>
+                            <constraint firstItem="evE-dd-pMr" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="k0v-jB-TbO"/>
+                            <constraint firstItem="TEs-GQ-xWN" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="lxR-dT-lxi"/>
+                            <constraint firstItem="4jh-bR-wXL" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="muP-uc-2iF"/>
                             <constraint firstItem="4jh-bR-wXL" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" constant="16" id="rx6-4c-WD7"/>
                             <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="4jh-bR-wXL" secondAttribute="trailing" id="s63-sP-XUC"/>
                             <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="4jh-bR-wXL" secondAttribute="bottom" constant="16" id="vRY-cm-7kg"/>
@@ -187,14 +187,14 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="A8g-0A-gn2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3832.8000000000002" y="875.26236881559225"/>
+            <point key="canvasLocation" x="3832.7253218884121" y="874.88372093023258"/>
         </scene>
         <!--Navigation View Controller-->
         <scene sceneID="N4b-dY-Waq">
             <objects>
                 <viewController storyboardIdentifier="NavigationViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="skD-wE-e5x" customClass="NavigationViewController" customModule="MapboxNavigation" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="2Pt-vL-Aor">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="932" height="430"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="spJ-9Q-y9C"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,7 +13,7 @@
         <scene sceneID="D7g-l8-Czc">
             <objects>
                 <viewController storyboardIdentifier="EndOfRouteViewController" id="WD9-Na-hrx" customClass="EndOfRouteViewController" customModule="MapboxNavigation" sceneMemberID="viewController">
-                    <view key="view" contentMode="center" id="IDF-XF-2Ta" userLabel="Root" customClass="EndOfRouteContentView" customModule="MapboxNavigation">
+                    <view key="view" contentMode="scaleToFill" id="IDF-XF-2Ta" userLabel="Root" customClass="EndOfRouteContentView" customModule="MapboxNavigation">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -22,7 +23,7 @@
                                     <constraint firstAttribute="height" constant="1" id="JsN-yF-tXj"/>
                                 </constraints>
                             </view>
-                            <view clipsSubviews="YES" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="4jh-bR-wXL" userLabel="Arrival Labels Container">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4jh-bR-wXL" userLabel="Arrival Labels Container">
                                 <rect key="frame" x="0.0" y="16" width="375" height="60"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You have arrived" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V4A-Bp-tr5" customClass="EndOfRouteStaticLabel" customModule="MapboxNavigation">
@@ -63,11 +64,11 @@
                                     <constraint firstItem="V4A-Bp-tr5" firstAttribute="top" secondItem="4jh-bR-wXL" secondAttribute="top" id="n8N-UX-05e"/>
                                 </constraints>
                             </view>
-                            <view clipsSubviews="YES" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="evE-dd-pMr" userLabel="Rate Your Trip Container">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="evE-dd-pMr" userLabel="Rate Your Trip Container">
                                 <rect key="frame" x="0.0" y="92" width="375" height="54"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rate your trip" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W5U-cV-cDO" customClass="EndOfRouteStaticLabel" customModule="MapboxNavigation">
-                                        <rect key="frame" x="143.5" y="0.0" width="88" height="17"/>
+                                        <rect key="frame" x="144" y="0.0" width="87.5" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.25098039220000001" green="0.36078431370000003" blue="0.47843137250000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
@@ -122,7 +123,7 @@
                                 <rect key="frame" x="0.0" y="350" width="375" height="50"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="D6B-Ff-n7b" userLabel="End Navigation Button Container">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D6B-Ff-n7b" userLabel="End Navigation Button Container">
                                 <rect key="frame" x="0.0" y="350" width="375" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5f2-dT-la4" customClass="EndOfRouteButton" customModule="MapboxNavigation">
@@ -140,27 +141,28 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="P8U-kf-mkb"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="unQ-4I-UPo" secondAttribute="trailing" id="1BB-nP-SYc"/>
-                            <constraint firstAttribute="trailing" secondItem="evE-dd-pMr" secondAttribute="trailing" id="3Da-jA-RLx"/>
+                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="evE-dd-pMr" secondAttribute="trailing" id="3Da-jA-RLx"/>
                             <constraint firstItem="TEs-GQ-xWN" firstAttribute="top" secondItem="evE-dd-pMr" secondAttribute="bottom" constant="65" id="6IH-iM-ln5"/>
-                            <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" constant="10" id="GFJ-yQ-Cye"/>
-                            <constraint firstAttribute="trailing" secondItem="D6B-Ff-n7b" secondAttribute="trailing" id="Ljt-Gw-pXu"/>
-                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="Qjw-oe-dVe"/>
-                            <constraint firstItem="ekW-06-trL" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="TeT-ls-Ns4"/>
-                            <constraint firstItem="ekW-06-trL" firstAttribute="trailing" secondItem="IDF-XF-2Ta" secondAttribute="trailing" id="UUM-FL-FrV"/>
-                            <constraint firstAttribute="trailing" secondItem="TEs-GQ-xWN" secondAttribute="trailing" id="Vg9-Xi-JtV"/>
+                            <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="P8U-kf-mkb" secondAttribute="top" constant="10" id="GFJ-yQ-Cye"/>
+                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="D6B-Ff-n7b" secondAttribute="trailing" id="Ljt-Gw-pXu"/>
+                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="Qjw-oe-dVe"/>
+                            <constraint firstItem="ekW-06-trL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="TeT-ls-Ns4"/>
+                            <constraint firstItem="ekW-06-trL" firstAttribute="trailing" secondItem="P8U-kf-mkb" secondAttribute="trailing" id="UUM-FL-FrV"/>
+                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="TEs-GQ-xWN" secondAttribute="trailing" id="Vg9-Xi-JtV"/>
                             <constraint firstItem="unQ-4I-UPo" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="WJ9-OZ-x1y"/>
                             <constraint firstAttribute="bottom" secondItem="ekW-06-trL" secondAttribute="bottom" id="f1v-ju-qen"/>
                             <constraint firstItem="unQ-4I-UPo" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" id="gVo-YH-zU7"/>
-                            <constraint firstItem="evE-dd-pMr" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="k0v-jB-TbO"/>
-                            <constraint firstItem="TEs-GQ-xWN" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="lxR-dT-lxi"/>
-                            <constraint firstItem="4jh-bR-wXL" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="muP-uc-2iF"/>
+                            <constraint firstItem="evE-dd-pMr" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="k0v-jB-TbO"/>
+                            <constraint firstItem="TEs-GQ-xWN" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="lxR-dT-lxi"/>
+                            <constraint firstItem="4jh-bR-wXL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="muP-uc-2iF"/>
                             <constraint firstItem="4jh-bR-wXL" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" constant="16" id="rx6-4c-WD7"/>
-                            <constraint firstAttribute="trailing" secondItem="4jh-bR-wXL" secondAttribute="trailing" id="s63-sP-XUC"/>
+                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="4jh-bR-wXL" secondAttribute="trailing" id="s63-sP-XUC"/>
                             <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="4jh-bR-wXL" secondAttribute="bottom" constant="16" id="vRY-cm-7kg"/>
-                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="bottom" secondItem="IDF-XF-2Ta" secondAttribute="bottom" id="xqf-EL-Wnt"/>
+                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="bottom" secondItem="P8U-kf-mkb" secondAttribute="bottom" id="xqf-EL-Wnt"/>
                             <constraint firstItem="ekW-06-trL" firstAttribute="top" secondItem="D6B-Ff-n7b" secondAttribute="top" id="zG7-CU-Ygb"/>
                         </constraints>
                         <variation key="default">

--- a/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
+++ b/Sources/MapboxNavigation/Resources/Base.lproj/Navigation.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,7 +12,7 @@
         <scene sceneID="D7g-l8-Czc">
             <objects>
                 <viewController storyboardIdentifier="EndOfRouteViewController" id="WD9-Na-hrx" customClass="EndOfRouteViewController" customModule="MapboxNavigation" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="IDF-XF-2Ta" userLabel="Root" customClass="EndOfRouteContentView" customModule="MapboxNavigation">
+                    <view key="view" contentMode="center" id="IDF-XF-2Ta" userLabel="Root" customClass="EndOfRouteContentView" customModule="MapboxNavigation">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -23,7 +22,7 @@
                                     <constraint firstAttribute="height" constant="1" id="JsN-yF-tXj"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4jh-bR-wXL" userLabel="Arrival Labels Container">
+                            <view clipsSubviews="YES" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="4jh-bR-wXL" userLabel="Arrival Labels Container">
                                 <rect key="frame" x="0.0" y="16" width="375" height="60"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You have arrived" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V4A-Bp-tr5" customClass="EndOfRouteStaticLabel" customModule="MapboxNavigation">
@@ -64,11 +63,11 @@
                                     <constraint firstItem="V4A-Bp-tr5" firstAttribute="top" secondItem="4jh-bR-wXL" secondAttribute="top" id="n8N-UX-05e"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="evE-dd-pMr" userLabel="Rate Your Trip Container">
+                            <view clipsSubviews="YES" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="evE-dd-pMr" userLabel="Rate Your Trip Container">
                                 <rect key="frame" x="0.0" y="92" width="375" height="54"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rate your trip" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W5U-cV-cDO" customClass="EndOfRouteStaticLabel" customModule="MapboxNavigation">
-                                        <rect key="frame" x="144" y="0.0" width="87.5" height="17"/>
+                                        <rect key="frame" x="143.5" y="0.0" width="88" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.25098039220000001" green="0.36078431370000003" blue="0.47843137250000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
@@ -123,7 +122,7 @@
                                 <rect key="frame" x="0.0" y="350" width="375" height="50"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D6B-Ff-n7b" userLabel="End Navigation Button Container">
+                            <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="D6B-Ff-n7b" userLabel="End Navigation Button Container">
                                 <rect key="frame" x="0.0" y="350" width="375" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5f2-dT-la4" customClass="EndOfRouteButton" customModule="MapboxNavigation">
@@ -141,28 +140,27 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="P8U-kf-mkb"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="unQ-4I-UPo" secondAttribute="trailing" id="1BB-nP-SYc"/>
-                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="evE-dd-pMr" secondAttribute="trailing" id="3Da-jA-RLx"/>
+                            <constraint firstAttribute="trailing" secondItem="evE-dd-pMr" secondAttribute="trailing" id="3Da-jA-RLx"/>
                             <constraint firstItem="TEs-GQ-xWN" firstAttribute="top" secondItem="evE-dd-pMr" secondAttribute="bottom" constant="65" id="6IH-iM-ln5"/>
-                            <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="P8U-kf-mkb" secondAttribute="top" constant="10" id="GFJ-yQ-Cye"/>
-                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="D6B-Ff-n7b" secondAttribute="trailing" id="Ljt-Gw-pXu"/>
-                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="Qjw-oe-dVe"/>
-                            <constraint firstItem="ekW-06-trL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="TeT-ls-Ns4"/>
-                            <constraint firstItem="ekW-06-trL" firstAttribute="trailing" secondItem="P8U-kf-mkb" secondAttribute="trailing" id="UUM-FL-FrV"/>
-                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="TEs-GQ-xWN" secondAttribute="trailing" id="Vg9-Xi-JtV"/>
+                            <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" constant="10" id="GFJ-yQ-Cye"/>
+                            <constraint firstAttribute="trailing" secondItem="D6B-Ff-n7b" secondAttribute="trailing" id="Ljt-Gw-pXu"/>
+                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="Qjw-oe-dVe"/>
+                            <constraint firstItem="ekW-06-trL" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="TeT-ls-Ns4"/>
+                            <constraint firstItem="ekW-06-trL" firstAttribute="trailing" secondItem="IDF-XF-2Ta" secondAttribute="trailing" id="UUM-FL-FrV"/>
+                            <constraint firstAttribute="trailing" secondItem="TEs-GQ-xWN" secondAttribute="trailing" id="Vg9-Xi-JtV"/>
                             <constraint firstItem="unQ-4I-UPo" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="WJ9-OZ-x1y"/>
                             <constraint firstAttribute="bottom" secondItem="ekW-06-trL" secondAttribute="bottom" id="f1v-ju-qen"/>
                             <constraint firstItem="unQ-4I-UPo" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" id="gVo-YH-zU7"/>
-                            <constraint firstItem="evE-dd-pMr" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="k0v-jB-TbO"/>
-                            <constraint firstItem="TEs-GQ-xWN" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="lxR-dT-lxi"/>
-                            <constraint firstItem="4jh-bR-wXL" firstAttribute="leading" secondItem="P8U-kf-mkb" secondAttribute="leading" id="muP-uc-2iF"/>
+                            <constraint firstItem="evE-dd-pMr" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="k0v-jB-TbO"/>
+                            <constraint firstItem="TEs-GQ-xWN" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="lxR-dT-lxi"/>
+                            <constraint firstItem="4jh-bR-wXL" firstAttribute="leading" secondItem="IDF-XF-2Ta" secondAttribute="leading" id="muP-uc-2iF"/>
                             <constraint firstItem="4jh-bR-wXL" firstAttribute="top" secondItem="IDF-XF-2Ta" secondAttribute="top" constant="16" id="rx6-4c-WD7"/>
-                            <constraint firstItem="P8U-kf-mkb" firstAttribute="trailing" secondItem="4jh-bR-wXL" secondAttribute="trailing" id="s63-sP-XUC"/>
+                            <constraint firstAttribute="trailing" secondItem="4jh-bR-wXL" secondAttribute="trailing" id="s63-sP-XUC"/>
                             <constraint firstItem="evE-dd-pMr" firstAttribute="top" secondItem="4jh-bR-wXL" secondAttribute="bottom" constant="16" id="vRY-cm-7kg"/>
-                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="bottom" secondItem="P8U-kf-mkb" secondAttribute="bottom" id="xqf-EL-Wnt"/>
+                            <constraint firstItem="D6B-Ff-n7b" firstAttribute="bottom" secondItem="IDF-XF-2Ta" secondAttribute="bottom" id="xqf-EL-Wnt"/>
                             <constraint firstItem="ekW-06-trL" firstAttribute="top" secondItem="D6B-Ff-n7b" secondAttribute="top" id="zG7-CU-Ygb"/>
                         </constraints>
                         <variation key="default">


### PR DESCRIPTION
### Description
This PR fixes the arrival feedback pop-up issue where it took up too much of the map view in landscape mode by 

### Implementation
- [x] Set constraints to same as `BottomBannerContainerView`
- [x] Refactor `EndOfRouteView` in `NavigationView`
- [x] Adjust camera behavior to reflect `EndOfRouteView` contraints
- [x] Check for right-to-left languages

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->