### PR TITLE
Remove usage of real GPS position when `simulationMode == .always`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Increased terminal offboard route request timeout from 4 to 15 seconds. ([#4367](https://github.com/mapbox/mapbox-navigation-ios/pull/4367))
 * Sped up onboard routing cancellation. ([#4367](https://github.com/mapbox/mapbox-navigation-ios/pull/4367))
 * Fixed an issue when a rerouting could cause a memory leak. ([#4380](https://github.com/mapbox/mapbox-navigation-ios/pull/4380))
+* Fixed usage of real GPS locations in simulated routes ([#4394](https://github.com/mapbox/mapbox-navigation-ios/pull/4394))
 
 ## v2.10.0
 

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -239,7 +239,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
     public func start() {
         // Feed the first location to the router if router doesn't have a location yet. See #1790, #3237 for reference.
         if router.location == nil {
-            if let currentLocation = locationManager.location {
+            if let currentLocation = locationManager.location, simulationMode != .always {
                 router.locationManager?(nativeLocationSource, didUpdateLocations: [
                    currentLocation
                 ])

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -165,6 +165,16 @@ class NavigationServiceTests: TestCase {
         XCTAssertEqual(routerSpy.passedLocations, [location])
     }
 
+    func testStartIgnoresManagerLocationWhenSimulationModeAlways() {
+        locationManager.returnedLocation = location
+        service.simulationMode = .always
+        service.start()
+
+        XCTAssertTrue(routerSpy.didUpdateLocationsCalled)
+        let expectedCoordinate = route.shape!.coordinates.first!
+        XCTAssertEqual(routerSpy.passedLocations?.first?.coordinate, expectedCoordinate)
+    }
+
     func testStartIfNilRouterLocationAndSimulatedLocation() {
         let coordinate = route.shape!.coordinates.first!
         service.start()


### PR DESCRIPTION
When NavigationService starts, it passes one real GPS location to the `Router`, even if the simulation mode is enabled.
This can lead to problems when simulating a route far away from the real user location.