### PR TITLE
Add example for CarPlay dashboard

### DIFF
--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -472,7 +472,27 @@ extension AppDelegate: CPListTemplateDelegate {
 // MARK: - CarPlaySceneDelegate methods
 
 @available(iOS 13.0, *)
-class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
+class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate, CPTemplateApplicationDashboardSceneDelegate {
+    
+    @available(iOS 13.4, *)
+    func templateApplicationDashboardScene(_ templateApplicationDashboardScene: CPTemplateApplicationDashboardScene,
+                                           didConnect dashboardController: CPDashboardController,
+                                           to window: UIWindow) {
+        guard let carImage = UIImage(systemName: "car"),
+              let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        
+        let button = CPDashboardButton(titleVariants: ["Example-CarPlay"], subtitleVariants: ["Mapbox"], image: carImage)
+        dashboardController.shortcutButtons.append(button)
+        
+        let carPlayMapViewController = CarPlayMapViewController(styles: appDelegate.carPlayManager.styles)
+        carPlayMapViewController.delegate = appDelegate.carPlayManager
+        window.rootViewController = carPlayMapViewController
+    }
+
+    @available(iOS 13.4, *)
+    func templateApplicationDashboardScene(_ templateApplicationDashboardScene: CPTemplateApplicationDashboardScene, didDisconnect dashboardController: CPDashboardController, from window: UIWindow) {
+        window.rootViewController = nil
+    }
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
                                   didConnect interfaceController: CPInterfaceController,

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -35,9 +35,20 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>CPSupportsDashboardNavigationScene</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
+			<key>CPTemplateApplicationDashboardSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateDashboardScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>Example.CarPlaySceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>ExampleCarPlayApplicationConfiguration</string>
+				</dict>
+			</array>
 			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
 			<array>
 				<dict>


### PR DESCRIPTION
### Description
This PR is to add example for CarPlay dashboard.

### Implementation
Because the CarPlay dashboard is an App level feature. Developers could provide their own dashboard root view controller for the dashboard window. This PR is to create a small example by using the `CarPlayMapViewController` as the window `rootViewController`. 

In fact, developers could create their own `UIViewController` with a valid `NavigationMapView` with user location indicator, route line, `SpeedLimitView`, `WayNameView` or any other features. And also provide the `CPDashboardButton` for their own Apps. 

### Screenshots or Gifs
In passive navigation
<img width="288" alt="passive" src="https://user-images.githubusercontent.com/48976398/200693132-3a236577-d01c-4902-8ab6-673fb56dec4f.png">

In active navigation
<img width="288" alt="active" src="https://user-images.githubusercontent.com/48976398/200693146-4de584e0-04c3-48ad-bc55-9901260ac0e4.png">


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->