### PR TITLE
Continuous alternatives metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fixed an issue where text in the route duration annotation was not centered correctly on devices with different screen sizes. ([#4130](https://github.com/mapbox/mapbox-navigation-ios/pull/4130))
 * Added `CarPlayManagerDelegate.carPlayManager(_:willAdd:for:)`, `NavigationMapViewDelegate.navigationMapView(_:willAdd:)` and `NavigationViewControllerDelegate.navigationViewController(_:willAdd:)` to modify the properties of the default layer which will be added to the map view during navigation. ([#4277](https://github.com/mapbox/mapbox-navigation-ios/pull/4277))
 * Fixed issue where the traversed route layer doesn't share the same width with the main route casing layer after developers providing their own layer or midfying the layer properties. ([#4277](https://github.com/mapbox/mapbox-navigation-ios/pull/4277))
+* Added `NavigationMapView.showcase(_:routesPresentationStyle:legIndex:animated:duration:completion:)` and `NavigationMapView.show(_:layerPosition:legIndex:)` methods to draw `IndexedRouteResponse` data and populate view's `routes` and `continuousAlternatives` properties accordingly. ([#4294](https://github.com/mapbox/mapbox-navigation-ios/pull/4294))
 
 ### Location tracking
 
@@ -44,6 +45,7 @@
 * `SimulatedLocationManager`'s  initializer `SimulatedLocationManager.init(route:currentDistance:currentSpeed:)` is now public. ([#4276](https://github.com/mapbox/mapbox-navigation-ios/pull/4276))
 * Added a console message when a newer version of Navigation SDK is available. ([#4280](https://github.com/mapbox/mapbox-navigation-ios/pull/4280))
 * Fixed an issue where `Bundle.string(forMapboxNavigationInfoDictionaryKey:)` and `Bundle.string(forMapboxCoreNavigationInfoDictionaryKey` returned values from the application bundle instead of the Navigation SDK when statically linking using Cocoapods. ([#4280](https://github.com/mapbox/mapbox-navigation-ios/pull/4280))
+* Added `IndexedRouteReponse.parseAlternativeRoutes` method to extract `AlternativeRoute`s data from a response. ([#4294](https://github.com/mapbox/mapbox-navigation-ios/pull/4294))
 
 ## v2.9.0
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -63,7 +63,8 @@ class ViewController: UIViewController {
     }
 
     func showCurrentRoute() {
-        guard var prioritizedRoutes = routes else { return }
+        guard let routeResponse = indexedRouteResponse,
+              var prioritizedRoutes = routes else { return }
         
         prioritizedRoutes.insert(prioritizedRoutes.remove(at: currentRouteIndex),
                                  at: 0)
@@ -71,7 +72,7 @@ class ViewController: UIViewController {
         // Show congestion levels on alternative route lines if there're multiple routes in the response.
         navigationMapView.showsCongestionForAlternativeRoutes = true
         navigationMapView.showsRestrictedAreasOnRoute = true
-        navigationMapView.show(prioritizedRoutes)
+        navigationMapView.show(routeResponse)
         navigationMapView.showWaypoints(on: prioritizedRoutes.first!)
         navigationMapView.showRouteDurations(along: prioritizedRoutes)
     }
@@ -742,11 +743,9 @@ extension ViewController: NavigationMapViewDelegate {
             }
         }
     }
-
-    func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
-        guard let index = routes?.firstIndex(where: { $0 === route }),
-              index != indexedRouteResponse?.routeIndex else { return }
-        indexedRouteResponse?.routeIndex = index
+    
+    func navigationMapView(_ navigationMapView: NavigationMapView, didSelect continuousAlternative: AlternativeRoute) {
+        indexedRouteResponse?.routeIndex = continuousAlternative.indexedRouteResponse.routeIndex
     }
 
     private func presentWaypointRemovalAlert(completionHandler approve: @escaping ((UIAlertAction) -> Void)) {

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -39,6 +39,11 @@ public struct IndexedRouteResponse {
         return routeResponse.routes?[routeIndex]
     }
     
+    /**
+     Parses routes in the current response, accounting `routeIndex` to be pointing to the primary route, while all the others being `AlternativeRoute`s.
+     
+     - returns: Array of `AlternativeRoutes` containing relative information to `currentRoute`.
+     */
     public func parseAlternativeRoutes() -> [AlternativeRoute] {
         guard let mainRoute = currentRoute,
               let routesData = routesData(routeParserType: RouteParser.self) else {

--- a/Sources/MapboxCoreNavigation/RoutesCoordinator.swift
+++ b/Sources/MapboxCoreNavigation/RoutesCoordinator.swift
@@ -9,7 +9,7 @@ final class RoutesCoordinator {
     }
 
     typealias RoutesResult = (mainRouteInfo: RouteInfo?, alternativeRoutes: [RouteAlternative])
-    typealias RoutesSetupHandler = (_ mainRoute: RouteInterface?, _ legIndex: UInt32, _ alternativeRoutes: [RouteInterface], _ completion: @escaping (Result<RoutesResult, Error>) -> Void) -> Void
+    typealias RoutesSetupHandler = (_ routesData: RoutesData?, _ legIndex: UInt32, _ completion: @escaping (Result<RoutesResult, Error>) -> Void) -> Void
     typealias AlternativeRoutesSetupHandler = (_ routes: [RouteInterface], _ completion: @escaping (Result<[RouteAlternative], Error>) -> Void) -> Void
 
     private struct ActiveNavigationSession {
@@ -36,10 +36,9 @@ final class RoutesCoordinator {
     /// - Parameters:
     ///   - uuid: The UUID of the current active guidances session. All reroutes should have the same uuid.
     ///   - legIndex: The index of the leg along which to begin navigating.
-    func beginActiveNavigation(with route: RouteInterface,
+    func beginActiveNavigation(with routesData: RoutesData,
                                uuid: UUID,
                                legIndex: UInt32,
-                               alternativeRoutes: [RouteInterface],
                                completion: @escaping (Result<RoutesResult, Error>) -> Void) {
         lock.lock()
         if case .activeNavigation(let currentUUID) = state, currentUUID != uuid {
@@ -49,7 +48,7 @@ final class RoutesCoordinator {
         state = .activeNavigation(uuid)
         lock.unlock()
 
-        routesSetupHandler(route, legIndex, alternativeRoutes, completion)
+        routesSetupHandler(routesData, legIndex, completion)
     }
 
     /// - Parameters:
@@ -64,7 +63,7 @@ final class RoutesCoordinator {
         state = .passiveNavigation
         lock.unlock()
         // TODO: Is it safe to set the leg index to 0 when unsetting a route?
-        routesSetupHandler(nil, 0, [], completion)
+        routesSetupHandler(nil, 0, completion)
     }
     
     func updateAlternativeRoutes(with routes: [RouteInterface], completion: @escaping (Result<[RouteAlternative], Error>) -> Void) {

--- a/Sources/MapboxNavigation/NavigationMapView+Annotations.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+Annotations.swift
@@ -8,7 +8,12 @@ extension NavigationMapView {
     
     // MARK: Route Duration Annotations
     
-    func showContinuousAlternativeRoutesDurations() {
+    /**
+     Shows a callout containing the relative duration to the primary route of each continuous alternative route.
+     Useful as a way to give the user more information when picking between multiple route alternatives.
+     If the route contains any tolled segments then the callout will specify that as well.
+     */
+    public func showContinuousAlternativeRoutesDurations() {
         // Remove any existing route annotation.
         removeContinuousAlternativeRoutesDurations()
         

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -358,7 +358,6 @@ open class NavigationMapView: UIView {
         customRouteLineLayerPosition = layerPosition
         
         applyRoutesDisplay(layerPosition: layerPosition)
-        updateRouteLineWithRouteLineTracksTraversal()
     }
     
     func applyRoutesDisplay(layerPosition: MapboxMaps.LayerPosition? = nil) {

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -236,6 +236,62 @@ open class NavigationMapView: UIView {
     }
     
     /**
+     Visualizes the given routes and it's alternatives, removing any existing from the map.
+     
+     Each route is visualized as a line. Each line is color-coded by traffic congestion, if congestion
+     levels are present and `NavigationMapView.crossfadesCongestionSegments` is set to `true`.
+     
+     Waypoints along the route are visualized as markers. Implement `NavigationMapViewDelegate` methods
+     to customize the appearance of the lines and markers representing the routes and waypoints.
+     
+     To only visualize the routes and not the waypoints, or to have more control over the camera,
+     use the `show(_:legIndex:)` method.
+     
+     - parameter routeResponse: `IndexedRouteResponse` containing routes to visualize. The selected route by `routeIndex` is considered primary, while the remaining routes are displayed as if they are currently deselected or inactive.
+     - parameter routesPresentationStyle: Route lines presentation style. By default the map will be
+     updated to fit all routes.
+     - parameter legIndex: The zero-based index of the currently active leg along the active route.
+     The active leg is highlighted more prominently than inactive legs.
+     - parameter animated: `true` to asynchronously animate the camera, or `false` to instantaneously
+     zoom and pan the map.
+     - parameter duration: Duration of the animation (in seconds). In case if `animated` parameter
+     is set to `false` this value is ignored.
+     - parameter completion: A completion handler that will be called once routes presentation completes.
+     */
+    public func showcase(_ routeResponse: IndexedRouteResponse,
+                         routesPresentationStyle: RoutesPresentationStyle = .all(),
+                         legIndex: Int? = nil,
+                         animated: Bool = false,
+                         duration: TimeInterval = 1.0,
+                         completion: AnimationCompletionHandler? = nil) {
+        guard let routes = routeResponse.routeResponse.routes,
+              let activeRoute = routeResponse.currentRoute,
+              let coordinates = activeRoute.shape?.coordinates,
+              !coordinates.isEmpty else { return }
+        
+        removeArrow()
+        removeRoutes()
+        removeWaypoints()
+        removeContinuousAlternativesRoutes()
+        
+        switch routesPresentationStyle {
+        case .single:
+            show([activeRoute], layerPosition: customRouteLineLayerPosition, legIndex: legIndex)
+        case .all:
+            show(routeResponse, layerPosition: customRouteLineLayerPosition, legIndex: legIndex)
+        }
+        
+        showWaypoints(on: activeRoute)
+        
+        navigationCamera.stop()
+        fitCamera(to: routes,
+                  routesPresentationStyle: routesPresentationStyle,
+                  animated: animated,
+                  duration: duration,
+                  completion: completion)
+    }
+    
+    /**
      Visualizes the given routes, removing any existing routes from the map.
      
      Each route is visualized as a line. Each line is color-coded by traffic congestion, if congestion
@@ -267,6 +323,42 @@ open class NavigationMapView: UIView {
         customRouteLineLayerPosition = layerPosition
         
         applyRoutesDisplay(layerPosition: layerPosition)
+    }
+    
+    /**
+     Visualizes the given routes and it's alternatives, removing any existing from the map.
+     
+     Each route is visualized as a line. Each line is color-coded by traffic congestion, if congestion
+     levels are present. Implement `NavigationMapViewDelegate` methods to customize the appearance of
+     the lines representing the routes. To also visualize waypoints and zoom the map to fit,
+     use the `showcase(_:animated:)` method.
+     
+     To undo the effects of this method, use `removeRoutes()` and `removeContinuousAlternativesRoutes()` methods.
+     
+     - parameter routeResponse: `IndexedRouteResponse` containing routes to visualize. The selected route by `routeIndex` is considered primary, while the remaining routes are displayed as if they are currently deselected or inactive.
+     - parameter layerPosition: Position of the first route layer. Remaining routes and their casings
+     are always displayed below the first and all other subsequent route layers. Defaults to `nil`.
+     If layer position is set to `nil`, the route layer appears below the bottommost symbol layer.
+     - parameter legIndex: The zero-based index of the currently active leg along the primary route.
+     The active leg is highlighted more prominently than inactive legs.
+     */
+    public func show(_ routeResponse: IndexedRouteResponse,
+                     layerPosition: MapboxMaps.LayerPosition? = nil,
+                     legIndex: Int? = nil) {
+        guard let mainRoute = routeResponse.currentRoute else {
+            return
+        }
+        
+        removeRoutes()
+        removeContinuousAlternativesRoutesLayers()
+        
+        self.routes = [mainRoute]
+        self.continuousAlternatives = routeResponse.parseAlternativeRoutes()
+        currentLegIndex = legIndex
+        customRouteLineLayerPosition = layerPosition
+        
+        applyRoutesDisplay(layerPosition: layerPosition)
+        updateRouteLineWithRouteLineTracksTraversal()
     }
     
     func applyRoutesDisplay(layerPosition: MapboxMaps.LayerPosition? = nil) {

--- a/Sources/TestHelper/CoreNavigatorSpy.swift
+++ b/Sources/TestHelper/CoreNavigatorSpy.swift
@@ -86,16 +86,15 @@ public final class CoreNavigatorSpy: CoreNavigator {
         stopUpdatingElectronicHorizonCalled = true
     }
 
-    public func setRoutes(_ route: RouteInterface,
+    public func setRoutes(_ routesData: RoutesData,
                           uuid: UUID,
                           legIndex: UInt32,
-                          alternativeRoutes: [RouteInterface],
                           completion: @escaping (Result<RoutesCoordinator.RoutesResult, Error>) -> Void) {
         setRoutesCalled = true
-        passedRoute = route
+        passedRoute = routesData.primaryRoute()
         passedUuid = uuid
         passedLegIndex = legIndex
-        passedAlternativeRoutes = alternativeRoutes
+        passedAlternativeRoutes = routesData.alternativeRoutes().map { $0.route }
         completion(returnedSetRoutesResult ?? .success((mainRouteInfo: nil, alternativeRoutes: [])))
     }
 


### PR DESCRIPTION
### Description
PR adds functionality to extrace `AlternativeRoute`s data from a `RouteResponse` without trigering a navigation session.

### Implementation
Added corresponding method to `IndexedRouteResponse`. SDK internals updated to also utilize this method and unify routes setup to the NN.Navigator. Added few convenience methods to draw routes on the NavigationMapView to be set up using `IndexedRouteResponse`.