### PR TITLE
Fix flaky SpriteRepositoryTests

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		2C193C31290A9BC30050A57F /* PredictiveCacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46D290A8CA10067FDCF /* PredictiveCacheManagerTests.swift */; };
 		2C193C32290A9BC30050A57F /* PredictiveCacheOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46C290A8CA10067FDCF /* PredictiveCacheOptionsTests.swift */; };
 		2C257379292B8BEC00941307 /* RouteStepProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C257378292B8BEB00941307 /* RouteStepProgressTests.swift */; };
+		2C257377292B836B00941307 /* ReentrantImageDownloaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C257376292B836B00941307 /* ReentrantImageDownloaderSpy.swift */; };
 		2C2880A1291A82630063E5B7 /* RerouteControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */; };
 		2C2880A6291AB7A10063E5B7 /* RerouteDetectorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */; };
 		2C4093B5292661FD0099FA0E /* RouteParserSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */; };
@@ -110,6 +111,8 @@
 		2C9006DB2919281F0012CCEA /* BannerDismissalViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9006DA2919281F0012CCEA /* BannerDismissalViewControllerSnapshotTests.swift */; };
 		2CDF5C972919628100C41082 /* NavigationLocationManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDF5C962919628100C41082 /* NavigationLocationManagerSpy.swift */; };
 		2CE25130291A56D900C0FA15 /* IdleTimerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2512E291A56CE00C0FA15 /* IdleTimerManagerTests.swift */; };
+		2CF3F8CB2926D3E600BB2B9C /* URLCacheSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF3F8CA2926D3E600BB2B9C /* URLCacheSpy.swift */; };
+		2CF3F8CD2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */; };
 		2CFAE203291C4E8300562E5F /* TestNavigationStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFAE202291C4E8300562E5F /* TestNavigationStatusProvider.swift */; };
 		2E50E0C0264E35CA009D3848 /* RoadObjectMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E0BF264E35CA009D3848 /* RoadObjectMatcher.swift */; };
 		2E50E0D2264E468B009D3848 /* RoadObjectMatcherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E0D1264E468B009D3848 /* RoadObjectMatcherError.swift */; };
