### PR TITLE
Fix incorrect remaining shape in SimulatedLocationManager

### DIFF
--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -60,7 +60,9 @@ open class SimulatedLocationManager: NavigationLocationManager {
         if currentDistance != 0 {
             self.remainingRouteShape = route.shape?.trimmed(from: currentDistance, to: LocationDistance.infinity)
         }
-        self.remainingRouteShape = route.shape
+        else {
+            self.remainingRouteShape = route.shape
+        }
         self.locations = route.shape?.coordinates.simulatedLocationsWithTurnPenalties()
 
         super.init()


### PR DESCRIPTION
Regression after https://github.com/mapbox/mapbox-navigation-ios/pull/4153 caused `remainingRouteShape` property to be overridden https://github.com/mapbox/mapbox-navigation-ios/blob/6c80fdb908509923e2915edd8fd1b40dd66f6abb/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift#LL63