### PR TITLE
Add the route preview and cancel function in CarPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v2.11.0
 
+### CarPlay
+
+* Added `CarPlayManagerDelegate.carPlayManagerDidCancelPreview(_:)` to notify developers after CarPlay canceled routes preview, and `CarPlayManager.cancelRoutesPreview()` method to cancel routes preview on CarPlay. ([#4311](https://github.com/mapbox/mapbox-navigation-ios/pull/4311))
+* Added `CPRouteChoice.indexedRouteResponse` property to allow developers to get access to the `IndexedRouteResponse` of `CPRouteChoice` on CarPlay. ([#4311](https://github.com/mapbox/mapbox-navigation-ios/pull/4311))
+
 ### Other changes
 
 * Fixed an issue where an incorrect upcoming intersection index cause a crash. ([#4314](https://github.com/mapbox/mapbox-navigation-ios/pull/4314))

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -67,6 +67,23 @@ extension AppDelegate: CPApplicationDelegate {
 // MARK: - CarPlayManagerDelegate methods
 
 extension AppDelegate: CarPlayManagerDelegate {
+    func carPlayManager(_ carPlayManager: CarPlayManager, selectedPreviewFor trip: CPTrip, using routeChoice: CPRouteChoice) {
+        guard let indexedRouteResponse = routeChoice.indexedRouteResponse,
+              shouldPreviewRoutes(for: indexedRouteResponse) else { return }
+        currentAppRootViewController?.indexedRouteResponse = indexedRouteResponse
+    }
+    
+    private func shouldPreviewRoutes(for indexedRouteResponse: IndexedRouteResponse) -> Bool {
+        guard let rootResponse = currentAppRootViewController?.indexedRouteResponse else {
+            return true
+        }
+        return indexedRouteResponse.routeResponse.routes != rootResponse.routeResponse.routes ||
+        indexedRouteResponse.routeIndex != rootResponse.routeIndex
+    }
+    
+    func carPlayManagerCanceledRoutesPreview(_ carPlayManager: CarPlayManager) {
+        currentAppRootViewController?.indexedRouteResponse = nil
+    }
     
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         navigationServiceFor indexedRouteResponse: IndexedRouteResponse,
@@ -484,6 +501,8 @@ class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
         //       navigation as well, otherwise, CarPlay will be in passive navigation and stay out of sync with iOS app. 
         if appDelegate.currentAppRootViewController?.activeNavigationViewController != nil {
             appDelegate.currentAppRootViewController?.beginCarPlayNavigation()
+        } else if let indexedRouteResponse = appDelegate.currentAppRootViewController?.indexedRouteResponse {
+            appDelegate.carPlayManager.previewRoutes(for: indexedRouteResponse)
         }
     }
 

--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -81,7 +81,7 @@ extension AppDelegate: CarPlayManagerDelegate {
         indexedRouteResponse.routeIndex != rootResponse.routeIndex
     }
     
-    func carPlayManagerCanceledRoutesPreview(_ carPlayManager: CarPlayManager) {
+    func carPlayManagerDidCancelPreview(_ carPlayManager: CarPlayManager) {
         currentAppRootViewController?.indexedRouteResponse = nil
     }
     

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -79,9 +79,7 @@ class ViewController: UIViewController {
         startButton.isEnabled = true
         clearMap.isHidden = false
         
-        if let delegate = UIApplication.shared.delegate as? AppDelegate {
-            delegate.carPlayManager.previewRoutes(for: routeResponse)
-        }
+        updateCarPlayRoutesPreview()
     }
     
     var currentRoute: Route? {
@@ -232,7 +230,14 @@ class ViewController: UIViewController {
 
         waypoints.removeAll()
         navigationMapView?.navigationCamera.follow()
-        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+        updateCarPlayRoutesPreview()
+    }
+    
+    private func updateCarPlayRoutesPreview() {
+        guard let delegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        if let indexedRouteResponse = indexedRouteResponse {
+            delegate.carPlayManager.previewRoutes(for: indexedRouteResponse)
+        } else {
             delegate.carPlayManager.cancelRoutesPreview()
         }
     }
@@ -250,7 +255,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func clearMapPressed(_ sender: Any) {
-        clearNavigationMapView()
+        indexedRouteResponse = nil
     }
 
     @IBAction func startButtonPressed(_ sender: Any) {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -75,6 +75,13 @@ class ViewController: UIViewController {
         navigationMapView.showcase(routeResponse)
         navigationMapView.showWaypoints(on: prioritizedRoutes.first!)
         navigationMapView.showRouteDurations(along: prioritizedRoutes)
+        
+        startButton.isEnabled = true
+        clearMap.isHidden = false
+        
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            delegate.carPlayManager.previewRoutes(for: routeResponse)
+        }
     }
     
     var currentRoute: Route? {
@@ -93,8 +100,6 @@ class ViewController: UIViewController {
                 clearNavigationMapView()
                 return
             }
-            
-            startButton.isEnabled = true
             showCurrentRoute()
         }
     }
@@ -226,6 +231,10 @@ class ViewController: UIViewController {
         navigationMapView?.removeContinuousAlternativesRoutes()
 
         waypoints.removeAll()
+        navigationMapView?.navigationCamera.follow()
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            delegate.carPlayManager.cancelRoutesPreview()
+        }
     }
     
     func requestNotificationCenterAuthorization() {
@@ -598,7 +607,6 @@ class ViewController: UIViewController {
             self.waypoints = waypoints
         }
         
-        self.clearMap.isHidden = false
         self.longPressHintView.isHidden = true
     }
 

--- a/Sources/MapboxNavigation/CPMapTemplate.swift
+++ b/Sources/MapboxNavigation/CPMapTemplate.swift
@@ -31,3 +31,10 @@ extension CLLocationDirection {
     }
 }
 
+extension CPTemplate {
+    var currentActivity: CarPlayActivity? {
+        guard let userInfo = userInfo as? CarPlayUserInfo else { return nil }
+        return userInfo[CarPlayManager.currentActivityKey] as? CarPlayActivity
+    }
+}
+

--- a/Sources/MapboxNavigation/CPRouteChoice.swift
+++ b/Sources/MapboxNavigation/CPRouteChoice.swift
@@ -21,4 +21,8 @@ extension CPRouteChoice {
         
         return userInfo[IndexedRouteResponseUserInfo.key] as? IndexedRouteResponseUserInfo
     }
+    
+    public var indexedRouteResponse: IndexedRouteResponse? {
+        return indexedRouteResponseUserInfo?.indexedRouteResponse
+    }
 }

--- a/Sources/MapboxNavigation/CPTrip.swift
+++ b/Sources/MapboxNavigation/CPTrip.swift
@@ -14,7 +14,7 @@ extension CPTrip {
             waypoints = matchOptions.waypoints
         }
         
-        let routeChoices = indexedRouteResponse.routeResponse.routes?.enumerated().map { (routeIndex, route) -> CPRouteChoice in
+        var routeChoices = indexedRouteResponse.routeResponse.routes?.enumerated().map { (routeIndex, route) -> CPRouteChoice in
             let summaryVariants = [
                 DateComponentsFormatter.fullDateComponentsFormatter.string(from: route.expectedTravelTime)!,
                 DateComponentsFormatter.shortDateComponentsFormatter.string(from: route.expectedTravelTime)!,
@@ -32,6 +32,9 @@ extension CPTrip {
             routeChoice.userInfo = userInfo
             return routeChoice
         } ?? []
+        
+        // The selected route within the `IndexedRouteResponse` will default to be the first in route choice.
+        routeChoices.insert(routeChoices.remove(at: indexedRouteResponse.routeIndex), at: 0)
         
         guard let originCoordinate = waypoints.first?.coordinate,
               let destinationCoordinate = waypoints.last?.coordinate else {

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -622,7 +622,7 @@ extension CarPlayManager {
         self.indexedRouteResponse = nil
         mainMapTemplate?.hideTripPreviews()
         popToRootTemplate(interfaceController: interfaceController, animated: true)
-        delegate?.carPlayManagerCanceledRoutesPreview(self)
+        delegate?.carPlayManagerDidCancelPreview(self)
     }
     
     func shouldPreviewRoutes(for indexedRouteResponse: IndexedRouteResponse) -> Bool {
@@ -637,7 +637,6 @@ extension CarPlayManager {
               }
         
         let modifiedTrip = delegate?.carPlayManager(self, willPreview: trip) ?? trip
-        self.indexedRouteResponse = modifiedTrip.routeChoices.first?.indexedRouteResponse
         
         let previewMapTemplate = mapTemplateProvider.mapTemplate(forPreviewing: modifiedTrip,
                                                                  traitCollection: traitCollection,

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -113,6 +113,14 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlay
                         selectedPreviewFor trip: CPTrip,
                         using routeChoice: CPRouteChoice)
     
+    /**
+     Called when CarPlay canceled routes preview.
+     This delegate method will be called after canceled the routes preview.
+     
+     - parameter carPlayManager: The CarPlay manager instance.
+     */
+    func carPlayManagerCanceledRoutesPreview(_ carPlayManager: CarPlayManager)
+    
     // MARK: Monitoring Route Progress and Updates
     
     /**
@@ -516,6 +524,13 @@ public extension CarPlayManagerDelegate {
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         selectedPreviewFor trip: CPTrip,
                         using routeChoice: CPRouteChoice) {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManagerCanceledRoutesPreview(_ carPlayManager: CarPlayManager) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
     

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -119,7 +119,7 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlay
      
      - parameter carPlayManager: The CarPlay manager instance.
      */
-    func carPlayManagerCanceledRoutesPreview(_ carPlayManager: CarPlayManager)
+    func carPlayManagerDidCancelPreview(_ carPlayManager: CarPlayManager)
     
     // MARK: Monitoring Route Progress and Updates
     
@@ -530,7 +530,7 @@ public extension CarPlayManagerDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
      */
-    func carPlayManagerCanceledRoutesPreview(_ carPlayManager: CarPlayManager) {
+    func carPlayManagerDidCancelPreview(_ carPlayManager: CarPlayManager) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
     

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -354,7 +354,7 @@ open class CarPlayMapViewController: UIViewController {
         // Trigger update of view constraints to correctly position views like `SpeedLimitView`.
         view.setNeedsUpdateConstraints()
         
-        guard let activeRoute = navigationMapView.routes?.first else {
+        guard let routes = navigationMapView.routes, !routes.isEmpty else {
             navigationMapView.navigationCamera.follow()
             return
         }
@@ -364,7 +364,7 @@ open class CarPlayMapViewController: UIViewController {
             cameraOptions.pitch = 0
             navigationMapView.mapView.mapboxMap.setCamera(to: cameraOptions)
             
-            navigationMapView.fitCamera(to: [activeRoute])
+            navigationMapView.fitCamera(to: routes)
         }
     }
     


### PR DESCRIPTION
### Description
This Pr is to add the routes preview and cancel preview function in CarPlay, and also notify the delegate about the preview and cancel preview events.

### Implementation

- Add `CPRouteChoice.indexedRouteResponse` to extract the `IndexedRouteResponse` from CarPlay trip preview. When preview routes on CarPlay, the first route choice is the chosen route from the `IndexedRouteResponse`.
- Add `CarPlayManagerDelegate.carPlayManagerDidCancelPreview(_:)` to notify when CarPlay did cancel routes preview.
- Developers could call `CarPlayManager.cancelRoutesPreview()` and `CarPlayManager.previewRoutes(for:)` to cancel and to add route preview.
- Developers will be notified from `CarPlayManagerDelegate.carPlayManagerDidCancelPreview(_ :)` and `CarPlayManagerDelegate.carPlayManager(_:selectedPreviewFor:using:)` about the routes preview and cancel events in CarPlay.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->