### PR TITLE
Remove long-disabled tests

### DIFF
--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxCoreNavigationIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxCoreNavigationIntegrationTests.swift
@@ -275,8 +275,7 @@ class MapboxCoreNavigationIntegrationTests: TestCase {
         }
     }
 
-    // NOTE: Investigate when makes it fail on CI and run well locally.
-    func disabled_testArrive() {
+    func testArrive() {
         let route = Fixture.route(from: "multileg-route", options: routeOptions)
         let replayLocations = Array(Fixture.generateTrace(for: route).shiftedToPresent().qualified()[0..<100])
         let routeResponse = RouteResponse(httpResponse: nil,

--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
@@ -376,8 +376,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
                                                              distanceToFirstCoordinateOnLeg: facingTowardsStartLocation.distance(from: firstLocation)), "Should not snap")
     }
 
-    //TODO: Broken by PortableRoutecontroller & MBNavigator -- needs team discussion.
-    func x_testLocationShouldUseHeading() {
+    func testLocationCourse() {
         dependencies = createDependencies()
 
         let navigation = dependencies.navigationService
@@ -385,6 +384,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [firstLocation])
 
         XCTAssertEqual(navigation.router.location!.course, firstLocation.course, "Course should be using course")
+        XCTAssertNil(navigation.router.heading)
 
         let invalidCourseLocation = CLLocation(coordinate: firstLocation.coordinate, altitude: firstLocation.altitude, horizontalAccuracy: firstLocation.horizontalAccuracy, verticalAccuracy: firstLocation.verticalAccuracy, course: -1, speed: firstLocation.speed, timestamp: firstLocation.timestamp)
 
@@ -393,7 +393,8 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
         navigation.locationManager!(navigation.locationManager, didUpdateLocations: [invalidCourseLocation])
         navigation.locationManager!(navigation.locationManager, didUpdateHeading: heading)
 
-        XCTAssertEqual(navigation.router.location!.course, mbTestHeading, "Course should be using bearing")
+        XCTAssertEqual(navigation.router.location!.course, invalidCourseLocation.course, "Course should be using invalid location course")
+        XCTAssertEqual(navigation.router.heading, heading)
     }
 
     // MARK: - Events & Delegation

--- a/Tests/MapboxNavigationTests/DataCacheTests.swift
+++ b/Tests/MapboxNavigationTests/DataCacheTests.swift
@@ -109,16 +109,4 @@ class DataCacheTests: TestCase {
         XCTAssertEqual(cache.fileCache.cacheKeyForKey("https://cool.com/neat"), cache.fileCache.cacheKeyForKey("https://cool.com/neat"))
         XCTAssertEqual(cache.fileCache.cacheKeyForKey("-"), cache.fileCache.cacheKeyForKey("-"))
     }
-
-    /// NOTE: This test is disabled pending https://github.com/mapbox/mapbox-navigation-ios/issues/1468
-    func x_testCacheKeyPerformance() {
-        let instructionTurn = "Turn left"
-        let instructionContinue = "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue on <say-as interpret-as=\"address\">I-80</say-as> East for 3 miles</prosody></amazon:effect></speak>"
-        measure {
-            for _ in 0...1000 {
-                _ = cache.fileCache.cacheKeyForKey(instructionTurn)
-                _ = cache.fileCache.cacheKeyForKey(instructionContinue)
-            }
-        }
-    }
 }

--- a/Tests/MapboxNavigationTests/InstructionPresenterTests.swift
+++ b/Tests/MapboxNavigationTests/InstructionPresenterTests.swift
@@ -29,27 +29,4 @@ class InstructionPresenterTests: TestCase {
         XCTAssert(attachment is ExitAttachment, "Attachment for exit shield should be of type ExitAttachment; got \(String(describing: attachment.self))")
     }
 
