### PR TITLE
Use .queued event priority by default

### DIFF
--- a/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
+++ b/MapboxNavigation.xcodeproj/xcshareddata/xcschemes/MapboxCoreNavigation.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/Feedback/NavigationEventsManager.swift
@@ -366,32 +366,32 @@ open class NavigationEventsManager {
 
     public func sendCarPlayConnectEvent() {
         let attributes = eventAttributes(type: .carplayConnect)
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
 
     public func sendCarPlayDisconnectEvent() {
         let attributes = eventAttributes(type: .carplayDisconnect)
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
     
     func sendRouteRetrievalEvent() {
         guard let attributes = try? navigationRouteRetrievalEvent()?.asDictionary() else { return }
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
 
     func sendDepartEvent() {
         guard let attributes = try? navigationDepartEvent()?.asDictionary() else { return }
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
     
     func sendArriveEvent() {
         guard let attributes = try? navigationArriveEvent()?.asDictionary() else { return }
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
     
     func sendCancelEvent(rating: Int? = nil, comment: String? = nil) {
         guard let attributes = try? navigationCancelEvent(rating: rating, comment: comment)?.asDictionary() else { return }
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
 
     func sendPassiveNavigationStart() {
@@ -401,12 +401,12 @@ open class NavigationEventsManager {
         }
 
         guard let attributes = try? passiveNavigationEvent(type: .start)?.asDictionary() else { return }
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
 
     func sendPassiveNavigationStop() {
         guard let attributes = try? passiveNavigationEvent(type: .stop)?.asDictionary() else { return }
-        eventsAPI.sendImmediateEvent(with: attributes)
+        sendEvent(with: attributes)
     }
     
     func sendFeedbackEvents(_ events: [CoreFeedbackEvent]) {
@@ -417,7 +417,7 @@ open class NavigationEventsManager {
             }
             
             let eventDictionary = navigationFeedbackEventWithLocationsAdded(event: event)
-            eventsAPI.sendImmediateEvent(with: eventDictionary)
+            sendEvent(with: eventDictionary)
         }
     }
 
@@ -540,5 +540,13 @@ open class NavigationEventsManager {
     
     func record(_ locations: [CLLocation]) {
         locations.forEach(sessionState.pastLocations.push(_:))
+    }
+
+    private func sendEvent(with attributes: [String : Any]) {
+        if shouldDelayEvents() {
+            eventsAPI.sendQueuedEvent(with: attributes)
+        } else {
+            eventsAPI.sendImmediateEvent(with: attributes)
+        }
     }
 }

--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
@@ -401,7 +401,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         let service = MapboxNavigationService(indexedRouteResponse: initialRouteResponse, customRoutingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
         let eventsManagerSpy = service.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.turnstile.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.turnstile.rawValue))
     }
 
     func testReroutingFromLocationUpdatesSimulatedLocationSource() {
@@ -417,7 +417,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
         navigationService.start()
 
         let eventsManagerSpy = navigationService.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.routeRetrieval.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.routeRetrieval.rawValue))
 
         let routeUpdated = expectation(description: "Route updated")
         router.updateRoute(with: .init(routeResponse: alternateRouteResponse, routeIndex: 0), routeOptions: nil) {
@@ -527,7 +527,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         // It queues and flushes a Depart event
         let eventsManagerSpy = navigation.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.depart.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.depart.rawValue))
         // When at a valid location just before the last location
         XCTAssertTrue(delegate.recentMessages.contains("navigationService(_:willArriveAt:after:distance:)"))
         // It tells the delegate that the user did arrive
@@ -535,7 +535,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         // It enqueues and flushes an arrival event
         let expectedEventName = EventType.arrive.rawValue
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: expectedEventName))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: expectedEventName))
     }
 
     func testNoReroutesAfterArriving() {
@@ -559,7 +559,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         let eventsManagerSpy = navigation.eventsManager as! NavigationEventsManagerSpy
         expectation(description: "Depart Event Flushed") {
-            eventsManagerSpy.hasImmediateEvent(with: EventType.depart.rawValue)
+            eventsManagerSpy.hasEvent(with: EventType.depart.rawValue)
         }
 
         // MARK: It tells the delegate that the user did arrive
@@ -594,7 +594,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         // It enqueues and flushes an arrival event
         let expectedEventName = EventType.arrive.rawValue
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: expectedEventName))
+        XCTAssertTrue(eventsManagerSpy.hasEvent(with: expectedEventName))
     }
 
     func testRouteControllerDoesNotHaveRetainCycle() {

--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
@@ -401,7 +401,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         let service = MapboxNavigationService(indexedRouteResponse: initialRouteResponse, customRoutingProvider: MapboxRoutingProvider(.offline), credentials: Fixture.credentials, locationSource: NavigationLocationManager(), eventsManagerType: NavigationEventsManagerSpy.self)
         let eventsManagerSpy = service.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.turnstile.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.turnstile.rawValue))
     }
 
     func testReroutingFromLocationUpdatesSimulatedLocationSource() {
@@ -417,7 +417,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
         navigationService.start()
 
         let eventsManagerSpy = navigationService.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.routeRetrieval.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.routeRetrieval.rawValue))
 
         let routeUpdated = expectation(description: "Route updated")
         router.updateRoute(with: .init(routeResponse: alternateRouteResponse, routeIndex: 0), routeOptions: nil) {
@@ -559,7 +559,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         let eventsManagerSpy = navigation.eventsManager as! NavigationEventsManagerSpy
         expectation(description: "Depart Event Flushed") {
-            eventsManagerSpy.hasEvent(with: EventType.depart.rawValue)
+            eventsManagerSpy.hasQueuedEvent(with: EventType.depart.rawValue)
         }
 
         // MARK: It tells the delegate that the user did arrive
@@ -594,7 +594,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
 
         // It enqueues and flushes an arrival event
         let expectedEventName = EventType.arrive.rawValue
-        XCTAssertTrue(eventsManagerSpy.hasEvent(with: expectedEventName))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: expectedEventName))
     }
 
     func testRouteControllerDoesNotHaveRetainCycle() {

--- a/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
+++ b/Tests/MapboxCoreNavigationTests/MapboxCoreNavigationTests.swift
@@ -25,3 +25,7 @@ func makeRoute() -> Route {
 func makeRouteWithNoDistance() -> Route {
     return Fixture.route(from: jsonFileNameEmptyDistance, options: routeOptions)
 }
+
+func makeRouteProgress() -> RouteProgress {
+    return RouteProgress(route: makeRoute(), options: routeOptions)
+}

--- a/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationEventsManagerTests.swift
@@ -3,8 +3,178 @@ import CoreLocation
 @testable import TestHelper
 @testable import MapboxCoreNavigation
 
+final class ActiveNavigationEventsManagerDataSourceSpy: ActiveNavigationEventsManagerDataSource {
+    var routeProgress: MapboxCoreNavigation.RouteProgress = makeRouteProgress()
+    var router: MapboxCoreNavigation.Router = RouterSpy(indexedRouteResponse: IndexedRouteResponse(routeResponse: makeRouteResponse(),
+                                                                                                   routeIndex: 0),
+                                                        dataSource: RouterDataSourceSpy())
+    var desiredAccuracy: CLLocationAccuracy = -1
+    var locationManagerType: MapboxCoreNavigation.NavigationLocationManager.Type = NavigationLocationManagerSpy.self
+}
+
+final class PassiveNavigationEventsManagerDataSourceSpy: PassiveNavigationEventsManagerDataSource {
+    var rawLocation: CLLocation? = nil
+    var locationManagerType: MapboxCoreNavigation.NavigationLocationManager.Type = NavigationLocationManagerSpy.self
+}
+
 class NavigationEventsManagerTests: TestCase {
-    
+    private var eventManager: NavigationEventsManager!
+    private var eventsAPI: EventsAPIMock!
+    private var activeNavigationDataSource: ActiveNavigationEventsManagerDataSourceSpy!
+    private var passiveNavigationDataSource: PassiveNavigationEventsManagerDataSourceSpy!
+
+    override func setUp() {
+        super.setUp()
+        eventsAPI = EventsAPIMock()
+        activeNavigationDataSource = ActiveNavigationEventsManagerDataSourceSpy()
+        passiveNavigationDataSource = PassiveNavigationEventsManagerDataSourceSpy()
+        eventManager = NavigationEventsManager(activeNavigationDataSource: activeNavigationDataSource,
+                                               passiveNavigationDataSource: passiveNavigationDataSource,
+                                               accessToken: "fake token",
+                                               eventsAPI: eventsAPI)
+    }
+
+    func testSendCarPlayConnectEventIfDelaysFlushing() {
+        eventManager.sendCarPlayConnectEvent()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.carplayConnect.rawValue))
+    }
+
+    func testSendCarPlayConnectEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        eventManager.sendCarPlayConnectEvent()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.carplayConnect.rawValue))
+    }
+
+    func testSendCarPlayDisconnectEventIfDelaysFlushing() {
+        eventManager.sendCarPlayDisconnectEvent()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.carplayDisconnect.rawValue))
+    }
+
+    func testSendCarPlayDisconnectEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        eventManager.sendCarPlayDisconnectEvent()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.carplayDisconnect.rawValue))
+    }
+
+    func testSendRouteRetrievalEventIfDelaysFlushing() {
+        eventManager.reportReroute(progress: makeRouteProgress(), proactive: false)
+
+        eventManager.sendRouteRetrievalEvent()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.routeRetrieval.rawValue))
+    }
+
+    func testSendRouteRetrievalEventIfDoesNotDelayFlushing() {
+        eventManager.reportReroute(progress: makeRouteProgress(), proactive: false)
+        eventManager.delaysEventFlushing = false
+
+        eventManager.sendRouteRetrievalEvent()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.routeRetrieval.rawValue))
+    }
+
+    func testNoDepartEventIfNoDatasource() {
+        eventManager.activeNavigationDataSource = nil
+        eventManager.sendDepartEvent()
+        XCTAssertFalse(eventsAPI.hasQueuedEvent(with: EventType.depart.rawValue))
+    }
+
+    func testSendDepartEventIfDelaysFlushing() {
+        eventManager.sendDepartEvent()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.depart.rawValue))
+    }
+
+    func testSendDepartEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        eventManager.sendDepartEvent()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.depart.rawValue))
+    }
+
+    func testNoArriveEventIfNoDatasource() {
+        eventManager.activeNavigationDataSource = nil
+        eventManager.sendArriveEvent()
+        XCTAssertFalse(eventsAPI.hasQueuedEvent(with: EventType.arrive.rawValue))
+    }
+
+    func testSendArriveEventIfDelaysFlushing() {
+        eventManager.sendArriveEvent()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.arrive.rawValue))
+    }
+
+    func testSendArriveEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        eventManager.sendArriveEvent()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.arrive.rawValue))
+    }
+
+    func testNoCancelEventIfNoDatasource() {
+        eventManager.activeNavigationDataSource = nil
+        eventManager.sendCancelEvent()
+        XCTAssertFalse(eventsAPI.hasQueuedEvent(with: EventType.cancel.rawValue))
+    }
+
+    func testSendCancelEventIfDelaysFlushing() {
+        eventManager.sendCancelEvent()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.cancel.rawValue))
+    }
+
+    func testSendCancelEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        eventManager.sendCancelEvent()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.cancel.rawValue))
+    }
+
+    func testNoPassiveNavigationStartEventIfNoDatasource() {
+        let eventManager = NavigationEventsManager(activeNavigationDataSource: activeNavigationDataSource,
+                                                   passiveNavigationDataSource: nil,
+                                                   accessToken: "fake token",
+                                                   eventsAPI: eventsAPI)
+        eventManager.sendPassiveNavigationStart()
+        XCTAssertFalse(eventsAPI.hasQueuedEvent(with: EventType.freeDrive.rawValue))
+    }
+
+    func testSendPassiveNavigationStartEventIfDelaysFlushing() {
+        eventManager.sendPassiveNavigationStart()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.freeDrive.rawValue))
+    }
+
+    func testSendPassiveNavigationStartEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        eventManager.sendPassiveNavigationStart()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.freeDrive.rawValue))
+    }
+
+    func testNoPassiveNavigationStopEventIfNoDatasource() {
+        let eventManager = NavigationEventsManager(activeNavigationDataSource: activeNavigationDataSource,
+                                                   passiveNavigationDataSource: nil,
+                                                   accessToken: "fake token",
+                                                   eventsAPI: eventsAPI)
+        eventManager.sendPassiveNavigationStop()
+        XCTAssertFalse(eventsAPI.hasQueuedEvent(with: EventType.freeDrive.rawValue))
+    }
+
+    func testSendPassiveNavigationStopEventIfDelaysFlushing() {
+        eventManager.sendPassiveNavigationStop()
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.freeDrive.rawValue))
+    }
+
+    func testSendPassiveNavigationStopEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        eventManager.sendPassiveNavigationStop()
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.freeDrive.rawValue))
+    }
+
+    func testSendFeedbackEventIfDelaysFlushing() {
+        let coreEvent = CoreFeedbackEvent(timestamp: Date(), eventDictionary: ["event":"feedback"])
+        eventManager.sendFeedbackEvents([coreEvent])
+        XCTAssertTrue(eventsAPI.hasQueuedEvent(with: "feedback"))
+    }
+
+    func testSendFeedbackEventIfDoesNotDelayFlushing() {
+        eventManager.delaysEventFlushing = false
+        let coreEvent = CoreFeedbackEvent(timestamp: Date(), eventDictionary: ["event":"feedback"])
+        eventManager.sendFeedbackEvents([coreEvent])
+        XCTAssertTrue(eventsAPI.hasImmediateEvent(with: "feedback"))
+    }
+
     func skipped_testDepartRerouteArrive() {
         
         let firstRouteOptions = NavigationRouteOptions(coordinates: [

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -129,7 +129,7 @@ class NavigationServiceTests: TestCase {
 
         XCTAssertTrue(locationManager.startUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.startUpdatingLocationCalled)
-        XCTAssertTrue(eventsManager.hasImmediateEvent(with: EventType.routeRetrieval.rawValue))
+        XCTAssertTrue(eventsManager.hasQueuedEvent(with: EventType.routeRetrieval.rawValue))
 
         XCTAssertTrue(routerSpy.delegate === service)
         waitForExpectations(timeout: expectationsTimeout)
@@ -144,7 +144,7 @@ class NavigationServiceTests: TestCase {
 
         XCTAssertTrue(locationManager.startUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.startUpdatingLocationCalled)
-        XCTAssertTrue(eventsManager.hasImmediateEvent(with: EventType.routeRetrieval.rawValue))
+        XCTAssertTrue(eventsManager.hasQueuedEvent(with: EventType.routeRetrieval.rawValue))
 
         XCTAssertTrue(routerSpy.delegate === service)
         waitForExpectations(timeout: expectationsTimeout)
@@ -256,7 +256,7 @@ class NavigationServiceTests: TestCase {
 
         XCTAssertTrue(locationManager.stopUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.stopUpdatingLocationCalled)
-        XCTAssertFalse(eventsManager.hasImmediateEvent(with: EventType.cancel.rawValue))
+        XCTAssertFalse(eventsManager.hasQueuedEvent(with: EventType.cancel.rawValue))
 
         waitForExpectations(timeout: expectationsTimeout)
     }
@@ -427,7 +427,7 @@ class NavigationServiceTests: TestCase {
         let feedback = EndOfRouteFeedback(rating: 5, comment: "comment")
         service.endNavigation(feedback: feedback)
 
-        XCTAssertTrue(eventsManager.hasImmediateEvent(with: EventType.cancel.rawValue))
+        XCTAssertTrue(eventsManager.hasQueuedEvent(with: EventType.cancel.rawValue))
         XCTAssertTrue(locationManager.stopUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.stopUpdatingLocationCalled)
 
@@ -459,7 +459,7 @@ class NavigationServiceTests: TestCase {
         let feedback = EndOfRouteFeedback(rating: 5, comment: "comment")
         service.endNavigation(feedback: feedback)
 
-        XCTAssertTrue(eventsManager.hasImmediateEvent(with: EventType.cancel.rawValue))
+        XCTAssertTrue(eventsManager.hasQueuedEvent(with: EventType.cancel.rawValue))
         XCTAssertTrue(locationManager.stopUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.stopUpdatingLocationCalled)
 
@@ -479,7 +479,7 @@ class NavigationServiceTests: TestCase {
         let feedback = EndOfRouteFeedback(rating: 5, comment: "comment")
         service.endNavigation(feedback: feedback)
 
-        XCTAssertTrue(eventsManager.hasImmediateEvent(with: EventType.cancel.rawValue))
+        XCTAssertTrue(eventsManager.hasQueuedEvent(with: EventType.cancel.rawValue))
         XCTAssertTrue(locationManager.stopUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.stopUpdatingLocationCalled)
         XCTAssertEqual(delegate.recentMessages, [])
@@ -529,7 +529,7 @@ class NavigationServiceTests: TestCase {
 
     func testDidUpdate() {
         service.router(routerSpy, didUpdate: routeProgress, with: location, rawLocation: lastLocation)
-        XCTAssertTrue(eventsManager.hasImmediateEvent(with: EventType.depart.rawValue))
+        XCTAssertTrue(eventsManager.hasQueuedEvent(with: EventType.depart.rawValue))
         let expectedCalls = ["navigationService(_:didUpdate:with:rawLocation:)"]
         XCTAssertEqual(delegate.recentMessages, expectedCalls)
     }

--- a/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/PassiveLocationManagerTests.swift
@@ -50,7 +50,7 @@ class PassiveLocationManagerTests: TestCase {
         passiveLocationManager.locationManager(locationManagerSpy, didUpdateLocations: [location])
 
         let eventsManagerSpy = passiveLocationManager.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.freeDrive.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.freeDrive.rawValue))
     }
 
     func testHandleDidUpdateHeading() {
@@ -134,11 +134,11 @@ class PassiveLocationManagerTests: TestCase {
         XCTAssertEqual(navigatorSpy.passedLocation, location)
 
         let eventsManagerSpy = passiveLocationManager.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.freeDrive.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.freeDrive.rawValue))
 
         eventsManagerSpy.reset()
         passiveLocationManager.updateLocation(location)
-        XCTAssertFalse(eventsManagerSpy.hasImmediateEvent(with: EventType.freeDrive.rawValue), "Do not report navigation twice")
+        XCTAssertFalse(eventsManagerSpy.hasQueuedEvent(with: EventType.freeDrive.rawValue), "Do not report navigation twice")
     }
 
     func testUpdatedLocationIfFailure() {
@@ -153,7 +153,7 @@ class PassiveLocationManagerTests: TestCase {
             XCTAssertEqual(error as! PassiveLocationManagerError, PassiveLocationManagerError.failedToChangeLocation)
         }
         let eventsManagerSpy = passiveLocationManager.eventsManager as! NavigationEventsManagerSpy
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.freeDrive.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.freeDrive.rawValue))
     }
 
     func testUpdatedLocationNoRunningBillingSession() {

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -54,10 +54,10 @@ class CarPlayManagerTests: TestCase {
     }
     
     func testEventsSentWhenCarPlayConnectedAndDisconnected() {
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.carplayConnect.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.carplayConnect.rawValue))
         
         simulateCarPlayDisconnection(carPlayManager)
-        XCTAssertTrue(eventsManagerSpy.hasImmediateEvent(with: EventType.carplayDisconnect.rawValue))
+        XCTAssertTrue(eventsManagerSpy.hasQueuedEvent(with: EventType.carplayDisconnect.rawValue))
     }
     
     func testWindowAndIntefaceControllerAreSetUpWithSearchWhenConnected() {


### PR DESCRIPTION
### Description
* Changes the priority for Telemetry Events
* Removes extra unused API
* Feature parity, Android mapbox/mapbox-navigation-android#6622


