### PR TITLE
[CarPlay] Fix panning snapback

### DIFF
--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -829,6 +829,9 @@ extension CarPlayManager: CPMapTemplateDelegate {
     }
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate, didEndPanGestureWithVelocity velocity: CGPoint) {
+        // Stop the navigation camera from following to prevent "snap back"
+        navigationMapView?.navigationCamera.stop()
+        
         // We want the panning surface to have "friction". If the user did not "flick" fast/hard enough, do not update the map with a final animation.
         guard sqrtf(Float(velocity.x * velocity.x + velocity.y * velocity.y)) > 100 else {
             return
@@ -907,6 +910,9 @@ extension CarPlayManager: CPMapTemplateDelegate {
     public func mapTemplate(_ mapTemplate: CPMapTemplate,
                             didUpdatePanGestureWithTranslation translation: CGPoint,
                             velocity: CGPoint) {
+        // Stop the navigation camera from following to prevent "snap back"
+        navigationMapView?.navigationCamera.stop()
+        
         updatePan(by: translation, mapTemplate: mapTemplate, animated: false)
     }
     

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -910,8 +910,10 @@ extension CarPlayManager: CPMapTemplateDelegate {
     public func mapTemplate(_ mapTemplate: CPMapTemplate,
                             didUpdatePanGestureWithTranslation translation: CGPoint,
                             velocity: CGPoint) {
+        
         // Stop the navigation camera from following to prevent "snap back"
         navigationMapView?.navigationCamera.stop()
+        navigationMapView?.mapView.camera.cancelAnimations()
         
         updatePan(by: translation, mapTemplate: mapTemplate, animated: false)
     }

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -930,7 +930,12 @@ extension CarPlayManager: CPMapTemplateDelegate {
 
         let coordinate = self.coordinate(of: offset, in: navigationMapView)
         let cameraOptions = CameraOptions(center: coordinate)
-        navigationMapView.mapView.camera.ease(to: cameraOptions, duration: 1.0)
+        
+        if animated {
+            navigationMapView.mapView.camera.ease(to: cameraOptions, duration: 1.0)
+        } else {
+            navigationMapView.mapView.mapboxMap.setCamera(to: cameraOptions)
+        }
     }
 
     func coordinate(of offset: CGPoint, in navigationMapView: NavigationMapView) -> CLLocationCoordinate2D {

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -829,9 +829,6 @@ extension CarPlayManager: CPMapTemplateDelegate {
     }
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate, didEndPanGestureWithVelocity velocity: CGPoint) {
-        // Stop the navigation camera from following to prevent "snap back"
-        navigationMapView?.navigationCamera.stop()
-        
         // We want the panning surface to have "friction". If the user did not "flick" fast/hard enough, do not update the map with a final animation.
         guard sqrtf(Float(velocity.x * velocity.x + velocity.y * velocity.y)) > 100 else {
             return
@@ -840,6 +837,10 @@ extension CarPlayManager: CPMapTemplateDelegate {
         let decelerationRate: CGFloat = 0.9
         let offset = CGPoint(x: velocity.x * decelerationRate / 4,
                              y: velocity.y * decelerationRate / 4)
+        
+        // Stop the navigation camera from following to prevent "snap back"
+        navigationMapView?.navigationCamera.stop()
+        
         updatePan(by: offset, mapTemplate: mapTemplate, animated: true)
     }
     

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -358,7 +358,6 @@ open class CarPlayMapViewController: UIViewController {
         view.setNeedsUpdateConstraints()
         
         guard let activeRoute = navigationMapView.routes?.first else {
-            navigationMapView.navigationCamera.follow()
             return
         }
         


### PR DESCRIPTION
### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->

Whilst developing a CarPlay enabled app, we discovered that panning around the map whilst using a touchscreen device kept "rubber banding" back to following the user's current location. 

This PR aims to prevent the camera following the current location whilst the user is panning. This was working fine if zooming in/out using the built in buttons before, as these call the `stop()` method when selected, but if these weren't used previous to panning, the camera would constantly snap to the centre.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

- Adds `navigationMapView?.navigationCamera.stop()` / `navigationMapView?.mapView.camera.cancelAnimations()` to CarPlay panning actions
- Prevents following on safe area update (e.g. when the navigation bar appears)
- Tested using a real device connected to the CarPlay simulator (as the external simulator display method doesn't support panning from testing)

Known Issue (attempted to fix this, but this might be more internal from what I've chased) - when the safe area updates, the coordinates returned after panning are massively different compared to the previous, which results in the camera moving large distances (please see video 3 for example). It may be a race condition somewhere as sometimes it is okay with the navigation bar open, other times it's when it is dismissed. My thoughts is that is occurs when updating the `mapboxMap` size, but confused to as to where. An option for now is to possibly disable the normal dragging behaviour (leaving the swiping pan in) until a fix can be identified for this.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

#### Video 1: Before Changes

https://user-images.githubusercontent.com/10659397/201904729-2e336ff1-df5f-4d0d-bf8c-1724b6620eb5.mov

#### Video 2: After Changes

https://user-images.githubusercontent.com/10659397/201904835-9b61a6f7-0fea-4955-8d56-dcd69882d288.mov

#### Video 3: Frame / Bounds Bug?

https://user-images.githubusercontent.com/10659397/201904931-6120dfd4-8a94-485d-aa4e-74e9f0897e34.mov

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->