-    /// NOTE: This test is disabled pending https://github.com/mapbox/mapbox-navigation-ios/issues/1468
-    func x_testAbbreviationPerformance() {
-        let route = Fixture.route(from: "route-with-banner-instructions", options: NavigationRouteOptions(coordinates: [
-            CLLocationCoordinate2D(latitude: 37.764793, longitude: -122.463161),
-            CLLocationCoordinate2D(latitude: 34.054081, longitude: -118.243412),
-        ]))
-        
-        let steps = route.legs.flatMap { $0.steps }
-        let instructions = steps.compactMap { $0.instructionsDisplayedAlongStep?.first?.primaryInstruction }
-        
-        let label = InstructionLabel(frame: CGRect(origin: .zero, size: CGSize.iPhone5))
-        label.availableBounds = { return CGRect(origin: .zero, size: CGSize.iPhone5) }
-        
-        self.measure {
-            for instruction in instructions {
-                let presenter = InstructionPresenter(instruction,
-                                                     dataSource: label,
-                                                     traitCollection: UITraitCollection(userInterfaceIdiom: .phone),
-                                                     downloadCompletion: nil)
-                label.attributedText = presenter.attributedText()
-            }
-        }
-    }
 }

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -142,7 +142,7 @@ class NavigationMapViewTests: TestCase {
 
     func testInitWithCustomMapView() {
         let customMapView = MapView(frame: .zero)
-        var navigationMapView = NavigationMapView(frame: .zero, navigationCameraType: .carPlay, mapView: customMapView)
+        let navigationMapView = NavigationMapView(frame: .zero, navigationCameraType: .carPlay, mapView: customMapView)
         XCTAssertEqual(navigationMapView.navigationCamera.type, .carPlay)
         XCTAssertEqual(navigationMapView.mapView, customMapView)
     }

--- a/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
+++ b/Tests/MapboxNavigationTests/StepsViewControllerTests.swift
@@ -46,32 +46,33 @@ class StepsViewControllerTests: TestCase {
         let stepsViewController = dependencies.stepsViewController
 
         XCTAssertNotNil(stepsViewController.view, "StepsViewController not initiated properly")
-//        measure {
-//            // Measure Performance - stepsViewController.rebuildDataSourceIfNecessary()
-//        }
         
         let containsStepsTableView = stepsViewController.view.subviews.contains(stepsViewController.tableView)
         XCTAssertTrue(containsStepsTableView, "StepsViewController does not have a table subview")
         XCTAssertNotNil(stepsViewController.tableView, "TableView not initiated")
     }
 
-    /// NOTE: This test is disabled pending https://github.com/mapbox/mapbox-navigation-ios/issues/1468
-    func x_testUpdateCellPerformance() {
+    func testUpdateCell() {
         let stepsViewController = dependencies.stepsViewController
-        
+
         // Test that Steps ViewController viewLoads
         XCTAssertNotNil(stepsViewController.view, "StepsViewController not initiated properly")
-        
-        let stepsTableView = stepsViewController.tableView!
-        
-        measure {
-            for i in 0..<stepsTableView.numberOfRows(inSection: 0) {
-                let indexPath = IndexPath(row: i, section: 0)
-                if let cell = stepsTableView.cellForRow(at: indexPath) as? StepTableViewCell {
-                    stepsViewController.updateCell(cell, at: indexPath)
-                }
-            }
-        }
+
+        let indexPath = IndexPath(row: 0, section: 0)
+        let cell = StepTableViewCell()
+
+        let expectedInstruction = Constants.route.legs[0].steps[1].instructionsDisplayedAlongStep?.last
+        cell.separatorView.isHidden = true
+        stepsViewController.updateCell(cell, at: indexPath)
+
+        XCTAssertEqual(cell.instructionsView.primaryLabel.instruction, expectedInstruction?.primaryInstruction)
+        XCTAssertEqual(cell.instructionsView.secondaryLabel.instruction, expectedInstruction?.secondaryInstruction)
+        XCTAssertTrue(cell.instructionsView.stepListIndicatorView.isHidden)
+        XCTAssertFalse(cell.separatorView.isHidden)
+
+        let lastIndexPath = IndexPath(row: 3, section: 0)
+        stepsViewController.updateCell(cell, at: lastIndexPath)
+        XCTAssertTrue(cell.separatorView.isHidden)
     }
 }
 


### PR DESCRIPTION
### Description
Performance tests in the Nav SDK repo were disabled in [2018](https://github.com/mapbox/mapbox-navigation-ios/issues/1468). There is no use in storing non-running test code for 4 years. We have separate MetricsTests for measuring memory usage. So disabled performance tests are removed in this PR.

As for non-performance, tests were modified to test the actual behavior of the SDK.