### PR TITLE
History replay improvements

### DIFF
--- a/.breakage-allowlist
+++ b/.breakage-allowlist
@@ -1,3 +1,2 @@
 Func CarPlayManagerDelegate.carPlayManagerDidCancelPreview(_:) has been added as a protocol requirement
 Constructor MapboxNavigationService.init(history:customRoutingProvider:credentials:eventsManagerType:routerType:customActivityType:) has been removed
-Constructor ReplayLocationManager.init(history:) has been removed

--- a/.breakage-allowlist
+++ b/.breakage-allowlist
@@ -1,1 +1,3 @@
 Func CarPlayManagerDelegate.carPlayManagerDidCancelPreview(_:) has been added as a protocol requirement
+Constructor MapboxNavigationService.init(history:customRoutingProvider:credentials:eventsManagerType:routerType:customActivityType:) has been removed
+Constructor ReplayLocationManager.init(history:) has been removed

--- a/Sources/MapboxCoreNavigation/HistoryEvent.swift
+++ b/Sources/MapboxCoreNavigation/HistoryEvent.swift
@@ -49,14 +49,17 @@ internal class StatusUpdateHistoryEvent: UnknownHistoryEvent {
     }
 }
 
-internal class PushRecordHistoryEvent: UnknownHistoryEvent {
-    let type: String
-    let properties: String
+/// History event being pushed by the user
+public struct PushRecordHistoryEvent: HistoryEvent {
+    public let timestamp: TimeInterval
+    /// The event type in the events log for this custom event.
+    public let type: String
+    /// The data value that contains a valid JSON attached to the event.
+    public let properties: String
     
     init(timestamp: TimeInterval, type: String, properties: String) {
         self.type = type
         self.properties = properties
-    
-        super.init(timestamp: timestamp)
+        self.timestamp = timestamp
     }
 }

--- a/Sources/MapboxCoreNavigation/HistoryEvent.swift
+++ b/Sources/MapboxCoreNavigation/HistoryEvent.swift
@@ -52,11 +52,13 @@ internal class StatusUpdateHistoryEvent: UnknownHistoryEvent {
 /// History event being pushed by the user
 ///
 /// Such events are created by calling `HistoryRecording.pushHistoryEvent(type:jsonData:)`.
-public struct PushRecordHistoryEvent: HistoryEvent {
+public struct UserPushedHistoryEvent: HistoryEvent {
     public let timestamp: TimeInterval
     /// The event type specified for this custom event.
     public let type: String
     /// The data value that contains a valid JSON attached to the event.
+    ///
+    /// This value was provided by user with `HistoryRecording.pushHistoryEvent` method's `dictionary` argument.
     public let properties: String
     
     init(timestamp: TimeInterval, type: String, properties: String) {

--- a/Sources/MapboxCoreNavigation/HistoryEvent.swift
+++ b/Sources/MapboxCoreNavigation/HistoryEvent.swift
@@ -50,9 +50,11 @@ internal class StatusUpdateHistoryEvent: UnknownHistoryEvent {
 }
 
 /// History event being pushed by the user
+///
+/// Such events are created by calling `HistoryRecording.pushHistoryEvent(type:jsonData:)`.
 public struct PushRecordHistoryEvent: HistoryEvent {
     public let timestamp: TimeInterval
-    /// The event type in the events log for this custom event.
+    /// The event type specified for this custom event.
     public let type: String
     /// The data value that contains a valid JSON attached to the event.
     public let properties: String

--- a/Sources/MapboxCoreNavigation/HistoryReader.swift
+++ b/Sources/MapboxCoreNavigation/HistoryReader.swift
@@ -88,7 +88,7 @@ public struct HistoryReader: Sequence {
                                                 status: event.result)
             case .pushHistory:
                 guard let event = record.pushHistory else { break }
-                return PushRecordHistoryEvent(timestamp: timestamp,
+                return UserPushedHistoryEvent(timestamp: timestamp,
                                               type: event.type,
                                               properties: event.properties)
             @unknown default:

--- a/Sources/MapboxCoreNavigation/HistoryReader.swift
+++ b/Sources/MapboxCoreNavigation/HistoryReader.swift
@@ -21,6 +21,16 @@ public struct History {
             return ($0 as? LocationUpdateHistoryEvent)?.location
         }
     }
+    
+    func rawLocationsShiftedToPresent() -> [CLLocation] {
+        return self.rawLocations.enumerated().map { CLLocation(coordinate: $0.element.coordinate,
+                                                               altitude: $0.element.altitude,
+                                                               horizontalAccuracy: $0.element.horizontalAccuracy,
+                                                               verticalAccuracy: $0.element.verticalAccuracy,
+                                                               course: $0.element.course,
+                                                               speed: $0.element.speed,
+                                                               timestamp: Date() + TimeInterval($0.offset)) }
+    }
 }
 
 /// Provides event-by-event access to history files contents.

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -476,7 +476,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      Intializes a new `NavigationService` for replaying a session from provided `History`.
      
      - parameter history: `History` object, containing initial route and location trace to be replayed.
-     - parameter customHistoryEventslistener: Custom `ReplayManagerHistoryEventsListener` which will be used to handle replay events. Default value (`nil`)  will also loop route assignment events to update the `Router`.
+     - parameter customHistoryEventsListener: Custom `ReplayManagerHistoryEventsListener` which will be used to handle replay events. Default value (`nil`)  will also loop route assignment events to update the `Router`.
      - parameter customRoutingProvider: Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
      - parameter credentials: Credentials to authorize additional data requests throughout the route.
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
@@ -484,7 +484,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - returns `nil` if provided `historyFileDump` does not contain valid initial route.
      */
     public convenience init?(history: History,
-                             customHistoryEventslistener: ReplayManagerHistoryEventsListener? = nil,
+                             customHistoryEventsListener: ReplayManagerHistoryEventsListener? = nil,
                              customRoutingProvider: RoutingProvider? = nil,
                              credentials: Credentials,
                              eventsManagerType: NavigationEventsManager.Type? = nil,
@@ -495,7 +495,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         }
         
         let replayLocationManager = ReplayLocationManager(history: history,
-                                                          listener: customHistoryEventslistener)
+                                                          listener: customHistoryEventsListener)
         self.init(indexedRouteResponse: routeResponse,
                   customRoutingProvider: customRoutingProvider,
                   credentials: credentials,
@@ -504,7 +504,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
                   routerType: routerType,
                   customActivityType: customActivityType)
         
-        if customHistoryEventslistener == nil {
+        if customHistoryEventsListener == nil {
             replayLocationManager.eventsListener = self
         }
     }
@@ -839,7 +839,7 @@ extension MapboxNavigationService {
 }
 
 extension MapboxNavigationService: ReplayManagerHistoryEventsListener {
-    public func onEventPublished(_ manager: ReplayLocationManager, event: HistoryEvent) {
+    public func replyLocationManager(_ manager: ReplayLocationManager, published event: HistoryEvent) {
         if let setRouteEvent = event as? RouteAssignmentHistoryEvent {
             updateRoute(with: setRouteEvent.routeResponse,
                         routeOptions: nil,

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -476,6 +476,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      Intializes a new `NavigationService` for replaying a session from provided `History`.
      
      - parameter history: `History` object, containing initial route and location trace to be replayed.
+     - parameter customHistoryEventslistener: Custom `ReplayManagerHistoryEventsListener` which will be used to handle replay events. Default value (`nil`)  will also loop route assignment events to update the `Router`.
      - parameter customRoutingProvider: Custom `RoutingProvider`, used to create a route during refreshing or rerouting.
      - parameter credentials: Credentials to authorize additional data requests throughout the route.
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
@@ -483,6 +484,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - returns `nil` if provided `historyFileDump` does not contain valid initial route.
      */
     public convenience init?(history: History,
+                             customHistoryEventslistener: ReplayManagerHistoryEventsListener? = nil,
                              customRoutingProvider: RoutingProvider? = nil,
                              credentials: Credentials,
                              eventsManagerType: NavigationEventsManager.Type? = nil,
@@ -491,13 +493,20 @@ public class MapboxNavigationService: NSObject, NavigationService {
         guard let routeResponse = history.initialRoute else {
             return nil
         }
+        
+        let replayLocationManager = ReplayLocationManager(history: history,
+                                                          listener: customHistoryEventslistener)
         self.init(indexedRouteResponse: routeResponse,
                   customRoutingProvider: customRoutingProvider,
                   credentials: credentials,
-                  locationSource: ReplayLocationManager(history: history),
+                  locationSource: replayLocationManager,
                   eventsManagerType: eventsManagerType,
                   routerType: routerType,
                   customActivityType: customActivityType)
+        
+        if customHistoryEventslistener == nil {
+            replayLocationManager.eventsListener = self
+        }
     }
 
     init(indexedRouteResponse: IndexedRouteResponse,
@@ -826,6 +835,16 @@ extension MapboxNavigationService {
     
     public var locationManagerType: NavigationLocationManager.Type {
         return type(of: locationManager)
+    }
+}
+
+extension MapboxNavigationService: ReplayManagerHistoryEventsListener {
+    public func onEventPublished(_ manager: ReplayLocationManager, event: HistoryEvent) {
+        if let setRouteEvent = event as? RouteAssignmentHistoryEvent {
+            updateRoute(with: setRouteEvent.routeResponse,
+                        routeOptions: nil,
+                        completion: nil)
+        }
     }
 }
 

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -840,6 +840,7 @@ extension MapboxNavigationService {
 
 extension MapboxNavigationService: ReplayManagerHistoryEventsListener {
     public func replyLocationManager(_ manager: ReplayLocationManager, published event: HistoryEvent) {
+        // handling `RouteAssignmentHistoryEvent` to replay route updates from user/reroutes/etc.
         if let setRouteEvent = event as? RouteAssignmentHistoryEvent {
             updateRoute(with: setRouteEvent.routeResponse,
                         routeOptions: nil,

--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -31,7 +31,7 @@ open class ReplayLocationManager: NavigationLocationManager {
     /**
      Events listener that will receive history events if replaying a `History`.
      */
-    public var eventsListener: ReplayManagerHistoryEventsListener? = nil
+    public weak var eventsListener: ReplayManagerHistoryEventsListener? = nil
     
     /**
      `simulatesLocation` used to indicate whether the location manager is providing simulated locations.
@@ -77,9 +77,13 @@ open class ReplayLocationManager: NavigationLocationManager {
         verifyParameters()
     }
     
-    public convenience init(history: History, listener: ReplayManagerHistoryEventsListener?) {
+    public convenience init(history: History) {
         self.init(locations: history.rawLocationsShiftedToPresent())
         self.events = history.events.map { ReplayEvent(from: $0) }
+    }
+    
+    public convenience init(history: History, listener: ReplayManagerHistoryEventsListener?) {
+        self.init(history: history)
         self.eventsListener = listener
     }
     
@@ -109,7 +113,7 @@ open class ReplayLocationManager: NavigationLocationManager {
                 onTick?(currentIndex, location)
                 nextTickWorkItem?.cancel()
             case .historyEvent(let historyEvent):
-                eventsListener?.onEventPublished(self, event: historyEvent)
+                eventsListener?.replyLocationManager(self, published: historyEvent)
             }
         }
 
@@ -194,8 +198,8 @@ open class ReplayLocationManager: NavigationLocationManager {
 /**
  `ReplayLocationManager`'s listener that will receive events feed when it is replaying a `History` data.
  */
-public protocol ReplayManagerHistoryEventsListener {
-    func onEventPublished(_ manager: ReplayLocationManager, event: HistoryEvent)
+public protocol ReplayManagerHistoryEventsListener: AnyObject {
+    func replyLocationManager(_ manager: ReplayLocationManager, published event: HistoryEvent)
 }
 
 

--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -77,12 +77,10 @@ open class ReplayLocationManager: NavigationLocationManager {
         verifyParameters()
     }
     
-    public init(history: History, listener: ReplayManagerHistoryEventsListener?) {
-        self.locations = history.rawLocationsShiftedToPresent()
+    public convenience init(history: History, listener: ReplayManagerHistoryEventsListener?) {
+        self.init(locations: history.rawLocationsShiftedToPresent())
         self.events = history.events.map { ReplayEvent(from: $0) }
         self.eventsListener = listener
-        super.init()
-        verifyParameters()
     }
     
     deinit {

--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -224,8 +224,8 @@ struct ReplayEvent {
             case let event as RouteAssignmentHistoryEvent:
                 return ReplayEvent(from: RouteAssignmentHistoryEvent(timestamp: date.timeIntervalSince1970,
                                                                      routeResponse: event.routeResponse))
-            case let event as PushRecordHistoryEvent:
-                return ReplayEvent(from: PushRecordHistoryEvent(timestamp: date.timeIntervalSince1970,
+            case let event as UserPushedHistoryEvent:
+                return ReplayEvent(from: UserPushedHistoryEvent(timestamp: date.timeIntervalSince1970,
                                                                 type: event.type,
                                                                 properties: event.properties))
             case is UnknownHistoryEvent:

--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -26,7 +26,7 @@ open class ReplayLocationManager: NavigationLocationManager {
         }
     }
     
-    var events: [ReplayEvent]
+    private(set) var events: [ReplayEvent]
     
     /**
      Events listener that will receive history events if replaying a `History`.

--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -22,8 +22,16 @@ open class ReplayLocationManager: NavigationLocationManager {
         didSet {
             currentIndex = 0
             verifyParameters()
+            self.events = locations.map { ReplayEvent(from: $0) }
         }
     }
+    
+    var events: [ReplayEvent]
+    
+    /**
+     Events listener that will receive history events if replaying a `History`.
+     */
+    public var eventsListener: ReplayManagerHistoryEventsListener? = nil
     
     /**
      `simulatesLocation` used to indicate whether the location manager is providing simulated locations.
@@ -64,12 +72,17 @@ open class ReplayLocationManager: NavigationLocationManager {
     
     public init(locations: [CLLocation]) {
         self.locations = locations.sorted { $0.timestamp < $1.timestamp }
+        self.events = locations.map { ReplayEvent(from: $0) }
         super.init()
         verifyParameters()
     }
     
-    public convenience init(history: History) {
-        self.init(locations: history.rawLocations)
+    public init(history: History, listener: ReplayManagerHistoryEventsListener?) {
+        self.locations = history.rawLocationsShiftedToPresent()
+        self.events = history.events.map { ReplayEvent(from: $0) }
+        self.eventsListener = listener
+        super.init()
+        verifyParameters()
     }
     
     deinit {
@@ -90,11 +103,16 @@ open class ReplayLocationManager: NavigationLocationManager {
     @objc internal func tick() {
         guard let startDate = startDate else { return }
 
-        func sendTick(with location: CLLocation) {
-            synthesizedLocation = location
-            delegate?.locationManager?(self, didUpdateLocations: [location])
-            onTick?(currentIndex, location)
-            nextTickWorkItem?.cancel()
+        func sendTick(_ event: ReplayEvent) {
+            switch event.kind {
+            case .location(let location):
+                synthesizedLocation = location
+                delegate?.locationManager?(self, didUpdateLocations: [location])
+                onTick?(currentIndex, location)
+                nextTickWorkItem?.cancel()
+            case .historyEvent(let historyEvent):
+                eventsListener?.onEventPublished(self, event: historyEvent)
+            }
         }
 
         func scheduleNextTick(afterDelay delay: TimeInterval) {
@@ -105,24 +123,25 @@ open class ReplayLocationManager: NavigationLocationManager {
             DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: nextTickWorkItem)
         }
 
-        guard locations.count > 1 else {
-            sendTick(with: locations[0])
+        guard events.count > 1 else {
+            sendTick(events[0])
+            
             let startFromBeginning = replayCompletionHandler?(self) ?? false
             if startFromBeginning {
-                advanceLocationsForNextLoop()
+                advanceEventsForNextLoop()
                 scheduleNextTick(afterDelay: 1 / speedMultiplier)
             }
             return
         }
 
-        let location = locations[currentIndex]
-        sendTick(with: location)
+        let event = events[currentIndex]
+        sendTick(event)
 
         var nextIndex = currentIndex + 1
-        if nextIndex == locations.count {
+        if nextIndex == events.count {
             let startFromBeginning = replayCompletionHandler?(self) ?? false
             if startFromBeginning {
-                advanceLocationsForNextLoop()
+                advanceEventsForNextLoop()
                 nextIndex = 0
             }
             else {
@@ -130,10 +149,10 @@ open class ReplayLocationManager: NavigationLocationManager {
             }
         }
 
-        let nextLocation = locations[nextIndex]
-        let interval = nextLocation.timestamp.timeIntervalSince(location.timestamp) / TimeInterval(speedMultiplier)
+        let nextEvent = events[nextIndex]
+        let interval = nextEvent.date.timeIntervalSince(event.date) / TimeInterval(speedMultiplier)
         let intervalSinceStart = Date().timeIntervalSince(startDate)+interval
-        let actualInterval = nextLocation.timestamp.timeIntervalSince(locations.first!.timestamp)
+        let actualInterval = nextEvent.date.timeIntervalSince(events.first!.date)
         let diff = min(max(0, intervalSinceStart-actualInterval), 0.9) // Don't try to resync more than 0.9 seconds per location update
         let syncedInterval = interval-diff
 
@@ -145,19 +164,83 @@ open class ReplayLocationManager: NavigationLocationManager {
         precondition(!locations.isEmpty)
     }
 
-    /// Shift `locations` so that sent locations always have increasing timestamps, taking into account location deltas.
-    private func advanceLocationsForNextLoop() {
+    /// Shift `events` and  `locations` so that sent locations always have increasing timestamps, taking into account event deltas.
+    private func advanceEventsForNextLoop() {
         /// Previous location that is used to calculate deltas between locations.
-        var previousOldLocation: CLLocation = locations.last!
+        var previousOldLocation = events.last!
         /// Previous timestamp that is used to advance timestamps.
-        var previousNewLocationTimestamp = previousOldLocation.timestamp
+        var previousNewLocationTimestamp = previousOldLocation.date
 
-        for (idx, location) in locations.enumerated() {
-            let delta: TimeInterval = idx == 0 ? 1 : location.timestamp.timeIntervalSince(previousOldLocation.timestamp)
+        var advancedLocations: [CLLocation] = []
+        
+        for (idx, event) in events.enumerated() {
+            let delta: TimeInterval = idx == 0 ? 1 : event.date.timeIntervalSince(previousOldLocation.date)
             let newTimestamp = previousNewLocationTimestamp.addingTimeInterval(delta)
-            previousOldLocation = location
-            locations[idx] = location.shifted(to: newTimestamp)
+            previousOldLocation = event
+            let shiftedEvent = event.shifted(to: newTimestamp)
+            events[idx] = shiftedEvent
+            
+            if case let .location(location) = shiftedEvent.kind {
+                advancedLocations.append(location)
+            } else if case let .historyEvent(historyEvent) = shiftedEvent.kind,
+                let locationEvent = historyEvent as? LocationUpdateHistoryEvent {
+                advancedLocations.append(locationEvent.location)
+            }
+            
             previousNewLocationTimestamp = newTimestamp
         }
+        self.locations = advancedLocations
+    }
+}
+
+/**
+ `ReplayLocationManager`'s listener that will receive events feed when it is replaying a `History` data.
+ */
+public protocol ReplayManagerHistoryEventsListener {
+    func onEventPublished(_ manager: ReplayLocationManager, event: HistoryEvent)
+}
+
+
+struct ReplayEvent {
+    var date: Date
+    
+    enum Kind {
+        case location(CLLocation)
+        case historyEvent(HistoryEvent)
+    }
+    var kind: Kind
+    
+    func shifted(to date: Date) -> ReplayEvent {
+        switch kind {
+        case .location(let location):
+            return ReplayEvent(from: location.shifted(to: date))
+        case .historyEvent(let historyEvent):
+            switch historyEvent {
+            case let event as LocationUpdateHistoryEvent:
+                return ReplayEvent(from: LocationUpdateHistoryEvent(timestamp: date.timeIntervalSince1970,
+                                                                    location: event.location.shifted(to: date)))
+            case let event as RouteAssignmentHistoryEvent:
+                return ReplayEvent(from: RouteAssignmentHistoryEvent(timestamp: date.timeIntervalSince1970,
+                                                                     routeResponse: event.routeResponse))
+            case let event as PushRecordHistoryEvent:
+                return ReplayEvent(from: PushRecordHistoryEvent(timestamp: date.timeIntervalSince1970,
+                                                                type: event.type,
+                                                                properties: event.properties))
+            case is UnknownHistoryEvent:
+                fallthrough
+            default:
+                return ReplayEvent(from: UnknownHistoryEvent(timestamp: date.timeIntervalSince1970))
+            }
+        }
+    }
+    
+    init(from location: CLLocation) {
+        self.date = location.timestamp
+        self.kind = .location(location)
+    }
+    
+    init(from historyEvent: HistoryEvent) {
+        self.date = Date(timeIntervalSince1970: historyEvent.timestamp)
+        self.kind = .historyEvent(historyEvent)
     }
 }


### PR DESCRIPTION
### Description
This PR improves history replaying capabilities by exposing more public history records types and modifying `ReplayLocationManager` to replicate all stored history events in chronological order, including `setRoute` events and actually setting them to the router.

### Implementation
Made `PushRecordHistoryEvent` public; refactored `ReplayLocationManager` to work with events feed and added a listener to report occurred events to.