### PR TITLE
Adding an empty variant to the alternatives list template on CarPlay

### DIFF
--- a/Example/en.lproj/Localizable.strings
+++ b/Example/en.lproj/Localizable.strings
@@ -28,3 +28,18 @@
 /* Title of alert confirming waypoint removal */
 "REMOVE_WAYPOINT_CONFIRM_TITLE" = "Remove Waypoint?";
 
+/* No comment provided by engineer. */
+"Start Cycling" = "Start Cycling";
+
+/* No comment provided by engineer. */
+"Start Driving" = "Start Driving";
+
+/* No comment provided by engineer. */
+"Start Driving Avoiding Traffic" = "Start Driving Avoiding Traffic";
+
+/* No comment provided by engineer. */
+"Start Navigation" = "Start Navigation";
+
+/* No comment provided by engineer. */
+"Start Walking" = "Start Walking";
+

--- a/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
+++ b/Sources/MapboxNavigation/CarPlayNavigationViewController.swift
@@ -177,6 +177,16 @@ open class CarPlayNavigationViewController: UIViewController, BuildingHighlighti
         let template = CPListTemplate(title: alternativesTitle,
                                       sections: variants)
         template.delegate = self
+        
+        if #available(iOS 14.0, *) {
+            let alternativesEmptyVariantsSubtitle = NSLocalizedString("CARPLAY_ALTERNATIVES_EMPTY_SUBTITLE",
+                                              bundle: .mapboxNavigation,
+                                              value: "No alternative routes found.",
+                                              comment: "Subtitle for the alternative list template empty variants")
+            
+            template.emptyViewSubtitleVariants = [alternativesEmptyVariantsSubtitle]
+        }
+        
         return template
     }
     

--- a/Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
+++ b/Sources/MapboxNavigation/Resources/en.lproj/Localizable.strings
@@ -1,8 +1,14 @@
 /* Combined alternatives selection notes about duration (first slot position) and distance (second slot position) delta. */
 "ALTERNATIVE_NOTES" = "%1$@ / %2$@";
 
+/* Title of the back button. */
+"BACK" = "BACK";
+
 /* Title for alternatives selection list button */
 "CARPLAY_ALTERNATIVES" = "Alternatives";
+
+/* Subtitle for the alternative list template empty variants */
+"CARPLAY_ALTERNATIVES_EMPTY_SUBTITLE" = "No alternative routes found.";
 
 /* Title on arrival action sheet */
 "CARPLAY_ARRIVED" = "You have arrived";
@@ -39,6 +45,9 @@
 
 /* Title for overview button in CPTripPreviewTextConfiguration */
 "CARPLAY_OVERVIEW" = "Overview";
+
+/* Title for trip preview back button */
+"CARPLAY_PREVIEW_BACK" = "BACK";
 
 /* Title for rating template in CarPlay */
 "CARPLAY_RATE_RIDE" = "Rate your ride";
@@ -265,5 +274,3 @@
 /* Format for displaying start and endpoint for leg; 1 = source ; 2 = destination */
 "WAYPOINT_SOURCE_DESTINATION_FORMAT" = "%1$@ and %2$@";
 
-/* Button title for back button in preview . */
-"BACK" = "Back";


### PR DESCRIPTION
### Description
On CarPlay when there are no alternative routes available the Alternatives List Template will display an empty screen.  This PR will add an empty variant to the Alternatives List Template. This will address #4355

### Screenshots or Gifs
<img width="300" alt="Alternative Empty Variant" src="https://user-images.githubusercontent.com/14284714/219875593-774c1788-a5e4-47a1-8e26-4055719eab2f.png">