### PR TITLE
Distribute versions with repeats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,9 +694,7 @@ jobs:
       - install-mbx-ci
       - run:
           name: Update version
-          command: |
-            pod repo update && pod trunk push MapboxCoreNavigation.podspec
-            pod repo update && pod trunk push MapboxNavigation.podspec
+          command: python3 scripts/distribute-version.py
       - *save-cache-podmaster
       - *save-cache-gems
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,6 +694,7 @@ jobs:
       - install-mbx-ci
       - run:
           name: Update version
+          no_output_timeout: 20m
           command: python3 scripts/distribute-version.py
       - *save-cache-podmaster
       - *save-cache-gems

--- a/scripts/distribute-version.py
+++ b/scripts/distribute-version.py
@@ -2,13 +2,15 @@ import subprocess
 import time
 
 
-def push_pod(name):
-    while True:
+def push_pod(name, max_attempts):
+    for attempt in range(0, max_attempts):
         status = subprocess.run('pod repo update && pod trunk push ' + name + '.podspec', shell=True)
         if status.returncode == 0:
-            break
-        time.sleep(10)
+            return
+        time.sleep(60 * pow(2, attempt))
+    raise Exception('Maximum number of attempts have been made for ' + name)
 
 
-push_pod('MapboxCoreNavigation')
-push_pod('MapboxNavigation')
+push_pod('MapboxCoreNavigation', 5)
+time.sleep(60)
+push_pod('MapboxNavigation', 5)

--- a/scripts/distribute-version.py
+++ b/scripts/distribute-version.py
@@ -1,0 +1,14 @@
+import subprocess
+import time
+
+
+def push_pod(name):
+    while True:
+        status = subprocess.run('pod repo update && pod trunk push ' + name + '.podspec', shell=True)
+        if status.returncode == 0:
+            break
+        time.sleep(10)
+
+
+push_pod('MapboxCoreNavigation')
+push_pod('MapboxNavigation')


### PR DESCRIPTION
https://mapbox.atlassian.net/browse/NAVSDK-772

There may be errors that occur when running the `pod trunk push` command, as well as errors that can happen when pushing the **MapboxNavigation** after a release of **MapboxCoreNavigation** due to pods not releasing instantly. I have created a retry script to help address these issues.