### PR TITLE
Fix deprecated build warnings in tests

### DIFF
--- a/Sources/TestHelper/TestCase.swift
+++ b/Sources/TestHelper/TestCase.swift
@@ -28,7 +28,7 @@ open class TestCase: XCTestCase {
         super.tearDown()
         // Reset navigator
         CoreNavigatorSpy.reset()
-        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: .default, routingProviderSource: .hybrid, alternativeRouteDetectionStrategy: .init())
+        Self.configureSettings()
     }
 
     /// Prepares tests for execution. Should be called once before any test runs.
@@ -36,12 +36,20 @@ open class TestCase: XCTestCase {
         guard !isInitializationCompleted else { return }
         isInitializationCompleted = true
 
-        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: .default, routingProviderSource: .hybrid, alternativeRouteDetectionStrategy: .init())
+        configureSettings()
         Credentials.injectSharedToken(.mockedAccessToken)
         #if canImport(MapboxMaps)
         ResourceOptionsManager.default.resourceOptions.accessToken = .mockedAccessToken
         #endif
         UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationWhenInUseUsageDescription")
         UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
+    }
+
+    private static func configureSettings() {
+        let settingsValues = NavigationSettings.Values(directions: .mocked,
+                                                       tileStoreConfiguration: .default,
+                                                       routingProviderSource: .hybrid,
+                                                       alternativeRouteDetectionStrategy: .init())
+        NavigationSettings.shared.initialize(with: settingsValues)
     }
 }

--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
@@ -67,9 +67,6 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
         dependencies = nil
         MapboxRoutingProvider.__testRoutesStub = nil
 
-        NavigationSettings.shared.initialize(directions: .shared,
-                                             tileStoreConfiguration: .default)
-
         super.tearDown()
     }
 
