### PR TITLE
Fix overlapping voice instructions from offline and online Speech Synthesizers

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -87,8 +87,8 @@
 		2C04E46A290A8C6B0067FDCF /* PredictiveCacheOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E465290A8C6B0067FDCF /* PredictiveCacheOptions.swift */; };
 		2C193C31290A9BC30050A57F /* PredictiveCacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46D290A8CA10067FDCF /* PredictiveCacheManagerTests.swift */; };
 		2C193C32290A9BC30050A57F /* PredictiveCacheOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46C290A8CA10067FDCF /* PredictiveCacheOptionsTests.swift */; };
-		2C257379292B8BEC00941307 /* RouteStepProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C257378292B8BEB00941307 /* RouteStepProgressTests.swift */; };
 		2C257377292B836B00941307 /* ReentrantImageDownloaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C257376292B836B00941307 /* ReentrantImageDownloaderSpy.swift */; };
+		2C257379292B8BEC00941307 /* RouteStepProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C257378292B8BEB00941307 /* RouteStepProgressTests.swift */; };
 		2C2880A1291A82630063E5B7 /* RerouteControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */; };
 		2C2880A6291AB7A10063E5B7 /* RerouteDetectorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */; };
 		2C4093B5292661FD0099FA0E /* RouteParserSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */; };
@@ -114,6 +114,7 @@
 		2CF3F8CB2926D3E600BB2B9C /* URLCacheSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF3F8CA2926D3E600BB2B9C /* URLCacheSpy.swift */; };
 		2CF3F8CD2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */; };
 		2CFAE203291C4E8300562E5F /* TestNavigationStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFAE202291C4E8300562E5F /* TestNavigationStatusProvider.swift */; };
+		2CFBC1CE2940BD230073EFFA /* MultiplexedSpeechSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFBC1CD2940BD230073EFFA /* MultiplexedSpeechSynthesizerTests.swift */; };
 		2E50E0C0264E35CA009D3848 /* RoadObjectMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E0BF264E35CA009D3848 /* RoadObjectMatcher.swift */; };
 		2E50E0D2264E468B009D3848 /* RoadObjectMatcherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E0D1264E468B009D3848 /* RoadObjectMatcherError.swift */; };
 		2E50E0DC264E49C8009D3848 /* RoadObjectMatcherDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E0DB264E49C8009D3848 /* RoadObjectMatcherDelegate.swift */; };
@@ -743,8 +744,8 @@
 		2C04E465290A8C6B0067FDCF /* PredictiveCacheOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheOptions.swift; sourceTree = "<group>"; };
 		2C04E46C290A8CA10067FDCF /* PredictiveCacheOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheOptionsTests.swift; sourceTree = "<group>"; };
 		2C04E46D290A8CA10067FDCF /* PredictiveCacheManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictiveCacheManagerTests.swift; sourceTree = "<group>"; };
-		2C257378292B8BEB00941307 /* RouteStepProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStepProgressTests.swift; sourceTree = "<group>"; };
 		2C257376292B836B00941307 /* ReentrantImageDownloaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReentrantImageDownloaderSpy.swift; sourceTree = "<group>"; };
+		2C257378292B8BEB00941307 /* RouteStepProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteStepProgressTests.swift; sourceTree = "<group>"; };
 		2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerouteControllerTests.swift; sourceTree = "<group>"; };
 		2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RerouteDetectorSpy.swift; sourceTree = "<group>"; };
 		2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteParserSpy.swift; sourceTree = "<group>"; };
@@ -766,6 +767,7 @@
 		2CF3F8CA2926D3E600BB2B9C /* URLCacheSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCacheSpy.swift; sourceTree = "<group>"; };
 		2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BimodalImageCacheSpy.swift; sourceTree = "<group>"; };
 		2CFAE202291C4E8300562E5F /* TestNavigationStatusProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNavigationStatusProvider.swift; sourceTree = "<group>"; };
+		2CFBC1CD2940BD230073EFFA /* MultiplexedSpeechSynthesizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplexedSpeechSynthesizerTests.swift; sourceTree = "<group>"; };
 		2E50E0BF264E35CA009D3848 /* RoadObjectMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadObjectMatcher.swift; sourceTree = "<group>"; };
 		2E50E0D1264E468B009D3848 /* RoadObjectMatcherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadObjectMatcherError.swift; sourceTree = "<group>"; };
 		2E50E0DB264E49C8009D3848 /* RoadObjectMatcherDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadObjectMatcherDelegate.swift; sourceTree = "<group>"; };
@@ -1829,6 +1831,7 @@
 			isa = PBXGroup;
 			children = (
 				2B81EC27241A237E00145086 /* SpeechSynthesizersControllerTests.swift */,
