### PR TITLE
Migrate to Transifex API v3

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,31 +1,31 @@
 [main]
-host = https://www.transifex.com
+host     = https://www.transifex.com
 lang_map = es_ES: es-ES, pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 minimum_perc = 80
-type = STRINGS
 
-[mapbox-navigation-ios.LocalizableStrings]
-file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Localizable.strings
-source_file = Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
-source_lang = en
-
-[mapbox-navigation-ios.localizablestringsdict]
-file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Localizable.stringsdict
-source_file = Sources/MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
-source_lang = en
-type = STRINGSDICT
-
-[mapbox-navigation-ios.LocalizableCoreStrings]
-file_filter = Sources/MapboxCoreNavigation/Resources/<lang>.lproj/Localizable.strings
-source_file = Sources/MapboxCoreNavigation/Resources/en.lproj/Localizable.strings
-source_lang = en
-
-[mapbox-navigation-ios.ExampleMainStrings]
+[o:mapbox:p:mapbox-navigation-ios:r:ExampleMainStrings]
 file_filter = Example/<lang>.lproj/Main.strings
 source_file = Example/en.lproj/Main.strings
 source_lang = en
 
-[mapbox-navigation-ios.navigationstrings]
+[o:mapbox:p:mapbox-navigation-ios:r:LocalizableCoreStrings]
+file_filter = Sources/MapboxCoreNavigation/Resources/<lang>.lproj/Localizable.strings
+source_file = Sources/MapboxCoreNavigation/Resources/en.lproj/Localizable.strings
+source_lang = en
+
+[o:mapbox:p:mapbox-navigation-ios:r:LocalizableStrings]
+file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Localizable.strings
+source_file = Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
+source_lang = en
+
+[o:mapbox:p:mapbox-navigation-ios:r:localizablestringsdict]
+file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Localizable.stringsdict
+source_file = Sources/MapboxNavigation/Resources/en.lproj/Localizable.stringsdict
+source_lang = en
+type        = STRINGSDICT
+
+[o:mapbox:p:mapbox-navigation-ios:r:navigationstrings]
 file_filter = Sources/MapboxNavigation/Resources/<lang>.lproj/Navigation.strings
 source_file = Sources/MapboxNavigation/Resources/en.lproj/Navigation.strings
 source_lang = en
+

--- a/Sources/MapboxNavigation/Resources/es-ES.lproj/Localizable.stringsdict
+++ b/Sources/MapboxNavigation/Resources/es-ES.lproj/Localizable.stringsdict
@@ -14,6 +14,8 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Dar la calificación de %ld estrella</string>
+			<key>many</key>
+			<string>Dar la calificación de %ld estrellas</string>
 			<key>other</key>
 			<string>Dar la calificación de %ld estrellas</string>
 		</dict>
@@ -30,6 +32,8 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Has calificado con %ld estrella.</string>
+			<key>many</key>
+			<string>Has calificado con %ld estrellas.</string>
 			<key>other</key>
 			<string>Has calificado con %ld estrellas.</string>
 		</dict>
@@ -46,6 +50,8 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Enviar 1 artículo</string>
+			<key>many</key>
+			<string>Enviar %ld artículos</string>
 			<key>other</key>
 			<string>Enviar %ld artículos</string>
 		</dict>

--- a/Sources/MapboxNavigation/Resources/es.lproj/Localizable.stringsdict
+++ b/Sources/MapboxNavigation/Resources/es.lproj/Localizable.stringsdict
@@ -14,6 +14,8 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Dar la calificación de una estrella</string>
+			<key>many</key>
+			<string>Dar la calificación de %ld estrellas</string>
 			<key>other</key>
 			<string>Dar la calificación de %ld estrellas</string>
 		</dict>
@@ -30,6 +32,8 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Ha calificado %ld estrella.</string>
+			<key>many</key>
+			<string>Has calificado con %ld estrellas.</string>
 			<key>other</key>
 			<string>Has calificado con %ld estrellas.</string>
 		</dict>
@@ -46,6 +50,8 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Enviar 1 Artículo</string>
+			<key>many</key>
+			<string>Enviar %ld Artículos</string>
 			<key>other</key>
 			<string>Enviar %ld Artículos</string>
 		</dict>

--- a/Sources/MapboxNavigation/Resources/fr.lproj/Localizable.stringsdict
+++ b/Sources/MapboxNavigation/Resources/fr.lproj/Localizable.stringsdict
@@ -14,6 +14,8 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Évaluer à %ld étoile</string>
+			<key>many</key>
+			<string>Évaluer à %ld étoiles</string>
 			<key>other</key>
 			<string>Évaluer à %ld étoiles</string>
 		</dict>
@@ -30,9 +32,16 @@
 			<string>ld</string>
 			<key>one</key>
 			<string>Évalué à %ld étoile.</string>
+			<key>many</key>
+			<string>Évalué à %ld étoiles.</string>
 			<key>other</key>
 			<string>Évalué à %ld étoiles.</string>
 		</dict>
+	</dict>
+	<key>NAVIGATION_REPORT_ISSUES</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@items@</string>
 	</dict>
 </dict>
 </plist>

--- a/Sources/MapboxNavigation/Resources/vi.lproj/Localizable.strings
+++ b/Sources/MapboxNavigation/Resources/vi.lproj/Localizable.strings
@@ -265,3 +265,5 @@
 /* Format for displaying start and endpoint for leg; 1 = source ; 2 = destination */
 "WAYPOINT_SOURCE_DESTINATION_FORMAT" = "%1$@ và %2$@";
 
+/* Button title for back button in preview . */
+"BACK" = "Quay lại";


### PR DESCRIPTION
[Migrated](https://developers.transifex.com/docs/migrating-from-older-versions-of-the-client) to Transifex’s v3 API and new Go-based `tx` client. Updated a few minor translations.

Fixes #4052.