### PR TITLE
Update Maps to v10.10.1 to fix CarPlay map view not loading issue in active navigation session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Packaging
 
 * MapboxCoreNavigation now requires [MapboxNavigationNative v123._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/123.1.0). ([#4298](https://github.com/mapbox/mapbox-navigation-ios/pull/4298))
-* MapboxNavigation now requires [MapboxMaps v10.10.0](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.10.0). ([#4298](https://github.com/mapbox/mapbox-navigation-ios/pull/4298))
+* MapboxNavigation now requires [MapboxMaps v10.10._x_](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.10.1). ([#4315](https://github.com/mapbox/mapbox-navigation-ios/pull/4315))
 * MapboxCoreNavigation now requires [MapboxDirections v2.9.0-rc.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.9.0-rc.1). ([#4300](https://github.com/mapbox/mapbox-navigation-ios/pull/4300))
 * Cocoapods podspec for MapboxCoreNavigation now references resources that will be copied into the application. ([#4280](https://github.com/mapbox/mapbox-navigation-ios/pull/4280))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Added `CarPlayManagerDelegate.carPlayManager(_:willAdd:for:)`, `NavigationMapViewDelegate.navigationMapView(_:willAdd:)` and `NavigationViewControllerDelegate.navigationViewController(_:willAdd:)` to modify the properties of the default layer which will be added to the map view during navigation. ([#4277](https://github.com/mapbox/mapbox-navigation-ios/pull/4277))
 * Fixed issue where the traversed route layer doesn't share the same width with the main route casing layer after developers providing their own layer or midfying the layer properties. ([#4277](https://github.com/mapbox/mapbox-navigation-ios/pull/4277))
 * Added `NavigationMapView.showcase(_:routesPresentationStyle:legIndex:animated:duration:completion:)` and `NavigationMapView.show(_:layerPosition:legIndex:)` methods to draw `IndexedRouteResponse` data and populate view's `routes` and `continuousAlternatives` properties accordingly. ([#4294](https://github.com/mapbox/mapbox-navigation-ios/pull/4294))
+* Fixed an issue where map wouldn't be loaded in active navigation session on CarPlay. ([#4315](https://github.com/mapbox/mapbox-navigation-ios/pull/4315))
 
 ### Location tracking
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" ~> 23.2.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 123.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 123.1.0
 github "mapbox/mapbox-directions-swift" == 2.9.0-rc.1
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 123.0"
+  s.dependency "MapboxNavigationNative", "~> 123.1.0"
   s.dependency "MapboxDirections-pre", "2.9.0-rc.1"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "7ba6d499e565d65da9ad54b6f4348eecdbb505da",
-          "version": "10.10.0"
+          "revision": "862ca6e0e57a2e13dd057332ee50f936a6b24fbf",
+          "version": "10.10.1"
         }
       },
       {

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", "~> 10.10"
+  s.dependency "MapboxMaps", "~> 10.10.1"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech", "~> 2.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .exact("2.9.0-rc.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
         .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "123.1.0"),
-        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.10.0"),
+        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.10.1"),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),
         .package(name: "CwlPreconditionTesting", url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - MapboxCoreNavigation (2.10.0-rc.1):
     - MapboxDirections-pre (= 2.9.0-rc.1)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (~> 123.0)
+    - MapboxNavigationNative (~> 123.1.0)
   - MapboxDirections-pre (2.9.0-rc.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.6.1)
@@ -54,7 +54,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 235bb9c27a8985d982e17f216795b1f7ab526782
   MapboxCoreMaps: 4075a9e415b9b3ab6229d09623fef5f791826a5b
-  MapboxCoreNavigation: e6e11d099b8886a0a245093c68eb228c419e3540
+  MapboxCoreNavigation: b5b7c244bbaacd477ad17fd068934faf339db0a4
   MapboxDirections-pre: 5534e43036da7b643014e5ebf316052eede7fd6a
   MapboxMaps: 0c2f7722016bc56aa27b5e6bcf72ae4df7a98670
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - MapboxDirections-pre (2.9.0-rc.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.6.1)
-  - MapboxMaps (10.10.0):
+  - MapboxMaps (10.10.1):
     - MapboxCommon (= 23.2.1)
     - MapboxCoreMaps (= 10.10.0)
     - MapboxMobileEvents (= 1.0.10)
@@ -17,7 +17,7 @@ PODS:
   - MapboxMobileEvents (1.0.10)
   - MapboxNavigation (2.10.0-rc.1):
     - MapboxCoreNavigation (= 2.10.0-rc.1)
-    - MapboxMaps (~> 10.10)
+    - MapboxMaps (~> 10.10.1)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
@@ -56,9 +56,9 @@ SPEC CHECKSUMS:
   MapboxCoreMaps: 4075a9e415b9b3ab6229d09623fef5f791826a5b
   MapboxCoreNavigation: e6e11d099b8886a0a245093c68eb228c419e3540
   MapboxDirections-pre: 5534e43036da7b643014e5ebf316052eede7fd6a
-  MapboxMaps: a5ad1977764731f97ba04bb7815b6b367e56039c
+  MapboxMaps: 0c2f7722016bc56aa27b5e6bcf72ae4df7a98670
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
-  MapboxNavigation: 06fa25887a2e1f375cd4b945681ef33afc156af6
+  MapboxNavigation: 2ce00edfb0c6cb25d9b869a265602b1ee7432fd1
   MapboxNavigationNative: 1c9b92539fd74400a8efd68cf0ff0e1580c1fea1
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77
   Polyline: 2a1f29f87f8d9b7de868940f4f76deb8c678a5b1


### PR DESCRIPTION
### Description
This Pr is to update MapboxMaps to [v10.10.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.10.1) to fix the CarPlay specific issue in active navigation session that the `NavigationMapView` is not loaded. And also to align the `NavNative` minimum version from `v123.1.0` in different dependency managers.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->