### PR TITLE
Remove unneeded if available iOS 12

### DIFF
--- a/Example/AppDelegate+CarPlay.swift
+++ b/Example/AppDelegate+CarPlay.swift
@@ -35,7 +35,6 @@ extension NavigationGeocodedPlacemark {
  - Download and select the provisioning profile for the "Example-CarPlay" example app
  - Be sure to select an iOS simulator or device running iOS 12 or greater
  */
-@available(iOS 12.0, *)
 extension AppDelegate: CPApplicationDelegate {
     
     func application(_ application: UIApplication,
@@ -67,7 +66,6 @@ extension AppDelegate: CPApplicationDelegate {
 
 // MARK: - CarPlayManagerDelegate methods
 
-@available(iOS 12.0, *)
 extension AppDelegate: CarPlayManagerDelegate {
     
     func carPlayManager(_ carPlayManager: CarPlayManager,
@@ -264,7 +262,6 @@ extension AppDelegate: CarPlayManagerDelegate {
 
 // MARK: - CarPlaySearchControllerDelegate methods
 
-@available(iOS 12.0, *)
 extension AppDelegate: CarPlaySearchControllerDelegate {
     
     struct MaximumSearchResults {
@@ -452,7 +449,6 @@ extension GeocodedPlacemark {
 
 // MARK: - CPListTemplateDelegate methods
 
-@available(iOS 12.0, *)
 extension AppDelegate: CPListTemplateDelegate {
     
     func listTemplate(_ listTemplate: CPListTemplate,

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -11,7 +11,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     var _carPlayManager: Any? = nil
-    @available(iOS 12.0, *)
     var carPlayManager: CarPlayManager {
         if _carPlayManager == nil {
             _carPlayManager = CarPlayManager(customRoutingProvider: MapboxRoutingProvider(.hybrid))
@@ -21,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     var _carPlaySearchController: Any? = nil
-    @available(iOS 12.0, *)
     var carPlaySearchController: CarPlaySearchController {
         if _carPlaySearchController == nil {
             _carPlaySearchController = CarPlaySearchController()
@@ -39,7 +37,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }()
     
     var _recentSearchItems: [Any]? = nil
-    @available(iOS 12.0, *)
     var recentSearchItems: [CPListItem]? {
         get {
             _recentSearchItems as! [CPListItem]?

--- a/Example/FavoritesList.swift
+++ b/Example/FavoritesList.swift
@@ -46,7 +46,6 @@ public enum FavoritesList {
             }
         }
         
-        @available(iOS 12.0, *)
         func listItem() -> CPListItem {
             return CPListItem(text: rawValue, detailText: subTitle, image: nil, showsDisclosureIndicator: true)
         }

--- a/Sources/MapboxNavigation/CPInterfaceController.swift
+++ b/Sources/MapboxNavigation/CPInterfaceController.swift
@@ -1,6 +1,5 @@
 import CarPlay
 
-@available(iOS 12.0, *)
 public extension CPInterfaceController {
     
     /**

--- a/Sources/MapboxNavigation/CPMapTemplate.swift
+++ b/Sources/MapboxNavigation/CPMapTemplate.swift
@@ -2,7 +2,6 @@ import Foundation
 import MapboxDirections
 import CarPlay
 
-@available(iOS 12.0, *)
 extension CLLocationDirection {
     init?(panDirection: CPMapTemplate.PanDirection) {
         var horizontalBias: Double? = nil

--- a/Sources/MapboxNavigation/CPRouteChoice.swift
+++ b/Sources/MapboxNavigation/CPRouteChoice.swift
@@ -2,7 +2,6 @@ import CarPlay
 import MapboxDirections
 import MapboxCoreNavigation
 
-@available(iOS 12.0, *)
 extension CPRouteChoice {
     
     struct IndexedRouteResponseUserInfo {

--- a/Sources/MapboxNavigation/CPTrip.swift
+++ b/Sources/MapboxNavigation/CPTrip.swift
@@ -2,7 +2,6 @@ import MapboxDirections
 import MapboxCoreNavigation
 import CarPlay
 
-@available(iOS 12.0, *)
 extension CPTrip {
     
     convenience init(indexedRouteResponse: IndexedRouteResponse) {

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -10,7 +10,6 @@ import MapboxMaps
  
  - note: It is very important you have a single `CarPlayManager` instance at any given time. This should be managed by your `UIApplicationDelegate` class if you choose to supply your `accessToken` to the `CarPlayManager.eventsManager` via `NavigationEventsManager` initializer, instead of the Info.plist.
  */
-@available(iOS 12.0, *)
 public class CarPlayManager: NSObject {
     
     // MARK: CarPlay Infrastructure
@@ -360,7 +359,6 @@ public class CarPlayManager: NSObject {
 
 // MARK: CPApplicationDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayManager: CPApplicationDelegate {
     
     public func application(_ application: UIApplication,
@@ -485,7 +483,6 @@ extension CarPlayManager: CPApplicationDelegate {
 
 // MARK: CPInterfaceControllerDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayManager: CPInterfaceControllerDelegate {
     
     public func templateWillAppear(_ template: CPTemplate, animated: Bool) {
@@ -533,7 +530,6 @@ extension CarPlayManager: CPInterfaceControllerDelegate {
     }
 }
 
-@available(iOS 12.0, *)
 extension CarPlayManager {
     
     // MARK: Route Preview
@@ -698,7 +694,6 @@ extension CarPlayManager {
 
 // MARK: CPMapTemplateDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayManager: CPMapTemplateDelegate {
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate,
@@ -1067,7 +1062,6 @@ extension CarPlayManager: CPMapTemplateDelegate {
 
 // MARK: CarPlayNavigationViewControllerDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
     
     public func carPlayNavigationViewControllerWillDismiss(_ carPlayNavigationViewController: CarPlayNavigationViewController,
@@ -1154,7 +1148,6 @@ extension CarPlayManager: CarPlayNavigationViewControllerDelegate {
 
 // MARK: CarPlayMapViewControllerDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayManager: CarPlayMapViewControllerDelegate {
     
     public func carPlayMapViewController(_ carPlayMapViewController: CarPlayMapViewController,
@@ -1203,7 +1196,6 @@ extension CarPlayManager: CarPlayMapViewControllerDelegate {
 
 // MARK: MapTemplateProviderDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayManager: MapTemplateProviderDelegate {
     
     func mapTemplateProvider(_ provider: MapTemplateProvider,
@@ -1281,7 +1273,6 @@ extension CarPlayManager {
 
 // MARK: CarPlayManager Constants
 
-@available(iOS 12.0, *)
 extension CarPlayManager {
     
     static let currentActivityKey = "com.mapbox.navigation.currentActivity"

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -11,7 +11,6 @@ import MapboxMaps
  
  If no delegate is set, a default built-in `MapboxNavigationService` will be created and used when a trip begins.
  */
-@available(iOS 12.0, *)
 public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlayManagerDelegateDeprecations {
     
     // MARK: Customizing the Bar Buttons
@@ -427,7 +426,6 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlay
                         in mapTemplate: CPMapTemplate) -> Bool
 }
 
-@available(iOS 12.0, *)
 public extension CarPlayManagerDelegate {
     /**
      `UnimplementedLogging` prints a warning to standard output the first time this method is called.
@@ -700,7 +698,6 @@ public extension CarPlayManagerDelegate {
  
  This protocol redeclares the deprecated methods of the `CarPlayManagerDelegate` protocol for the purpose of calling implementations of these methods that have not been upgraded yet.
  */
-@available(iOS 12.0, *)
 public protocol CarPlayManagerDelegateDeprecations {
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         navigationServiceFor routeResponse: RouteResponse,

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -2,8 +2,6 @@ import Foundation
 @_spi(Restricted) import MapboxMaps
 import MapboxCoreNavigation
 import MapboxDirections
-
-#if canImport(CarPlay)
 import CarPlay
 
 /**
@@ -465,4 +463,3 @@ extension CarPlayMapViewController: CPSessionConfigurationDelegate {
         applyStyleIfNeeded(contentStyle)
     }
 }
-#endif

--- a/Sources/MapboxNavigation/CarPlayMapViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewController.swift
@@ -9,7 +9,6 @@ import CarPlay
 /**
  `CarPlayMapViewController` is responsible for administering the Mapbox map, the interface styles and the map template buttons to display on CarPlay.
  */
-@available(iOS 12.0, *)
 open class CarPlayMapViewController: UIViewController {
     
     // MARK: UI Elements Configuration
@@ -386,7 +385,6 @@ open class CarPlayMapViewController: UIViewController {
 
 // MARK: StyleManagerDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayMapViewController: StyleManagerDelegate {
     
     public func location(for styleManager: StyleManager) -> CLLocation? {
@@ -420,7 +418,6 @@ extension CarPlayMapViewController: StyleManagerDelegate {
 
 // MARK: NavigationMapViewDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayMapViewController: NavigationMapViewDelegate {
     
     public func navigationMapView(_ navigationMapView: NavigationMapView,
@@ -460,7 +457,6 @@ extension CarPlayMapViewController: NavigationMapViewDelegate {
     }
 }
 
-@available(iOS 12.0, *)
 extension CarPlayMapViewController: CPSessionConfigurationDelegate {
     
     @available(iOS 13.0, *)

--- a/Sources/MapboxNavigation/CarPlayMapViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayMapViewControllerDelegate.swift
@@ -4,7 +4,6 @@ import MapboxCoreNavigation
 /**
  The `CarPlayMapViewControllerDelegate` protocol provides methods for reacting to events during free-drive navigation or route previewing in `CarPlayMapViewController`.
  */
-@available(iOS 12.0, *)
 public protocol CarPlayMapViewControllerDelegate: AnyObject, UnimplementedLogging {
     
     /**
@@ -71,7 +70,6 @@ public protocol CarPlayMapViewControllerDelegate: AnyObject, UnimplementedLoggin
                                   willAdd layer: Layer) -> Layer?
 }
 
-@available(iOS 12.0, *)
 public extension CarPlayMapViewControllerDelegate {
     
     /**

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -13,7 +13,6 @@ let CarPlayAlternativeIDKey: String = "MBCarPlayAlternativeID"
  
  - seealso: `NavigationViewController`
  */
-@available(iOS 12.0, *)
 open class CarPlayNavigationViewController: UIViewController, BuildingHighlighting {
     
     // MARK: Child Views and Styling Configuration
@@ -1048,7 +1047,6 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
 
 // MARK: StyleManagerDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayNavigationViewController: StyleManagerDelegate {
     
     public func location(for styleManager: StyleManager) -> CLLocation? {
@@ -1093,7 +1091,6 @@ extension CarPlayNavigationViewController: StyleManagerDelegate {
 
 // MARK: NavigationServiceDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayNavigationViewController: NavigationServiceDelegate {
     
     public func navigationService(_ service: NavigationService, didArriveAt waypoint: Waypoint) -> Bool {
@@ -1110,7 +1107,6 @@ extension CarPlayNavigationViewController: NavigationServiceDelegate {
 
 // MARK: NavigationMapViewDelegate Methods
 
-@available(iOS 12.0, *)
 extension CarPlayNavigationViewController: NavigationMapViewDelegate {
     
     public func navigationMapView(_ navigationMapView: NavigationMapView,
@@ -1150,7 +1146,6 @@ extension CarPlayNavigationViewController: NavigationMapViewDelegate {
     }
 }
 
-@available(iOS 12.0, *)
 extension CarPlayNavigationViewController: CPSessionConfigurationDelegate {
     
     @available(iOS 13.0, *)
@@ -1160,7 +1155,6 @@ extension CarPlayNavigationViewController: CPSessionConfigurationDelegate {
     }
 }
 
-@available(iOS 12.0, *)
 extension CarPlayNavigationViewController: CPListTemplateDelegate {
     
     public func listTemplate(_ listTemplate: CPListTemplate,

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -2,8 +2,6 @@ import Foundation
 import MapboxDirections
 import MapboxCoreNavigation
 @_spi(Restricted) import MapboxMaps
-
-#if canImport(CarPlay)
 import CarPlay
 
 let CarPlayAlternativeIDKey: String = "MBCarPlayAlternativeID"
@@ -1176,5 +1174,3 @@ extension CarPlayNavigationViewController: CPListTemplateDelegate {
         })
     }
 }
-
-#endif

--- a/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewControllerDelegate.swift
@@ -5,7 +5,6 @@ import MapboxMaps
 /**
  The `CarPlayNavigationViewControllerDelegate` protocol provides methods for reacting to significant events during turn-by-turn navigation with `CarPlayNavigationViewController`.
  */
-@available(iOS 12.0, *)
 public protocol CarPlayNavigationViewControllerDelegate: AnyObject, UnimplementedLogging {
     
     /**
@@ -100,7 +99,6 @@ public protocol CarPlayNavigationViewControllerDelegate: AnyObject, Unimplemente
                                          willAdd layer: Layer) -> Layer?
 }
 
-@available(iOS 12.0, *)
 public extension CarPlayNavigationViewControllerDelegate {
     
     /**

--- a/Sources/MapboxNavigation/CarPlaySearchController+CPSearchTemplateDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlaySearchController+CPSearchTemplateDelegate.swift
@@ -2,7 +2,6 @@ import Foundation
 import CarPlay
 import MapboxDirections
 
-@available(iOS 12.0, *)
 extension CarPlaySearchController: CPSearchTemplateDelegate {
     
     public static let CarPlayGeocodedPlacemarkKey: String = "NavigationGeocodedPlacemark"
@@ -61,7 +60,6 @@ extension CarPlaySearchController: CPSearchTemplateDelegate {
     }
 }
 
-@available(iOS 12.0, *)
 extension CarPlaySearchController: CPListTemplateDelegate {
     
     // MARK: CPListTemplateDelegate Implementation

--- a/Sources/MapboxNavigation/CarPlaySearchController.swift
+++ b/Sources/MapboxNavigation/CarPlaySearchController.swift
@@ -7,7 +7,6 @@ import Foundation
  
  - note: It is very important you have a single `CarPlaySearchController` instance at any given time. 
  */
-@available(iOS 12.0, *)
 public class CarPlaySearchController: NSObject {
     
     /**

--- a/Sources/MapboxNavigation/CarPlaySearchControllerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlaySearchControllerDelegate.swift
@@ -4,7 +4,6 @@ import MapboxDirections
 /**
  Delegate, which is used to control behavior based on certain actions from the user when performing search on CarPlay.
  */
-@available(iOS 12.0, *)
 public protocol CarPlaySearchControllerDelegate: CPSearchTemplateDelegate {
     
     // MARK: Previewing the Route

--- a/Sources/MapboxNavigation/CongestionLevel+CarPlay.swift
+++ b/Sources/MapboxNavigation/CongestionLevel+CarPlay.swift
@@ -6,7 +6,6 @@ extension CongestionLevel {
     /**
      Converts a CongestionLevel to a CPTimeRemainingColor.
      */
-    @available(iOS 12.0, *)
     public var asCPTimeRemainingColor: CPTimeRemainingColor {
         switch self {
         case .unknown:

--- a/Sources/MapboxNavigation/DayStyle.swift
+++ b/Sources/MapboxNavigation/DayStyle.swift
@@ -447,7 +447,6 @@ open class DayStyle: Style {
      Applies default styling for lane views, exit views and shields on CarPlay versions that support
      light and dark appearance changes.
      */
-    @available(iOS 12.0, *)
     func applyCarPlayManeuversStyling(for traitCollection: UITraitCollection) {
         // On CarPlay, `ExitView` and `GenericRouteShield` styling depends on `UIUserInterfaceStyle`,
         // which was set on CarPlay external screen.

--- a/Sources/MapboxNavigation/MapTemplateProvider.swift
+++ b/Sources/MapboxNavigation/MapTemplateProvider.swift
@@ -1,6 +1,5 @@
 import CarPlay
 
-@available(iOS 12.0, *)
 class MapTemplateProvider: NSObject {
     
     weak var delegate: MapTemplateProviderDelegate?

--- a/Sources/MapboxNavigation/MapTemplateProviderDelegate.swift
+++ b/Sources/MapboxNavigation/MapTemplateProviderDelegate.swift
@@ -1,6 +1,5 @@
 import CarPlay
 
-@available(iOS 12.0, *)
 protocol MapTemplateProviderDelegate: AnyObject {
     
     func mapTemplateProvider(_ provider: MapTemplateProvider,

--- a/Sources/MapboxNavigation/NavigationGeocodedPlacemark.swift
+++ b/Sources/MapboxNavigation/NavigationGeocodedPlacemark.swift
@@ -86,7 +86,6 @@ public struct NavigationGeocodedPlacemark: Equatable, Codable {
      
      - returns: A `CPListItem` instance.
      */
-    @available(iOS 12.0, *)
     public func listItem() -> CPListItem {
         let item = CPListItem(text: title,
                               detailText: subtitle,

--- a/Sources/MapboxNavigation/VisualInstruction.swift
+++ b/Sources/MapboxNavigation/VisualInstruction.swift
@@ -93,7 +93,6 @@ extension VisualInstruction {
      
      - returns: An image set with light and dark versions of an image.
      */
-    @available(iOS 12.0, *)
     public func maneuverImageSet(side: DrivingSide) -> CPImageSet? {
         let colors: [UIColor] = [.black, .white]
         let maneuverIcons: [UIImage] = colors.compactMap { (color) in
@@ -163,7 +162,6 @@ extension VisualInstruction {
      
      - returns: An `NSAttributedString` with maneuver instructions.
      */
-    @available(iOS 12.0, *)
     public func carPlayManeuverLabelAttributedText<T: InstructionLabel>(bounds: @escaping () -> (CGRect),
                                                                         shieldHeight: CGFloat,
                                                                         window: UIWindow?,
@@ -195,7 +193,6 @@ extension VisualInstruction {
      
      - returns: Light and dark representations of an image that contains maneuver lane configuration.
      */
-    @available(iOS 12.0, *)
     public func lanesImageSet(side: DrivingSide,
                               direction: ManeuverDirection?,
                               scale: CGFloat) -> CPImageSet? {


### PR DESCRIPTION
### Description
The current minimum deployment target for the project is iOS 12.0.

`@available(iOS 12.0, *)` and similar can be removed from the project