### PR TITLE
Create Navigation v2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.4.3
+
+### Packaging
+
+* Fixed an issue where dependencies couldn't be resolved when using Swift Package Manager. ([#4332](https://github.com/mapbox/mapbox-navigation-ios/pull/4332))
+* MapboxNavigation now requires [MapboxMaps v10.5.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.5.1). ([#4332](https://github.com/mapbox/mapbox-navigation-ios/pull/4332))
+* MapboxCoreNavigation now requires [MapboxDirections v2.6._x_ or v2.7._x_](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.7.0). ([#4332](https://github.com/mapbox/mapbox-navigation-ios/pull/4332))
+
 ## v2.4.2
 
 ### Packaging

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxCoreNavigation"
 
   s.dependency "MapboxNavigationNative", ">= 94.0.5", "< 95.0.0"
-  s.dependency "MapboxDirections", "~> 2.6"
+  s.dependency "MapboxDirections",">= 2.6.0", "< 2.8.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"
   s.dependency "MapboxCommon", "21.3.0"
 

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", ">= 10.4.3", "< 11.0.0"
+  s.dependency "MapboxMaps", "~> 10.5.1"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech", "~> 2.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -22,16 +22,16 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.6.0"),
+        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", "2.6.0"..<"2.8.0"),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
         .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "94.0.5"),
-        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.5.1"),
+        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", .upToNextMinor(from: "10.5.1")),
         .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", .exact("21.3.0")),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", from: "3.1.2"),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", from: "9.0.1"),
-        .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.8.1"),
+        .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.9.0")),
         .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
     ],
     targets: [


### PR DESCRIPTION
### Description
Use MapboxMaps constraint upToNextMinor(from: "10.5.1") for `v2.4.3`


#### Details
The `breaking API detection` build fails because this branch is not synced with the last `develop` branch. This branch does not contain any API changes so I guess it's better to have min diff in PR than trying to fix slightly change API breakage detection in the release branch.