@@ -436,9 +433,11 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
     }
 
     func testReroutingFromALocationSendsEvents() {
-        NavigationSettings.shared.initialize(directions: .shared,
-                                             tileStoreConfiguration: .default,
-                                             alternativeRouteDetectionStrategy: .init(refreshesAfterPassingDeviation: false))
+        let settingsValues = NavigationSettings.Values(directions: .mocked,
+                                                       tileStoreConfiguration: .default,
+                                                       routingProviderSource: .offline,
+                                                       alternativeRouteDetectionStrategy: .init(refreshesAfterPassingDeviation: false))
+        NavigationSettings.shared.initialize(with: settingsValues)
 
         dependencies = createDependencies()
 

--- a/Tests/MapboxCoreNavigationIntegrationTests/PassiveLocationManagerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/PassiveLocationManagerIntegrationTests.swift
@@ -66,7 +66,11 @@ class PassiveLocationManagerIntegrationTests: TestCase {
 
         let bundle = Bundle(for: Fixture.self)
         let filePathURL: URL = URL(fileURLWithPath: bundle.bundlePath.appending("/tiles/liechtenstein"))
-        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .custom(filePathURL), mapLocation: nil), routingProviderSource: .offline, alternativeRouteDetectionStrategy: .init())
+        let settingsValues = NavigationSettings.Values(directions: .mocked,
+                                                       tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .custom(filePathURL), mapLocation: nil),
+                                                       routingProviderSource: .offline,
+                                                       alternativeRouteDetectionStrategy: .init())
+        NavigationSettings.shared.initialize(with: settingsValues)
     }
 
     override func tearDown() {

--- a/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
@@ -194,10 +194,11 @@ class RouteControllerIntegrationTests: TestCase {
     }
 
     func testAlternativeRoutesNotReported() {
-        NavigationSettings.shared.initialize(directions: .mocked,
-                                             tileStoreConfiguration: .default,
-                                             routingProviderSource: .hybrid,
-                                             alternativeRouteDetectionStrategy: nil)
+        let settingsValues = NavigationSettings.Values(directions: .mocked,
+                                                       tileStoreConfiguration: .default,
+                                                       routingProviderSource: .hybrid,
+                                                       alternativeRouteDetectionStrategy: nil)
+        NavigationSettings.shared.initialize(with: settingsValues)
 
         let routeOptions = RouteOptions(coordinates: [.init(latitude: 37.33243586131637,
                                                             longitude: -122.03140541047281),

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
@@ -20,7 +20,12 @@ class PassiveLocationManagerTests: TestCase {
 
         let bundle = Bundle(for: Fixture.self)
         let filePathURL: URL = URL(fileURLWithPath: bundle.bundlePath.appending("/tiles/liechtenstein"))
-        NavigationSettings.shared.initialize(directions: .mocked, tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .custom(filePathURL), mapLocation: nil), routingProviderSource: .offline, alternativeRouteDetectionStrategy: .init())
+
+        let settingsValues = NavigationSettings.Values(directions: .mocked,
+                                                       tileStoreConfiguration: TileStoreConfiguration(navigatorLocation: .custom(filePathURL), mapLocation: nil),
+                                                       routingProviderSource: .offline,
+                                                       alternativeRouteDetectionStrategy: .init())
+        NavigationSettings.shared.initialize(with: settingsValues)
 
         locationManagerSpy = .init()
         directionsSpy = .init()

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -63,7 +63,6 @@ class RouteControllerTests: TestCase {
     override func setUp() {
         super.setUp()
 
-        resetNavigationSettings()
         delegate = .init()
         locationManagerSpy = .init()
         routingProvider = .init()
@@ -90,7 +89,6 @@ class RouteControllerTests: TestCase {
         RouteParserSpy.returnedRoutes = nil
         RouteParserSpy.returnedError = nil
         MapboxRoutingProvider.__testRoutesStub = nil
-        resetNavigationSettings()
         
         super.tearDown()
     }
@@ -1061,10 +1059,12 @@ class RouteControllerTests: TestCase {
     }
 
     func testNotifyDelegateDidFailToChangeAlternativeRoutesIfNilAlternativeRouteDetectionStrategy() {
-        NavigationSettings.shared.initialize(directions: .shared,
-                                             tileStoreConfiguration: .default,
-                                             routingProviderSource: .hybrid,
-                                             alternativeRouteDetectionStrategy: nil)
+        let settingsValues = NavigationSettings.Values(directions: .mocked,
+                                                       tileStoreConfiguration: .default,
+                                                       routingProviderSource: .hybrid,
+                                                       alternativeRouteDetectionStrategy: nil)
+        NavigationSettings.shared.initialize(with: settingsValues)
+
         let message = "error message"
         let callbackExpectation = expectation(description: "Error updating aternative routes should not be reported")
         callbackExpectation.isInverted = true
@@ -1533,13 +1533,6 @@ class RouteControllerTests: TestCase {
     }
     
     // MARK: Helpers
-
-    private func resetNavigationSettings() {
-        NavigationSettings.shared.initialize(directions: .shared,
-                                             tileStoreConfiguration: .default,
-                                             routingProviderSource: .hybrid,
-                                             alternativeRouteDetectionStrategy: .init())
-    }
 
     private func createRouteAlternative(id: UInt32) -> RouteAlternative {
         let intersectionStep = route.legs[0].steps[3]

--- a/Tests/MapboxCoreNavigationTests/TilesetDescriptorFactoryTests.swift
+++ b/Tests/MapboxCoreNavigationTests/TilesetDescriptorFactoryTests.swift
@@ -7,16 +7,12 @@ import MapboxDirections
 
 final class TilesetDescriptorFactoryTests: TestCase {
     
-    override func tearDown() {
-        NavigationSettings.shared.initialize(directions: .shared, tileStoreConfiguration: .default, routingProviderSource: .hybrid, alternativeRouteDetectionStrategy: .init())
-        super.tearDown()
-    }
-    
     func testLatestDescriptorsAreFromGlobalNavigatorCacheHandle() {
-        NavigationSettings.shared.initialize(directions: .mocked,
-                                             tileStoreConfiguration: .custom(FileManager.default.temporaryDirectory),
-                                             routingProviderSource: .offline,
-                                             alternativeRouteDetectionStrategy: .init())
+        let settingsValues = NavigationSettings.Values(directions: .mocked,
+                                                       tileStoreConfiguration: .custom(FileManager.default.temporaryDirectory),
+                                                       routingProviderSource: .offline,
+                                                       alternativeRouteDetectionStrategy: .init())
+        NavigationSettings.shared.initialize(with: settingsValues)
         _ = Navigator.shared
 
         let tilesetReceived = expectation(description: "Tileset received")


### PR DESCRIPTION
### Description
Fixes warnings about the use of deprecated `NavigationSettings.initialize(directions:tileStoreConfiguration:routingProviderSource:alternativeRouteDetectionStrategy:)` in the tests