### PR TITLE
Use mocks in RouteControllerTests

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,4 +5,5 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - MapboxCoreNavigationTests
   - MapboxNavigationTests
+  - MapboxCoreNavigationIntegrationTests
   - scripts

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -89,6 +89,12 @@
 		2C193C32290A9BC30050A57F /* PredictiveCacheOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46C290A8CA10067FDCF /* PredictiveCacheOptionsTests.swift */; };
 		2C2880A1291A82630063E5B7 /* RerouteControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */; };
 		2C2880A6291AB7A10063E5B7 /* RerouteDetectorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */; };
+		2C585157292521C20077A558 /* MapboxCoreNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5ADFBC91DDCC7840011824B /* MapboxCoreNavigation.framework */; };
+		2C58515F292523670077A558 /* RouteControllerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */; };
+		2C58516329252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58516229252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift */; };
+		2C585164292530AF0077A558 /* TestHelper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35CDA85E2190F2A30072B675 /* TestHelper.framework */; };
+		2C585165292530B70077A558 /* MapboxNavigationNative.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; };
+		2C585167292531340077A558 /* PassiveLocationManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */; };
 		2C67751C290AC4A6009C5EE4 /* MapboxNavigationNative.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; };
 		2C7FAF96291ABE62000217A7 /* TestRouteProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FAF95291ABE62000217A7 /* TestRouteProvider.swift */; };
 		2C7FAF98291BB1CA000217A7 /* RerouteControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FAF97291BB1CA000217A7 /* RerouteControllerSpy.swift */; };
@@ -563,6 +569,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2C585158292521C20077A558 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C5ADFBC01DDCC7840011824B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C5ADFBC81DDCC7840011824B;
+			remoteInfo = MapboxCoreNavigation;
+		};
+		2C58516029252A740077A558 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C5ADFBC01DDCC7840011824B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 35CDA85D2190F2A30072B675;
+			remoteInfo = TestHelper;
+		};
 		3525449B1E663D2C004C8F1C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C5ADFBC01DDCC7840011824B /* Project object */;
@@ -720,6 +740,10 @@
 		2C04E46D290A8CA10067FDCF /* PredictiveCacheManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheManagerTests.swift; sourceTree = "<group>"; };
 		2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerouteControllerTests.swift; sourceTree = "<group>"; };
 		2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RerouteDetectorSpy.swift; sourceTree = "<group>"; };
+		2C585153292521C20077A558 /* MapboxCoreNavigationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxCoreNavigationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteControllerIntegrationTests.swift; sourceTree = "<group>"; };
+		2C58516229252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxCoreNavigationIntegrationTests.swift; sourceTree = "<group>"; };
+		2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassiveLocationManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		2C7FAF95291ABE62000217A7 /* TestRouteProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRouteProvider.swift; sourceTree = "<group>"; };
 		2C7FAF97291BB1CA000217A7 /* RerouteControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerouteControllerSpy.swift; sourceTree = "<group>"; };
 		2C9006C7291927850012CCEA /* RoutingProviderSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutingProviderSpy.swift; sourceTree = "<group>"; };
@@ -1291,6 +1315,16 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2C585150292521C20077A558 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2C585165292530B70077A558 /* MapboxNavigationNative.xcframework in Frameworks */,
+				2C585164292530AF0077A558 /* TestHelper.framework in Frameworks */,
+				2C585157292521C20077A558 /* MapboxCoreNavigation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		351BEBD31E5BCC28006FE110 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1428,6 +1462,17 @@
 				2C7FAF95291ABE62000217A7 /* TestRouteProvider.swift */,
 			);
 			path = NavNative;
+			sourceTree = "<group>";
+		};
+		2C585154292521C20077A558 /* MapboxCoreNavigationIntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */,
+				2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */,
+				2C58516229252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift */,
+			);
+			name = MapboxCoreNavigationIntegrationTests;
+			path = Tests/MapboxCoreNavigationIntegrationTests;
 			sourceTree = "<group>";
 		};
 		3507F9FD213430CB0086B39E /* CarPlay */ = {
@@ -2213,6 +2258,7 @@
 				351BEBD81E5BCC28006FE110 /* MapboxNavigation */,
 				C5ADFBD61DDCC7840011824B /* MapboxCoreNavigationTests */,
 				35B711D01E5E7AD2001EDA8D /* MapboxNavigationTests */,
+				2C585154292521C20077A558 /* MapboxCoreNavigationIntegrationTests */,
 				C5ADFBCA1DDCC7840011824B /* Products */,
 				A9E2B43473B53369153F54C6 /* Frameworks */,
 			);
@@ -2227,6 +2273,7 @@
 				35B711CF1E5E7AD2001EDA8D /* MapboxNavigationTests.xctest */,
 				35CDA85E2190F2A30072B675 /* TestHelper.framework */,
 				E2D1494E265CF97D008135A3 /* CarPlayTestHelper.framework */,
+				2C585153292521C20077A558 /* MapboxCoreNavigationIntegrationTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2504,6 +2551,25 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		2C585152292521C20077A558 /* MapboxCoreNavigationIntegrationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2C58515C292521C20077A558 /* Build configuration list for PBXNativeTarget "MapboxCoreNavigationIntegrationTests" */;
+			buildPhases = (
+				2C58514F292521C20077A558 /* Sources */,
+				2C585150292521C20077A558 /* Frameworks */,
+				2C585151292521C20077A558 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2C58516129252A740077A558 /* PBXTargetDependency */,
+				2C585159292521C20077A558 /* PBXTargetDependency */,
+			);
+			name = MapboxCoreNavigationIntegrationTests;
+			productName = MapboxCoreNavigationIntegrationTests;
+			productReference = 2C585153292521C20077A558 /* MapboxCoreNavigationIntegrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		351BEBD61E5BCC28006FE110 /* MapboxNavigation */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 351BEBDE1E5BCC28006FE110 /* Build configuration list for PBXNativeTarget "MapboxNavigation" */;
@@ -2631,10 +2697,14 @@
 				KnownAssetTags = (
 					New,
 				);
-				LastSwiftUpdateCheck = 1220;
+				LastSwiftUpdateCheck = 1410;
 				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
+					2C585152292521C20077A558 = {
+						CreatedOnToolsVersion = 14.1;
+						LastSwiftMigration = 1410;
+					};
 					351BEBD61E5BCC28006FE110 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = GJZR2MEM28;
@@ -2721,11 +2791,19 @@
 				E2D1494D265CF97D008135A3 /* CarPlayTestHelper */,
 				35B711CE1E5E7AD2001EDA8D /* MapboxNavigationTests */,
 				C5ADFBD11DDCC7840011824B /* MapboxCoreNavigationTests */,
+				2C585152292521C20077A558 /* MapboxCoreNavigationIntegrationTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2C585151292521C20077A558 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		351BEBD51E5BCC28006FE110 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2866,6 +2944,16 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2C58514F292521C20077A558 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2C585167292531340077A558 /* PassiveLocationManagerIntegrationTests.swift in Sources */,
+				2C58516329252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift in Sources */,
+				2C58515F292523670077A558 /* RouteControllerIntegrationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		351BEBD21E5BCC28006FE110 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3381,6 +3469,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2C585159292521C20077A558 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C5ADFBC81DDCC7840011824B /* MapboxCoreNavigation */;
+			targetProxy = 2C585158292521C20077A558 /* PBXContainerItemProxy */;
+		};
+		2C58516129252A740077A558 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 35CDA85D2190F2A30072B675 /* TestHelper */;
+			targetProxy = 2C58516029252A740077A558 /* PBXContainerItemProxy */;
+		};
 		3525449C1E663D2C004C8F1C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C5ADFBC81DDCC7840011824B /* MapboxCoreNavigation */;
@@ -3541,6 +3639,71 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		2C58515A292521C20077A558 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Tests/MapboxCoreNavigationIntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxCoreNavigationIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2C58515B292521C20077A558 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Tests/MapboxCoreNavigationIntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxCoreNavigationIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		351BEBDC1E5BCC28006FE110 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4007,6 +4170,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2C58515C292521C20077A558 /* Build configuration list for PBXNativeTarget "MapboxCoreNavigationIntegrationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2C58515A292521C20077A558 /* Debug */,
+				2C58515B292521C20077A558 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		351BEBDE1E5BCC28006FE110 /* Build configuration list for PBXNativeTarget "MapboxNavigation" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		2C193C32290A9BC30050A57F /* PredictiveCacheOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46C290A8CA10067FDCF /* PredictiveCacheOptionsTests.swift */; };
 		2C2880A1291A82630063E5B7 /* RerouteControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */; };
 		2C2880A6291AB7A10063E5B7 /* RerouteDetectorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */; };
+		2C4093B5292661FD0099FA0E /* RouteParserSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */; };
 		2C585157292521C20077A558 /* MapboxCoreNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5ADFBC91DDCC7840011824B /* MapboxCoreNavigation.framework */; };
 		2C58515F292523670077A558 /* RouteControllerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */; };
 		2C58516329252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58516229252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift */; };
@@ -740,6 +741,7 @@
 		2C04E46D290A8CA10067FDCF /* PredictiveCacheManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheManagerTests.swift; sourceTree = "<group>"; };
 		2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerouteControllerTests.swift; sourceTree = "<group>"; };
 		2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RerouteDetectorSpy.swift; sourceTree = "<group>"; };
+		2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteParserSpy.swift; sourceTree = "<group>"; };
 		2C585153292521C20077A558 /* MapboxCoreNavigationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxCoreNavigationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteControllerIntegrationTests.swift; sourceTree = "<group>"; };
 		2C58516229252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxCoreNavigationIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1460,6 +1462,7 @@
 				2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */,
 				2C04E45E290A8C0F0067FDCF /* NativeNavigatorSpy.swift */,
 				2C7FAF95291ABE62000217A7 /* TestRouteProvider.swift */,
+				2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */,
 			);
 			path = NavNative;
 			sourceTree = "<group>";
@@ -3270,6 +3273,7 @@
 				2C7FAF96291ABE62000217A7 /* TestRouteProvider.swift in Sources */,
 				E2C9D8A7268DCB7B005D8955 /* XCTestCase++.swift in Sources */,
 				E26AB4FD269F7BCA00FD756B /* TestCase.swift in Sources */,
+				2C4093B5292661FD0099FA0E /* RouteParserSpy.swift in Sources */,
 				B47C1B7D261FD3D50078546C /* NavigationEventsManagerTestDoubles.swift in Sources */,
 				E20F43C326BBD0A600346E71 /* RouterDelegateSpy.swift in Sources */,
 				B47C1B8F261FD3E70078546C /* NavigationServiceTestDoubles.swift in Sources */,

--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigationIntegrationTests.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigationIntegrationTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2C585152292521C20077A558"
+               BuildableName = "MapboxCoreNavigationIntegrationTests.xctest"
+               BlueprintName = "MapboxCoreNavigationIntegrationTests"
+               ReferencedContainer = "container:MapboxNavigation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -106,13 +106,5 @@ let package = Package(
                 "__Snapshots__", // Ignore snapshots folder
             ]
         ),
-        .testTarget(
-            name: "MapboxCoreNavigationIntegrationTests",
-            dependencies: ["TestHelper"],
-            exclude: ["Info.plist"],
-            resources: [
-                .process("Fixtures"),
-            ]
-        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -106,5 +106,13 @@ let package = Package(
                 "__Snapshots__", // Ignore snapshots folder
             ]
         ),
+        .testTarget(
+            name: "MapboxCoreNavigationIntegrationTests",
+            dependencies: ["TestHelper"],
+            exclude: ["Info.plist"],
+            resources: [
+                .process("Fixtures"),
+            ]
+        ),
     ]
 )

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -239,6 +239,7 @@ open class RouteController: NSObject {
     }()
 
     private let navigatorType: CoreNavigator.Type
