### PR TITLE
Fix the error message of restricted road features with no coordinates

### DIFF
--- a/Sources/MapboxNavigation/Route.swift
+++ b/Sources/MapboxNavigation/Route.swift
@@ -45,7 +45,7 @@ extension Route {
     }
     
     func restrictedRoadsFeatures() -> [Feature] {
-        guard shape != nil else { return [] }
+        guard let shape = shape else { return [] }
         
         var hasRestriction = false
         var features: [Feature] = []
@@ -79,7 +79,15 @@ extension Route {
             })
         }
         
-        return hasRestriction ? features : []
+        if hasRestriction {
+            return features
+        } else {
+            var feature = Feature(geometry: .lineString(shape))
+            feature.properties = [
+                RestrictedRoadClassAttribute: .boolean(false),
+            ]
+            return [feature]
+        }
     }
     
     func congestionFeatures(legIndex: Int? = nil,

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -354,7 +354,16 @@ class NavigationMapViewTests: TestCase {
         let route = loadRoute(from: "route-with-missing-road-classes")
         let restrictedFeatures = route.restrictedRoadsFeatures()
 
-        XCTAssertTrue(restrictedFeatures.isEmpty, "Restricted Road Features should be empty")
+        XCTAssertEqual(restrictedFeatures.count, 1, "Restricted road features should have one valid feature")
+        let restrictedFeature = restrictedFeatures.first!
+        let expectedGeometry = Geometry.lineString(route.shape!)
+        let isRestrictedRoad = isRestricted(restrictedFeature)!
+        XCTAssertEqual(restrictedFeature.geometry, expectedGeometry)
+        XCTAssertFalse(isRestrictedRoad)
+
+        let routeLineStops = navigationMapView.routeLineRestrictionsGradient(restrictedFeatures)
+        let expectedStops: [Double: UIColor] = [0.0: .defaultTraversedRouteColor]
+        XCTAssertEqual(routeLineStops, expectedStops, "Failed to hide restricted gradient stops with default traversed route color")
     }
 
     func isRestricted(_ feature: Turf.Feature) -> Bool? {


### PR DESCRIPTION
### Description
This Pr is to fix the error message when show restricted road feature is on, but there's no restricted area on the route.

### Implementation
When `NavigationMapView.showsRestrictedAreasOnRoute` is on, but there's no restricted area on the route, previously it generates an empty `Features` as the source, and cause the `A line string must have two or more coordinate points.` error for the linString geometry.
Instead, this Pr will generate a `Feature` with the whole route as the source, and set the `RestrictedRoadClassAttribute` property to `false` to hide it with the default traversed route color. Otherwise, 

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->