### PR TITLE
Crash fix during reroute and refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added `RouterDelegate.router(:shouldProactivelyRerouteFrom:to:completion)`, `NavigationServiceDelegate.navigationService(:shouldProactivelyRerouteFrom:to:completion)` and `NavigationViewControllerDelegate.navigationViewController(:shouldProactivelyRerouteFrom:to:completion)` methods to inform and providing control over each individual proactive rerouting attempt. ([#4229](https://github.com/mapbox/mapbox-navigation-ios/pull/4229))
 
+### Other changes
+
+* Fixed potential issue when rerouting and route refreshing happen simultaneously which could lead to old route restoration or even a crash. ([#4238](https://github.com/mapbox/mapbox-navigation-ios/pull/4238))
+
 ## v2.9.0
 
 ### Packaging

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -312,6 +312,8 @@ extension InternalRouter where Self: Router {
             return
         }
         isRefreshing = true
+        let routeIndex = indexedRouteResponse.routeIndex
+        let routeOrigin = indexedRouteResponse.responseOrigin
         resolvedRoutingProvider.refreshRoute(indexedRouteResponse: indexedRouteResponse,
                                              fromLegAtIndex: UInt32(legIndex),
                                              currentRouteShapeIndex: routeShapeIndex,
@@ -325,14 +327,17 @@ extension InternalRouter where Self: Router {
             guard case let .success(response) = result, let self = self else {
                 return
             }
-            self.indexedRouteResponse = .init(routeResponse: response, routeIndex: self.indexedRouteResponse.routeIndex)
+            self.indexedRouteResponse = .init(routeResponse: response,
+                                              routeIndex: routeIndex,
+                                              responseOrigin: routeOrigin)
             
             guard let currentRoute = self.indexedRouteResponse.currentRoute else {
                 assertionFailure("Refreshed `RouteResponse` did not contain required `routeIndex`!")
                 return
             }
             
-            self.routeProgress.refreshRoute(with: currentRoute, at: self.location ?? location,
+            self.routeProgress.refreshRoute(with: currentRoute,
+                                            at: self.location ?? location,
                                             legIndex: legIndex,
                                             legShapeIndex: legShapeIndex)
             

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -327,6 +327,9 @@ extension InternalRouter where Self: Router {
             guard case let .success(response) = result, let self = self else {
                 return
             }
+            guard response.identifier == self.indexedRouteResponse.routeResponse.identifier else {
+                return
+            }
             self.indexedRouteResponse = .init(routeResponse: response,
                                               routeIndex: routeIndex,
                                               responseOrigin: routeOrigin)


### PR DESCRIPTION
### Description
There is a potential race condition in case if rerouting and route refreshing events are happening at the same time.

### Implementation
It is potentially possible that when applying route refresh, it may select incorrect route index, if refreshing route had non 0 index or even restore the previous route. This PR preserves and checks that route was not updated during the refresh.