+    private let routeParserType: RouteParser.Type
 
     var navigator: MapboxNavigationNative.Navigator {
         return sharedNavigator.navigator
@@ -294,9 +295,9 @@ open class RouteController: NSObject {
         let routeRequest = Directions(credentials: indexedRouteResponse.routeResponse.credentials)
                                 .url(forCalculating: routeOptions).absoluteString
         
-        let parsedRoutes = RouteParser.parseDirectionsResponse(forResponse: routeJSONString,
-                                                               request: routeRequest,
-                                                               routeOrigin: indexedRouteResponse.responseOrigin)
+        let parsedRoutes = routeParserType.parseDirectionsResponse(forResponse: routeJSONString,
+                                                                   request: routeRequest,
+                                                                   routeOrigin: indexedRouteResponse.responseOrigin)
         if parsedRoutes.isValue(),
            var routes = parsedRoutes.value as? [RouteInterface],
            routes.count > indexedRouteResponse.routeIndex {
@@ -643,6 +644,7 @@ open class RouteController: NSObject {
         Self.checkUniqueInstance()
 
         self.navigatorType = Navigator.self
+        self.routeParserType = RouteParser.self
         self.indexedRouteResponse = indexedRouteResponse
         self.dataSource = source
 
@@ -665,10 +667,12 @@ open class RouteController: NSObject {
     init(indexedRouteResponse: IndexedRouteResponse,
          customRoutingProvider: RoutingProvider?,
          dataSource source: RouterDataSource,
-         navigatorType: CoreNavigator.Type) {
+         navigatorType: CoreNavigator.Type,
+         routeParserType: RouteParser.Type) {
         Self.checkUniqueInstance()
 
         self.navigatorType = navigatorType
+        self.routeParserType = routeParserType
         self.indexedRouteResponse = indexedRouteResponse
         self.dataSource = source
         let options = indexedRouteResponse.validatedRouteOptions

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -602,7 +602,7 @@ open class RouteController: NSObject {
                                      options: RouteOptions,
                                      routingProvider: RoutingProvider,
                                      dataSource source: RouterDataSource) {
-        self.init(alongRouteAtIndex:routeIndex,
+        self.init(alongRouteAtIndex: routeIndex,
                   in: routeResponse,
                   options: options,
                   customRoutingProvider: routingProvider,

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -411,7 +411,7 @@ extension InternalRouter where Self: Router {
                     routeOptions = options
                 }
 
-                DispatchQueue.main.async {
+                onMainAsync {
                     // Prefer the most optimal route (the first one) over the route that matched the original choice.
                     self.updateRoute(with: indexedResponse,
                                      routeOptions: routeOptions ?? self.routeProgress.routeOptions,

--- a/Sources/TestHelper/CoreNavigatorSpy.swift
+++ b/Sources/TestHelper/CoreNavigatorSpy.swift
@@ -47,6 +47,30 @@ public final class CoreNavigatorSpy: CoreNavigator {
 
     public var rerouteController: MapboxCoreNavigation.RerouteController = RerouteControllerSpy()
 
+    public func reset() {
+        setRoutesCalled = false
+        passedRoute = nil
+        passedUuid = nil
+        passedLegIndex = nil
+        passedAlternativeRoutes = nil
+
+        restartNavigatorCalled = false
+
+        setAlternativeRoutesCalled = false
+        passedRoutes = nil
+
+        unsetRoutesCalled = false
+        passedUuid = nil
+
+        updateLocationCalled = false
+        passedLocation = nil
+
+        startUpdatingElectronicHorizonCalled = false
+        passedElectronicHorizonOptions = nil
+
+        stopUpdatingElectronicHorizonCalled = false
+    }
+
     public func restartNavigator(forcing version: String?) {
         restartNavigatorCalled = true
     }

--- a/Sources/TestHelper/Fixture.swift
+++ b/Sources/TestHelper/Fixture.swift
@@ -162,18 +162,24 @@ public class Fixture: NSObject {
         return traceCollector.locations
     }
     
-    public class func routeLegProgress() -> RouteLegProgress {
-        let routeStep = RouteStep(transportType: .automobile,
-                                  maneuverLocation: .init(),
-                                  maneuverType: .arrive,
-                                  instructions: "empty",
-                                  drivingSide: .right,
-                                  distance: 0.0,
-                                  expectedTravelTime: 0.0)
-        return RouteLegProgress(leg: RouteLeg(steps: [routeStep],
+    public class func routeLegProgress(expectedTravelTime: TimeInterval = 0.0,
+                                       stepDistance: Turf.LocationDistance = 0.0,
+                                       stepCount: Int = 1) -> RouteLegProgress {
+        var steps = [RouteStep]()
+        for i in 0..<stepCount {
+            let maneuverType: ManeuverType = i == stepCount - 1 ? .arrive : i == 0 ? .depart : .turn
+            steps.append(RouteStep(transportType: .automobile,
+                                   maneuverLocation: .init(),
+                                   maneuverType: maneuverType,
+                                   instructions: "empty",
+                                   drivingSide: .right,
+                                   distance: stepDistance,
+                                   expectedTravelTime: expectedTravelTime))
+        }
+        return RouteLegProgress(leg: RouteLeg(steps: steps,
                                               name: "empty",
                                               distance: 0.0,
-                                              expectedTravelTime: 0.0,
+                                              expectedTravelTime: expectedTravelTime,
                                               profileIdentifier: .automobile))
     }
 

--- a/Sources/TestHelper/NavNative/NativeNavigatorSpy.swift
+++ b/Sources/TestHelper/NavNative/NativeNavigatorSpy.swift
@@ -8,6 +8,8 @@ public class NativeNavigatorSpy: MapboxNavigationNative.Navigator {
     public var passedDescriptors: [TilesetDescriptor]?
     public var passedCacheOptions: PredictiveCacheControllerOptions?
     public var passedRerouteController: RerouteControllerInterface?
+    public var passedLeg: UInt32? = nil
+    public var returnedChangeLegResult = true
 
     public var passedNavigationTrackerOptions: PredictiveLocationTrackerOptions?
     public var passedDescriptorsTrackerOptions: PredictiveLocationTrackerOptions?
@@ -45,6 +47,11 @@ public class NativeNavigatorSpy: MapboxNavigationNative.Navigator {
         passedCacheOptions = cacheOptions
         passedDatasetTrackerOptions = locationTrackerOptions
         return super.createPredictiveCacheController(for: locationTrackerOptions)
+    }
+
+    public override func changeLeg(forLeg leg: UInt32, callback: @escaping ChangeLegCallback) {
+        passedLeg = leg
+        callback(returnedChangeLegResult)
     }
 
     @_implementationOnly public override func setRerouteControllerForController(_ controller: RerouteControllerInterface) {

--- a/Sources/TestHelper/NavNative/RouteParserSpy.swift
+++ b/Sources/TestHelper/NavNative/RouteParserSpy.swift
@@ -1,0 +1,19 @@
+import MapboxNavigationNative
+@_implementationOnly import MapboxCommon_Private
+@_implementationOnly import MapboxNavigationNative_Private
+
+public final class RouteParserSpy: RouteParser  {
+    public static var returnedRoutes: [RouteInterface]?
+    public static var returnedError: String?
+
+    @_implementationOnly
+    public override class func parseDirectionsResponse(forResponse response: String,
+                                                       request: String,
+                                                       routeOrigin: RouterOrigin) -> Expected<NSArray, NSString> {
+        if returnedRoutes == nil && returnedError == nil {
+            return RouteParser.parseDirectionsRoutes(forResponse: response, request: request, routeOrigin: routeOrigin)
+        }
+        return returnedRoutes != nil ? Expected(value: (returnedRoutes ?? []) as NSArray) :
+            Expected(error: (returnedError ?? "") as NSString)
+    }
+}

--- a/Sources/TestHelper/NavNative/TestNavigationStatusProvider.swift
+++ b/Sources/TestHelper/NavNative/TestNavigationStatusProvider.swift
@@ -5,32 +5,44 @@ import MapboxNavigationNative
 @testable import MapboxCoreNavigation
 
 public final class TestNavigationStatusProvider {
-    public static func createNavigationStatus(speedLimit: SpeedLimit? = nil) -> NavigationStatus {
-        let location = FixLocation(CLLocation(latitude: 37.788443, longitude: -122.4020258))
-        let road = MapboxNavigationNative.Road(text: "name", imageBaseUrl: "base image url", shield: nil)
+    public static func createNavigationStatus(routeState: RouteState = .tracking,
+                                              location: CLLocation? = nil,
+                                              routeIndex: UInt32 = 0,
+                                              legIndex: UInt32 = 0,
+                                              stepIndex: UInt32 = 0,
+                                              geometryIndex: UInt32 = 0,
+                                              shapeIndex: UInt32 = 0,
+                                              intersectionIndex: UInt32 = 0,
+                                              voiceInstruction: VoiceInstruction? = nil,
+                                              bannerInstruction: BannerInstruction? = nil,
+                                              speedLimit: SpeedLimit? = nil,
+                                              activeGuidanceInfo: ActiveGuidanceInfo? = nil) -> NavigationStatus {
+        let fixLocation = FixLocation(location ?? CLLocation(latitude: 37.788443, longitude: -122.4020258))
+        let shield = Shield(baseUrl: "shield_url", displayRef: "ref", name: "shield", textColor: "")
+        let road = MapboxNavigationNative.Road(text: "name", imageBaseUrl: "base_image_url", shield: shield)
         let mapMatch = MapMatch(position: .init(edgeId: 0, percentAlong: 0), proba: 42)
         let mapMatcherOutput = MapMatcherOutput(matches: [mapMatch], isTeleport: false)
-        return .init(routeState: .tracking,
+        return .init(routeState: routeState,
                      locatedAlternativeRouteId: nil,
                      stale: false,
-                     location: location,
-                     routeIndex: 0,
-                     legIndex: 0,
-                     step: 0,
+                     location: fixLocation,
+                     routeIndex: routeIndex,
+                     legIndex: legIndex,
+                     step: stepIndex,
                      isFallback: false,
                      inTunnel: false,
                      predicted: 10,
-                     geometryIndex: 0,
-                     shapeIndex: 0,
-                     intersectionIndex: 0,
+                     geometryIndex: geometryIndex,
+                     shapeIndex: shapeIndex,
+                     intersectionIndex: intersectionIndex,
                      roads: [road],
-                     voiceInstruction: nil,
-                     bannerInstruction: nil,
+                     voiceInstruction: voiceInstruction,
+                     bannerInstruction: bannerInstruction,
                      speedLimit: speedLimit,
                      keyPoints: [],
                      mapMatcherOutput: mapMatcherOutput,
                      offRoadProba: 0,
-                     activeGuidanceInfo: nil,
+                     activeGuidanceInfo: activeGuidanceInfo,
                      upcomingRouteAlerts: [],
                      nextWaypointIndex: 0,
                      layer: nil)

--- a/Sources/TestHelper/NavNative/TestRouteProvider.swift
+++ b/Sources/TestHelper/NavNative/TestRouteProvider.swift
@@ -3,16 +3,21 @@ import XCTest
 import MapboxNavigationNative
 
 public final class TestRouteProvider {
-    public static func createRoutes() -> RouteInterface? {
+    public static func createRoute() -> RouteInterface? {
         let route = Fixture.route(between: .init(latitude: 0, longitude: 0),
                                   and: .init(latitude: 1, longitude: 1))
-        guard case let .route(routeOptions) = route.response.options else {
+        return createRoute(routeResponse: route.response)
+    }
+
+    public static func createRoute(routeResponse: RouteResponse) -> RouteInterface? {
+        guard case let .route(routeOptions) = routeResponse.options else {
             XCTFail("Failed to generate test Route.")
             return nil
         }
+
         let encoder = JSONEncoder()
         encoder.userInfo[.options] = routeOptions
-        guard let routeData = try? encoder.encode(route.response),
+        guard let routeData = try? encoder.encode(routeResponse),
               let routeJSONString = String(data: routeData, encoding: .utf8) else {
             XCTFail("Failed to encode generated test Route.")
             return nil

--- a/Sources/TestHelper/RerouteControllerSpy.swift
+++ b/Sources/TestHelper/RerouteControllerSpy.swift
@@ -2,13 +2,24 @@ import Foundation
 import MapboxNavigationNative
 @testable import MapboxCoreNavigation
 
-public class RerouteControllerSpy: RerouteController {
+public final class RerouteControllerSpy: RerouteController {
+    public var returnedUserIsOnRoute = true
+    public var forceRerouteCalled = false
+
     public convenience init() {
         self.init(NativeNavigatorSpy(), config: NativeHandlersFactory.configHandle())
     }
 
     required init(_ navigator: MapboxNavigationNative.Navigator, config: ConfigHandle) {
         super.init(navigator, config: config)
+    }
+
+    public override func userIsOnRoute() -> Bool {
+        return returnedUserIsOnRoute
+    }
+
+    public override func forceReroute() {
+        forceRerouteCalled = true
     }
 
 }

--- a/Sources/TestHelper/RoutingProviderSpy.swift
+++ b/Sources/TestHelper/RoutingProviderSpy.swift
@@ -1,45 +1,80 @@
+import CoreLocation
 import MapboxCoreNavigation
 import MapboxDirections
 
 public class RoutingProviderSpy: RoutingProvider {
     public var calculateRoutesCalled = false
     public var refreshRoutesCalled = false
+
+    public var passedRouteOptions: RouteOptions?
+    public var passedMatchOptions: MatchOptions?
+    public var passedIndexedRouteResponse: IndexedRouteResponse?
+    public var passedFromLegAtIndex: UInt32?
+    public var passedCurrentRouteShapeIndex: Int?
+    public var passedCurrentLegShapeIndex: Int?
+
     public var returnedNavigationProviderRequest: NavigationProviderRequest?
+    public var returnedRoutesResult: Result<IndexedRouteResponse, DirectionsError> = .failure(.unableToRoute)
+    public var returnedDirectionsRoutesResult: Result<RouteResponse, DirectionsError> = .failure(.unableToRoute)
+    public var returnedMapMatchingRoutesResult: Result<MapMatchingResponse, DirectionsError> = .failure(.unableToRoute)
+    public var returnedRefreshResult: Result<RouteResponse, DirectionsError> = .failure(.unableToRoute)
+
+    public var session: Directions.Session!
 
     public func calculateRoutes(options: RouteOptions,
                                 completionHandler: @escaping IndexedRouteResponseCompletionHandler) -> NavigationProviderRequest? {
         calculateRoutesCalled = true
+        passedRouteOptions = options
+        completionHandler(returnedRoutesResult)
         return returnedNavigationProviderRequest
     }
 
     public func calculateRoutes(options: RouteOptions,
                                 completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
         calculateRoutesCalled = true
+        passedRouteOptions = options
+        completionHandler(session, returnedDirectionsRoutesResult)
         return returnedNavigationProviderRequest
     }
 
     public func calculateRoutes(options: MatchOptions,
                                 completionHandler: @escaping MapboxDirections.Directions.MatchCompletionHandler) -> NavigationProviderRequest? {
         calculateRoutesCalled = true
+        passedMatchOptions = options
+        completionHandler(session, returnedMapMatchingRoutesResult)
         return returnedNavigationProviderRequest
     }
 
-    public func refreshRoute(indexedRouteResponse:IndexedRouteResponse,
+    public func refreshRoute(indexedRouteResponse: IndexedRouteResponse,
                              fromLegAtIndex: UInt32,
                              completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
         refreshRoutesCalled = true
+        passedIndexedRouteResponse = indexedRouteResponse
+        passedFromLegAtIndex = fromLegAtIndex
+        completionHandler(session, returnedRefreshResult)
         return returnedNavigationProviderRequest
     }
 
-    public func refreshRoute(indexedRouteResponse:IndexedRouteResponse,
+    public func refreshRoute(indexedRouteResponse: IndexedRouteResponse,
                              fromLegAtIndex: UInt32,
                              currentRouteShapeIndex: Int,
                              currentLegShapeIndex: Int,
                              completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
         refreshRoutesCalled = true
+        passedIndexedRouteResponse = indexedRouteResponse
+        passedFromLegAtIndex = fromLegAtIndex
+        passedCurrentRouteShapeIndex = currentRouteShapeIndex
+        passedCurrentLegShapeIndex = currentLegShapeIndex
+        completionHandler(session, returnedRefreshResult)
         return returnedNavigationProviderRequest
     }
     
-    public init() {}
+    public init() {
+        let routeOptions = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 38.878206, longitude: -77.037265),
+            CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
+        ])
+        session = (options: routeOptions, credentials: .mocked)
+    }
 
 }

--- a/Tests/MapboxCoreNavigationIntegrationTests/Info.plist
+++ b/Tests/MapboxCoreNavigationIntegrationTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Location Usage Description</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location Usage Description</string>
+</dict>
+</plist>

--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxCoreNavigationIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxCoreNavigationIntegrationTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import CoreLocation
+import MapboxDirections
+import Turf
+import TestHelper
+import MapboxNavigationNative
+@testable import MapboxCoreNavigation
+
+let jsonFileName = "routeWithInstructions"
+let jsonFileNameEmptyDistance = "routeWithNoDistance"
+var routeOptions: NavigationRouteOptions {
+    let from = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.795042, longitude: -122.413165))
+    let to = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 37.7727, longitude: -122.433378))
+    return NavigationRouteOptions(waypoints: [from, to])
+}
+let response = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
+let route: Route = {
+    return Fixture.route(from: jsonFileName, options: routeOptions)
+}()
+let routeWithNoDistance: Route = {
+    return Fixture.route(from: jsonFileNameEmptyDistance, options: routeOptions)
+}()
+
+let waitForInterval: TimeInterval = 5

--- a/Tests/MapboxCoreNavigationIntegrationTests/PassiveLocationManagerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/PassiveLocationManagerIntegrationTests.swift
@@ -61,8 +61,8 @@ class PassiveLocationManagerIntegrationTests: TestCase {
         }
     }
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() {
+        super.setUp()
 
         let bundle = Bundle(for: Fixture.self)
         let filePathURL: URL = URL(fileURLWithPath: bundle.bundlePath.appending("/tiles/liechtenstein"))

--- a/Tests/MapboxCoreNavigationIntegrationTests/PassiveLocationManagerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/PassiveLocationManagerIntegrationTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import MapboxNavigationNative
+import TestHelper
+import XCTest
+@testable import MapboxCoreNavigation
+
+class Road {
+    let from: CLLocationCoordinate2D
+    let to: CLLocationCoordinate2D
+    let length: Double
+
+    init(from: CLLocationCoordinate2D, to: CLLocationCoordinate2D) {
+        self.from = from
+        self.to = to
+        self.length = (to - from).length()
+    }
+
+    func whichCloser(a: CLLocationCoordinate2D, b: CLLocationCoordinate2D) -> CLLocationCoordinate2D {
+        return proximity(of: a) > proximity(of: b) ? b : a
+    }
+
+    func proximity(of: CLLocationCoordinate2D) -> Double {
+        return ((of - from).length() + (of - to).length()) / length
+    }
+}
+
+extension CLLocationCoordinate2D {
+    static func -(a: CLLocationCoordinate2D, b: CLLocationCoordinate2D) -> CLLocationCoordinate2D {
+        return CLLocationCoordinate2D(latitude: a.latitude - b.latitude, longitude: a.longitude - b.longitude)
+    }
+
+    func length() -> Double {
+        return sqrt(latitude * latitude + longitude * longitude)
+    }
+}
+
+class PassiveLocationManagerIntegrationTests: TestCase {
+    class Delegate: PassiveLocationManagerDelegate {
+        let road: Road
+        let locationUpdateExpectation: XCTestExpectation
+
+        init(road: Road, locationUpdateExpectation: XCTestExpectation) {
+            self.road = road
+            self.locationUpdateExpectation = locationUpdateExpectation
+        }
+
+        func passiveLocationManagerDidChangeAuthorization(_ manager: PassiveLocationManager) {
+        }
+
+        func passiveLocationManager(_ manager: PassiveLocationManager, didUpdateLocation location: CLLocation, rawLocation: CLLocation) {
+            print("Got location: \(rawLocation.coordinate.latitude), \(rawLocation.coordinate.longitude) → \(location.coordinate.latitude), \(location.coordinate.longitude)")
+            print("Value: \(road.proximity(of: location.coordinate)) should be less or equal to \(road.proximity(of: rawLocation.coordinate))")
+
+            XCTAssert(road.proximity(of: location.coordinate) <= road.proximity(of: rawLocation.coordinate), "Raw Location wasn't mapped to a road")
+        }
+
+        func passiveLocationManager(_ manager: PassiveLocationManager, didUpdateHeading newHeading: CLHeading) {
+        }
+
+        func passiveLocationManager(_ manager: PassiveLocationManager, didFailWithError error: Error) {
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let bundle = Bundle(for: Fixture.self)
+        let filePathURL: URL = URL(fileURLWithPath: bundle.bundlePath.appending("/tiles/liechtenstein"))
+        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .custom(filePathURL), mapLocation: nil), routingProviderSource: .offline, alternativeRouteDetectionStrategy: .init())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        PassiveLocationManager.historyDirectoryURL = nil
+        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .default, mapLocation: nil), routingProviderSource: .hybrid, alternativeRouteDetectionStrategy: .init())
+        HistoryRecorder._recreateHistoryRecorder()
+    }
+
+    func testManualLocations() {
+        let locationUpdateExpectation = expectation(description: "Location manager takes some time to start mapping locations to a road graph")
+        locationUpdateExpectation.expectedFulfillmentCount = 1
+
+        let road = Road(from: CLLocationCoordinate2D(latitude: 47.207966, longitude: 9.527012), to: CLLocationCoordinate2D(latitude: 47.209518, longitude: 9.522167))
+        let delegate = Delegate(road: road, locationUpdateExpectation: locationUpdateExpectation)
+        let date = Date()
+        let locationManager = PassiveLocationManager()
+        locationManager.updateLocation(CLLocation(latitude: 47.208674, longitude: 9.524650, timestamp: date.addingTimeInterval(-5)))
+        locationManager.delegate = delegate
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            Navigator.shared.navigator.reset {
+                locationManager.updateLocation(CLLocation(latitude: 47.208943, longitude: 9.524707, timestamp: date.addingTimeInterval(-4)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209082, longitude: 9.524319, timestamp: date.addingTimeInterval(-3)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209229, longitude: 9.523838, timestamp: date.addingTimeInterval(-2)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209612, longitude: 9.522629, timestamp: date.addingTimeInterval(-1)))
+                locationManager.updateLocation(CLLocation(latitude: 47.209842, longitude: 9.522377, timestamp: date.addingTimeInterval(0)))
+
+                locationUpdateExpectation.fulfill()
+            }
+        }
+        wait(for: [locationUpdateExpectation], timeout: 5)
+    }
+}
+
+private extension CLLocation {
+    convenience init(latitude: CLLocationDegrees, longitude: CLLocationDegrees, timestamp: Date) {
+        self.init(
+            coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: timestamp
+        )
+    }
+}

--- a/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
@@ -11,13 +11,22 @@ import MapboxNavigationNative
 class RouteControllerIntegrationTests: TestCase {
     var replayManager: ReplayLocationManager?
 
+    override func setUp() {
+        super.setUp()
+        reset()
+    }
+
     override func tearDown() {
         replayManager = nil
+        reset()
+
+        super.tearDown()
+    }
+
+    private func reset() {
         MapboxRoutingProvider.__testRoutesStub = nil
         Navigator._recreateNavigator()
         NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .default, mapLocation: nil), routingProviderSource: .hybrid, alternativeRouteDetectionStrategy: .init())
-
-        super.tearDown()
     }
 
     func testRouteSnappingOvershooting() {

--- a/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
@@ -11,14 +11,11 @@ import MapboxNavigationNative
 class RouteControllerIntegrationTests: TestCase {
     var replayManager: ReplayLocationManager?
 
-    override func setUp() {
-        super.setUp()
-    }
-
     override func tearDown() {
         replayManager = nil
         MapboxRoutingProvider.__testRoutesStub = nil
         Navigator._recreateNavigator()
+        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .default, mapLocation: nil), routingProviderSource: .hybrid, alternativeRouteDetectionStrategy: .init())
 
         super.tearDown()
     }

--- a/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
@@ -1,0 +1,451 @@
+import XCTest
+import Turf
+import MapboxDirections
+import CoreLocation
+@testable import MapboxCoreNavigation
+import TestHelper
+import MapboxNavigationNative
+@_implementationOnly import MapboxCommon_Private
+@_implementationOnly import MapboxNavigationNative_Private
+
+class RouteControllerIntegrationTests: TestCase {
+    var replayManager: ReplayLocationManager?
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        replayManager = nil
+        MapboxRoutingProvider.__testRoutesStub = nil
+        Navigator._recreateNavigator()
+
+        super.tearDown()
+    }
+
+    func testRouteSnappingOvershooting() {
+        let options = NavigationMatchOptions(coordinates: [
+            .init(latitude: 59.337928, longitude: 18.076841),
+            .init(latitude: 59.33865, longitude: 18.074935),
+        ])
+        let routeResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponseFromMatches(at: "sthlm-double-back", options: options), routeIndex: 0)
+        let locations = Array<CLLocation>.locations(from: "sthlm-double-back-replay").shiftedToPresent()
+        let locationManager = ReplayLocationManager(locations: locations)
+        replayManager = locationManager
+        let routeController = RouteController(indexedRouteResponse: routeResponse,
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
+                                              dataSource: self)
+        locationManager.delegate = routeController
+        let routerDelegateSpy = RouterDelegateSpy()
+        routeController.delegate = routerDelegateSpy
+        routeController.reroutesProactively = false
+
+        var actualCoordinates = [CLLocationCoordinate2D]()
+        routerDelegateSpy.onShouldDiscard = { location in
+            actualCoordinates.append(location.coordinate)
+            return false
+        }
+        let expectedTestCoordinatesCount = locationManager.locations.count
+        expectation(description: "All coordinates processed") {
+            actualCoordinates.count == expectedTestCoordinatesCount
+        }
+
+        let replayFinished = expectation(description: "Replay Finished")
+        locationManager.replayCompletionHandler = { _ in
+            replayFinished.fulfill()
+            return false
+        }
+
+        let speedMultiplier: TimeInterval = 100
+        locationManager.speedMultiplier = speedMultiplier
+        locationManager.startUpdatingLocation()
+
+        waitForExpectations(timeout: locationManager.expectedReplayTime, handler: nil)
+
+        let expectedCoordinates = locations.map(\.coordinate)
+        XCTAssertEqual(expectedCoordinates, actualCoordinates)
+    }
+
+    func testRerouteAfterArrival() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
+            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
+        ]
+
+        let navigationRouteOptions = NavigationRouteOptions(coordinates: coordinates)
+        let route = Fixture.route(from: "route-for-off-route", options: navigationRouteOptions)
+        var replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+        let routeResponse = IndexedRouteResponse(routeResponse: RouteResponse(httpResponse: nil,
+                                                                              routes: [route],
+                                                                              options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
+                                                                              credentials: .mocked),
+                                                 routeIndex: 0)
+
+        guard let lastReplayLocation = replayLocations.last else {
+            XCTFail("First and last route locations should be valid.")
+            return
+        }
+
+        let routeController = RouteController(indexedRouteResponse: routeResponse,
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
+                                              dataSource: self)
+
+        let routerDelegateSpy = RouterDelegateSpy()
+        routeController.delegate = routerDelegateSpy
+
+        // Generate additional coordinates right after the last coordinate on the original route
+        // to simulate off route navigation.
+        let overshootingDestination = CLLocationCoordinate2D(latitude: 37.775395, longitude: -122.389875)
+        let offRouteReplayLocation = Fixture.generateCoordinates(between: lastReplayLocation.coordinate,
+                                                                 and: overshootingDestination,
+                                                                 count: 100).map {
+            CLLocation(coordinate: $0)
+        }.shiftedToPresent()
+
+        replayLocations.append(contentsOf: offRouteReplayLocation)
+
+        let locationManager = ReplayLocationManager(locations: replayLocations)
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+
+        let shouldRerouteCalled = expectation(description: "Reroute event should be called.")
+        shouldRerouteCalled.assertForOverFulfill = false
+
+        routerDelegateSpy.onShouldRerouteFrom = { _ in
+            shouldRerouteCalled.fulfill()
+            return true
+        }
+
+        let shouldPreventReroutesCalled = expectation(description: "Prevent reroutes event should be called.")
+        shouldPreventReroutesCalled.assertForOverFulfill = false
+
+        routerDelegateSpy.onShouldPreventReroutesWhenArrivingAt = { _ in
+            shouldPreventReroutesCalled.fulfill()
+            return false
+        }
+
+        let didRerouteCalled = expectation(description: "Did reroute event should be called.")
+        didRerouteCalled.assertForOverFulfill = false
+
+        routerDelegateSpy.onDidRerouteAlong = { _ in
+            didRerouteCalled.fulfill()
+        }
+
+        let calculateRouteCalled = expectation(description: "Calculate route event should called.")
+        calculateRouteCalled.assertForOverFulfill = false
+
+        MapboxRoutingProvider.__testRoutesStub = { (options, completionHandler) in
+            DispatchQueue.main.async {
+                completionHandler(.success(routeResponse))
+
+                calculateRouteCalled.fulfill()
+            }
+            return nil
+        }
+
+        let replayFinished = expectation(description: "Replay should be successfully finished.")
+        locationManager.speedMultiplier = 50
+        locationManager.replayCompletionHandler = { _ in
+            replayFinished.fulfill()
+            return false
+        }
+        locationManager.startUpdatingLocation()
+        wait(for: [replayFinished], timeout: locationManager.expectedReplayTime)
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testAlternativeRoutesReported() {
+        let routeOptions = RouteOptions(coordinates: [.init(latitude: 37.33243586131637,
+                                                            longitude: -122.03140541047281),
+                                                      .init(latitude: 37.33318065375225,
+                                                            longitude: -122.03148874952787)],
+                                        profileIdentifier: .automobileAvoidingTraffic)
+        routeOptions.shapeFormat = .geoJSON
+        let routeResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "routeResponseWithAlternatives",
+                                                                                      options: routeOptions),
+                                                 routeIndex: 0)
+
+        let alternativesExpectation = XCTestExpectation(description: "Alternative route should be reported")
+        alternativesExpectation.assertForOverFulfill = true
+
+        let routerDelegateSpy = RouterDelegateSpy()
+
+        routerDelegateSpy.onDidUpdateAlternativeRoutes = { newAlternatives, removedAlternatives in
+            XCTAssertTrue(removedAlternatives.isEmpty)
+            if newAlternatives.count == 1 {
+                alternativesExpectation.fulfill()
+            }
+        }
+
+        let routeController = RouteController(indexedRouteResponse: routeResponse,
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
+                                              dataSource: self)
+
+        routeController.delegate = routerDelegateSpy
+
+        wait(for: [alternativesExpectation], timeout: 2)
+    }
+
+    func testAlternativeRoutesNotReported() {
+        NavigationSettings.shared.initialize(directions: .mocked,
+                                             tileStoreConfiguration: .default,
+                                             routingProviderSource: .hybrid,
+                                             alternativeRouteDetectionStrategy: nil)
+
+        let routeOptions = RouteOptions(coordinates: [.init(latitude: 37.33243586131637,
+                                                            longitude: -122.03140541047281),
+                                                      .init(latitude: 37.33318065375225,
+                                                            longitude: -122.03148874952787)],
+                                        profileIdentifier: .automobileAvoidingTraffic)
+        routeOptions.shapeFormat = .geoJSON
+        let routeResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "routeResponseWithAlternatives",
+                                                                                      options: routeOptions),
+                                                 routeIndex: 0)
+
+        let alternativesExpectation = XCTestExpectation(description: "Alternative route should not be reported")
+        alternativesExpectation.assertForOverFulfill = true
+        alternativesExpectation.isInverted = true
+
+        let routerDelegateSpy = RouterDelegateSpy()
+
+        routerDelegateSpy.onDidUpdateAlternativeRoutes = { newAlternatives, removedAlternatives in
+            alternativesExpectation.fulfill()
+        }
+
+        let routeController = RouteController(indexedRouteResponse: routeResponse,
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
+                                              dataSource: self)
+
+        routeController.delegate = routerDelegateSpy
+
+        wait(for: [alternativesExpectation], timeout: 2)
+    }
+
+    func testCustomRoutingProvider() {
+        let routingProviderStub = CustomRoutingProviderStub()
+        let routeExpectation = XCTestExpectation(description: "Route calculation should be called")
+
+        routingProviderStub.indexedRouteStub = { _ in
+            routeExpectation.fulfill()
+        }
+
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
+            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
+        ]
+
+        let options = NavigationRouteOptions(coordinates: coordinates)
+        let route = Fixture.route(from: "route-for-off-route", options: options)
+        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+        let routeResponse = RouteResponse(httpResponse: nil,
+                                          routes: [route],
+                                          options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
+                                          credentials: .mocked)
+
+        let offRouteLocation = CLLocationCoordinate2D(latitude: coordinates[1].latitude,
+                                                      longitude: -coordinates[1].longitude)
+        let offRouteReplayLocation = Fixture.generateCoordinates(between: coordinates[0],
+                                                                 and: offRouteLocation,
+                                                                 count: 100).map {
+            CLLocation(coordinate: $0)
+        }.shiftedToPresent()
+
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse,
+                                                        routeIndex: 0)
+        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
+                                              customRoutingProvider: routingProviderStub,
+                                              dataSource: self)
+
+        let locationManager = ReplayLocationManager(locations: offRouteReplayLocation)
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+
+        locationManager.speedMultiplier = 50
+        locationManager.startUpdatingLocation()
+        wait(for: [routeExpectation], timeout: locationManager.expectedReplayTime)
+    }
+
+    func testReroutingUpdatesRouteOptions() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
+            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
+        ]
+
+        let options = NavigationRouteOptions(coordinates: coordinates)
+        let route = Fixture.route(from: "route-for-off-route", options: options)
+        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+        let routeResponse = RouteResponse(httpResponse: nil,
+                                          routes: [route],
+                                          options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
+                                          credentials: .mocked)
+
+        let offRouteLocation = CLLocationCoordinate2D(latitude: coordinates[1].latitude,
+                                                      longitude: -coordinates[1].longitude)
+        let offRouteReplayLocation = Fixture.generateCoordinates(between: coordinates[0],
+                                                                 and: offRouteLocation,
+                                                                 count: 100).map {
+            CLLocation(coordinate: $0)
+        }.shiftedToPresent()
+
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse,
+                                                        routeIndex: 0)
+        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
+                                              customRoutingProvider: nil,
+                                              dataSource: self)
+
+        let routerDelegateSpy = RouterDelegateSpy()
+        let modifyExpectation = expectation(description: "Reroute should request options editing.")
+        modifyExpectation.assertForOverFulfill = false
+
+        routerDelegateSpy.onModifiedOptionsForReroute = { options in
+            modifyExpectation.fulfill()
+            return options
+        }
+        routeController.delegate = routerDelegateSpy
+
+        let locationManager = ReplayLocationManager(locations: offRouteReplayLocation)
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+
+        locationManager.speedMultiplier = 50
+        locationManager.startUpdatingLocation()
+        wait(for: [modifyExpectation], timeout: locationManager.expectedReplayTime)
+    }
+
+    func testSwitchToOnlineRoute() {
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: response,
+                                                        routeIndex: 0,
+                                                        responseOrigin: .onboard)
+        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
+                                              customRoutingProvider: MapboxRoutingProvider(.offline),
+                                              dataSource: self)
+        let routerDelegateSpy = RouterDelegateSpy()
+        routeController.delegate = routerDelegateSpy
+
+        expectation(forNotification: .routeControllerDidSwitchToCoincidentOnlineRoute, object: nil)
+
+        let routeOptions = indexedRouteResponse.validatedRouteOptions
+        let encoder = JSONEncoder()
+        encoder.userInfo[.options] = routeOptions
+        guard let routeData = try? encoder.encode(indexedRouteResponse.routeResponse),
+              let routeJSONString = String(data: routeData, encoding: .utf8) else {
+                  XCTFail()
+                  return
+        }
+        let routeRequest = Directions(credentials: indexedRouteResponse.routeResponse.credentials)
+                                .url(forCalculating: routeOptions).absoluteString
+        let parsedRoutes = RouteParser.parseDirectionsResponse(forResponse: routeJSONString,
+                                                               request: routeRequest,
+                                                               routeOrigin: indexedRouteResponse.responseOrigin)
+        let userInfo: [MapboxCoreNavigation.Navigator.NotificationUserInfoKey: Any] = [
+            .coincideOnlineRouteKey: (parsedRoutes.value as! [RouteInterface]).first!
+        ]
+        NotificationCenter.default.post(name: .navigatorWantsSwitchToCoincideOnlineRoute, object: nil, userInfo: userInfo)
+
+        waitForExpectations(timeout: 2)
+    }
+
+    func testProactiveRerouting() {
+        let defaultInterval = RouteControllerProactiveReroutingInterval
+        RouteControllerProactiveReroutingInterval = 1
+
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 38.853108, longitude: -77.043331),
+            CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
+        ]
+
+        let options = NavigationRouteOptions(coordinates: coordinates)
+        let route = Fixture.route(from: "DCA-Arboretum", options: options)
+        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+        let routeResponse = RouteResponse(httpResponse: nil,
+                                          routes: [route],
+                                          options: .route(.init(locations: replayLocations,
+                                                                profileIdentifier: nil)),
+                                          credentials: .mocked)
+
+        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse,
+                                                        routeIndex: 0)
+
+        let routingProviderStub = CustomRoutingProviderStub()
+
+        routingProviderStub.indexedRouteStub = { completion in
+            let route = Fixture.route(from: "DCA-Arboretum-duration-edited", options: options)
+            let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
+            let routeResponse = RouteResponse(httpResponse: nil,
+                                              routes: [route],
+                                              options: .route(.init(locations: replayLocations,
+                                                                    profileIdentifier: nil)),
+                                              credentials: .mocked)
+
+            completion(.success(IndexedRouteResponse(routeResponse: routeResponse,
+                                                     routeIndex: 0)))
+        }
+
+        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
+                                              customRoutingProvider: routingProviderStub,
+                                              dataSource: self)
+        let routerDelegateSpy = RouterDelegateSpy()
+        let routeExpectation = XCTestExpectation(description: "Proactive ReRoute should be called")
+
+        routerDelegateSpy.onShouldProactivelyRerouteFrom = { _, _ in
+            routeExpectation.fulfill()
+            return true
+        }
+
+        routeController.delegate = routerDelegateSpy
+
+        let locationManager = ReplayLocationManager(locations: [CLLocation(coordinate: coordinates[0])].shiftedToPresent())
+        locationManager.startDate = Date()
+        locationManager.delegate = routeController
+
+        locationManager.speedMultiplier = 1
+        locationManager.startUpdatingLocation()
+        wait(for: [routeExpectation], timeout: 15)
+
+        RouteControllerProactiveReroutingInterval = defaultInterval
+    }
+}
+
+extension RouteControllerIntegrationTests: RouterDataSource {
+    var location: CLLocation? {
+        return replayManager?.location
+    }
+
+    var locationManagerType: NavigationLocationManager.Type {
+        return NavigationLocationManager.self
+    }
+}
+
+class CustomRoutingProviderStub: RoutingProvider {
+    var routeStub: (() -> Void)?
+    var indexedRouteStub: ((IndexedRouteResponseCompletionHandler) -> Void)?
+    var matchStub: (() -> Void)?
+    var refreshStub: (() -> Void)?
+    var refreshByIndexStub: (() -> Void)?
+
+    func calculateRoutes(options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        routeStub?()
+        return nil
+    }
+
+    func calculateRoutes(options: RouteOptions, completionHandler: @escaping IndexedRouteResponseCompletionHandler) -> NavigationProviderRequest? {
+        indexedRouteStub?(completionHandler)
+        return nil
+    }
+
+    func calculateRoutes(options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> NavigationProviderRequest? {
+        matchStub?()
+        return nil
+    }
+
+    func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        refreshStub?()
+        return nil
+    }
+
+    func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, currentRouteShapeIndex: Int, currentLegShapeIndex: Int, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        refreshByIndexStub?()
+        return nil
+    }
+}

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
@@ -188,10 +188,10 @@ class PassiveLocationManagerTests: TestCase {
     }
 
     func testStartUpdatingElectronicHorizon() {
-        let options: MapboxCoreNavigation.ElectronicHorizonOptions = .init(length: 100,
-                                                                           expansionLevel: 10,
-                                                                           branchLength: 100,
-                                                                           minTimeDeltaBetweenUpdates: nil)
+        let options = MapboxCoreNavigation.ElectronicHorizonOptions(length: 100,
+                                                                    expansionLevel: 10,
+                                                                    branchLength: 100,
+                                                                    minTimeDeltaBetweenUpdates: nil)
         passiveLocationManager.startUpdatingElectronicHorizon(with: options)
         XCTAssertTrue(navigatorSpy.startUpdatingElectronicHorizonCalled)
         XCTAssertNotNil(navigatorSpy.passedElectronicHorizonOptions)
@@ -252,15 +252,11 @@ class PassiveLocationManagerTests: TestCase {
                                          expectedTravelTime: -1,
                                          confidence: 42,
                                          weight: .routability(value: 1))]
