### PR TITLE
Fix the continuous routes remain in routes preview

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -72,7 +72,7 @@ class ViewController: UIViewController {
         // Show congestion levels on alternative route lines if there're multiple routes in the response.
         navigationMapView.showsCongestionForAlternativeRoutes = true
         navigationMapView.showsRestrictedAreasOnRoute = true
-        navigationMapView.show(routeResponse)
+        navigationMapView.showcase(routeResponse)
         navigationMapView.showWaypoints(on: prioritizedRoutes.first!)
         navigationMapView.showRouteDurations(along: prioritizedRoutes)
     }
@@ -223,6 +223,7 @@ class ViewController: UIViewController {
         navigationMapView?.removeRoutes()
         navigationMapView?.removeRouteDurations()
         navigationMapView?.removeWaypoints()
+        navigationMapView?.removeContinuousAlternativesRoutes()
 
         waypoints.removeAll()
     }


### PR DESCRIPTION
### Description
This Pr is to remove the continuous alternative routes remain on `NavigationMapView` after clear the routes in the `Example` App.

### Implementation
#4294 introduced the `NavigationMapView.showcase(_:routesPresentationStyle:legIndex:animated:duration:completion:)` and `NavigationMapView.show(_:layerPosition:legIndex:)`. Right now the alternative routes in route preview within the `IndexedRouteResponse` will be presented as continuous alternative routes. 

So to clear the route preview with `IndexedRouteResponse`, except to remove routes, which used to remove the alternative routes, it should also remove the continuous alternative routes specifically.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->