### PR TITLE
Fix flaky NavigationMapViewTests

### DIFF
--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -12,6 +12,7 @@ class NavigationMapViewTests: TestCase {
         CLLocationCoordinate2D(latitude: 29.99908, longitude: -102.828197),
     ]))
     var navigationMapView: NavigationMapView!
+    var navigator: CoreNavigator!
     
     let options: NavigationRouteOptions = .init(coordinates: [
         CLLocationCoordinate2D(latitude: 40.311012, longitude: -112.47926),
@@ -23,11 +24,13 @@ class NavigationMapViewTests: TestCase {
     }()
     
     override func setUp() {
+        navigator = Navigator.shared
         super.setUp()
         navigationMapView = NavigationMapView(frame: CGRect(origin: .zero, size: .iPhone6Plus))
     }
     
     override func tearDown() {
+        navigator = nil
         navigationMapView = nil
         super.tearDown()
     }


### PR DESCRIPTION
### Description
Should fix flaky `NavigationMapViewTests.testEnablePredictiveCaching()`
[Example](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-ios/10991/workflows/9bd7c838-7e90-4c2a-a8bd-262510e58ae9) of failing builds