### PR TITLE
Adds a new NavigationMapView init

### DIFF
--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -140,6 +140,13 @@ class NavigationMapViewTests: TestCase {
         XCTAssertEqual(0, pointAnnotationManager?.annotations.count)
     }
 
+    func testInitWithCustomMapView() {
+        let customMapView = MapView(frame: .zero)
+        var navigationMapView = NavigationMapView(frame: .zero, navigationCameraType: .carPlay, mapView: customMapView)
+        XCTAssertEqual(navigationMapView.navigationCamera.type, .carPlay)
+        XCTAssertEqual(navigationMapView.mapView, customMapView)
+    }
+
     // MARK: - Route congestion consistency tests
 
     func loadRoute(from jsonFile: String) -> Route {


### PR DESCRIPTION
It is an advanced usage init that gives access to all initialization parameters in underlying `MapboxMaps.MapView` type. This is advanced usage method intended for the developers that knows what are they doing.