### PR TITLE
Replay Manager fixes

### DIFF
--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -76,7 +76,7 @@ open class ReplayLocationManager: NavigationLocationManager {
         super.init()
         
         verifyParameters()
-        advanceEventsForNextLoop()
+        advanceEventsForNextLoop(starting: Date())
     }
     
     public init(history: History) {
@@ -86,7 +86,7 @@ open class ReplayLocationManager: NavigationLocationManager {
         super.init()
         
         verifyParameters()
-        advanceEventsForNextLoop()
+        advanceEventsForNextLoop(starting: Date())
     }
     
     public convenience init(history: History, listener: ReplayManagerHistoryEventsListener?) {
@@ -177,11 +177,11 @@ open class ReplayLocationManager: NavigationLocationManager {
     }
 
     /// Shift `events` and  `locations` so that sent locations always have increasing timestamps, taking into account event deltas.
-    private func advanceEventsForNextLoop() {
+    private func advanceEventsForNextLoop(starting startDate: Date? = nil) {
         /// Previous location that is used to calculate deltas between locations.
         var previousOldLocation = events.last!
         /// Previous timestamp that is used to advance timestamps.
-        var previousNewLocationTimestamp = previousOldLocation.date
+        var previousNewLocationTimestamp = startDate ?? previousOldLocation.date
 
         var advancedLocations: [CLLocation] = []
         

--- a/Tests/MapboxCoreNavigationTests/ReplayLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/ReplayLocationManagerTests.swift
@@ -37,6 +37,49 @@ final class ReplayLocationManagerTests: TestCase {
         XCTAssertEqual(ticksCount, 1)
     }
 
+    func testInitializationUpdatesRecordedTimestamps() {
+        let deltaBetweenLocations: TimeInterval = 2
+        let firstLocationTimestamp = Date(timeIntervalSinceNow: -1000)
+        let secondLocationTimestamp = firstLocationTimestamp.addingTimeInterval(deltaBetweenLocations)
+        let firstLocation = CLLocation(coordinate: .init(latitude: 0, longitude: 0),
+                                       altitude: 0,
+                                       horizontalAccuracy: 0,
+                                       verticalAccuracy: 0,
+                                       timestamp: firstLocationTimestamp)
+        let secondLocation = CLLocation(coordinate: .init(latitude: 1, longitude: 1),
+                                        altitude: 0,
+                                        horizontalAccuracy: 0,
+                                        verticalAccuracy: 0,
+                                        timestamp: secondLocationTimestamp)
+        var manager = ReplayLocationManager(locations: [
+            firstLocation,
+            secondLocation,
+        ])
+        
+        XCTAssertTrue(abs((manager.locations.first?.timestamp.timeIntervalSince1970 ?? 0) - Date().timeIntervalSince1970) < 1, "Locations should have timestamps shifted to present time.")
+        XCTAssertEqual(manager.locations.first?.timestamp.timeIntervalSince1970,
+                       (manager.locations.last?.timestamp.timeIntervalSince1970 ?? 0) - deltaBetweenLocations,
+                       "Locations where not shifted proportionally")
+        
+        manager = ReplayLocationManager(history: History(events: [
+            LocationUpdateHistoryEvent(timestamp: firstLocationTimestamp.timeIntervalSince1970,
+                                       location: firstLocation),
+            LocationUpdateHistoryEvent(timestamp: secondLocationTimestamp.timeIntervalSince1970,
+                                       location: secondLocation)
+        ]))
+        
+        XCTAssertTrue(abs((manager.locations.first?.timestamp.timeIntervalSince1970 ?? 0) - Date().timeIntervalSince1970) < 1, "History locations should have timestamps shifted to present time.")
+        XCTAssertEqual(manager.locations.first?.timestamp.timeIntervalSince1970,
+                       (manager.locations.last?.timestamp.timeIntervalSince1970 ?? 0) - deltaBetweenLocations,
+                       "History locations where not shifted proportionally")
+        
+        XCTAssertTrue(abs((manager.events.first?.date.timeIntervalSince1970 ?? 0) - Date().timeIntervalSince1970) < 1, "History events should have timestamps shifted to present time.")
+        XCTAssertEqual(manager.events.first?.date.timeIntervalSince1970,
+                       (manager.events.last?.date.timeIntervalSince1970 ?? 0) - deltaBetweenLocations,
+                       "History events where not shifted proportionally")
+        
+    }
+    
     func testReplayLoopAlwaysAdvanceTimestamps() {
         let deltaBetweenLocations: TimeInterval = 2
         let firstLocationTimestamp = Date()


### PR DESCRIPTION
### Description
Fixed updating initial history events and locations timestamps and pushing location update events to delegates when replaying history feed