### PR TITLE
Add "created" field to passive navigation feedback events

### DIFF
--- a/Sources/MapboxCoreNavigation/PassiveNavigationEventDetails.swift
+++ b/Sources/MapboxCoreNavigation/PassiveNavigationEventDetails.swift
@@ -32,6 +32,7 @@ struct PassiveNavigationEventDetails: NavigationEventDetails {
         case latitude = "lat"
         case longitude = "lng"
         case userIdentifier = "userId"
+        case created
         case appMetadata
         case event
         case feedbackType
@@ -62,6 +63,7 @@ struct PassiveNavigationEventDetails: NavigationEventDetails {
         try container.encodeIfPresent(event, forKey: .event)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(screenshot, forKey: .screenshot)
+        try container.encode(created.ISO8601, forKey: .created)
         try container.encode(audioType, forKey: .audioType)
         try container.encode(applicationState, forKey: .applicationState)
         try container.encode(batteryLevel, forKey: .batteryLevel)


### PR DESCRIPTION
Fixes a bug introduced in 2.9.0-alpha.3 after migration from MME to CoreTelemetry, that caused passive navigation feedback events to be discarded by server API since the event payload didn't contain the "created" field. 

This wasn't a problem before because MME used to add this field on their own.

Probably we don't need a changelog entry for this since this bug didn't exist in 2.8.0.