+				2CFBC1CD2940BD230073EFFA /* MultiplexedSpeechSynthesizerTests.swift */,
 			);
 			name = Speech;
 			sourceTree = "<group>";
@@ -3217,6 +3220,7 @@
 				35DC585D1FABC61100B5A956 /* InstructionsBannerViewIntegrationTests.swift in Sources */,
 				E2D14983265CFD3C008135A3 /* StatusViewTests.swift in Sources */,
 				8AB8F30026DD7C30003FF4EE /* CGPointTests.swift in Sources */,
+				2CFBC1CE2940BD230073EFFA /* MultiplexedSpeechSynthesizerTests.swift in Sources */,
 				8A5B281226D82AB600622FBD /* UserPuckCourseViewSnapshotTests.swift in Sources */,
 				B4C8E39E286B72FA004D3EDD /* FeedbackViewControllerSnapshotTests.swift in Sources */,
 				8AD12F4C26C193560008AE55 /* LeaksTests.swift in Sources */,

--- a/Sources/MapboxNavigation/MapboxSpeechSynthesizer.swift
+++ b/Sources/MapboxNavigation/MapboxSpeechSynthesizer.swift
@@ -141,9 +141,8 @@ open class MapboxSpeechSynthesizer: NSObject, SpeechSynthesizing {
      - parameter data: audio data, as provided by `remoteSpeechSynthesizer`, to be played.
      */
     open func speak(_ instruction: SpokenInstruction, data: Data) {
-        
         if let audioPlayer = audioPlayer {
-            if let previousInstruction = previousInstruction, audioPlayer.isPlaying{
+            if let previousInstruction = previousInstruction, audioPlayer.isPlaying {
                 delegate?.speechSynthesizer(self,
                                             didInterrupt: previousInstruction,
                                             with: instruction)

--- a/Sources/MapboxNavigation/MultiplexedSpeechSynthesizer.swift
+++ b/Sources/MapboxNavigation/MultiplexedSpeechSynthesizer.swift
@@ -143,6 +143,13 @@ extension MultiplexedSpeechSynthesizer: SpeechSynthesizingDelegate {
                                         with: nil)
         }
     }
+
+    public func speechSynthesizer(_ speechSynthesizer: SpeechSynthesizing, willSpeak instruction: SpokenInstruction) -> SpokenInstruction? {
+        speechSynthesizers.filter { $0.isSpeaking && $0 !== speechSynthesizer}
+            .forEach { $0.interruptSpeaking() }
+        
+        return delegate?.speechSynthesizer(speechSynthesizer, willSpeak: instruction)
+    }
     
     // Just forward delegate calls
     
@@ -152,9 +159,5 @@ extension MultiplexedSpeechSynthesizer: SpeechSynthesizingDelegate {
     
     public func speechSynthesizer(_ speechSynthesizer: SpeechSynthesizing, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction) {
         delegate?.speechSynthesizer(speechSynthesizer, didInterrupt: interruptedInstruction, with: interruptingInstruction)
-    }
-    
-    public func speechSynthesizer(_ speechSynthesizer: SpeechSynthesizing, willSpeak instruction: SpokenInstruction) -> SpokenInstruction? {
-        return delegate?.speechSynthesizer(speechSynthesizer, willSpeak: instruction)
     }
 }

--- a/Tests/MapboxNavigationTests/MultiplexedSpeechSynthesizerTests.swift
+++ b/Tests/MapboxNavigationTests/MultiplexedSpeechSynthesizerTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import MapboxDirections
+@testable import MapboxNavigation
+
+class SpeechSynthesizingDelegateSpy: SpeechSynthesizingDelegate {
+    var encounteredErrorCalled = false
+    var didSpeakCalled = false
+    var didInterruptCalled = false
+    var willSpeakCalled = false
+
+    var passedSpeechSynthesizer: SpeechSynthesizing!
+
+    func speechSynthesizer(_ speechSynthesizer: SpeechSynthesizing, encounteredError error: SpeechError) {
+        encounteredErrorCalled = true
+        passedSpeechSynthesizer = speechSynthesizer
+    }
+
+    func speechSynthesizer(_ speechSynthesizer: SpeechSynthesizing, didSpeak instruction: SpokenInstruction, with error: SpeechError?) {
+        didSpeakCalled = true
+        passedSpeechSynthesizer = speechSynthesizer
+    }
+
+    func speechSynthesizer(_ speechSynthesizer: SpeechSynthesizing, didInterrupt interruptedInstruction: SpokenInstruction, with interruptingInstruction: SpokenInstruction) {
+        didInterruptCalled = true
+        passedSpeechSynthesizer = speechSynthesizer
+    }
+
+    func speechSynthesizer(_ speechSynthesizer: SpeechSynthesizing, willSpeak instruction: SpokenInstruction) -> SpokenInstruction? {
+        willSpeakCalled = true
+        passedSpeechSynthesizer = speechSynthesizer
+        return instruction
+    }
+
+}
+
+final class MultiplexedSpeechSynthesizerTests: XCTestCase {
+    var synthesizer: MultiplexedSpeechSynthesizer!
+    var delegate: SpeechSynthesizingDelegateSpy!
+    
+    var innerSynthesizer1: SpeechSynthesizerStub!
+    var innerSynthesizer2: SpeechSynthesizerStub!
+
+    let spokenInstruction = SpokenInstruction(distanceAlongStep: 100, text: "Text", ssmlText: "ssml text")
+
+    override func setUp() {
+        super.setUp()
+
+        innerSynthesizer1 = SpeechSynthesizerStub()
+        innerSynthesizer2 = SpeechSynthesizerStub()
+        delegate = SpeechSynthesizingDelegateSpy()
+        synthesizer = MultiplexedSpeechSynthesizer([innerSynthesizer1, innerSynthesizer2])
+        synthesizer.delegate = delegate
+
+        innerSynthesizer1.interruptSpeakingCalled = false
+        innerSynthesizer2.interruptSpeakingCalled = false
+    }
+
+    func testWillSpeakIfNoOtherSynthesizersAreSpeaking() {
+        let instruction = synthesizer.speechSynthesizer(innerSynthesizer1, willSpeak: spokenInstruction)
+
+        XCTAssertEqual(instruction, spokenInstruction)
+        XCTAssertTrue(delegate.passedSpeechSynthesizer === innerSynthesizer1)
+        XCTAssertTrue(delegate.willSpeakCalled)
+
+        XCTAssertFalse(innerSynthesizer1.interruptSpeakingCalled)
+        XCTAssertFalse(innerSynthesizer2.interruptSpeakingCalled)
+    }
+
+    func testWillSpeakIfOtherSynthesizerIsSpeaking() {
+        innerSynthesizer1.isSpeaking = true
+
+        let instruction = synthesizer.speechSynthesizer(innerSynthesizer2, willSpeak: spokenInstruction)
+
+        XCTAssertEqual(instruction, spokenInstruction)
+        XCTAssertTrue(innerSynthesizer1.interruptSpeakingCalled)
+        XCTAssertFalse(innerSynthesizer2.interruptSpeakingCalled)
+    }
+
+}

--- a/Tests/MapboxNavigationTests/NavigationViewControllerTestDoubles.swift
+++ b/Tests/MapboxNavigationTests/NavigationViewControllerTestDoubles.swift
@@ -17,22 +17,35 @@ class SpeechSynthesizerStub: SpeechSynthesizing {
     var volume: Float = 1.0
     var isSpeaking: Bool = false
     var locale: Locale? = Locale.autoupdatingCurrent
-    var managesAudioSession: Bool = true
+    var managesAudioSession = true
+
+    var passedLocale: Locale?
+    var passedInstruction: SpokenInstruction?
+    var passedInstructions: [SpokenInstruction]?
+
+    var prepareIncomingSpokenInstructionsCalled = false
+    var speakCalled = false
+    var stopSpeakingCalled = false
+    var interruptSpeakingCalled = false
     
     func prepareIncomingSpokenInstructions(_ instructions: [SpokenInstruction], locale: Locale?) {
-        // do nothing
+        prepareIncomingSpokenInstructionsCalled = true
+        passedInstructions = instructions
+        passedLocale = locale
     }
     
     func speak(_ instruction: SpokenInstruction, during legProgress: RouteLegProgress, locale: Locale?) {
-        // do nothing
+        speakCalled = true
+        passedInstruction = instruction
+        passedLocale = locale
     }
     
     func stopSpeaking() {
-        // do nothing
+        stopSpeakingCalled = true
     }
     
     func interruptSpeaking() {
-        // do nothing
+        interruptSpeakingCalled = true
     }
 }
 


### PR DESCRIPTION
### Description
When user starts offline navigation and this user previously started online navigations some of voice instructions were alredy cached. In situations like this, for `MapboxSpeechSynthesizer` is used for cached instructions and `SystemSpeechSynthesizer` for non-cached.  But we only track overlapping within one synthesizer, not across multiple synthesizers.