-            let imageBaseURL = URL(string: "base image url")
-            let expectedRouteShieldRepresentation = VisualInstruction.Component.ImageRepresentation(imageBaseURL: imageBaseURL,
-                                                                                                    shield: nil)
-
             XCTAssertEqual(newLocation?.coordinate, CLLocation(status.location).coordinate)
             XCTAssertEqual(rawLocation, self.location)
             XCTAssertEqual(roadName, "name")
             XCTAssertEqual(matches, expectedMatches)
-            XCTAssertEqual(routeShieldRepresentation, expectedRouteShieldRepresentation)
+            XCTAssertEqual(routeShieldRepresentation, status.routeShieldRepresentation)
             XCTAssertNotNil(mapMatchingResult)
             XCTAssertEqual(speedLimit, expectedSpeedLimit)
             XCTAssertEqual(signStandard, .mutcd)

--- a/Tests/MapboxCoreNavigationTests/RerouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RerouteControllerTests.swift
@@ -53,7 +53,7 @@ final class RerouteControllerTests: TestCase {
     private var navigatorSpy: NativeNavigatorSpy!
     private var configHandle: ConfigHandle!
     private var rerouteDetector: RerouteDetectorSpy!
-    private var customRoutingProvider: CustomRoutingProviderStub!
+    private var customRoutingProvider: RoutingProviderSpy!
 
     private var delegate: DelegateSpy!
     private var rerouteController: RerouteController!
@@ -61,7 +61,7 @@ final class RerouteControllerTests: TestCase {
     override func setUp() {
         super.setUp()
 
-        route = TestRouteProvider.createRoutes()
+        route = TestRouteProvider.createRoute()
         routeOptions = RouteOptions(url: URL(string: route.getRequestUri())!)
 
         rerouteDetector = .init()
@@ -83,7 +83,7 @@ final class RerouteControllerTests: TestCase {
     }
 
     func testSetCustomRoutingProvider() {
-        let customRoutingProvider = CustomRoutingProviderStub()
+        let customRoutingProvider = RoutingProviderSpy()
         rerouteController.customRoutingProvider = customRoutingProvider
         XCTAssertTrue(navigatorSpy.passedRerouteController === rerouteController)
     }

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -9,97 +9,321 @@ import MapboxNavigationNative
 @_implementationOnly import MapboxNavigationNative_Private
 
 class RouteControllerTests: TestCase {
+    final class RouterDataSourceSpy: RouterDataSource {
+        var locationManagerType: NavigationLocationManager.Type = NavigationLocationManagerSpy.self
+    }
+
+    private let expectationsTimeout = 0.5
+    
     private var locationManagerSpy: NavigationLocationManagerSpy!
-    private var replayManager: ReplayLocationManager?
     private var navigatorSpy: CoreNavigatorSpy!
+    private var nativeNavigatorSpy: NativeNavigatorSpy!
     private var routingProvider: RoutingProviderSpy!
     private var delegate: RouterDelegateSpy!
+    private var indexedRouteResponse: IndexedRouteResponse!
+    private var rerouteController: RerouteControllerSpy!
+    private var dataSource: RouterDataSourceSpy!
+    private var routeProgress: RouteProgress!
+    
+    private var routeController: RouteController!
 
+    private var routeResponse: RouteResponse!
+    private var singleRouteResponse: RouteResponse!
+    private var multilegRouteResponse: RouteResponse!
+    
     private let rawLocation = CLLocation(latitude: 47.208674, longitude: 9.524650)
+    private var locationWithDate: CLLocation {
+        let coordinate = CLLocationCoordinate2D(latitude: 59.337928, longitude: 18.076841)
+        return CLLocation(coordinate: coordinate,
+                          altitude: 0,
+                          horizontalAccuracy: 0,
+                          verticalAccuracy: 0,
+                          timestamp: Date())
+    }
 
-    private let options = NavigationMatchOptions(coordinates: [
-        CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
-        CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
-    ])
-
+    private var options: RouteOptions {
+        let from = Waypoint(coordinate: .init(latitude: 37.33243586131637, longitude: -122.03140541047281))
+        let to = Waypoint(coordinate: .init(latitude: 37.33318065375225, longitude: -122.03148874952787))
+        let options = RouteOptions(waypoints: [from, to])
+        options.shapeFormat = .geoJSON
+        return options
+    }
+    
     override func setUp() {
         super.setUp()
 
+        resetNavigationSettings()
         delegate = .init()
         locationManagerSpy = .init()
         routingProvider = .init()
         navigatorSpy = CoreNavigatorSpy.shared
-    }
+        nativeNavigatorSpy = navigatorSpy.navigatorSpy
+        rerouteController = CoreNavigatorSpy.shared.rerouteController as? RerouteControllerSpy
+        dataSource = .init()
+        routingProvider = .init()
+        routeResponse = makeRouteResponse()
+        indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
+        routeProgress = .init(route: routeResponse.routes![0], options: options)
 
+        singleRouteResponse = makeSingleRouteResponse()
+        multilegRouteResponse = makeMultilegRouteResponse()
+
+        routeController = makeRouteController()
+        routeController.delegate = delegate
+    }
+    
     override func tearDown() {
-        replayManager = nil
+        delegate = nil
+        routeController = nil
         MapboxRoutingProvider.__testRoutesStub = nil
         Navigator._recreateNavigator()
-
+        resetNavigationSettings()
+        
         super.tearDown()
     }
 
-    private func createRouteController() -> RouteController {
-        let routeResponse = Fixture.routeResponseFromMatches(at: "sthlm-double-back", options: options)
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
+    func testConfigureInstance() {
         let controller = RouteController(indexedRouteResponse: indexedRouteResponse,
                                          customRoutingProvider: routingProvider,
-                                         dataSource: self,
-                                         navigatorType: CoreNavigatorSpy.self)
-        controller.delegate = delegate
-        return controller
+                                         dataSource: dataSource)
+        XCTAssertEqual(controller.indexedRouteResponse.currentRoute, indexedRouteResponse.currentRoute)
+        XCTAssertTrue(controller.dataSource === dataSource)
+        XCTAssertEqual(controller.routeProgress.legIndex, 0)
     }
 
+    func testConfigurerefreshesRoute() {
+        indexedRouteResponse.validatedRouteOptions.refreshingEnabled = true
+        indexedRouteResponse.validatedRouteOptions.profileIdentifier = .automobileAvoidingTraffic
+        let controller1 = RouteController(indexedRouteResponse: indexedRouteResponse,
+                                          customRoutingProvider: routingProvider,
+                                          dataSource: dataSource)
+        XCTAssertTrue(controller1.refreshesRoute, "Should refresh for automobileAvoidingTraffic")
+
+        indexedRouteResponse.validatedRouteOptions.profileIdentifier = .automobile
+        let controller2 = RouteController(indexedRouteResponse: indexedRouteResponse,
+                                          customRoutingProvider: routingProvider,
+                                          dataSource: dataSource)
+        XCTAssertFalse(controller2.refreshesRoute, "Should not refresh for automobile")
+    }
+    
     func testReturnIsFirstLocation() {
-        let routeController = createRouteController()
         XCTAssertTrue(routeController.isFirstLocation)
         routeController.rawLocation = CLLocation(latitude: 59.337928, longitude: 18.076841)
         XCTAssertFalse(routeController.isFirstLocation)
     }
+    
+    func testReturnSnappedLocation() {
+        XCTAssertNil(routeController.snappedLocation)
+        
+        routeController.rawLocation = CLLocation(latitude: 59.337928, longitude: 18.076841)
+        XCTAssertNil(routeController.snappedLocation)
+        
+        routeController.rawLocation = self.locationWithDate
+        XCTAssertNil(routeController.snappedLocation)
+        
+        navigatorSpy.mostRecentNavigationStatus = TestNavigationStatusProvider.createNavigationStatus(routeState: .invalid)
+        XCTAssertNil(routeController.snappedLocation)
+        
+        navigatorSpy.mostRecentNavigationStatus = TestNavigationStatusProvider.createNavigationStatus(routeState: .tracking)
+        XCTAssertEqual(routeController.snappedLocation?.coordinate, navigatorSpy.mostRecentNavigationStatus?.location.coordinate)
+        
+        navigatorSpy.mostRecentNavigationStatus = TestNavigationStatusProvider.createNavigationStatus(routeState: .complete)
+        XCTAssertEqual(routeController.snappedLocation?.coordinate, navigatorSpy.mostRecentNavigationStatus?.location.coordinate)
+    }
 
+    func testReturnIsValidNavigationStatus() {
+        let statusWithCorrectLegIndex = TestNavigationStatusProvider.createNavigationStatus(stepIndex: 1)
+        XCTAssertTrue(routeController.isValidNavigationStatus(statusWithCorrectLegIndex))
+
+        let statusWithIncorrectLegIndex = TestNavigationStatusProvider.createNavigationStatus(stepIndex: 11)
+        XCTAssertFalse(routeController.isValidNavigationStatus(statusWithIncorrectLegIndex))
+    }
+    
     func testReturnLocation() {
-        let routeController = createRouteController()
         XCTAssertNil(routeController.location)
-
+        
         let rawLocation = CLLocation(latitude: 47.208674, longitude: 9.524650)
         routeController.locationManager(locationManagerSpy, didUpdateLocations: [rawLocation])
         XCTAssertEqual(routeController.location, rawLocation)
     }
-
+    
     func testSetDatasetProfileIdentifier() {
         CoreNavigatorSpy.datasetProfileIdentifier = .walking
-        _ = createRouteController()
-        XCTAssertEqual(CoreNavigatorSpy.datasetProfileIdentifier, .automobileAvoidingTraffic)
+        _ = makeRouteController()
+        XCTAssertEqual(CoreNavigatorSpy.datasetProfileIdentifier, indexedRouteResponse.validatedRouteOptions.profileIdentifier)
     }
-
+    
+    func testReturnTileStore() {
+        XCTAssertEqual(makeRouteController().navigatorTileStore, navigatorSpy.tileStore)
+    }
+    
+    func testReturnResolvedRoutingProvider() {
+        let resolvedRoutingProvider = makeRouteController().resolvedRoutingProvider as? RoutingProviderSpy
+        XCTAssertTrue(resolvedRoutingProvider === routingProvider)
+        XCTAssertNotNil(makeRouteController(routingProvider: nil).resolvedRoutingProvider)
+    }
+    
+    func testReturnRouteProgress() {
+        XCTAssertEqual(routeController.routeProgress.legIndex, 0)
+        XCTAssertEqual(routeController.routeProgress.currentLegProgress.stepIndex, 0)
+        
+        let status = TestNavigationStatusProvider.createNavigationStatus(stepIndex: 1)
+        routeController.updateIndexes(status: status, progress: routeController.routeProgress)
+        XCTAssertEqual(routeController.routeProgress.currentLegProgress.stepIndex, 1)
+    }
+    
+    func testReturnRoute() {
+        XCTAssertEqual(routeController.route, routeResponse.routes?[0])
+    }
+    
+    func testReturnRoadGraph() {
+        XCTAssertTrue(makeRouteController().roadGraph === navigatorSpy.roadGraph)
+    }
+    
+    func testReturnRoadObjectStore() {
+        XCTAssertTrue(makeRouteController().roadObjectStore === navigatorSpy.roadObjectStore)
+    }
+    
+    func testReturnRoadObjectMatcher() {
+        XCTAssertTrue(makeRouteController().roadObjectMatcher === navigatorSpy.roadObjectMatcher)
+    }
+    
+    func testReturnUserIsOnRoute() {
+        let status = TestNavigationStatusProvider.createNavigationStatus()
+        XCTAssertTrue(routeController.userIsOnRoute(rawLocation))
+        XCTAssertTrue(routeController.userIsOnRoute(rawLocation, status: status))
+        
+        rerouteController.returnedUserIsOnRoute = false
+        XCTAssertFalse(routeController.userIsOnRoute(rawLocation))
+        XCTAssertFalse(routeController.userIsOnRoute(rawLocation, status: status))
+    }
+    
     func testFallbackToOffline() {
-        let routeController = createRouteController()
         NotificationCenter.default.post(name: .navigationDidSwitchToFallbackVersion, object: nil, userInfo: nil)
         XCTAssertTrue(navigatorSpy.setRoutesCalled)
         XCTAssertEqual(navigatorSpy.passedUuid, routeController.sessionUUID)
         XCTAssertEqual(navigatorSpy.passedLegIndex, UInt32(routeController.routeProgress.legIndex))
     }
-
+    
     func testRestoreToOnline() {
-        let routeController = createRouteController()
         NotificationCenter.default.post(name: .navigationDidSwitchToTargetVersion, object: nil, userInfo: nil)
         XCTAssertTrue(navigatorSpy.setRoutesCalled)
         XCTAssertEqual(navigatorSpy.passedUuid, routeController.sessionUUID)
         XCTAssertEqual(navigatorSpy.passedLegIndex, UInt32(routeController.routeProgress.legIndex))
     }
     
-    func testHandleNavigationStatusDidChange() {
-        let callbackExpectation = expectation(description: "Progress Callback")
-        let routeController = createRouteController()
+    func testStartUpdatingElectronicHorizon() {
+        let options = MapboxCoreNavigation.ElectronicHorizonOptions(length: 100,
+                                                                    expansionLevel: 10,
+                                                                    branchLength: 100,
+                                                                    minTimeDeltaBetweenUpdates: nil)
+        routeController.startUpdatingElectronicHorizon(with: options)
+        XCTAssertTrue(navigatorSpy.startUpdatingElectronicHorizonCalled)
+        XCTAssertNotNil(navigatorSpy.passedElectronicHorizonOptions)
+    }
+    
+    func testStopUpdatingElectronicHorizon() {
+        routeController.stopUpdatingElectronicHorizon()
+        XCTAssertTrue(navigatorSpy.stopUpdatingElectronicHorizonCalled)
+    }
+    
+    func testAdvanceLegIndexIfFinished() {
+        routeController.finishRouting()
+        routeController.advanceLegIndex()
+        XCTAssertNil(nativeNavigatorSpy.passedLeg)
+    }
+    
+    func testAdvanceLegIndexIfSuccessFromNavNative() {
+        let callbackExpectation = expectation(description: "Advance leg index should be called")
+        routeController.advanceLegIndex() { result in
+            guard case .success(let routeProgress) = result else {
+                return XCTFail("Expected a success but got a failure with \(result)")
+            }
+            XCTAssertEqual(routeProgress.legIndex, 0, "Leg index not changed until notification")
+            callbackExpectation.fulfill()
+        }
+        XCTAssertEqual(nativeNavigatorSpy.passedLeg, 1)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testAdvanceLegIndexIfFailureFromNavNative() {
+        let callbackExpectation = expectation(description: "Advance leg index should be called")
+        nativeNavigatorSpy.returnedChangeLegResult = false
+        routeController.advanceLegIndex() { result in
+            guard case .failure(let error) = result else {
+                return XCTFail("Expected a failure but got a success with \(result)")
+            }
+            let expectedError = RouteControllerError.failedToChangeRouteLeg
+            XCTAssertEqual(error as? RouteControllerError, expectedError)
+            callbackExpectation.fulfill()
+        }
+        XCTAssertEqual(nativeNavigatorSpy.passedLeg, 1)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testReturnInitialManeuverAvoidanceRadius() {
+        rerouteController.initialManeuverAvoidanceRadius = 3.0
+        XCTAssertEqual(routeController.initialManeuverAvoidanceRadius, 3.0)
+
+        routeController.initialManeuverAvoidanceRadius = 4.0
+        XCTAssertEqual(routeController.initialManeuverAvoidanceRadius, 4.0)
+        XCTAssertEqual(rerouteController.initialManeuverAvoidanceRadius, 4.0)
+    }
+    
+    func testDidUpdateLocationIfShouldDiscard() {
+        let callbackExpectation = expectation(description: "Discard should called")
+        delegate.onShouldDiscard = { passedLocation in
+            XCTAssertEqual(passedLocation, self.rawLocation)
+            callbackExpectation.fulfill()
+            return true
+        }
+        routeController.locationManager(locationManagerSpy, didUpdateLocations: [rawLocation])
+        XCTAssertFalse(navigatorSpy.updateLocationCalled)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testDidUpdateLocationIfShouldNotDiscard() {
+        let callbackExpectation = expectation(description: "Discard should called")
+        delegate.onShouldDiscard = { passedLocation in
+            XCTAssertEqual(passedLocation, self.rawLocation)
+            callbackExpectation.fulfill()
+            return false
+        }
+        routeController.locationManager(locationManagerSpy, didUpdateLocations: [rawLocation])
+        XCTAssertTrue(navigatorSpy.updateLocationCalled)
+        XCTAssertEqual(navigatorSpy.passedLocation, rawLocation)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testUpdatedHeading() {
+        XCTAssertNil(routeController.heading)
+        
+        let heading = CLHeading(heading: 50, accuracy: 1)!
+        routeController.locationManager(locationManagerSpy, didUpdateHeading: heading)
+        XCTAssertEqual(routeController.heading, heading)
+        
+        let headingAfterFinished = CLHeading(heading: 10, accuracy: 1)!
+        routeController.finishRouting()
+        routeController.locationManager(locationManagerSpy, didUpdateHeading: headingAfterFinished)
+        XCTAssertEqual(routeController.heading, heading)
+    }
+
+    func testUpdateWhenNavigationStatusDidChangeAndActiveGuidance() {
+        let callbackExpectation = expectation(description: "Progress callback should be called")
         routeController.locationManager(locationManagerSpy, didUpdateLocations: [rawLocation])
 
-        let status = TestNavigationStatusProvider.createNavigationStatus()
+        let activeGuidanceInfo = makeActiveGuidanceInfo()
+        let statusLocation = CLLocation(coordinate: route.legs[0].steps[0].maneuverLocation)
+        let status = TestNavigationStatusProvider.createNavigationStatus(location: statusLocation,
+                                                                         activeGuidanceInfo: activeGuidanceInfo)
         let userInfo = [Navigator.NotificationUserInfoKey.statusKey : status]
 
+        let expectedDistanceTraveled = activeGuidanceInfo.stepProgress.distanceTraveled
         delegate.onDidUpdate = { arguments in
-            let (_, location, rawLocation) = arguments
-            XCTAssertEqual(location.coordinate, CLLocation(status.location).coordinate)
+            let (progress, location, rawLocation) = arguments
+            XCTAssertEqual(location.coordinate, statusLocation.coordinate)
             XCTAssertEqual(rawLocation, self.rawLocation)
+            XCTAssertEqual(progress.currentLegProgress.currentStepProgress.distanceTraveled, expectedDistanceTraveled)
             callbackExpectation.fulfill()
         }
 
@@ -107,440 +331,1073 @@ class RouteControllerTests: TestCase {
             let userInfo = notification.userInfo
             let newLocation = userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
             let rawLocation = userInfo?[RouteController.NotificationUserInfoKey.rawLocationKey] as? CLLocation
+            let updatedRoadProgress = userInfo?[RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
 
-            XCTAssertEqual(newLocation?.coordinate, CLLocation(status.location).coordinate)
-            XCTAssertEqual(rawLocation, self.rawLocation)
+            XCTAssertEqual(newLocation?.coordinate, statusLocation.coordinate)
+            XCTAssertEqual(rawLocation?.coordinate, self.rawLocation.coordinate)
+            XCTAssertEqual(updatedRoadProgress?.currentLegProgress.currentStepProgress.distanceTraveled, expectedDistanceTraveled)
 
             return true
         }
 
         NotificationCenter.default.post(name: .navigationStatusDidChange, object: nil, userInfo: userInfo)
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: expectationsTimeout)
     }
 
-    func testRouteSnappingOvershooting() {
-        let options = NavigationMatchOptions(coordinates: [
-            .init(latitude: 59.337928, longitude: 18.076841),
-            .init(latitude: 59.33865, longitude: 18.074935),
-        ])
-        let routeResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponseFromMatches(at: "sthlm-double-back", options: options), routeIndex: 0)
-        let locations = Array<CLLocation>.locations(from: "sthlm-double-back-replay").shiftedToPresent()
-        let locationManager = ReplayLocationManager(locations: locations)
-        replayManager = locationManager
-        let routeController = RouteController(indexedRouteResponse: routeResponse,
-                                              customRoutingProvider: MapboxRoutingProvider(.offline),
-                                              dataSource: self)
-        locationManager.delegate = routeController
-        let routerDelegateSpy = RouterDelegateSpy()
-        routeController.delegate = routerDelegateSpy
-        routeController.reroutesProactively = false
+    func testUpdateWhenNavigationStatusDidChangeAndNoActiveGuidance() {
+        let callbackExpectation = expectation(description: "Progress callback should be called")
+        routeController.locationManager(locationManagerSpy, didUpdateLocations: [rawLocation])
 
-        var actualCoordinates = [CLLocationCoordinate2D]()
-        routerDelegateSpy.onShouldDiscard = { location in
-            actualCoordinates.append(location.coordinate)
-            return false
-        }
-        let expectedTestCoordinatesCount = locationManager.locations.count
-        expectation(description: "All coordinates processed") {
-            actualCoordinates.count == expectedTestCoordinatesCount
+        let step = routeResponse.routes![0].legs[0].steps[0]
+        let statusLocation = CLLocation(coordinate: step.shape!.coordinates.last!)
+        let status = TestNavigationStatusProvider.createNavigationStatus(location: statusLocation)
+        let userInfo = [Navigator.NotificationUserInfoKey.statusKey : status]
+
+        let expectedDistanceTraveled = step.distance
+        delegate.onDidUpdate = { arguments in
+            let (progress, _, _) = arguments
+            XCTAssertEqual(progress.currentLegProgress.currentStepProgress.distanceTraveled, expectedDistanceTraveled)
+            callbackExpectation.fulfill()
         }
 
-        let replayFinished = expectation(description: "Replay Finished")
-        locationManager.replayCompletionHandler = { _ in
-            replayFinished.fulfill()
-            return false
+        expectation(forNotification: .routeControllerProgressDidChange, object: nil) { (notification) -> Bool in
+            let updatedRoadProgress = notification.userInfo?[RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
+            XCTAssertEqual(updatedRoadProgress?.currentLegProgress.currentStepProgress.distanceTraveled, expectedDistanceTraveled)
+            return true
         }
 
-        let speedMultiplier: TimeInterval = 100
-        locationManager.speedMultiplier = speedMultiplier
-        locationManager.startUpdatingLocation()
-
-        waitForExpectations(timeout: locationManager.expectedReplayTime, handler: nil)
-
-        let expectedCoordinates = locations.map(\.coordinate)
-        XCTAssertEqual(expectedCoordinates, actualCoordinates)
+        NotificationCenter.default.post(name: .navigationStatusDidChange, object: nil, userInfo: userInfo)
+        waitForExpectations(timeout: expectationsTimeout)
     }
 
-    func testRerouteAfterArrival() {
-        let coordinates = [
-            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
-            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
-        ]
-        
-        let navigationRouteOptions = NavigationRouteOptions(coordinates: coordinates)
-        let route = Fixture.route(from: "route-for-off-route", options: navigationRouteOptions)
-        var replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
-        let routeResponse = IndexedRouteResponse(routeResponse: RouteResponse(httpResponse: nil,
-                                                                              routes: [route],
-                                                                              options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
-                                                                              credentials: .mocked),
-                                                 routeIndex: 0)
-        
-        guard let lastReplayLocation = replayLocations.last else {
-            XCTFail("First and last route locations should be valid.")
-            return
+    func testUpdateIndexesWhenNavigationStatusDidChange() {
+        let response = IndexedRouteResponse(routeResponse: multilegRouteResponse, routeIndex: 0)
+        routeController = makeRouteController(routeResponse: response)
+        routeController.locationManager(locationManagerSpy, didUpdateLocations: [rawLocation])
+
+        let activeGuidanceInfo = makeActiveGuidanceInfo()
+        let voiceInstruction = VoiceInstruction(ssmlAnnouncement: "a", announcement: "b", remainingStepDistance: 10, index: 5)
+        let bannerSection = BannerSection(text: "", type: nil, modifier: nil, degrees: nil, drivingSide: nil, components: nil)
+        let bannerInstruction = BannerInstruction(primary: bannerSection,
+                                                  view: nil,
+                                                  secondary: nil,
+                                                  sub: nil,
+                                                  remainingStepDistance: 10,
+                                                  index: 6)
+        let status = TestNavigationStatusProvider.createNavigationStatus(legIndex: 1,
+                                                                         stepIndex: 2,
+                                                                         shapeIndex: 3,
+                                                                         intersectionIndex: 4,
+                                                                         voiceInstruction: voiceInstruction,
+                                                                         bannerInstruction: bannerInstruction,
+                                                                         activeGuidanceInfo: activeGuidanceInfo)
+        let userInfo = [Navigator.NotificationUserInfoKey.statusKey : status]
+
+        expectation(forNotification: .routeControllerProgressDidChange, object: nil) { (notification) -> Bool in
+            let progress = notification.userInfo?[RouteController.NotificationUserInfoKey.routeProgressKey] as? RouteProgress
+
+            XCTAssertEqual(progress?.legIndex, 1)
+            XCTAssertEqual(progress?.currentLegProgress.stepIndex, 2)
+            XCTAssertEqual(progress?.currentLegProgress.shapeIndex, 0, "Should not use shapeIndex from status")
+            XCTAssertEqual(progress?.currentLegProgress.currentStepProgress.intersectionIndex, 4)
+            XCTAssertEqual(progress?.currentLegProgress.currentStepProgress.spokenInstructionIndex, 5)
+            XCTAssertEqual(progress?.currentLegProgress.currentStepProgress.visualInstructionIndex, 6)
+            return true
+        }
+
+        NotificationCenter.default.post(name: .navigationStatusDidChange, object: nil, userInfo: userInfo)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testUpdateRoadName() {
+        let status = TestNavigationStatusProvider.createNavigationStatus()
+        expectation(forNotification: .currentRoadNameDidChange, object: nil) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+            let roadName = userInfo?[RouteController.NotificationUserInfoKey.roadNameKey] as? String
+            let routeShieldRepresentation = userInfo?[RouteController.NotificationUserInfoKey.routeShieldRepresentationKey] as? VisualInstruction.Component.ImageRepresentation
+
+            XCTAssertEqual(roadName, status.roadName)
+            XCTAssertEqual(routeShieldRepresentation, status.routeShieldRepresentation)
+
+            return true
+        }
+
+        routeController.updateRoadName(status: status)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testDoNotUpdateRouteLegProgressIfTooManyStepsLeft() {
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .complete)
+
+        let notificationExpectation = expectation(forNotification: .didArriveAtWaypoint, object: nil) { (notification) -> Bool in
+            return true
+        }
+        notificationExpectation.isInverted = true
+
+        routeController.updateRouteLegProgress(status: status)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testNotifyDidArriveAtWaypointIfCompleteStatus() {
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .complete)
+        let destination = self.routeResponse.routes![0].legs[0].destination
+
+        expectation(forNotification: .didArriveAtWaypoint, object: nil) { (notification) -> Bool in
+            let waypoint = notification.userInfo?[RouteController.NotificationUserInfoKey.waypointKey] as? MapboxDirections.Waypoint
+            XCTAssertEqual(waypoint, destination)
+            return true
+        }
+
+        routeController.routeProgress.currentLegProgress.stepIndex = 4
+        routeController.updateRouteLegProgress(status: status)
+
+        XCTAssertEqual(routeController.previousArrivalWaypoint, destination)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testNotifyWillArriveAt() {
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .tracking)
+        routeController.routeProgress.currentLegProgress.stepIndex = 4
+        let legProgress = routeController.routeProgress.currentLegProgress
+        let destination = routeResponse.routes![0].legs[0].destination
+
+        let callbackExpectation = expectation(description: "Will arrive should called")
+        delegate.onWillArriveAt = { arguments in
+            let (waypoint, remainingTimeInterval, distance) = arguments
+            XCTAssertEqual(waypoint, destination)
+            XCTAssertEqual(remainingTimeInterval, legProgress.durationRemaining)
+            XCTAssertEqual(distance, legProgress.distanceRemaining)
+            callbackExpectation.fulfill()
+        }
+
+        let notificationExpectation = expectation(forNotification: .didArriveAtWaypoint, object: nil) { (notification) -> Bool in
+            return true
+        }
+        notificationExpectation.isInverted = true
+
+        routeController.updateRouteLegProgress(status: status)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testRerouteIfNilCustomRoutingProvider() {
+        let routeController = makeRouteController(routingProvider: nil)
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertTrue(rerouteController.forceRerouteCalled)
+    }
+    
+    func testRerouteIfFinishedRouting() {
+        routeController.finishRouting()
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertFalse(rerouteController.forceRerouteCalled)
+    }
+    
+    func testNotifyWillRerouteIfRoutingProviderFailed() {
+        let willRerouteExpectation = expectation(description: "Will reroute call on delegate")
+        delegate.onWillRerouteFrom = { location in
+            XCTAssertEqual(location, self.rawLocation)
+            willRerouteExpectation.fulfill()
         }
         
-        let routeController = RouteController(indexedRouteResponse: routeResponse,
-                                              customRoutingProvider: MapboxRoutingProvider(.offline),
-                                              dataSource: self)
+        let didFailToReroutExpectation = expectation(description: "Did fail to reroute call on delegate")
+        delegate.onDidFailToRerouteWith = { error in
+            XCTAssertEqual(error as! DirectionsError, .unableToRoute)
+            didFailToReroutExpectation.fulfill()
+        }
+        
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertFalse(rerouteController.forceRerouteCalled)
+        XCTAssertTrue(routingProvider.calculateRoutesCalled)
 
-        let routerDelegateSpy = RouterDelegateSpy()
-        routeController.delegate = routerDelegateSpy
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testSendRerouteNotificationIfRoutingProviderFailed() {
+        let heading = CLHeading(heading: 50, accuracy: 1)!
+        routeController.heading = heading
         
-        // Generate additional coordinates right after the last coordinate on the original route
-        // to simulate off route navigation.
-        let overshootingDestination = CLLocationCoordinate2D(latitude: 37.775395, longitude: -122.389875)
-        let offRouteReplayLocation = Fixture.generateCoordinates(between: lastReplayLocation.coordinate,
-                                                                 and: overshootingDestination,
-                                                                 count: 100).map {
-            CLLocation(coordinate: $0)
-        }.shiftedToPresent()
-        
-        replayLocations.append(contentsOf: offRouteReplayLocation)
-        
-        let locationManager = ReplayLocationManager(locations: replayLocations)
-        locationManager.startDate = Date()
-        locationManager.delegate = routeController
-
-        let shouldRerouteCalled = expectation(description: "Reroute event should be called.")
-        shouldRerouteCalled.assertForOverFulfill = false
-        
-        routerDelegateSpy.onShouldRerouteFrom = { _ in
-            shouldRerouteCalled.fulfill()
+        expectation(forNotification: .routeControllerWillReroute, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+            
+            let notificationLocation = userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
+            let notificationHeading = userInfo?[RouteController.NotificationUserInfoKey.headingKey] as? CLHeading
+            XCTAssertEqual(notificationLocation, self.rawLocation)
+            XCTAssertEqual(notificationHeading, heading)
+            
             return true
         }
         
-        let shouldPreventReroutesCalled = expectation(description: "Prevent reroutes event should be called.")
-        shouldPreventReroutesCalled.assertForOverFulfill = false
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertFalse(rerouteController.forceRerouteCalled)
+        XCTAssertTrue(routingProvider.calculateRoutesCalled)
         
-        routerDelegateSpy.onShouldPreventReroutesWhenArrivingAt = { _ in
-            shouldPreventReroutesCalled.fulfill()
-            return false
-        }
-
-        let didRerouteCalled = expectation(description: "Did reroute event should be called.")
-        didRerouteCalled.assertForOverFulfill = false
+        let expectedRouteOptions = routeProgress.reroutingOptions(from: rawLocation)
+        XCTAssertEqual(routingProvider.passedRouteOptions, expectedRouteOptions)
         
-        routerDelegateSpy.onDidRerouteAlong = { _ in
-            didRerouteCalled.fulfill()
-        }
-        
-        let calculateRouteCalled = expectation(description: "Calculate route event should called.")
-        calculateRouteCalled.assertForOverFulfill = false
-        
-        MapboxRoutingProvider.__testRoutesStub = { (options, completionHandler) in
-            DispatchQueue.main.async {
-                completionHandler(.success(routeResponse))
-                
-                calculateRouteCalled.fulfill()
-            }
-            return nil
-        }
-
-        let replayFinished = expectation(description: "Replay should be successfully finished.")
-        locationManager.speedMultiplier = 50
-        locationManager.replayCompletionHandler = { _ in
-            replayFinished.fulfill()
-            return false
-        }
-        locationManager.startUpdatingLocation()
-        wait(for: [replayFinished], timeout: locationManager.expectedReplayTime)
-
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: expectationsTimeout)
     }
     
-    func testAlternativeRoutesReported() {
-        let routeOptions = RouteOptions(coordinates: [.init(latitude: 37.33243586131637,
-                                                            longitude: -122.03140541047281),
-                                                      .init(latitude: 37.33318065375225,
-                                                            longitude: -122.03148874952787)],
-                                        profileIdentifier: .automobileAvoidingTraffic)
-        routeOptions.shapeFormat = .geoJSON
-        let routeResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "routeResponseWithAlternatives",
-                                                                                      options: routeOptions),
-                                                 routeIndex: 0)
+    func testSendRerouteNotificationIfRoutingProviderSucceed() {
+        let heading = CLHeading(heading: 50, accuracy: 1)!
+        routeController.heading = heading
         
-        let alternativesExpectation = XCTestExpectation(description: "Alternative route should be reported")
-        alternativesExpectation.assertForOverFulfill = true
-        
-        let routerDelegateSpy = RouterDelegateSpy()
-        
-        routerDelegateSpy.onDidUpdateAlternativeRoutes = { newAlternatives, removedAlternatives in
-            XCTAssertTrue(removedAlternatives.isEmpty)
-            if newAlternatives.count == 1 {
-                alternativesExpectation.fulfill()
-            }
+        let didFailToReroutExpectation = expectation(description: "Did fail to reroute call on delegate")
+        didFailToReroutExpectation.isInverted = true
+        delegate.onDidFailToRerouteWith = { error in
+            didFailToReroutExpectation.fulfill()
         }
         
-        let routeController = RouteController(indexedRouteResponse: routeResponse,
-                                              customRoutingProvider: MapboxRoutingProvider(.offline),
-                                              dataSource: self)
+        expectation(forNotification: .routeControllerWillReroute, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+            
+            let notificationLocation = userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
+            let notificationHeading = userInfo?[RouteController.NotificationUserInfoKey.headingKey] as? CLHeading
+            XCTAssertEqual(notificationLocation, self.rawLocation)
+            XCTAssertEqual(notificationHeading, heading)
+            
+            return true
+        }
+        let response = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
+        routingProvider.returnedRoutesResult = .success(response)
         
-        routeController.delegate = routerDelegateSpy
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertFalse(rerouteController.forceRerouteCalled)
+        XCTAssertTrue(routingProvider.calculateRoutesCalled)
+        XCTAssertEqual(routeController.indexedRouteResponse.currentRoute, response.currentRoute)
         
-        wait(for: [alternativesExpectation], timeout: 2)
+        let expectedRouteOptions = routeProgress.reroutingOptions(from: rawLocation)
+        XCTAssertEqual(routingProvider.passedRouteOptions, expectedRouteOptions)
+        
+        waitForExpectations(timeout: expectationsTimeout)
     }
     
-    func testAlternativeRoutesNotReported() {
-        NavigationSettings.shared.initialize(directions: .mocked,
+    func testSendRerouteNotificationIfRoutIsEmptyRoute() {
+        let heading = CLHeading(heading: 50, accuracy: 1)!
+        routeController.heading = heading
+        
+        let didFailToReroutExpectation = expectation(description: "Did fail to reroute call on delegate")
+        delegate.onDidFailToRerouteWith = { error in
+            XCTAssertEqual(error as! DirectionsError, .unableToRoute)
+            didFailToReroutExpectation.fulfill()
+        }
+        
+        expectation(forNotification: .routeControllerWillReroute, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+            
+            let notificationLocation = userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
+            let notificationHeading = userInfo?[RouteController.NotificationUserInfoKey.headingKey] as? CLHeading
+            XCTAssertEqual(notificationLocation, self.rawLocation)
+            XCTAssertEqual(notificationHeading, heading)
+            
+            return true
+        }
+        
+        let routeResponse = RouteResponse(httpResponse: nil,
+                                          routes: [],
+                                          options: .route(options),
+                                          credentials: .mocked)
+        let response = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
+        routingProvider.returnedRoutesResult = .success(response)
+        
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertFalse(rerouteController.forceRerouteCalled)
+        XCTAssertTrue(routingProvider.calculateRoutesCalled)
+        
+        let expectedRouteOptions = routeProgress.reroutingOptions(from: rawLocation)
+        XCTAssertEqual(routingProvider.passedRouteOptions, expectedRouteOptions)
+        
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testUpdateRouteWhenReroutingAndNavigatorSucceed() {
+        let response = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
+        routingProvider.returnedRoutesResult = .success(response)
+        
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertTrue(navigatorSpy.setRoutesCalled)
+        XCTAssertEqual(navigatorSpy.passedUuid, routeController.sessionUUID)
+        XCTAssertEqual(navigatorSpy.passedLegIndex, 0)
+        XCTAssertEqual(navigatorSpy.passedAlternativeRoutes?.count, 0)
+        
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertFalse(routeController.didProactiveReroute)
+        
+        XCTAssertTrue(routeController.routeProgress.route === response.currentRoute)
+        guard case .route(let expectedRouteOptions) = singleRouteResponse.options else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(routeController.routeProgress.routeOptions, expectedRouteOptions)
+    }
+    
+    func testUpdateRouteWhenReroutingAndNavigatorFailed() {
+        let response = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
+        routingProvider.returnedRoutesResult = .success(response)
+        navigatorSpy.returnedSetRoutesResult = .failure(DirectionsError.unableToRoute)
+        
+        routeController.reroute(from: rawLocation, along: routeProgress)
+        XCTAssertTrue(navigatorSpy.setRoutesCalled)
+        XCTAssertFalse(routeController.isRerouting)
+    }
+    
+    func testHandleDidDetectRerouteEventIfShouldReroute() {
+        let callbackExpectation = expectation(description: "Reroute should called")
+        routeController.rawLocation = rawLocation
+        delegate.onShouldRerouteFrom = { location in
+            XCTAssertEqual(location, self.rawLocation)
+            callbackExpectation.fulfill()
+            return true
+        }
+        XCTAssertTrue(routeController.rerouteControllerDidDetectReroute(rerouteController))
+        XCTAssertTrue(routeController.isRerouting)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testHandleDidDetectRerouteEventIfShouldNotReroute() {
+        routeController.rawLocation = rawLocation
+        delegate.onShouldRerouteFrom = { location in
+            return false
+        }
+        XCTAssertFalse(routeController.rerouteControllerDidDetectReroute(rerouteController))
+        XCTAssertFalse(routeController.isRerouting)
+    }
+    
+    func testHandleDidDetectRerouteEventIfDefaultBehavior() {
+        routeController.rawLocation = rawLocation
+        routeController.delegate = nil
+        XCTAssertTrue(routeController.rerouteControllerDidDetectReroute(rerouteController))
+        XCTAssertTrue(routeController.isRerouting)
+    }
+    
+    func testHandleDidRecieveRerouteEvent() {
+        let response = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
+        routingProvider.returnedRoutesResult = .success(response)
+        _ = routeController.rerouteControllerDidDetectReroute(rerouteController)
+        
+        let routerOrigin = indexedRouteResponse.responseOrigin
+        routeController.rerouteControllerDidRecieveReroute(rerouteController,
+                                                           response: response.routeResponse,
+                                                           options: options,
+                                                           routeOrigin: routerOrigin)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertTrue(routeController.routeProgress.route === response.currentRoute)
+    }
+
+    func testHandleDidCancelRerouteEvent() {
+        routeController.isRerouting = true
+        routeController.rerouteControllerDidCancelReroute(rerouteController)
+        XCTAssertFalse(routeController.isRerouting)
+    }
+
+    func testHandleWillModifyOptionsEvent() {
+        let routeOptions = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 9.519172, longitude: 47.210823),
+            CLLocationCoordinate2D(latitude: 9.52222, longitude: 47.214268)
+            ])
+        let callbackExpectation = expectation(description: "Did fail to reroute call on delegate")
+        delegate.onModifiedOptionsForReroute = { passedOptions in
+            XCTAssertEqual(passedOptions, self.options)
+            callbackExpectation.fulfill()
+            return routeOptions
+        }
+
+        let rerouteOptions = routeController.rerouteControllerWillModify(options: options)
+        XCTAssertEqual(rerouteOptions, routeOptions)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testHandleDidFailToRerouteEvent() {
+        let didFailToReroutExpectation = expectation(description: "Did fail to reroute call on delegate")
+        delegate.onDidFailToRerouteWith = { error in
+            XCTAssertEqual(error as! DirectionsError, .noData)
+            didFailToReroutExpectation.fulfill()
+        }
+
+        expectation(forNotification: .routeControllerDidFailToReroute, object: routeController) { (notification) -> Bool in
+            let error = notification.userInfo?[RouteController.NotificationUserInfoKey.routingErrorKey] as? DirectionsError
+            XCTAssertEqual(error, .noData)
+
+            return true
+        }
+
+        routeController.rerouteControllerDidFailToReroute(rerouteController, with: .noData)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testDoNotProactiveRerouting() {
+        routeController.reroutesProactively = false
+        let routeExpectation = expectation(description: "Proactive ReRoute should not be called")
+        routeExpectation.isInverted = true
+        delegate.onShouldProactivelyRerouteFrom = { _, _ in
+            routeExpectation.fulfill()
+            return true
+        }
+        
+        routeController.checkForFasterRoute(from: rawLocation, routeProgress: routeProgress)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testDoNotProactiveReroutingIfSmallDurationRemaining() {
+        routeController.reroutesProactively = true
+        let routeExpectation = expectation(description: "Proactive ReRoute should not be called")
+        routeExpectation.isInverted = true
+        delegate.onShouldProactivelyRerouteFrom = { _, _ in
+            routeExpectation.fulfill()
+            return true
+        }
+        
+        routeController.checkForFasterRoute(from: rawLocation, routeProgress: routeProgress)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testDoNotProactiveReroutingIfNoNextStep() {
+        routeController.reroutesProactively = true
+        let routeExpectation = expectation(description: "Proactive ReRoute should not be called")
+        routeExpectation.isInverted = true
+        delegate.onShouldProactivelyRerouteFrom = { _, _ in
+            routeExpectation.fulfill()
+            return true
+        }
+        
+        let updatedRouteProgress = self.routeProgress!
+        let legProgress = Fixture.routeLegProgress(expectedTravelTime: 1000, stepDistance: 9000)
+        legProgress.currentStepProgress.distanceTraveled = 2000
+        updatedRouteProgress.currentLegProgress = legProgress
+        routeController.checkForFasterRoute(from: rawLocation, routeProgress: updatedRouteProgress)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testProactiveReroutingIfNilLastProactiveRerouteDate() {
+        routeController.reroutesProactively = true
+        let response = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
+        routingProvider.returnedRoutesResult = .success(response)
+        let routeExpectation = expectation(description: "Proactive ReRoute should not be called")
+        routeExpectation.isInverted = true
+        delegate.onShouldProactivelyRerouteFrom = { _, _ in
+            routeExpectation.fulfill()
+            return true
+        }
+        
+        let updatedRouteProgress = self.routeProgress!
+        let legProgress = Fixture.routeLegProgress(expectedTravelTime: 1000, stepDistance: 9000, stepCount: 2)
+        legProgress.currentStepProgress.distanceTraveled = 2000
+        updatedRouteProgress.currentLegProgress = legProgress
+        routeController.checkForFasterRoute(from: locationWithDate, routeProgress: updatedRouteProgress)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testProactiveReroutingIfNotMatchingSteps() {
+        routeController.reroutesProactively = true
+        routingProvider.returnedRoutesResult = .success(indexedRouteResponse)
+        let routeExpectation = expectation(description: "Proactive ReRoute should not be called")
+        routeExpectation.isInverted = true
+        delegate.onShouldProactivelyRerouteFrom = { location, route in
+            routeExpectation.fulfill()
+            return true
+        }
+        
+        let updatedRouteProgress = self.routeProgress!
+        let legProgress = Fixture.routeLegProgress(expectedTravelTime: 1000, stepDistance: 9000, stepCount: 2)
+        legProgress.currentStepProgress.distanceTraveled = 2000
+        updatedRouteProgress.currentLegProgress = legProgress
+        routeController.lastProactiveRerouteDate = locationWithDate.timestamp.addingTimeInterval(-121)
+        routeController.checkForFasterRoute(from: locationWithDate, routeProgress: updatedRouteProgress)
+        
+        XCTAssertNil(routeController.lastProactiveRerouteDate)
+        XCTAssertFalse(routeController.isRerouting)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testProactiveReroutingIfNotFasterRoad() {
+        routeController.reroutesProactively = true
+        routingProvider.returnedRoutesResult = .success(indexedRouteResponse)
+        let routeExpectation = expectation(description: "Proactive ReRoute should not be called")
+        routeExpectation.isInverted = true
+        delegate.onShouldProactivelyRerouteFrom = { location, route in
+            routeExpectation.fulfill()
+            return true
+        }
+        
+        let updatedRouteProgress = self.routeProgress!
+        let legProgress = Fixture.routeLegProgress(expectedTravelTime: 1000, stepDistance: 9000, stepCount: 2)
+        legProgress.currentStepProgress.distanceTraveled = 2000
+        updatedRouteProgress.currentLegProgress = legProgress
+        routeController.lastProactiveRerouteDate = locationWithDate.timestamp.addingTimeInterval(-121)
+        routeController.checkForFasterRoute(from: locationWithDate, routeProgress: updatedRouteProgress)
+        
+        XCTAssertNil(routeController.lastProactiveRerouteDate)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testProactiveReroutingIfNonNilCompletion() {
+        routeController.reroutesProactively = true
+        indexedRouteResponse.currentRoute!.expectedTravelTime *= 0.85
+        routingProvider.returnedRoutesResult = .success(indexedRouteResponse)
+        let routeExpectation = expectation(description: "Proactive ReRoute should be called")
+        delegate.onShouldProactivelyRerouteFrom = { location, route in
+            routeExpectation.fulfill()
+            return true
+        }
+        
+        let updatedRouteProgress = self.routeProgress!
+        updatedRouteProgress.currentLegProgress.currentStep.expectedTravelTime = 2000
+        updatedRouteProgress.currentLegProgress.currentStepProgress.distanceTraveled = 2
+        routeController.lastProactiveRerouteDate = locationWithDate.timestamp.addingTimeInterval(-121)
+        routeController.checkForFasterRoute(from: locationWithDate, routeProgress: updatedRouteProgress)
+        
+        XCTAssertNil(routeController.lastProactiveRerouteDate)
+        XCTAssertFalse(routeController.isRerouting)
+        XCTAssertTrue(navigatorSpy.setRoutesCalled)
+        
+        XCTAssertTrue(routeController.didProactiveReroute)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testProactiveReroutingIfNoCompletion() {
+        routeController.reroutesProactively = true
+        indexedRouteResponse.currentRoute!.expectedTravelTime *= 0.85
+        routingProvider.returnedRoutesResult = .success(indexedRouteResponse)
+        let routeExpectation = expectation(description: "Proactive ReRoute should be called")
+        delegate.onShouldProactivelyRerouteFrom = { location, route in
+            routeExpectation.fulfill()
+            return false
+        }
+        
+        let updatedRouteProgress = self.routeProgress!
+        updatedRouteProgress.currentLegProgress.currentStep.expectedTravelTime = 2000
+        updatedRouteProgress.currentLegProgress.currentStepProgress.distanceTraveled = 2
+        routeController.lastProactiveRerouteDate = locationWithDate.timestamp.addingTimeInterval(-121)
+        routeController.checkForFasterRoute(from: locationWithDate, routeProgress: updatedRouteProgress)
+        
+        XCTAssertNil(routeController.lastProactiveRerouteDate)
+        XCTAssertTrue(routeController.isRerouting)
+        XCTAssertFalse(navigatorSpy.setRoutesCalled)
+        XCTAssertFalse(routeController.didProactiveReroute)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testAlternativeRoutesNotReportedIfNoData() {
+        let alternativesExpectation = expectation(description: "Alternative route should not be reported")
+        alternativesExpectation.isInverted = true
+        delegate.onDidUpdateAlternativeRoutes = { _, _ in
+            alternativesExpectation.fulfill()
+        }
+        NotificationCenter.default.post(name: .navigatorDidChangeAlternativeRoutes, object: nil, userInfo: nil)
+
+        XCTAssertFalse(navigatorSpy.setAlternativeRoutesCalled)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testAlternativeRoutesReportedIfError() {
+        let alternativesExpectation = expectation(description: "Alternative route should be reported")
+        alternativesExpectation.isInverted = true
+        delegate.onDidUpdateAlternativeRoutes = { newAlternatives, removedAlternatives in
+            alternativesExpectation.fulfill()
+        }
+
+        let innerError = DirectionsError.noData
+        navigatorSpy.returnedSetAlternativeRoutesResult = .failure(innerError)
+        expectation(forNotification: .routeControllerDidFailToUpdateAlternatives, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+
+            let alternativesError = userInfo?[RouteController.NotificationUserInfoKey.alternativesErrorKey] as? AlternativeRouteError
+            let expectedError = AlternativeRouteError.failedToUpdateAlternativeRoutes(reason: innerError.localizedDescription)
+            XCTAssertEqual(alternativesError?.localizedDescription, expectedError.localizedDescription)
+
+            return true
+        }
+
+        let alternativeRoute = createRouteAlternative(id: 1)
+        let removedAlternativeRoute = createRouteAlternative(id: 2)
+        let userInfo = [
+            Navigator.NotificationUserInfoKey.alternativesListKey: [alternativeRoute],
+            Navigator.NotificationUserInfoKey.removedAlternativesKey: [removedAlternativeRoute]
+        ]
+        NotificationCenter.default.post(name: .navigatorDidChangeAlternativeRoutes, object: nil, userInfo: userInfo)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+    
+    func testAlternativeRoutesReportedIfEmptyCurrentContinuousAlternatives() {
+        let alternativesExpectation = expectation(description: "Alternative route should be reported")
+        delegate.onDidUpdateAlternativeRoutes = { newAlternatives, removedAlternatives in
+            XCTAssertEqual(newAlternatives.count, 1)
+            XCTAssertEqual(removedAlternatives.count, 0)
+            alternativesExpectation.fulfill()
+        }
+
+        let alternativeRoute = createRouteAlternative(id: 1)
+        let removedAlternativeRoute = createRouteAlternative(id: 2)
+        let userInfo = [
+            Navigator.NotificationUserInfoKey.alternativesListKey: [alternativeRoute],
+            Navigator.NotificationUserInfoKey.removedAlternativesKey: [removedAlternativeRoute]
+        ]
+        navigatorSpy.returnedSetAlternativeRoutesResult = .success([alternativeRoute])
+        NotificationCenter.default.post(name: .navigatorDidChangeAlternativeRoutes, object: nil, userInfo: userInfo)
+
+        XCTAssertTrue(navigatorSpy.setAlternativeRoutesCalled)
+        XCTAssertEqual(routeController.continuousAlternatives.count, 1)
+        XCTAssertEqual(routeController.continuousAlternatives[0].id, 1)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testSendAlternativeRoutesNotificationIfEmptyCurrentContinuousAlternatives() {
+        expectation(forNotification: .routeControllerDidUpdateAlternatives, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+
+            let updatedAlternatives = userInfo?[RouteController.NotificationUserInfoKey.updatedAlternativesKey] as? [AlternativeRoute]
+            let removedAlternatives = userInfo?[RouteController.NotificationUserInfoKey.removedAlternativesKey] as? [AlternativeRoute]
+            XCTAssertEqual(updatedAlternatives?.count, 1)
+            XCTAssertEqual(removedAlternatives?.count, 0)
+
+            return true
+        }
+
+        let alternativeRoute = createRouteAlternative(id: 1)
+        let removedAlternativeRoute = createRouteAlternative(id: 2)
+        let userInfo = [
+            Navigator.NotificationUserInfoKey.alternativesListKey: [alternativeRoute],
+            Navigator.NotificationUserInfoKey.removedAlternativesKey: [removedAlternativeRoute]
+        ]
+        navigatorSpy.returnedSetAlternativeRoutesResult = .success([alternativeRoute])
+        NotificationCenter.default.post(name: .navigatorDidChangeAlternativeRoutes, object: nil, userInfo: userInfo)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testAlternativeRoutesReportedIfNonEmptyCurrentContinuousAlternatives() {
+        navigatorSpy.returnedSetRoutesResult = .success((mainRouteInfo: nil, alternativeRoutes: [createRouteAlternative(id: 2)]))
+        routeController = makeRouteController()
+
+        let alternativesExpectation = expectation(description: "Alternative route should be reported")
+        delegate.onDidUpdateAlternativeRoutes = { newAlternatives, removedAlternatives in
+            XCTAssertEqual(newAlternatives.count, 1)
+            XCTAssertEqual(removedAlternatives.count, 1)
+            alternativesExpectation.fulfill()
+        }
+
+        let alternativeRoute = createRouteAlternative(id: 1)
+        let removedAlternativeRoute = createRouteAlternative(id: 2)
+        let userInfo = [
+            Navigator.NotificationUserInfoKey.alternativesListKey: [alternativeRoute],
+            Navigator.NotificationUserInfoKey.removedAlternativesKey: [removedAlternativeRoute]
+        ]
+        navigatorSpy.returnedSetAlternativeRoutesResult = .success([alternativeRoute])
+        NotificationCenter.default.post(name: .navigatorDidChangeAlternativeRoutes, object: nil, userInfo: userInfo)
+
+        XCTAssertTrue(navigatorSpy.setAlternativeRoutesCalled)
+        XCTAssertEqual(routeController.continuousAlternatives.count, 1)
+        XCTAssertEqual(routeController.continuousAlternatives[0].id, 1)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testSendAlternativeRoutesNotificationIfNonEmptyCurrentContinuousAlternatives() {
+        navigatorSpy.returnedSetRoutesResult = .success((mainRouteInfo: nil, alternativeRoutes: [createRouteAlternative(id: 2)]))
+        routeController = makeRouteController()
+
+        expectation(forNotification: .routeControllerDidUpdateAlternatives, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+
+            let updatedAlternatives = userInfo?[RouteController.NotificationUserInfoKey.updatedAlternativesKey] as? [AlternativeRoute]
+            let removedAlternatives = userInfo?[RouteController.NotificationUserInfoKey.removedAlternativesKey] as? [AlternativeRoute]
+            XCTAssertEqual(updatedAlternatives?.count, 1)
+            XCTAssertEqual(removedAlternatives?.count, 1)
+
+            return true
+        }
+
+        let alternativeRoute = createRouteAlternative(id: 1)
+        let removedAlternativeRoute = createRouteAlternative(id: 2)
+        let userInfo = [
+            Navigator.NotificationUserInfoKey.alternativesListKey: [alternativeRoute],
+            Navigator.NotificationUserInfoKey.removedAlternativesKey: [removedAlternativeRoute]
+        ]
+        navigatorSpy.returnedSetAlternativeRoutesResult = .success([alternativeRoute])
+        NotificationCenter.default.post(name: .navigatorDidChangeAlternativeRoutes, object: nil, userInfo: userInfo)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testNotifyDidFailToChangeAlternativeRoutesIfNilUserInfo() {
+        let callbackExpectation = expectation(description: "Error updating aternative routes should not be reported")
+        callbackExpectation.isInverted = true
+        delegate.onDidFailToUpdateAlternativeRoutes = { _ in
+            callbackExpectation.fulfill()
+        }
+        NotificationCenter.default.post(name: .navigatorDidFailToChangeAlternativeRoutes, object: nil, userInfo: nil)
+
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testNotifyDelegateDidFailToChangeAlternativeRoutesIfNilAlternativeRouteDetectionStrategy() {
+        NavigationSettings.shared.initialize(directions: .shared,
                                              tileStoreConfiguration: .default,
                                              routingProviderSource: .hybrid,
                                              alternativeRouteDetectionStrategy: nil)
-        
-        let routeOptions = RouteOptions(coordinates: [.init(latitude: 37.33243586131637,
-                                                            longitude: -122.03140541047281),
-                                                      .init(latitude: 37.33318065375225,
-                                                            longitude: -122.03148874952787)],
-                                        profileIdentifier: .automobileAvoidingTraffic)
-        routeOptions.shapeFormat = .geoJSON
-        let routeResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: "routeResponseWithAlternatives",
-                                                                                      options: routeOptions),
-                                                 routeIndex: 0)
-        
-        let alternativesExpectation = XCTestExpectation(description: "Alternative route should not be reported")
-        alternativesExpectation.assertForOverFulfill = true
-        alternativesExpectation.isInverted = true
-        
-        let routerDelegateSpy = RouterDelegateSpy()
-        
-        routerDelegateSpy.onDidUpdateAlternativeRoutes = { newAlternatives, removedAlternatives in
-            alternativesExpectation.fulfill()
+        let message = "error message"
+        let callbackExpectation = expectation(description: "Error updating aternative routes should not be reported")
+        callbackExpectation.isInverted = true
+        delegate.onDidFailToUpdateAlternativeRoutes = { _ in
+            callbackExpectation.fulfill()
         }
-        
-        let routeController = RouteController(indexedRouteResponse: routeResponse,
-                                              customRoutingProvider: MapboxRoutingProvider(.offline),
-                                              dataSource: self)
-        
-        routeController.delegate = routerDelegateSpy
-        
-        wait(for: [alternativesExpectation], timeout: 2)
+        let userInfo = [Navigator.NotificationUserInfoKey.messageKey: message]
+        NotificationCenter.default.post(name: .navigatorDidFailToChangeAlternativeRoutes, object: nil, userInfo: userInfo)
+
+        waitForExpectations(timeout: expectationsTimeout)
     }
-    
-    func testCustomRoutingProvider() {
-        let routingProviderStub = CustomRoutingProviderStub()
-        let routeExpectation = XCTestExpectation(description: "Route calculation should be called")
-        
-        routingProviderStub.indexedRouteStub = { _ in
-            routeExpectation.fulfill()
+
+    func testNotifyDelegateDidFailToChangeAlternativeRoutes() {
+        let message = "error message"
+        let callbackExpectation = expectation(description: "Error updating aternative routes should be reported")
+        delegate.onDidFailToUpdateAlternativeRoutes = { error in
+            let expectedError = AlternativeRouteError.failedToUpdateAlternativeRoutes(reason: message)
+            XCTAssertEqual(error.localizedDescription, expectedError.localizedDescription)
+            callbackExpectation.fulfill()
         }
-        
-        let coordinates = [
-            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
-            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
-        ]
-        
-        let options = NavigationRouteOptions(coordinates: coordinates)
-        let route = Fixture.route(from: "route-for-off-route", options: options)
-        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
-        let routeResponse = RouteResponse(httpResponse: nil,
-                                          routes: [route],
-                                          options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
-                                          credentials: .mocked)
-        
-        let offRouteLocation = CLLocationCoordinate2D(latitude: coordinates[1].latitude,
-                                                      longitude: -coordinates[1].longitude)
-        let offRouteReplayLocation = Fixture.generateCoordinates(between: coordinates[0],
-                                                                 and: offRouteLocation,
-                                                                 count: 100).map {
-            CLLocation(coordinate: $0)
-        }.shiftedToPresent()
-        
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse,
-                                                        routeIndex: 0)
-        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
-                                              customRoutingProvider: routingProviderStub,
-                                              dataSource: self)
-        
-        let locationManager = ReplayLocationManager(locations: offRouteReplayLocation)
-        locationManager.startDate = Date()
-        locationManager.delegate = routeController
-        
-        locationManager.speedMultiplier = 50
-        locationManager.startUpdatingLocation()
-        wait(for: [routeExpectation], timeout: locationManager.expectedReplayTime)
+        let userInfo = [Navigator.NotificationUserInfoKey.messageKey: message]
+        NotificationCenter.default.post(name: .navigatorDidFailToChangeAlternativeRoutes, object: nil, userInfo: userInfo)
+
+        waitForExpectations(timeout: expectationsTimeout)
     }
-    
-    func testReroutingUpdatesRouteOptions() {
-        let coordinates = [
-            CLLocationCoordinate2D(latitude: 37.750384, longitude: -122.387487),
-            CLLocationCoordinate2D(latitude: 37.764343, longitude: -122.388664),
-        ]
-        
-        let options = NavigationRouteOptions(coordinates: coordinates)
-        let route = Fixture.route(from: "route-for-off-route", options: options)
-        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
-        let routeResponse = RouteResponse(httpResponse: nil,
-                                          routes: [route],
-                                          options: .route(.init(locations: replayLocations, profileIdentifier: nil)),
-                                          credentials: .mocked)
-        
-        let offRouteLocation = CLLocationCoordinate2D(latitude: coordinates[1].latitude,
-                                                      longitude: -coordinates[1].longitude)
-        let offRouteReplayLocation = Fixture.generateCoordinates(between: coordinates[0],
-                                                                 and: offRouteLocation,
-                                                                 count: 100).map {
-            CLLocation(coordinate: $0)
-        }.shiftedToPresent()
-        
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse,
-                                                        routeIndex: 0)
-        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
-                                              customRoutingProvider: nil,
-                                              dataSource: self)
-        
-        let routerDelegateSpy = RouterDelegateSpy()
-        let modifyExpectation = expectation(description: "Reroute should request options editing.")
-        modifyExpectation.assertForOverFulfill = false
-        
-        routerDelegateSpy.onModifiedOptionsForReroute = { options in
-            modifyExpectation.fulfill()
-            return options
-        }
-        routeController.delegate = routerDelegateSpy
-        
-        let locationManager = ReplayLocationManager(locations: offRouteReplayLocation)
-        locationManager.startDate = Date()
-        locationManager.delegate = routeController
-        
-        locationManager.speedMultiplier = 50
-        locationManager.startUpdatingLocation()
-        wait(for: [modifyExpectation], timeout: locationManager.expectedReplayTime)
-    }
-    
-    func testSwitchToOnlineRoute() {
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: response,
-                                                        routeIndex: 0,
-                                                        responseOrigin: .onboard)
-        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
-                                              customRoutingProvider: MapboxRoutingProvider(.offline),
-                                              dataSource: self)
-        let routerDelegateSpy = RouterDelegateSpy()
-        routeController.delegate = routerDelegateSpy
-        
-        expectation(forNotification: .routeControllerDidSwitchToCoincidentOnlineRoute, object: nil)
-        
-        let routeOptions = indexedRouteResponse.validatedRouteOptions
-        let encoder = JSONEncoder()
-        encoder.userInfo[.options] = routeOptions
-        guard let routeData = try? encoder.encode(indexedRouteResponse.routeResponse),
-              let routeJSONString = String(data: routeData, encoding: .utf8) else {
-                  XCTFail()
-                  return
-        }
-        let routeRequest = Directions(credentials: indexedRouteResponse.routeResponse.credentials)
-                                .url(forCalculating: routeOptions).absoluteString
-        let parsedRoutes = RouteParser.parseDirectionsResponse(forResponse: routeJSONString,
-                                                               request: routeRequest,
-                                                               routeOrigin: indexedRouteResponse.responseOrigin)
-        let userInfo: [MapboxCoreNavigation.Navigator.NotificationUserInfoKey: Any] = [
-            .coincideOnlineRouteKey: (parsedRoutes.value as! [RouteInterface]).first!
-        ]
-        NotificationCenter.default.post(name: .navigatorWantsSwitchToCoincideOnlineRoute, object: nil, userInfo: userInfo)
-        
-        waitForExpectations(timeout: 2)
-    }
-    
-    func testProactiveRerouting() {
-        let defaultInterval = RouteControllerProactiveReroutingInterval
-        RouteControllerProactiveReroutingInterval = 1
-        
-        let coordinates = [
-            CLLocationCoordinate2D(latitude: 38.853108, longitude: -77.043331),
-            CLLocationCoordinate2D(latitude: 38.910736, longitude: -76.966906),
-        ]
-        
-        let options = NavigationRouteOptions(coordinates: coordinates)
-        let route = Fixture.route(from: "DCA-Arboretum", options: options)
-        let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
-        let routeResponse = RouteResponse(httpResponse: nil,
-                                          routes: [route],
-                                          options: .route(.init(locations: replayLocations,
-                                                                profileIdentifier: nil)),
-                                          credentials: .mocked)
-        
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse,
-                                                        routeIndex: 0)
-        
-        let routingProviderStub = CustomRoutingProviderStub()
-        
-        routingProviderStub.indexedRouteStub = { completion in
-            let route = Fixture.route(from: "DCA-Arboretum-duration-edited", options: options)
-            let replayLocations = Fixture.generateTrace(for: route).shiftedToPresent().qualified()
-            let routeResponse = RouteResponse(httpResponse: nil,
-                                              routes: [route],
-                                              options: .route(.init(locations: replayLocations,
-                                                                    profileIdentifier: nil)),
-                                              credentials: .mocked)
-            
-            completion(.success(IndexedRouteResponse(routeResponse: routeResponse,
-                                                     routeIndex: 0)))
-        }
-        
-        let routeController = RouteController(indexedRouteResponse: indexedRouteResponse,
-                                              customRoutingProvider: routingProviderStub,
-                                              dataSource: self)
-        let routerDelegateSpy = RouterDelegateSpy()
-        let routeExpectation = XCTestExpectation(description: "Proactive ReRoute should be called")
-        
-        routerDelegateSpy.onShouldProactivelyRerouteFrom = { _, _ in
-            routeExpectation.fulfill()
+
+    func testHandleFailToChangeAlternativeRoutesEvent() {
+        let message = "error message"
+        expectation(forNotification: .routeControllerDidFailToUpdateAlternatives, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+
+            let error = userInfo?[RouteController.NotificationUserInfoKey.alternativesErrorKey] as? AlternativeRouteError
+            let expectedError = AlternativeRouteError.failedToUpdateAlternativeRoutes(reason: message)
+            XCTAssertEqual(error?.localizedDescription, expectedError.localizedDescription)
+
             return true
         }
-        
-        routeController.delegate = routerDelegateSpy
-        
-        let locationManager = ReplayLocationManager(locations: [CLLocation(coordinate: coordinates[0])].shiftedToPresent())
-        locationManager.startDate = Date()
-        locationManager.delegate = routeController
-        
-        locationManager.speedMultiplier = 1
-        locationManager.startUpdatingLocation()
-        wait(for: [routeExpectation], timeout: 15)
-        
-        RouteControllerProactiveReroutingInterval = defaultInterval
-    }
-}
 
-extension RouteControllerTests: RouterDataSource {
-    var location: CLLocation? {
-        return replayManager?.location
-    }
-    
-    var locationManagerType: NavigationLocationManager.Type {
-        return NavigationLocationManager.self
-    }
-}
+        let userInfo = [Navigator.NotificationUserInfoKey.messageKey: message]
+        NotificationCenter.default.post(name: .navigatorDidFailToChangeAlternativeRoutes, object: nil, userInfo: userInfo)
 
-class CustomRoutingProviderStub: RoutingProvider {
-    var routeStub: (() -> Void)?
-    var indexedRouteStub: ((IndexedRouteResponseCompletionHandler) -> Void)?
-    var matchStub: (() -> Void)?
-    var refreshStub: (() -> Void)?
-    var refreshByIndexStub: (() -> Void)?
-    
-    func calculateRoutes(options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
-        routeStub?()
-        return nil
+        waitForExpectations(timeout: expectationsTimeout)
     }
-    
-    func calculateRoutes(options: RouteOptions, completionHandler: @escaping IndexedRouteResponseCompletionHandler) -> NavigationProviderRequest? {
-        indexedRouteStub?(completionHandler)
-        return nil
+
+    func testSwitchToCoincideOnlineRouteIfNilUserInfo() {
+        let callbackExpectation = expectation(description: "Switch to coincident online route should not be reported")
+        callbackExpectation.isInverted = true
+        delegate.onDidSwitchToCoincideRoute = { _ in
+            callbackExpectation.fulfill()
+        }
+        NotificationCenter.default.post(name: .navigatorWantsSwitchToCoincideOnlineRoute, object: nil, userInfo: nil)
+
+        waitForExpectations(timeout: expectationsTimeout)
     }
-    
-    func calculateRoutes(options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> NavigationProviderRequest? {
-        matchStub?()
-        return nil
+
+    func testSwitchToCoincideOnlineRouteIfErrorInNavNative() {
+        let route = TestRouteProvider.createRoute(routeResponse: routeResponse)!
+        let callbackExpectation = expectation(description: "Switch to coincident online route should be reported")
+        delegate.onDidSwitchToCoincideRoute = { actualRoute in
+            XCTAssertEqual(actualRoute, self.routeResponse.routes?[0])
+            XCTAssertEqual(self.routeController.indexedRouteResponse.routeIndex, 0)
+            XCTAssertEqual(self.routeController.indexedRouteResponse.responseOrigin, route.getRouterOrigin())
+            callbackExpectation.fulfill()
+        }
+        navigatorSpy.returnedSetRoutesResult = .failure(DirectionsError.unableToRoute)
+        
+        let userInfo = [Navigator.NotificationUserInfoKey.coincideOnlineRouteKey: route]
+        NotificationCenter.default.post(name: .navigatorWantsSwitchToCoincideOnlineRoute, object: nil, userInfo: userInfo)
+
+        waitForExpectations(timeout: expectationsTimeout)
     }
-    
-    func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
-        refreshStub?()
-        return nil
+
+    func testRerouteAfterArrivalIfUserHasNotArrivedAtWaypoint() {
+        let callbackExpectation = expectation(description: "Should prevent reroute")
+        callbackExpectation.isInverted = true
+        delegate.onShouldPreventReroutesWhenArrivingAt = { _ in
+            callbackExpectation.fulfill()
+            return true
+        }
+        routeController.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = false
+        routeController.rerouteAfterArrivalIfNeeded(rawLocation, status: nil)
+        waitForExpectations(timeout: expectationsTimeout)
     }
-    
-    func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, currentRouteShapeIndex: Int, currentLegShapeIndex: Int, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
-        refreshByIndexStub?()
-        return nil
+
+    func testRerouteAfterArrivalIfNotCompleteStatus() {
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .tracking)
+        routeController.rerouteAfterArrivalIfNeeded(rawLocation, status: status)
+
+        XCTAssertFalse(navigatorSpy.setRoutesCalled)
+    }
+
+    func testPreventRerouteAfterArrivalIfDefaultPolicy() {
+        routeController.delegate = nil
+        routeController.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .complete)
+        routeController.rerouteAfterArrivalIfNeeded(rawLocation, status: status)
+
+        XCTAssertFalse(navigatorSpy.setRoutesCalled)
+    }
+
+    func testRerouteAfterArrivalIfNeededIfUserHasArrivedAtWaypoint() {
+        let callbackExpectation = expectation(description: "Should prevent reroute")
+        delegate.onShouldPreventReroutesWhenArrivingAt = { _ in
+            callbackExpectation.fulfill()
+            return true
+        }
+        routeController.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
+        routeController.rerouteAfterArrivalIfNeeded(rawLocation, status: nil)
+
+        XCTAssertFalse(navigatorSpy.setRoutesCalled)
+        XCTAssertFalse(routingProvider.calculateRoutesCalled)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testRerouteAfterArrivalIfShouldNotPreventAndFailedReroute() {
+        let callbackExpectation = expectation(description: "Should not prevent reroute")
+        callbackExpectation.assertForOverFulfill = false
+        delegate.onShouldPreventReroutesWhenArrivingAt = { destination in
+            XCTAssertEqual(destination, self.routeProgress.currentLeg.destination)
+            callbackExpectation.fulfill()
+            return false
+        }
+
+        let didFailToReroutExpectation = expectation(description: "Did fail to reroute call on delegate")
+        delegate.onDidFailToRerouteWith = { error in
+            XCTAssertEqual(error as? DirectionsError, .unableToRoute)
+            didFailToReroutExpectation.fulfill()
+        }
+
+        routeController.routeProgress.currentLegProgress.userHasArrivedAtWaypoint = true
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .complete)
+        routeController.rerouteAfterArrivalIfNeeded(rawLocation, status: status)
+        
+        XCTAssertFalse(navigatorSpy.setRoutesCalled)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testRerouteAfterArrivalIfCloseToStep() {
+        let didFailToReroutExpectation = expectation(description: "Did fail to reroute call on delegate")
+        didFailToReroutExpectation.isInverted = true
+        delegate.onDidFailToRerouteWith = { _ in
+            didFailToReroutExpectation.fulfill()
+        }
+
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .complete)
+        let newLocation = CLLocation(coordinate: indexedRouteResponse.validatedRouteOptions.waypoints[0].coordinate)
+        routeController.rerouteAfterArrivalIfNeeded(newLocation, status: status)
+
+        XCTAssertFalse(navigatorSpy.setRoutesCalled)
+        XCTAssertFalse(routingProvider.calculateRoutesCalled)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testRerouteAfterArrival() {
+        let didFailToReroutExpectation = expectation(description: "Did fail to reroute call on delegate")
+        didFailToReroutExpectation.isInverted = true
+        delegate.onDidFailToRerouteWith = { _ in
+            didFailToReroutExpectation.fulfill()
+        }
+
+        let newResponse = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
+        routingProvider.returnedRoutesResult = .success(newResponse)
+
+        let status = TestNavigationStatusProvider.createNavigationStatus(routeState: .complete)
+        routeController.rerouteAfterArrivalIfNeeded(rawLocation, status: status)
+
+        XCTAssertTrue(navigatorSpy.setRoutesCalled)
+        XCTAssertEqual(routeController.indexedRouteResponse.currentRoute, newResponse.currentRoute)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testDoNotUpdateRouteIfFinishedRouting() {
+        let newResponse = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
+        routeController.finishRouting()
+        let expectation = expectation(description: "Should not call callback")
+        expectation.isInverted = true
+        routeController.updateRoute(with: newResponse, routeOptions: options) { _ in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testUpdateRouteIfNavNativeFailed() {
+        let completionExpectation = expectation(description: "Should call callback")
+        let newResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 1)
+
+        navigatorSpy.returnedSetRoutesResult = .failure(DirectionsError.noData)
+        
+        routeController.updateRoute(with: newResponse, routeOptions: options) { result in
+            XCTAssertFalse(result)
+            completionExpectation.fulfill()
+        }
+        XCTAssertEqual(routeController.route, routeResponse.routes?[0])
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testUpdateRouteIfIfNavNativeSucceed() {
+        let completionExpectation = expectation(description: "Should call callback")
+        let newResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 1)
+
+        routeController.updateRoute(with: newResponse, routeOptions: options) { result in
+            XCTAssertTrue(result)
+            completionExpectation.fulfill()
+        }
+        XCTAssertEqual(routeController.route, routeResponse.routes?[1])
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testHandleWillSwitchToAlternativeEvent() {
+        routeController.rawLocation = rawLocation
+        expectation(forNotification: .routeControllerWillTakeAlternativeRoute, object: routeController) { (notification) -> Bool in
+            let userInfo = notification.userInfo
+            let newLocation = userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
+            let newRoute = userInfo?[RouteController.NotificationUserInfoKey.routeKey] as? Route
+
+            XCTAssertEqual(newLocation, self.rawLocation)
+            XCTAssertEqual(newRoute, self.singleRouteResponse.routes?[0])
+
+            return true
+        }
+
+        let callbackExpectation = expectation(description: "Will take alternative route should be called")
+        delegate.onWillTakeAlternativeRoute = { newRoute, newLocation in
+            XCTAssertEqual(newLocation, self.rawLocation)
+            XCTAssertEqual(newRoute, self.singleRouteResponse.routes?[0])
+            callbackExpectation.fulfill()
+        }
+
+        routeController.rerouteControllerWantsSwitchToAlternative(rerouteController,
+                                                                  response: singleRouteResponse,
+                                                                  routeIndex: 0,
+                                                                  options: options,
+                                                                  routeOrigin: .custom)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testHandleDidSwitchToAlternativeEventIfSuccess() {
+        routeController.rawLocation = rawLocation
+        expectation(forNotification: .routeControllerDidTakeAlternativeRoute, object: routeController) { (notification) -> Bool in
+            let newLocation = notification.userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
+            XCTAssertEqual(newLocation, self.rawLocation)
+            return true
+        }
+
+        let callbackExpectation = expectation(description: "Did take alternative route should be called")
+        delegate.onDidTakeAlternativeRoute = { newLocation in
+            XCTAssertEqual(newLocation, self.rawLocation)
+            callbackExpectation.fulfill()
+        }
+        routeController.rerouteControllerWantsSwitchToAlternative(rerouteController,
+                                                                  response: singleRouteResponse,
+                                                                  routeIndex: 0,
+                                                                  options: options,
+                                                                  routeOrigin: .custom)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    func testHandleDidSwitchToAlternativeEventIfFailure() {
+        routeController.rawLocation = rawLocation
+        navigatorSpy.returnedSetRoutesResult = .failure(DirectionsError.noData)
+        expectation(forNotification: .routeControllerDidFailToTakeAlternativeRoute, object: routeController) { (notification) -> Bool in
+            let newLocation = notification.userInfo?[RouteController.NotificationUserInfoKey.locationKey] as? CLLocation
+            XCTAssertEqual(newLocation, self.rawLocation)
+            return true
+        }
+
+        let callbackExpectation = expectation(description: "Did fail to take alternative route should be called")
+        delegate.onDidFailToTakeAlternativeRoute = { newLocation in
+            XCTAssertEqual(newLocation, self.rawLocation)
+            callbackExpectation.fulfill()
+        }
+        routeController.rerouteControllerWantsSwitchToAlternative(rerouteController,
+                                                                  response: singleRouteResponse,
+                                                                  routeIndex: 0,
+                                                                  options: options,
+                                                                  routeOrigin: .custom)
+        waitForExpectations(timeout: expectationsTimeout)
+    }
+
+    // MARK: Helpers
+
+    private func resetNavigationSettings() {
+        NavigationSettings.shared.initialize(directions: .shared,
+                                             tileStoreConfiguration: .default,
+                                             routingProviderSource: .hybrid,
+                                             alternativeRouteDetectionStrategy: .init())
+    }
+
+    private func createRouteAlternative(id: UInt32) -> RouteAlternative {
+        let intersectionStep = routeResponse.routes![0].legs[0].steps[3]
+        let intersection = RouteIntersection(location: intersectionStep.maneuverLocation,
+                                             geometryIndex: 6,
+                                             segmentIndex: 6,
+                                             legIndex: 0)
+        let routeInfo = AlternativeRouteInfo(distance: intersectionStep.distance, duration: intersectionStep.expectedTravelTime)
+        return .init(id: id,
+                     route: TestRouteProvider.createRoute(routeResponse: routeResponse)!,
+                     mainRouteFork: intersection,
+                     alternativeRouteFork: intersection,
+                     infoFromFork: routeInfo,
+                     infoFromStart: routeInfo,
+                     isNew: true)
+    }
+
+    private func makeRouteController(routeResponse: IndexedRouteResponse? = nil) -> RouteController {
+        return makeRouteController(routeResponse: routeResponse,
+                                   routingProvider: routingProvider)
+    }
+
+    private func makeRouteController(routeResponse: IndexedRouteResponse? = nil,
+                                     routingProvider: RoutingProvider?) -> RouteController {
+        let controller = RouteController(indexedRouteResponse: routeResponse ?? indexedRouteResponse,
+                                         customRoutingProvider: routingProvider,
+                                         dataSource: dataSource,
+                                         navigatorType: CoreNavigatorSpy.self)
+        controller.delegate = delegate
+        navigatorSpy.reset()
+        return controller
+    }
+
+    private func makeRouteResponse() -> RouteResponse {
+        return Fixture.routeResponse(from: "routeResponseWithAlternatives", options: options)
+    }
+
+    private func makeSingleRouteResponse() -> RouteResponse {
+        let routeOptions = options
+        routeOptions.shapeFormat = .polyline
+        return Fixture.routeResponse(from: "route", options: routeOptions)
+    }
+
+    private func makeMultilegRouteResponse() -> RouteResponse {
+        let routeOptions = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 9.519172, longitude: 47.210823),
+            CLLocationCoordinate2D(latitude: 9.52222, longitude: 47.214268),
+            CLLocationCoordinate2D(latitude: 47.212326, longitude: 9.512569),
+        ])
+        return Fixture.routeResponse(from: "multileg-route", options: routeOptions)
+    }
+
+    private func makeActiveGuidanceInfo() -> ActiveGuidanceInfo {
+        let routeProgress = ActiveGuidanceProgress(distanceTraveled: 110,
+                                                   fractionTraveled: 0.11,
+                                                   remainingDistance: 890,
+                                                   remainingDuration: 2000)
+        let legProgress = ActiveGuidanceProgress(distanceTraveled: 100,
+                                                 fractionTraveled: 0.9,
+                                                 remainingDistance: 200,
+                                                 remainingDuration: 2000)
+        let stepProgress = ActiveGuidanceProgress(distanceTraveled: 10,
+                                                  fractionTraveled: 0.25,
+                                                  remainingDistance: 30,
+                                                  remainingDuration: 200)
+        return ActiveGuidanceInfo(routeProgress: routeProgress,
+                                  legProgress: legProgress,
+                                  step: stepProgress)
     }
 }

--- a/Tests/MapboxCoreNavigationTests/RoutesCoordinatorTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RoutesCoordinatorTests.swift
@@ -38,7 +38,7 @@ final class RoutesCoordinatorTests: TestCase {
 
 private extension RoutesCoordinatorTests {
     func createRoutes() -> RouteInterface? {
-        return TestRouteProvider.createRoutes()
+        return TestRouteProvider.createRoute()
     }
 
     struct RoutesCoordinatorTestCase {

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,7 @@ ignore:
   - "Example"
   - "MapboxNavigationTests"
   - "MapboxCoreNavigationTests"
+  - "MapboxCoreNavigationIntegrationTests"
   - "TestHelper"
 
 coverage:


### PR DESCRIPTION
### Description
Adds unit tests for RouteController. 
The old tests that depended on NavNative were replaced by new test using mocked dependencies.
