### PR TITLE
Add LanesStyleKit.swift to ignored list for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,7 @@ ignore:
   - "MapboxCoreNavigationTests"
   - "MapboxCoreNavigationIntegrationTests"
   - "TestHelper"
+  - "Sources/MapboxNavigation/LanesStyleKit.swift"
 
 coverage:
   status:


### PR DESCRIPTION
Let's add this file to the ignored list since it's a huge autogenerated (with paintcodeapp.com) file that makes our codecov stats look bad.
Btw it's actually tested in our screenshot tests [here](https://github.com/mapbox/mapbox-navigation-ios/tree/main/Tests/MapboxNavigationTests/__Snapshots__/iPhone15_3/16.0/ManeuverViewSnapshotTests).