### PR TITLE
Dependency update for patch release from NavNative and MapboxMaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Packaging
 
 * MapboxCoreNavigation now requires [MapboxNavigationNative v123._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/123.1.0). ([#4298](https://github.com/mapbox/mapbox-navigation-ios/pull/4298))
-* MapboxNavigation now requires [MapboxMaps v10.10.0](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.10.0). ([#4298](https://github.com/mapbox/mapbox-navigation-ios/pull/4298))
+* MapboxNavigation now requires [MapboxMaps v10.10._x_](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.10.1). ([#4315](https://github.com/mapbox/mapbox-navigation-ios/pull/4315))
 * MapboxCoreNavigation now requires [MapboxDirections v2.9.0-rc.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.9.0-rc.1). ([#4300](https://github.com/mapbox/mapbox-navigation-ios/pull/4300))
 * Cocoapods podspec for MapboxCoreNavigation now references resources that will be copied into the application. ([#4280](https://github.com/mapbox/mapbox-navigation-ios/pull/4280))
 
@@ -34,6 +34,7 @@
 * Added `CarPlayManagerDelegate.carPlayManager(_:willAdd:for:)`, `NavigationMapViewDelegate.navigationMapView(_:willAdd:)` and `NavigationViewControllerDelegate.navigationViewController(_:willAdd:)` to modify the properties of the default layer which will be added to the map view during navigation. ([#4277](https://github.com/mapbox/mapbox-navigation-ios/pull/4277))
 * Fixed issue where the traversed route layer doesn't share the same width with the main route casing layer after developers providing their own layer or midfying the layer properties. ([#4277](https://github.com/mapbox/mapbox-navigation-ios/pull/4277))
 * Added `NavigationMapView.showcase(_:routesPresentationStyle:legIndex:animated:duration:completion:)` and `NavigationMapView.show(_:layerPosition:legIndex:)` methods to draw `IndexedRouteResponse` data and populate view's `routes` and `continuousAlternatives` properties accordingly. ([#4294](https://github.com/mapbox/mapbox-navigation-ios/pull/4294))
+* Fixed an issue where map wouldn't be loaded in active navigation session on CarPlay. ([#4315](https://github.com/mapbox/mapbox-navigation-ios/pull/4315))
 
 ### Location tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Packaging
 
-* MapboxCoreNavigation now requires [MapboxNavigationNative v123._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/123.0.0). ([#4298](https://github.com/mapbox/mapbox-navigation-ios/pull/4298))
+* MapboxCoreNavigation now requires [MapboxNavigationNative v123._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/123.1.0). ([#4298](https://github.com/mapbox/mapbox-navigation-ios/pull/4298))
 * MapboxNavigation now requires [MapboxMaps v10.10.0](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.10.0). ([#4298](https://github.com/mapbox/mapbox-navigation-ios/pull/4298))
 * MapboxCoreNavigation now requires [MapboxDirections v2.9.0-rc.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.9.0-rc.1). ([#4300](https://github.com/mapbox/mapbox-navigation-ios/pull/4300))
 * Cocoapods podspec for MapboxCoreNavigation now references resources that will be copied into the application. ([#4280](https://github.com/mapbox/mapbox-navigation-ios/pull/4280))

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" ~> 23.2.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 123.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 123.1.0
 github "mapbox/mapbox-directions-swift" == 2.9.0-rc.1
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.2.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "123.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "123.1.0"
 github "mapbox/mapbox-directions-swift" "v2.9.0-rc.1"
 github "mapbox/mapbox-events-ios" "v1.0.10"
 github "mapbox/turf-swift" "v2.6.1"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 123.1.0"
+  s.dependency "MapboxNavigationNative", "~> 123.1"
   s.dependency "MapboxDirections-pre", "2.9.0-rc.1"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 123.0"
+  s.dependency "MapboxNavigationNative", "~> 123.1.0"
   s.dependency "MapboxDirections-pre", "2.9.0-rc.1"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "7ba6d499e565d65da9ad54b6f4348eecdbb505da",
-          "version": "10.10.0"
+          "revision": "862ca6e0e57a2e13dd057332ee50f936a6b24fbf",
+          "version": "10.10.1"
         }
       },
       {

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "c6573ffca8861a9912f9718a21f7fc7c690c315c",
-          "version": "123.0.0"
+          "revision": "25539af7104ec49ab924ccb566e614fb983ead97",
+          "version": "123.1.0"
         }
       },
       {

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", "~> 10.10.1"
+  s.dependency "MapboxMaps", "~> 10.10"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech", "~> 2.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", "~> 10.10"
+  s.dependency "MapboxMaps", "~> 10.10.1"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech", "~> 2.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "c6573ffca8861a9912f9718a21f7fc7c690c315c",
-          "version": "123.0.0"
+          "revision": "25539af7104ec49ab924ccb566e614fb983ead97",
+          "version": "123.1.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-speech-swift.git",
         "state": {
           "branch": null,
-          "revision": "285622fa9734d4b28c9eca10fa59a47699ca39fd",
-          "version": "2.1.0"
+          "revision": "a9ef284deae227c6111c27a3535098c1e9a9d8e3",
+          "version": "2.1.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .exact("2.9.0-rc.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
         .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "123.1.0"),
-        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.10.0"),
+        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.10.1"),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),
         .package(name: "CwlPreconditionTesting", url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     dependencies: [
         .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .exact("2.9.0-rc.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "123.0.0"),
+        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "123.1.0"),
         .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.10.0"),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - MapboxCoreNavigation (2.10.0-beta.2):
     - MapboxDirections-pre (= 2.9.0-rc.1)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (~> 123.0)
+    - MapboxNavigationNative (~> 123.1.0)
   - MapboxDirections-pre (2.9.0-rc.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.6.1)
-  - MapboxMaps (10.10.0):
+  - MapboxMaps (10.10.1):
     - MapboxCommon (= 23.2.1)
     - MapboxCoreMaps (= 10.10.0)
     - MapboxMobileEvents (= 1.0.10)
@@ -17,11 +17,11 @@ PODS:
   - MapboxMobileEvents (1.0.10)
   - MapboxNavigation (2.10.0-beta.2):
     - MapboxCoreNavigation (= 2.10.0-beta.2)
-    - MapboxMaps (~> 10.10)
+    - MapboxMaps (~> 10.10.1)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (123.0.0):
+  - MapboxNavigationNative (123.1.0):
     - MapboxCommon (~> 23.2)
   - MapboxSpeech (2.1.1)
   - Polyline (5.1.0)
@@ -54,12 +54,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 235bb9c27a8985d982e17f216795b1f7ab526782
   MapboxCoreMaps: 4075a9e415b9b3ab6229d09623fef5f791826a5b
-  MapboxCoreNavigation: 8af41a517fc604fe1134d8182f4fea154f721d3a
+  MapboxCoreNavigation: daacf32d105dde0596b7a9d9e4028ec3414d6756
   MapboxDirections-pre: 5534e43036da7b643014e5ebf316052eede7fd6a
-  MapboxMaps: a5ad1977764731f97ba04bb7815b6b367e56039c
+  MapboxMaps: 0c2f7722016bc56aa27b5e6bcf72ae4df7a98670
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
-  MapboxNavigation: 003575a8eb637a365d249299bd2faed3fb580f75
-  MapboxNavigationNative: dcb368ffbd99dd49aa2a1d413d5db1a24d93867c
+  MapboxNavigation: ca914b28edc4f7fa16cc5923a2105349bcca4eda
+  MapboxNavigationNative: 1c9b92539fd74400a8efd68cf0ff0e1580c1fea1
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77
   Polyline: 2a1f29f87f8d9b7de868940f4f76deb8c678a5b1
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
   - MapboxMobileEvents (1.0.10)
   - MapboxNavigation (2.10.0-beta.2):
     - MapboxCoreNavigation (= 2.10.0-beta.2)
-    - MapboxMaps (~> 10.10.1)
+    - MapboxMaps (~> 10.10)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
@@ -58,7 +58,7 @@ SPEC CHECKSUMS:
   MapboxDirections-pre: 5534e43036da7b643014e5ebf316052eede7fd6a
   MapboxMaps: 0c2f7722016bc56aa27b5e6bcf72ae4df7a98670
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
-  MapboxNavigation: ca914b28edc4f7fa16cc5923a2105349bcca4eda
+  MapboxNavigation: 003575a8eb637a365d249299bd2faed3fb580f75
   MapboxNavigationNative: 1c9b92539fd74400a8efd68cf0ff0e1580c1fea1
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77
   Polyline: 2a1f29f87f8d9b7de868940f4f76deb8c678a5b1

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - MapboxCoreNavigation (2.10.0-beta.2):
     - MapboxDirections-pre (= 2.9.0-rc.1)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (~> 123.1.0)
+    - MapboxNavigationNative (~> 123.1)
   - MapboxDirections-pre (2.9.0-rc.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.6.1)
@@ -54,7 +54,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 235bb9c27a8985d982e17f216795b1f7ab526782
   MapboxCoreMaps: 4075a9e415b9b3ab6229d09623fef5f791826a5b
-  MapboxCoreNavigation: daacf32d105dde0596b7a9d9e4028ec3414d6756
+  MapboxCoreNavigation: 2daaea20c3be285a5caefe4c112a0fd0e8fbab53
   MapboxDirections-pre: 5534e43036da7b643014e5ebf316052eede7fd6a
   MapboxMaps: 0c2f7722016bc56aa27b5e6bcf72ae4df7a98670
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6


### PR DESCRIPTION
### Description
This Pr is to cheery pick the dependency update PRs #4310 and #4315 to adopt the patch release of `NavNative v123.1.0` and `MapboxMaps v10.10.1 ` to the `main` branch.

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->