### PR TITLE
Switching to correct online route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Predictive cache optimization for reducing memory and CPU consumption on very long and complex routes. ([#4283](https://github.com/mapbox/mapbox-navigation-ios/pull/4283))
 * Fixed reset of DR driving out of the tunnel for a brief moment. ([#4283](https://github.com/mapbox/mapbox-navigation-ios/pull/4283))
 * Fix the issue where continuous alternative routes are not vanishied correctly. ([#4283](https://github.com/mapbox/mapbox-navigation-ios/pull/4283))
-* Fixed an issue when sometimes switching to conincident online route could result in using a route with different geometry then original one. ([#4305](https://github.com/mapbox/mapbox-navigation-ios/pull/4305))
+* Fixed an issue where switching to a coincident online route sometimes resulted in using a route with different geometry than the original one. ([#4305](https://github.com/mapbox/mapbox-navigation-ios/pull/4305))
 
 ### Map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Predictive cache optimization for reducing memory and CPU consumption on very long and complex routes. ([#4283](https://github.com/mapbox/mapbox-navigation-ios/pull/4283))
 * Fixed reset of DR driving out of the tunnel for a brief moment. ([#4283](https://github.com/mapbox/mapbox-navigation-ios/pull/4283))
 * Fix the issue where continuous alternative routes are not vanishied correctly. ([#4283](https://github.com/mapbox/mapbox-navigation-ios/pull/4283))
+* Fixed an issue when sometimes switching to conincident online route could result in using a route with different geometry then original one. ([#4305](https://github.com/mapbox/mapbox-navigation-ios/pull/4305))
 
 ### Map
 

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -1091,7 +1091,7 @@ extension RouteController {
         }
         
         let indexedRouteResponse = IndexedRouteResponse(routeResponse: decoded.routeResponse,
-                                                        routeIndex: 0,
+                                                        routeIndex: Int(onlineRoute.getRouteIndex()),
                                                         responseOrigin: onlineRoute.getRouterOrigin())
         guard let newRoute = indexedRouteResponse.currentRoute else {
             return


### PR DESCRIPTION
### Description
Fixes an issue when while driving onboard route with route index !=0, switching to online route could result in using route with different geometry.

### Implementation
Issue is resolved by fixing usage of suggested route index from NN during the switch.