### PR TITLE
[CarPlay] Add Delegate Method Before CarPlayNavigationViewController Presented

### DIFF
--- a/Sources/MapboxNavigation/CarPlayManager.swift
+++ b/Sources/MapboxNavigation/CarPlayManager.swift
@@ -809,6 +809,9 @@ extension CarPlayManager: CPMapTemplateDelegate {
         carPlayNavigationViewController.delegate = self
         carPlayNavigationViewController.modalPresentationStyle = .fullScreen
         self.carPlayNavigationViewController = carPlayNavigationViewController
+        
+        carPlayNavigationViewController.loadViewIfNeeded()
+        delegate?.carPlayManager(self, willPresent: carPlayNavigationViewController)
 
         carPlayMapViewController.present(carPlayNavigationViewController, animated: true) { [weak self] in
             guard let self = self else { return }

--- a/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
+++ b/Sources/MapboxNavigation/CarPlayManagerDelegate.swift
@@ -235,6 +235,21 @@ public protocol CarPlayManagerDelegate: AnyObject, UnimplementedLogging, CarPlay
      and enable when disconnected.
      */
     func carPlayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool
+    
+    /**
+     Called when the CarPlayManager creates a new CarPlayNavigationViewController upon start of a
+     navigation session.
+     
+     Implementing this method will allow developers to query or customize properties of the
+     CarPlayNavigationViewController before it is presented. For example, a developer may wish to perform custom map styling
+     on the presented NavigationMapView.
+     
+     - parameter carPlayManager: The CarPlay manager instance.
+     - parameter navigationViewController: The CarPlayNavigationViewController that will be presented
+     on the CarPlay display.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        willPresent navigationViewController: CarPlayNavigationViewController)
 
     /**
      Called when the CarPlayManager presents a new CarPlayNavigationViewController upon start of a
@@ -627,6 +642,14 @@ public extension CarPlayManagerDelegate {
     func carPlayManagerShouldDisableIdleTimer(_ carPlayManager: CarPlayManager) -> Bool {
         logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
         return true
+    }
+    
+    /**
+     `UnimplementedLogging` prints a warning to standard output the first time this method is called.
+     */
+    func carPlayManager(_ carPlayManager: CarPlayManager,
+                        willPresent navigationViewController: CarPlayNavigationViewController) {
+        logUnimplemented(protocolType: CarPlayManagerDelegate.self, level: .debug)
     }
 
     /**

--- a/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
+++ b/Tests/MapboxNavigationTests/CarPlayManagerTests.swift
@@ -224,6 +224,13 @@ class CarPlayManagerTests: TestCase {
         XCTAssertEqual(mapTemplateSpy.passedTripPreviews?.first, customTrip)
         XCTAssertEqual(mapTemplateSpy.passedPreviewTextConfiguration?.startButtonTitle, startButtonTitle)
     }
+    
+    func testWillPresentNavigationViewController() {
+        startNavigation()
+        
+        XCTAssertTrue(delegate.willPresentCalled)
+        XCTAssertEqual(delegate.passedWillPresentNavigationViewController, carPlayManager.carPlayNavigationViewController)
+    }
 
     func testStartWhenConfiguredToSimulate() {
         carPlayManager.simulatesLocations = true

--- a/Tests/MapboxNavigationTests/CarPlayUtils.swift
+++ b/Tests/MapboxNavigationTests/CarPlayUtils.swift
@@ -72,6 +72,7 @@ class CarPlayManagerDelegateSpy: CarPlayManagerDelegate {
     var didBeginNavigationCalled = false
     var didEndNavigationCalled = false
     var legacyDidEndNavigationCalled = false
+    var willPresentCalled = false
     var didPresentCalled = false
     var didFailToFetchRouteCalled = false
     var didBeginPanGestureCalled = false
@@ -84,6 +85,7 @@ class CarPlayManagerDelegateSpy: CarPlayManagerDelegate {
     var passedError: DirectionsError?
     var passedTemplate: CPMapTemplate?
     var passedNavigationEndedByCanceling = false
+    var passedWillPresentNavigationViewController: CarPlayNavigationViewController?
 
     var returnedTripPreviewTextConfiguration: CPTripPreviewTextConfiguration?
     var returnedTrip: CPTrip?
@@ -117,6 +119,11 @@ class CarPlayManagerDelegateSpy: CarPlayManagerDelegate {
     func carPlayManagerDidEndNavigation(_ carPlayManager: CarPlayManager) {
         XCTAssertTrue(didBeginNavigationCalled)
         legacyDidEndNavigationCalled = true
+    }
+    
+    func carPlayManager(_ carPlayManager: CarPlayManager, willPresent navigationViewController: CarPlayNavigationViewController) {
+        willPresentCalled = true
+        passedWillPresentNavigationViewController = navigationViewController
     }
 
     func carPlayManager(_ carPlayManager: CarPlayManager, didPresent navigationViewController: CarPlayNavigationViewController) {


### PR DESCRIPTION
### Description

Hi 👋 

There are some changes to the UI that may need to update before being presented, for example we have found that updating the `UserLocationStyle` of the map within the `didPresent` delegate method results in the default one being added, before shortly after updating to the overridden one. This PR adds a method to allow a user to hook in & modify the view before being presented.

Thank you

### Implementation

- Adds a new delegate method to `CarPlayManagerDelegate`: `func carPlayManager(_ carPlayManager: CarPlayManager, willPresent navigationViewController: CarPlayNavigationViewController)`
- Loads the view before being presented to ensure internal views such as `NavigationMapView` are loaded before delegates are called

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->