### PR TITLE
Do not generate docs for undocumented classes/enums

### DIFF
--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -78,7 +78,6 @@ custom_categories:
       - StyleManagerDelegate
       - DayStyle
       - NightStyle
-      - StyleType
   - name: Formatters
     children:
       - DistanceFormatter
@@ -93,10 +92,6 @@ custom_categories:
       - FloatingButton
       - WayNameLabel
       - WayNameView
-      - TopBannerView
-      - TopPaddingView
-      - BottomBannerView
-      - BottomPaddingView
   - name: Guidance Instruction UI
     children:
       - TopBannerViewController
@@ -110,7 +105,6 @@ custom_categories:
       - ManeuverView
       - JunctionView
       - GenericRouteShield
-      - StepsViewController
       - StepsViewControllerDelegate
       - BottomBannerViewController
       - BottomBannerViewControllerDelegate
@@ -180,8 +174,6 @@ custom_categories:
       - PassiveNavigationRoadIssueSubtype
       - PassiveNavigationWrongTrafficSubtype
       - LooksIncorrectSubtype
-      - FeedbackViewControllerType
-      - FeedbackItemType
   - name: Camera
     children:
       - NavigationCamera
@@ -218,7 +210,6 @@ custom_categories:
       - RoutePreviewViewControllerDelegate
       - RoutePreviewOptions
       - RoutePreviewDataSource
-      - BackButton
   - name: Electronic Horizon
     children:
       - ElectronicHorizonOptions


### PR DESCRIPTION
### Description
Fixes failing docs generation.

There are no docs comments for the following classes/enums, some of them marked as `:nodoc:`, some just lack docs.

Docs comments for these classes/enums should be added separately if they are needed. This pill request simply excludes non-generated docs from Contents