### PR TITLE
Localize map labels into user-preferred languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * `NavigationMapView.removeAlternativeRoutes()` and `NavigationMapView.removeContinuousAlternativeRoutesDurations()` were made public to provide a way to remove previously shown alternative routes and alternative routes duration annotations, respectively. ([#4134](https://github.com/mapbox/mapbox-navigation-ios/pull/4134))
 * Fixed an issue where tapping on a route duration annotation that overlaps a different route would cause the wrong route to be passed into `NavigationMapViewDelegate.navigationMapView(_:didSelect:)` or `NavigationMapViewDelegate.navigationMapView(_:didSelect:)`. ([#4133](https://github.com/mapbox/mapbox-navigation-ios/pull/4133))
 * Fixed an issue where the shields in the instruction are using the style from last navigation session with the `NavigationMapView` injection used in the new session. ([#4197](https://github.com/mapbox/mapbox-navigation-ios/pull/4197))
+* Fixed an issue where the `NavigationMapView.localizeLabels()` method only localized map labels according to the user’s Preferred Language Order setting if the application also had a localization in the preferred language. ([#4205](https://github.com/mapbox/mapbox-navigation-ios/pull/4205))
 
 ### Banners and guidance instructions
 

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -1757,7 +1757,7 @@ open class NavigationMapView: UIView {
      need to call this method on the value of `NavigationViewController.navigationMapView`.
      */
     public func localizeLabels() {
-        guard let preferredLocale = VectorSource.preferredMapboxStreetsLocale(for: .nationalizedCurrent) else { return }
+        guard let preferredLocale = VectorSource.preferredMapboxStreetsLocale(for: nil) else { return }
         mapView.localizeLabels(into: preferredLocale)
     }
     


### PR DESCRIPTION
Fixed an issue where the `NavigationMapView.localizeLabels()` method only localized map labels according to the user’s Preferred Language Order setting if the application also had a localization in the preferred language. The application’s UI language is irrelevant to whether the map should be localized into a language that the user says they prefer.

This change won’t be a problem for backwards compatibility: the method’s documentation comment says it honors the preference and doesn’t mention anything about the preference being constrained to the application bundle’s languages.

Fixes #4190.

/cc @mapbox/navigation-ios