### PR TITLE
Fix `Index out of bounds` crash in SimulatedLocationManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 * `RoadName` type changed from enum to struct with additional properties. ([#4333](https://github.com/mapbox/mapbox-navigation-ios/pull/4333))
 * Electronic Horizon Notifications (`Notification.Name.electronicHorizonDidUpdatePosition`, `Notification.Name.electronicHorizonDidEnterRoadObject`, `Notification.Name.electronicHorizonDidExitRoadObject`, `Notification.Name.electronicHorizonDidPassRoadObject`) are now called on the main thread. ([#4333](https://github.com/mapbox/mapbox-navigation-ios/pull/4333))
 
+### Location tracking
+
+* Fixed a possible crash that could happen during route simulation. ([#4366](https://github.com/mapbox/mapbox-navigation-ios/pull/4366))
+
 ### Other changes
 
 * Fixed an issue where an incorrect upcoming intersection index cause a crash. ([#4314](https://github.com/mapbox/mapbox-navigation-ios/pull/4314))

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -799,7 +799,7 @@ extension MapboxNavigationService: RouterDelegate {
     
     public func router(_ router: Router, didSwitchToCoincidentOnlineRoute coincideRoute: Route) {
         //update the route progress model of the simulated location manager, if applicable.
-        simulatedLocationSource?.route = router.route
+        simulatedLocationSource?.update(route: router.route)
         
         delegate?.navigationService(self, didSwitchToCoincidentOnlineRoute: coincideRoute)
     }

--- a/Tests/MapboxCoreNavigationTests/SimulatedLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/SimulatedLocationManagerTests.swift
@@ -6,27 +6,36 @@ import CoreLocation
 import TestHelper
 
 class SimulatedLocationManagerTests: TestCase {
-    func testSimulateRouteDoublesBack() {
-        let coordinates:[CLLocationCoordinate2D] = [
-            .init(latitude: 59.337928, longitude: 18.076841),
-            .init(latitude: 59.337661, longitude: 18.075897),
-            .init(latitude: 59.337129, longitude: 18.075478),
-            .init(latitude: 59.336866, longitude: 18.075273),
-            .init(latitude: 59.336623, longitude: 18.075806),
-            .init(latitude: 59.336391, longitude: 18.076943),
-            .init(latitude: 59.338731, longitude: 18.079343),
-            .init(latitude: 59.339058, longitude: 18.07774),
-            .init(latitude: 59.338901, longitude: 18.076929),
-            .init(latitude: 59.338333, longitude: 18.076467),
-            .init(latitude: 59.338156, longitude: 18.075723),
-            .init(latitude: 59.338311, longitude: 18.074968),
-            .init(latitude: 59.33865, longitude: 18.074935),
-        ]
-        let route = Fixture.routesFromMatches(at: "sthlm-double-back", options: NavigationMatchOptions(coordinates: coordinates))![0]
-        let locationManager = SimulatedLocationManager(route: route)
-        let locationManagerSpy = CLLocationManagerDelegateSpy()
+    var locationManager: SimulatedLocationManager!
+    var locationManagerSpy: CLLocationManagerDelegateSpy!
+
+    var route: Route!
+    var coordinates: [CLLocationCoordinate2D] = [
+        .init(latitude: 59.337928, longitude: 18.076841),
+        .init(latitude: 59.337661, longitude: 18.075897),
+        .init(latitude: 59.337129, longitude: 18.075478),
+        .init(latitude: 59.336866, longitude: 18.075273),
+        .init(latitude: 59.336623, longitude: 18.075806),
+        .init(latitude: 59.336391, longitude: 18.076943),
+        .init(latitude: 59.338731, longitude: 18.079343),
+        .init(latitude: 59.339058, longitude: 18.07774),
+        .init(latitude: 59.338901, longitude: 18.076929),
+        .init(latitude: 59.338333, longitude: 18.076467),
+        .init(latitude: 59.338156, longitude: 18.075723),
+        .init(latitude: 59.338311, longitude: 18.074968),
+        .init(latitude: 59.33865, longitude: 18.074935),
+    ]
+
+    override func setUp() {
+        super.setUp()
+
+        route = Fixture.routesFromMatches(at: "sthlm-double-back", options: NavigationMatchOptions(coordinates: coordinates))![0]
+        locationManager = SimulatedLocationManager(route: route)
+        locationManagerSpy = CLLocationManagerDelegateSpy()
         locationManager.delegate = locationManagerSpy
-        
+    }
+
+    func testSimulateRouteDoublesBack() {
         while locationManager.currentDistance < route.shape?.distance() ?? 0 {
             locationManager.tick()
         }
@@ -38,6 +47,12 @@ class SimulatedLocationManagerTests: TestCase {
         
         let endPointDifferences = (testCoordinates.first?.distance(to: coordinates.first!))! + (testCoordinates.last?.distance(to: coordinates.last!))!
         XCTAssert(endPointDifferences < 5)
+    }
+
+    func testUpdateRoute() {
+        let newRoute = makeRoute()
+        locationManager.update(route: newRoute)
+        XCTAssertTrue(locationManager.route === newRoute)
     }
 }
 


### PR DESCRIPTION
### Description
When the reroute happens, `route`, `routeProgress`, `locations`, and `remainingRouteShape` should be updated.
The cause for a possible crash is that `route` and `shape` updates are synced on the main thread, but `locations` and `remainingRouteShape` aren't, so some additional work should be done.