@@ -741,6 +744,7 @@
 		2C04E46C290A8CA10067FDCF /* PredictiveCacheOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheOptionsTests.swift; sourceTree = "<group>"; };
 		2C04E46D290A8CA10067FDCF /* PredictiveCacheManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheManagerTests.swift; sourceTree = "<group>"; };
 		2C257378292B8BEB00941307 /* RouteStepProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStepProgressTests.swift; sourceTree = "<group>"; };
+		2C257376292B836B00941307 /* ReentrantImageDownloaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReentrantImageDownloaderSpy.swift; sourceTree = "<group>"; };
 		2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerouteControllerTests.swift; sourceTree = "<group>"; };
 		2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RerouteDetectorSpy.swift; sourceTree = "<group>"; };
 		2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteParserSpy.swift; sourceTree = "<group>"; };
@@ -759,6 +763,8 @@
 		2C9006DA2919281F0012CCEA /* BannerDismissalViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerDismissalViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		2CDF5C962919628100C41082 /* NavigationLocationManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationManagerSpy.swift; sourceTree = "<group>"; };
 		2CE2512E291A56CE00C0FA15 /* IdleTimerManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdleTimerManagerTests.swift; sourceTree = "<group>"; };
+		2CF3F8CA2926D3E600BB2B9C /* URLCacheSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCacheSpy.swift; sourceTree = "<group>"; };
+		2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BimodalImageCacheSpy.swift; sourceTree = "<group>"; };
 		2CFAE202291C4E8300562E5F /* TestNavigationStatusProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNavigationStatusProvider.swift; sourceTree = "<group>"; };
 		2E50E0BF264E35CA009D3848 /* RoadObjectMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadObjectMatcher.swift; sourceTree = "<group>"; };
 		2E50E0D1264E468B009D3848 /* RoadObjectMatcherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadObjectMatcherError.swift; sourceTree = "<group>"; };
@@ -1480,6 +1486,16 @@
 			path = Tests/MapboxCoreNavigationIntegrationTests;
 			sourceTree = "<group>";
 		};
+		2CF3F8C92926D38A00BB2B9C /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				2CF3F8CA2926D3E600BB2B9C /* URLCacheSpy.swift */,
+				2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */,
+				2C257376292B836B00941307 /* ReentrantImageDownloaderSpy.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		3507F9FD213430CB0086B39E /* CarPlay */ = {
 			isa = PBXGroup;
 			children = (
@@ -1566,6 +1582,7 @@
 		35B711D01E5E7AD2001EDA8D /* MapboxNavigationTests */ = {
 			isa = PBXGroup;
 			children = (
+				2CF3F8C92926D38A00BB2B9C /* Helper */,
 				8A0155E628F8EC58009E299C /* Preview */,
 				8AB316BD26BC9F1800C3AC76 /* Camera */,
 				8AB316C526BCA0DA00C3AC76 /* Navigation */,
@@ -3218,6 +3235,7 @@
 				8AF23ED527AA0B9C0038B40D /* CarPlayManagerSpec.swift in Sources */,
 				DADD82802161EC0300B8B47D /* UIViewAnimationOptionsTests.swift in Sources */,
 				8DFD949E221F66BE00152F45 /* BottomBannerSnapshotTests.swift in Sources */,
+				2CF3F8CB2926D3E600BB2B9C /* URLCacheSpy.swift in Sources */,
 				355B469B22B902C9009CE634 /* SKUTests.swift in Sources */,
 				DAD17202214DB12B009C8161 /* CPMapTemplateTests.swift in Sources */,
 				8AD6F25B272216A500326D13 /* MapViewStyleTests.swift in Sources */,
@@ -3225,6 +3243,7 @@
 				35EFD009207CA5E800BF3873 /* ManeuverViewSnapshotTests.swift in Sources */,
 				B432986228D53AF4005AFB98 /* URLDataCacheTests.swift in Sources */,
 				8AD12F4D26C1A5C10008AE55 /* Snapshot++.swift in Sources */,
+				2C257377292B836B00941307 /* ReentrantImageDownloaderSpy.swift in Sources */,
 				DA85D5EF25DB4AA4008A2AD4 /* LaneViewTests.swift in Sources */,
 				35A262B92050A5CD00AEFF6D /* InstructionsBannerViewSnapshotTests.swift in Sources */,
 				8A3474F5269F8B9D00BCF135 /* MapViewTests.swift in Sources */,
@@ -3255,6 +3274,7 @@
 				16E3625C201265D600DF0592 /* ImageDownloadOperationSpy.swift in Sources */,
 				B40B1C61270380EC0065F57D /* VanishingRouteLineTests.swift in Sources */,
 				1662244B2029059C00EA4824 /* ImageCacheTests.swift in Sources */,
+				2CF3F8CD2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift in Sources */,
 				DA1755F82357B6BD00B06C1D /* StringTests.swift in Sources */,
 				355B469D22B9031E009CE634 /* SKUTestable.swift in Sources */,
 				3510300F1F54B67000E3B7E7 /* LaneSnapshotTests.swift in Sources */,

--- a/Sources/MapboxNavigation/SpriteRepository.swift
+++ b/Sources/MapboxNavigation/SpriteRepository.swift
@@ -5,31 +5,33 @@ import MapboxDirections
 
 class SpriteRepository {
     let baseURL: URL = URL(string: "https://api.mapbox.com/styles/v1")!
-    let defaultStyleURI: StyleURI = .navigationDay
-    fileprivate(set) var imageDownloader: ReentrantImageDownloader
-    
+    private let defaultStyleURI: StyleURI = .navigationDay
+    private let requestTimeOut: TimeInterval = 10
+    private(set) var userInterfaceIdiomStyles = [UIUserInterfaceIdiom: StyleURI]()
+
+    private(set) var imageDownloader: ReentrantImageDownloader
     let requestCache: URLCaching
     let derivedCache: BimodalImageCache
-    static let shared = SpriteRepository.init()
-    
-    private let requestTimeOut: TimeInterval = 10
-    
+
     var sessionConfiguration: URLSessionConfiguration {
         didSet {
             imageDownloader = ImageDownloader(sessionConfiguration: sessionConfiguration)
         }
     }
-    
-    var userInterfaceIdiomStyles = [UIUserInterfaceIdiom: StyleURI]()
 
-    init() {
-        sessionConfiguration = URLSessionConfiguration.default
-        sessionConfiguration.timeoutIntervalForRequest = self.requestTimeOut
-        imageDownloader = ImageDownloader(sessionConfiguration: sessionConfiguration)
-        requestCache = URLDataCache()
-        derivedCache = ImageCache()
+    static let shared = SpriteRepository.init()
+
+    init(imageDownloader: ReentrantImageDownloader? = nil,
+         requestCache: URLCaching = URLDataCache(),
+         derivedCache: BimodalImageCache = ImageCache()) {
+        self.sessionConfiguration = URLSessionConfiguration.default
+        self.sessionConfiguration.timeoutIntervalForRequest = self.requestTimeOut
+        self.requestCache = requestCache
+        self.derivedCache = derivedCache
+
+        self.imageDownloader = imageDownloader ?? ImageDownloader(sessionConfiguration: sessionConfiguration)
     }
-    
+
     func updateStyle(styleURI: StyleURI?,
                      idiom: UIUserInterfaceIdiom = .phone,
                      completion: @escaping ImageDownloadCompletionHandler) {

--- a/Tests/MapboxNavigationTests/Helper/BimodalImageCacheSpy.swift
+++ b/Tests/MapboxNavigationTests/Helper/BimodalImageCacheSpy.swift
@@ -1,0 +1,29 @@
+import UIKit
+@testable import MapboxNavigation
+
+final class BimodalImageCacheSpy: BimodalImageCache {
+    var cache = [String: UIImage]()
+    var clearMemoryCalled = false
+    var clearDiskCalled = false
+
+    func store(_ image: UIImage, forKey key: String, toDisk: Bool, completion completionBlock: CompletionHandler?) {
+        cache[key] = image
+        completionBlock?()
+    }
+    func image(forKey key: String?) -> UIImage? {
+        guard let key = key else { return nil }
+        return cache[key]
+    }
+
+    func clearMemory() {
+        clearMemoryCalled = true
+        cache = [:]
+    }
+
+    func clearDisk(completion: CompletionHandler?) {
+        clearDiskCalled = true
+        clearMemory()
+        completion?()
+    }
+    
+}

--- a/Tests/MapboxNavigationTests/Helper/ReentrantImageDownloaderSpy.swift
+++ b/Tests/MapboxNavigationTests/Helper/ReentrantImageDownloaderSpy.swift
@@ -1,0 +1,36 @@
+import UIKit
+import MapboxDirections
+@testable import MapboxNavigation
+
+final class ReentrantImageDownloaderSpy: ReentrantImageDownloader {
+    var passedDownloadUrl: URL?
+    var passedOperationType: ImageDownload.Type?
+    var returnedDownloadResults = [URL: Data]()
+    var returnedOperation: ImageDownload?
+
+    func download(with url: URL, completion: CachedResponseCompletionHandler?) -> Void {
+        passedDownloadUrl = url
+        let response = cachedResponse(with: returnedDownloadResults[url], url: url)
+        completion?(response, response == nil ? DirectionsError.noData : nil)
+    }
+
+    func activeOperation(with url: URL) -> ImageDownload? {
+        return returnedOperation
+    }
+
+    func setOperationType(_ operationType: ImageDownload.Type?) {
+        passedOperationType = operationType
+    }
+
+    private func cachedResponse(with data: Data?, url: URL) -> CachedURLResponse? {
+        guard let data = data else { return nil }
+
+        let response = URLResponse(url: url,
+                                   mimeType: nil,
+                                   expectedContentLength: data.count,
+                                   textEncodingName: nil)
+        return CachedURLResponse(response: response,
+                                 data: data,
+                                 storagePolicy: .allowed)
+    }
+}

--- a/Tests/MapboxNavigationTests/Helper/URLCacheSpy.swift
+++ b/Tests/MapboxNavigationTests/Helper/URLCacheSpy.swift
@@ -1,0 +1,25 @@
+import Foundation
+@testable import MapboxNavigation
+
+final class URLCacheSpy: URLCaching {
+    var cache = [URL: CachedURLResponse]()
+    var clearCacheCalled = false
+
+    func store(_ cachedResponse: CachedURLResponse, for url: URL) {
+        cache[url] = cachedResponse
+    }
+
+    func response(for url: URL) -> CachedURLResponse? {
+        return cache[url]
+    }
+
+    func clearCache() {
+        clearCacheCalled = true
+        cache = [:]
+    }
+
+    func removeCache(for url: URL) {
+        cache[url] = nil
+    }
+
+}


### PR DESCRIPTION
### Description
Uses spies instead of real cache and image loader in repository.
Fixes fails like [this one](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-ios/10188/workflows/788164c2-000c-40e2-b769-5ef4b24bd088/jobs/95044)