### PR TITLE
[CarPlay] Add delegate methods for CarPlay panning

### DIFF
--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -937,6 +937,8 @@ extension CarPlayManager: CPMapTemplateDelegate {
             let shouldShowRecenterButton = carPlayMapViewController.navigationMapView.navigationCamera.state == .idle
             carPlayMapViewController.recenterButton.isHidden = !shouldShowRecenterButton
         }
+        
+        delegate?.carPlayManager(self, willDismissPanningInterface: mapTemplate)
     }
     
     public func mapTemplateDidDismissPanningInterface(_ mapTemplate: CPMapTemplate) {
@@ -945,6 +947,8 @@ extension CarPlayManager: CPMapTemplateDelegate {
         self.currentActivity = currentActivity
         
         updateNavigationButtons(for: mapTemplate)
+        
+        delegate?.carPlayManager(self, didDismissPanningInterface: mapTemplate)
     }
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate,

--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -877,11 +877,13 @@ extension CarPlayManager: CPMapTemplateDelegate {
     public func mapTemplateDidBeginPanGesture(_ mapTemplate: CPMapTemplate) {
         // Whenever panning starts - stop any navigation camera updates.
         activeNavigationMapView?.navigationCamera.stop()
+        delegate?.carPlayManager(self, didBeginPanGesture: mapTemplate)
     }
     
     public func mapTemplate(_ mapTemplate: CPMapTemplate, didEndPanGestureWithVelocity velocity: CGPoint) {
         // After panning is stopped - allow navigation bar dismissal.
         mapTemplate.automaticallyHidesNavigationBar = true
+        delegate?.carPlayManager(self, didEndPanGesture: mapTemplate)
     }
     
     public func mapTemplateDidShowPanningInterface(_ mapTemplate: CPMapTemplate) {

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -312,6 +312,8 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlay
                         templateDidDisappear template: CPTemplate,
                         animated: Bool)
     
+    // MARK: Map Panning
+    
     /**
      Called when the system detects a user starting to pan a map template visible on the screen.
      
@@ -329,6 +331,24 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlay
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         didEndPanGesture template: CPMapTemplate)
+    
+    /**
+     Called when the panning interface will close on a map template.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter template: The template that disappeared from the screen.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        willDismissPanningInterface template: CPMapTemplate)
+    
+    /**
+     Called when the panning interface did close on a map template.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter template: The template that disappeared from the screen.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        didDismissPanningInterface template: CPMapTemplate)
     
     /**
      Asks the receiver to return a `LineLayer` for the route line, given a layer identifier and a source identifier.
@@ -667,6 +687,22 @@ public extension CarPlayManagerDelegate {
      */
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         didEndPanGesture template: CPMapTemplate) {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        willDismissPanningInterface template: CPMapTemplate) {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        didDismissPanningInterface template: CPMapTemplate) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
     

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -313,6 +313,24 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlay
                         animated: Bool)
     
     /**
+     Called when the system detects a user starting to pan a map template visible on the screen.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter template: The template that disappeared from the screen.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        didBeginPanGesture template: CPMapTemplate)
+    
+    /**
+     Called when the system detects a user stops panning a map template.
+     
+     - parameter carPlayManager: The `CarPlayManager` object.
+     - parameter template: The template that disappeared from the screen.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        didEndPanGesture template: CPMapTemplate)
+    
+    /**
      Asks the receiver to return a `LineLayer` for the route line, given a layer identifier and a source identifier.
      This method is invoked when the map view loads and any time routes are added.
      
@@ -633,6 +651,22 @@ public extension CarPlayManagerDelegate {
     func carPlayManager(_ carPlayManager: CarPlayManager,
                         templateDidDisappear template: CPTemplate,
                         animated: Bool) {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        didBeginPanGesture template: CPMapTemplate) {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        didEndPanGesture template: CPMapTemplate) {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
     


### PR DESCRIPTION
### Description

Being able to access underlying CarPlay MapTemplate delegate methods can be extremely useful for applying custom updates for an app, for example updating the visibility of custom buttons (e.g. if not using the built in recenter button) or preventing the navigation bar from hiding automatically (currently the property is set back to `true` [here](https://github.com/mapbox/mapbox-navigation-ios/blob/43b56855335ffa95e028f99f3b68fe1fb27bb8dc/Sources/MapboxNavigation/CarPlayManager.swift#L884), which is often desired behaviour in most cases, but in some cases it would be good to override this based on a particular event.

### Implementation

- Adds 4 new delegate methods to `CarPlayManagerDelegate`:
    - `carPlayManager(_ carPlayManager: CarPlayManager, didBeginPanGesture template: CPMapTemplate)`
    - `carPlayManager(_ carPlayManager: CarPlayManager, didEndPanGesture template: CPMapTemplate)`
    - `carPlayManager(_ carPlayManager: CarPlayManager, willDismissPanningInterface template: CPMapTemplate)`
    - `carPlayManager(_ carPlayManager: CarPlayManager,  didDismissPanningInterface template: CPMapTemplate)`
- This is a non-breaking change, adding optional delegate methods for end users to implement if required