### PR TITLE
Add the ability to pass userInfo to NavigationService constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * MapboxCoreNavigation now requires [MapboxDirections v2.11.0-alpha.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.11.0-alpha.1). ([#4396](https://github.com/mapbox/mapbox-navigation-ios/pull/4396))
 * MapboxNavigation now requires [MapboxMaps v10.12.0-rc.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.12.0-rc.1). ([#4408](https://github.com/mapbox/mapbox-navigation-ios/pull/4408))
 
+### Routing
+* Added an optional `userInfo` argument to the `NavigationService(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)`. ([#4395](https://github.com/mapbox/mapbox-navigation-ios/pull/4395))
+
 ### Visual instructions
 * Fixed duplication of the road name components in the road shield and the label. ([#4401](https://github.com/mapbox/mapbox-navigation-ios/pull/4401))
 * Added support for localized road shields. ([#4401](https://github.com/mapbox/mapbox-navigation-ios/pull/4401))

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		2C18A12E2988729C00750CEE /* EventStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C18A12D2988729C00750CEE /* EventStep.swift */; };
 		2C193C31290A9BC30050A57F /* PredictiveCacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46D290A8CA10067FDCF /* PredictiveCacheManagerTests.swift */; };
 		2C193C32290A9BC30050A57F /* PredictiveCacheOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C04E46C290A8CA10067FDCF /* PredictiveCacheOptionsTests.swift */; };
+		2C234B4329AEAD2B00830723 /* PassiveLocationManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */; };
 		2C257377292B836B00941307 /* ReentrantImageDownloaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C257376292B836B00941307 /* ReentrantImageDownloaderSpy.swift */; };
 		2C2880A1291A82630063E5B7 /* RerouteControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A0291A82630063E5B7 /* RerouteControllerTests.swift */; };
 		2C2880A6291AB7A10063E5B7 /* RerouteDetectorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2880A5291AB7A10063E5B7 /* RerouteDetectorSpy.swift */; };
@@ -108,7 +109,6 @@
 		2C58515F292523670077A558 /* RouteControllerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */; };
 		2C585164292530AF0077A558 /* TestHelper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35CDA85E2190F2A30072B675 /* TestHelper.framework */; };
 		2C585165292530B70077A558 /* MapboxNavigationNative.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; };
-		2C585167292531340077A558 /* PassiveLocationManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */; };
 		2C59B995298330F8003D4EA0 /* FeedbackMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C59B994298330F8003D4EA0 /* FeedbackMetadata.swift */; };
 		2C67751C290AC4A6009C5EE4 /* MapboxNavigationNative.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; };
 		2C71DE02292F821E00620775 /* BillingHandlerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C71DE01292F821E00620775 /* BillingHandlerIntegrationTests.swift */; };
@@ -142,6 +142,9 @@
 		2CA6105429802ACF003E49A7 /* MonitorConnectivityTypeProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA6105329802ACF003E49A7 /* MonitorConnectivityTypeProviderTests.swift */; };
 		2CAEABD12930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAEABD02930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift */; };
 		2CAEABD32930D87B00DE851A /* RouterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAEABD22930D87B00DE851A /* RouterSpy.swift */; };
+		2CAEDB1D29AEC08B00E59543 /* MapboxNavigationNative.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CAEDB1C29AEC08B00E59543 /* MapboxNavigationNative.framework */; platformFilter = ios; };
+		2CAEDB1E29AEC08B00E59543 /* MapboxNavigationNative.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2CAEDB1C29AEC08B00E59543 /* MapboxNavigationNative.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		2CAEDB2029AF7F4200E59543 /* Dictionary+Equality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D1F8A12696EBD40053A93F /* Dictionary+Equality.swift */; };
 		2CC3043529A3DCDE00A3318F /* NavigationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3043429A3DCDE00A3318F /* NavigationStatusTests.swift */; };
 		2CDF5C972919628100C41082 /* NavigationLocationManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDF5C962919628100C41082 /* NavigationLocationManagerSpy.swift */; };
 		2CE25130291A56D900C0FA15 /* IdleTimerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2512E291A56CE00C0FA15 /* IdleTimerManagerTests.swift */; };
@@ -152,6 +155,7 @@
 		2CF3F8CD2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */; };
 		2CF5F5CA298155EC00B34C8C /* NavigationNativeEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF5F5C82981500E00B34C8C /* NavigationNativeEventsManagerTests.swift */; };
 		2CF5F5CC29816B2000B34C8C /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF5F5CB29816B2000B34C8C /* Telemetry.swift */; };
+		2CF8318B29AEBB0F001D26C9 /* NativeTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE1B2F329ACDC4E00745556 /* NativeTelemetryIntegrationTests.swift */; };
 		2CFAE203291C4E8300562E5F /* TestNavigationStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFAE202291C4E8300562E5F /* TestNavigationStatusProvider.swift */; };
 		2CFBC1CE2940BD230073EFFA /* MultiplexedSpeechSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFBC1CD2940BD230073EFFA /* MultiplexedSpeechSynthesizerTests.swift */; };
 		2E50E0C0264E35CA009D3848 /* RoadObjectMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E50E0BF264E35CA009D3848 /* RoadObjectMatcher.swift */; };
@@ -577,8 +581,6 @@
 		E2C1CDA1265E22AA00E158E0 /* MapboxDirections.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CD9F265E22AA00E158E0 /* MapboxDirections.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E2C1CDA4265E22AF00E158E0 /* MapboxMobileEvents.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA3265E22AF00E158E0 /* MapboxMobileEvents.xcframework */; };
 		E2C1CDA5265E22AF00E158E0 /* MapboxMobileEvents.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA3265E22AF00E158E0 /* MapboxMobileEvents.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E2C1CDA7265E22B400E158E0 /* MapboxNavigationNative.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; };
-		E2C1CDA8265E22B400E158E0 /* MapboxNavigationNative.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E2C1CDAA265E22B900E158E0 /* Polyline.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA9265E22B900E158E0 /* Polyline.xcframework */; };
 		E2C1CDAB265E22B900E158E0 /* Polyline.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA9265E22B900E158E0 /* Polyline.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E2C1CDAD265E22BD00E158E0 /* Turf.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDAC265E22BD00E158E0 /* Turf.xcframework */; };
@@ -692,8 +694,8 @@
 				E2C1CDA1265E22AA00E158E0 /* MapboxDirections.xcframework in Embed Frameworks */,
 				E2C1CDB1265E22C100E158E0 /* MapboxCommon.xcframework in Embed Frameworks */,
 				E2C1CDA5265E22AF00E158E0 /* MapboxMobileEvents.xcframework in Embed Frameworks */,
-				E2C1CDA8265E22B400E158E0 /* MapboxNavigationNative.xcframework in Embed Frameworks */,
 				E2C1CDAE265E22BD00E158E0 /* Turf.xcframework in Embed Frameworks */,
+				2CAEDB1E29AEC08B00E59543 /* MapboxNavigationNative.framework in Embed Frameworks */,
 				E2C1CDAB265E22B900E158E0 /* Polyline.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -833,8 +835,10 @@
 		2CA6105329802ACF003E49A7 /* MonitorConnectivityTypeProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorConnectivityTypeProviderTests.swift; sourceTree = "<group>"; };
 		2CAEABD02930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapboxNavigationServiceIntegrationTests.swift; sourceTree = "<group>"; };
 		2CAEABD22930D87B00DE851A /* RouterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterSpy.swift; sourceTree = "<group>"; };
+		2CAEDB1C29AEC08B00E59543 /* MapboxNavigationNative.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapboxNavigationNative.framework; path = "Carthage/Build/MapboxNavigationNative.xcframework/ios-arm64_x86_64-simulator/MapboxNavigationNative.framework"; sourceTree = "<group>"; };
 		2CC3043429A3DCDE00A3318F /* NavigationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStatusTests.swift; sourceTree = "<group>"; };
 		2CDF5C962919628100C41082 /* NavigationLocationManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationManagerSpy.swift; sourceTree = "<group>"; };
+		2CE1B2F329ACDC4E00745556 /* NativeTelemetryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTelemetryIntegrationTests.swift; sourceTree = "<group>"; };
 		2CE2512E291A56CE00C0FA15 /* IdleTimerManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdleTimerManagerTests.swift; sourceTree = "<group>"; };
 		2CE89C2A299E6C2A000A2E34 /* InterchangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterchangeTests.swift; sourceTree = "<group>"; };
 		2CE89C2C299E6D09000A2E34 /* JunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JunctionTests.swift; sourceTree = "<group>"; };
@@ -1428,9 +1432,9 @@
 			files = (
 				E2C1CDAA265E22B900E158E0 /* Polyline.xcframework in Frameworks */,
 				E2C1CDB0265E22C100E158E0 /* MapboxCommon.xcframework in Frameworks */,
-				E2C1CDA7265E22B400E158E0 /* MapboxNavigationNative.xcframework in Frameworks */,
 				E2C1CDA0265E22AA00E158E0 /* MapboxDirections.xcframework in Frameworks */,
 				E2C1CDAD265E22BD00E158E0 /* Turf.xcframework in Frameworks */,
+				2CAEDB1D29AEC08B00E59543 /* MapboxNavigationNative.framework in Frameworks */,
 				E2C1CDA4265E22AF00E158E0 /* MapboxMobileEvents.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1580,6 +1584,7 @@
 		2C585154292521C20077A558 /* MapboxCoreNavigationIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				2CE1B2F329ACDC4E00745556 /* NativeTelemetryIntegrationTests.swift */,
 				2CAEABD02930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift */,
 				2C71DE01292F821E00620775 /* BillingHandlerIntegrationTests.swift */,
 				2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */,
@@ -1588,16 +1593,6 @@
 			);
 			name = MapboxCoreNavigationIntegrationTests;
 			path = Tests/MapboxCoreNavigationIntegrationTests;
-			sourceTree = "<group>";
-		};
-		2CE89C29299E6C17000A2E34 /* EV */ = {
-			isa = PBXGroup;
-			children = (
-				2CE89C2A299E6C2A000A2E34 /* InterchangeTests.swift */,
-				2CE89C2C299E6D09000A2E34 /* JunctionTests.swift */,
-				2CE89C2E299E6E08000A2E34 /* RoadObjectKindTests.swift */,
-			);
-			path = EV;
 			sourceTree = "<group>";
 		};
 		2C856447297AD64C006EFCBB /* Telemetry */ = {
@@ -1625,6 +1620,23 @@
 				2CA6104C297EF78C003E49A7 /* DeviceSpy.swift */,
 			);
 			path = System;
+			sourceTree = "<group>";
+		};
+		2CE1B2F229ACDA4A00745556 /* Telemtry */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Telemtry;
+			sourceTree = "<group>";
+		};
+		2CE89C29299E6C17000A2E34 /* EV */ = {
+			isa = PBXGroup;
+			children = (
+				2CE89C2A299E6C2A000A2E34 /* InterchangeTests.swift */,
+				2CE89C2C299E6D09000A2E34 /* JunctionTests.swift */,
+				2CE89C2E299E6E08000A2E34 /* RoadObjectKindTests.swift */,
+			);
+			path = EV;
 			sourceTree = "<group>";
 		};
 		2CF3F8C92926D38A00BB2B9C /* Helper */ = {
@@ -1723,6 +1735,7 @@
 		35B711D01E5E7AD2001EDA8D /* MapboxNavigationTests */ = {
 			isa = PBXGroup;
 			children = (
+				2CE1B2F229ACDA4A00745556 /* Telemtry */,
 				2CF3F8C92926D38A00BB2B9C /* Helper */,
 				8A0155E628F8EC58009E299C /* Preview */,
 				8AB316BD26BC9F1800C3AC76 /* Camera */,
@@ -2174,6 +2187,7 @@
 		A9E2B43473B53369153F54C6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2CAEDB1C29AEC08B00E59543 /* MapboxNavigationNative.framework */,
 				E2C9D8A8268DCE31005D8955 /* XCTest.framework */,
 				E2CC18F3265FA28900D61CBC /* Cedar.framework */,
 				8D424F26215ECA5D00432491 /* CoreLocation.framework */,
@@ -3130,7 +3144,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2C585167292531340077A558 /* PassiveLocationManagerIntegrationTests.swift in Sources */,
+				2CF8318B29AEBB0F001D26C9 /* NativeTelemetryIntegrationTests.swift in Sources */,
+				2CAEDB2029AF7F4200E59543 /* Dictionary+Equality.swift in Sources */,
 				2C71DE02292F821E00620775 /* BillingHandlerIntegrationTests.swift in Sources */,
 				2C9DDBE42934D8FD007F8CFD /* MapboxCoreNavigationIntegrationTests.swift in Sources */,
 				2C58515F292523670077A558 /* RouteControllerIntegrationTests.swift in Sources */,
@@ -3438,6 +3453,7 @@
 				2CF3F8CD2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift in Sources */,
 				DA1755F82357B6BD00B06C1D /* StringTests.swift in Sources */,
 				355B469D22B9031E009CE634 /* SKUTestable.swift in Sources */,
+				2C234B4329AEAD2B00830723 /* PassiveLocationManagerIntegrationTests.swift in Sources */,
 				3510300F1F54B67000E3B7E7 /* LaneSnapshotTests.swift in Sources */,
 				B47C1B86261FD3E00078546C /* NavigationPlotter.swift in Sources */,
 				169A970A216440820082A6A0 /* NavigationViewControllerTestDoubles.swift in Sources */,
@@ -4243,7 +4259,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 140;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/MapboxNavigationNative.xcframework/ios-arm64_x86_64-simulator",
+				);
 				INFOPLIST_FILE = Sources/MapboxCoreNavigation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -4270,7 +4289,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 140;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/MapboxNavigationNative.xcframework/ios-arm64_x86_64-simulator",
+				);
 				INFOPLIST_FILE = Sources/MapboxCoreNavigation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -317,7 +317,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -350,7 +350,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -384,17 +384,17 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter routerType: An optional router type to use for traversing the route.
      - parameter customActivityType: Custom `CLActivityType` to be used for location updates. If not specified, SDK will pick it automatically for current navigation profile.
      */
-    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)")
     required public convenience init(routeResponse: RouteResponse,
-                         routeIndex: Int,
-                         routeOptions: RouteOptions,
-                         customRoutingProvider: RoutingProvider? = nil,
-                         credentials: Credentials,
-                         locationSource: NavigationLocationManager? = nil,
-                         eventsManagerType: NavigationEventsManager.Type? = nil,
-                         simulating simulationMode: SimulationMode? = nil,
-                         routerType: Router.Type? = nil,
-                         customActivityType: CLActivityType? = nil) {
+                                     routeIndex: Int,
+                                     routeOptions: RouteOptions,
+                                     customRoutingProvider: RoutingProvider? = nil,
+                                     credentials: Credentials,
+                                     locationSource: NavigationLocationManager? = nil,
+                                     eventsManagerType: NavigationEventsManager.Type? = nil,
+                                     simulating simulationMode: SimulationMode? = nil,
+                                     routerType: Router.Type? = nil,
+                                     customActivityType: CLActivityType? = nil) {
         self.init(indexedRouteResponse: .init(routeResponse: routeResponse,
                                               routeIndex: routeIndex),
                   customRoutingProvider: customRoutingProvider,
@@ -416,6 +416,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
+     - parameter userInfo: An optional metadata to be provided as initial value of `NavigationEventsManager.userInfo` property.
      */
     required public init(indexedRouteResponse: IndexedRouteResponse,
                          customRoutingProvider: RoutingProvider? = nil,
@@ -424,7 +425,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                          eventsManagerType: NavigationEventsManager.Type? = nil,
                          simulating simulationMode: SimulationMode? = nil,
                          routerType: Router.Type? = nil,
-                         customActivityType: CLActivityType? = nil) {
+                         customActivityType: CLActivityType? = nil,
+                         userInfo: [String: String?]? = nil) {
         nativeLocationSource = locationSource ?? NavigationLocationManager()
         self.credentials = credentials
         self.simulationMode = simulationMode ?? .inTunnels
@@ -442,14 +444,16 @@ public class MapboxNavigationService: NSObject, NavigationService {
                    indexedRouteResponse: indexedRouteResponse,
                    customRoutingProvider: customRoutingProvider,
                    eventsManagerType: eventsManagerType,
-                   customActivityType: customActivityType)
+                   customActivityType: customActivityType,
+                   userInfo: userInfo)
     }
 
     private func commonInit(routerType: Router.Type?,
                             indexedRouteResponse: IndexedRouteResponse,
                             customRoutingProvider: RoutingProvider?,
                             eventsManagerType: NavigationEventsManager.Type?,
-                            customActivityType: CLActivityType?) {
+                            customActivityType: CLActivityType?,
+                            userInfo: [String: String?]?) {
         resumeNotifications()
 
         let routerType = routerType ?? DefaultRouter.self
@@ -462,6 +466,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         let eventType = eventsManagerType ?? NavigationEventsManager.self
         _eventsManager = eventType.init(activeNavigationDataSource: self,
                                         accessToken: self.credentials.accessToken)
+        _eventsManager?.userInfo = userInfo
         locationManager.activityType = customActivityType ?? options.activityType
         bootstrapEvents()
         
@@ -481,6 +486,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter credentials: Credentials to authorize additional data requests throughout the route.
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
      - parameter routerType: An optional router type to use for traversing the route.
+     - parameter customActivityType: Custom `CLActivityType` to be used for location updates. If not specified, SDK will pick it automatically for current navigation profile.
+     - parameter userInfo: An optional metadata to be provided as initial value of `NavigationEventsManager.userInfo` property.
      - returns `nil` if provided `historyFileDump` does not contain valid initial route.
      */
     public convenience init?(history: History,
@@ -489,7 +496,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                              credentials: Credentials,
                              eventsManagerType: NavigationEventsManager.Type? = nil,
                              routerType: Router.Type? = nil,
-                             customActivityType: CLActivityType? = nil) {
+                             customActivityType: CLActivityType? = nil,
+                             userInfo: [String: String?]? = nil) {
         guard let routeResponse = history.initialRoute else {
             return nil
         }
@@ -502,7 +510,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                   locationSource: replayLocationManager,
                   eventsManagerType: eventsManagerType,
                   routerType: routerType,
-                  customActivityType: customActivityType)
+                  customActivityType: customActivityType,
+                  userInfo: userInfo)
         
         if customHistoryEventsListener == nil {
             replayLocationManager.eventsListener = self
@@ -518,7 +527,9 @@ public class MapboxNavigationService: NSObject, NavigationService {
          routerType: Router.Type?,
          customActivityType: CLActivityType?,
          simulatedLocationSourceType: SimulatedLocationManager.Type,
-         poorGPSTimer: DispatchTimer) {
+         poorGPSTimer: DispatchTimer,
+         userInfo: [String: String?]? = nil
+    ) {
         self.nativeLocationSource = locationSource
         self.credentials = credentials
         self.simulationMode = simulationMode
@@ -530,7 +541,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                    indexedRouteResponse: indexedRouteResponse,
                    customRoutingProvider: customRoutingProvider,
                    eventsManagerType: eventsManagerType,
-                   customActivityType: customActivityType)
+                   customActivityType: customActivityType,
+                   userInfo: userInfo)
     }
     
     deinit {

--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
@@ -57,7 +57,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
         delegate = NavigationServiceDelegateSpy()
         routeResponse = makeRouteResponse()
         route = routeResponse.routes!.first!
-        initialRouteResponse = IndexedRouteResponse.init(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions), routeIndex: 0)
+        initialRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions), routeIndex: 0)
 
         alternateRouteResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
         alternateRoute = Fixture.route(from: jsonFileName, options: routeOptions)

--- a/Tests/MapboxCoreNavigationIntegrationTests/NativeTelemetryIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/NativeTelemetryIntegrationTests.swift
@@ -1,0 +1,539 @@
+import XCTest
+import MapboxDirections
+import MapboxNavigationNative
+import CoreLocation
+import AVFoundation
+import Polyline
+@testable import TestHelper
+@_implementationOnly import MapboxCommon_Private
+@testable @_spi(MapboxInternal) import MapboxCoreNavigation
+
+class NativeTelemetryIntegrationTests: TestCase {
+    let expectationsTimeout: Double = 2
+    var navigationService: NavigationService!
+    var locationManager: ReplayLocationManager!
+    var passiveLocationManager: PassiveLocationManager!
+
+    var indexedRouteResponse: IndexedRouteResponse!
+    var route: Route!
+    var routeResponse: RouteResponse!
+    var alternateRouteResponse: RouteResponse!
+    var alternateRoute: Route!
+
+    var directions: Directions!
+    var navigator: MapboxCoreNavigation.Navigator!
+    var eventsAPI: EventsService!
+    var telemetryObserver: TelemetryObserver!
+    let userInfo = [
+        "userId": "user_id_value",
+        "sessionId": "session_id_value",
+        "name": "name_value",
+        "version": "version_value",
+    ]
+    var dictionaryUserInfo: NSDictionary {
+        NSDictionary(dictionary: userInfo)
+    }
+
+    private var device: UIDevice { UIDevice.current }
+    private var screenBrightness: Int { Int(UIScreen.main.brightness * 100) }
+    private var deviceString: String { "\(device.model) (\(cpu); Simulator)" }
+    private var platformName: String { device.systemName }
+    private var platformVersion: String { ProcessInfo.processInfo.operatingSystemVersionString }
+    private var volumeLevel: Int { Int(AVAudioSession.sharedInstance().outputVolume * 100) }
+    private var batteryPluggedIn: Bool { [.charging, .full].contains(UIDevice.current.batteryState) }
+
+    override func setUp() {
+        NavigationTelemetryConfiguration.useNavNativeTelemetryEvents = true
+        directions = .mocked
+        configureEventsObserver()
+
+        let routeOptions = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 9.519172, longitude: 47.210823),
+            CLLocationCoordinate2D(latitude: 9.52222, longitude: 47.214268),
+            CLLocationCoordinate2D(latitude: 47.212326, longitude: 9.512569),
+        ])
+        routeOptions.includesAlternativeRoutes = false
+        let jsonFileName = "multileg-route"
+        routeResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+        route = routeResponse.routes!.first!
+        indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
+        alternateRouteResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+        alternateRoute = Fixture.route(from: jsonFileName, options: routeOptions)
+
+        let customConfig = ["telemetry": ["eventsPriority": "Immediate"]]
+        UserDefaults.standard.set(customConfig, forKey: customConfigKey)
+
+        UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationWhenInUseUsageDescription")
+        UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
+
+        Navigator.shared.rerouteController.reroutesProactively = false
+
+        let steps = route.legs[0].steps
+        var coordinates: [CLLocationCoordinate2D] = []
+        if let firstStep = steps[0].shape, let secondStep = steps[1].shape {
+            coordinates = firstStep.coordinates + secondStep.coordinates.prefix(1)
+        }
+
+        locationManager = ReplayLocationManager(locations: coordinates
+            .map { CLLocation(coordinate: $0) }
+            .shiftedToPresent())
+
+        locationManager.speedMultiplier = 10
+        navigator = .shared
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+        NavigationTelemetryConfiguration.useNavNativeTelemetryEvents = false
+        Navigator.shared.rerouteController.reroutesProactively = true
+        navigationService = nil
+        passiveLocationManager = nil
+        navigator = nil
+        UserDefaults.resetStandardUserDefaults()
+        eventsAPI.unregisterObserver(for: telemetryObserver)
+        telemetryObserver = nil
+
+        super.tearDown()
+    }
+
+    func testStartFreeDrive() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+    }
+
+    func testStartActiveNavigation() {
+        updateLocation()
+        let firstLocation = locationManager.locations.first!
+        configureActiveNavigation()
+
+
+        // TODO: do not skip events after fix in NN
+        telemetryObserver.shouldSkipEventsCount = 2
+
+        var activeAttributesKeys = activeNoValueCheckAttributesKeys
+        activeAttributesKeys.insert("locationsAfter")
+        telemetryObserver.expectedEvents = [
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.depart",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate,
+                                  noValueCheckAttributesKeys: activeAttributesKeys),
+        ]
+        startActiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: 5)
+    }
+
+    func testStartActiveNavigationAfterFreeRide() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+        telemetryObserver.reset()
+
+        configureActiveNavigation()
+
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "stop", coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+        ]
+        startActiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+    }
+
+    func testFinishRoute() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+        telemetryObserver.reset()
+
+        configureActiveNavigation()
+
+        var activeAttributesKeys = activeNoValueCheckAttributesKeys
+        activeAttributesKeys.insert("locationsAfter")
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "stop", coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.depart",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate,
+                                  noValueCheckAttributesKeys: activeAttributesKeys),
+// TODO: enable after fix in NN
+//            activeNavigationEvent(eventName: "navigation.arrive",
+//                                  routeProgress: navigationService.routeProgress,
+//                                  coordinate: firstLocation.coordinate,
+//                                  noValueCheckAttributesKeys: activeAttributesKeys)
+        ]
+        startActiveNavigation()
+
+        let navigationFinished = expectation(description: "Navigation finished")
+        locationManager.replayCompletionHandler = { [weak self] _ in
+            navigationFinished.fulfill()
+            self?.navigationService.endNavigation(feedback: nil)
+            return false
+        }
+
+        wait(for: [telemetryObserver.expectation, navigationFinished], timeout: 5)
+    }
+
+    func testStartFreeRideAfterActiveNavigation() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+
+        telemetryObserver.reset()
+        configureActiveNavigation()
+
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "stop", coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+        ]
+        startActiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+
+        telemetryObserver.reset()
+
+        var activeAttributesKeys = activeNoValueCheckAttributesKeys
+        activeAttributesKeys.insert("locationsBefore")
+        telemetryObserver.expectedEvents = [
+            activeNavigationEvent(eventName: "navigation.cancel",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate,
+                                 noValueCheckAttributesKeys: activeAttributesKeys),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_ended",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate),
+        ]
+        navigationService.router.finishRouting()
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+    }
+
+    struct Event: Equatable {
+        let eventName: String
+        let attributes: [String: Any]
+        let approximateValueCheckAttributes: [String: (Double, Double)]
+        let noValueCheckAttributesKeys: Set<String>
+
+        static func ==(lhs: NativeTelemetryIntegrationTests.Event, rhs: NativeTelemetryIntegrationTests.Event) -> Bool {
+            lhs.eventName == rhs.eventName &&
+            lhs.attributes.count == rhs.attributes.count &&
+            lhs.noValueCheckAttributesKeys == rhs.noValueCheckAttributesKeys &&
+            lhs.approximateValueCheckAttributes.count == rhs.approximateValueCheckAttributes.count &&
+            lhs.approximateValueCheckAttributes.allSatisfy { key, value in
+                guard let rightValue = rhs.approximateValueCheckAttributes[key] else { return false }
+                return abs(value.0 - rightValue.0) <= value.1
+            }
+        }
+    }
+
+    final class TelemetryObserver: EventsServiceObserver {
+        var actualEvents: [Event] = []
+        var expectedEvents: [Event] = []
+
+        var shouldSkipEventsCount: Int = 0
+        private(set) var skippedEventsCount: Int = 0
+
+        var expectation = XCTestExpectation(description: "Events sent expectation")
+
+        func reset() {
+            actualEvents = []
+            expectation = XCTestExpectation(description: "Events sent expectation")
+        }
+
+        func didEncounterError(forError error: EventsServiceError, events: Any) {
+            DispatchQueue.main.async { [weak self] in
+                self?.handleEvents(events)
+            }
+        }
+
+        func didSendEvents(forEvents events: Any) {
+            DispatchQueue.main.async { [weak self] in
+                self?.handleEvents(events)
+            }
+        }
+
+        private func handleEvents(_ events: Any) {
+            guard let eventAttributes = events as? [[String: Any]] else {
+                return XCTFail("Events has incorrect type")
+            }
+            for event in eventAttributes {
+                handleEvent(event)
+            }
+        }
+
+        private func handleEvent(_ event: [String: Any]) {
+            guard skippedEventsCount >= shouldSkipEventsCount else {
+                skippedEventsCount += 1
+                return
+            }
+
+            guard let eventName = event["event"] as? String else {
+                return XCTFail("Event \(event) has no name")
+            }
+
+            guard actualEvents.count < expectedEvents.count else {
+                return XCTFail("Event \(eventName) was not expected")
+            }
+
+            print("\(eventName) event revieved. Details \(event)")
+            let expectedEvent = expectedEvents[actualEvents.count]
+            let typedEvent = Event(eventName: eventName,
+                                   attributes: event,
+                                   expectedEvent: expectedEvent)
+            actualEvents.append(typedEvent)
+            XCTAssertEqual(typedEvent, expectedEvent)
+
+            if expectedEvents.count == actualEvents.count {
+                expectation.fulfill()
+            }
+        }
+    }
+
+    fileprivate var navigationBaseAttributes: [String: Any] {
+        [
+            "connectivity": "WiFi",
+            "sdkIdentifier": "mapbox-navigation-ios",
+            "eventVersion": 2.4,
+            "version": 2.4,
+            "operatingSystem": "\(platformName) \(platformVersion)",
+            "device": deviceString,
+            "simulation": 0,
+            "locationEngine": "sim:0,acc:0",
+            "volumeLevel": volumeLevel,
+            "audioType": "speaker",
+            "screenBrightness": screenBrightness,
+            "percentTimeInForeground": 100,
+            "percentTimeInPortrait": 100,
+            "batteryPluggedIn": batteryPluggedIn as NSNumber,
+            "appMetadata": dictionaryUserInfo
+        ]
+    }
+
+    private var passiveNoValueCheckAttributesKeys: Set<String> {
+        [
+            "created",
+            "createdMonotime",
+            "driverModeStartTimestamp",
+            "driverModeStartTimestampMonotime",
+            "driverModeId"
+        ]
+    }
+
+    private var activeNoValueCheckAttributesKeys: Set<String> {
+        let attributes: Set<String> = [
+            "originalRequestIdentifier",
+            "requestIdentifier"
+        ]
+        return attributes.union(passiveNoValueCheckAttributesKeys)
+    }
+
+    private var cpu: String {
+#if arch(x86_64)
+        return "x86_64"
+#elseif arch(arm)
+        return "arm"
+#elseif arch(arm64)
+        return "arm64"
+#else
+        return ""
+#endif
+    }
+
+    private func stepLocations(legIndex: Int = 0, stepIndex: Int = 0) -> [CLLocation] {
+        guard let shape = route.legs[legIndex].steps[stepIndex].shape else { return [] }
+        let now = Date()
+        return shape.coordinates.enumerated().map {
+            CLLocation(coordinate: $0.element,
+                       altitude: -1,
+                       horizontalAccuracy: 10,
+                       verticalAccuracy: -1,
+                       course: -1,
+                       speed: 10,
+                       timestamp: now + $0.offset)
+        }
+    }
+
+    private func configureEventsObserver() {
+        let accessToken = Fixture.credentials.accessToken ?? ""
+        let options = EventsServerOptions(
+            token: accessToken,
+            userAgentFragment: MapboxNavigationNative.Navigator.getUserAgentFragment(),
+            deferredDeliveryServiceOptions: nil
+        )
+        eventsAPI = EventsService.getOrCreate(for: options)
+        telemetryObserver = TelemetryObserver()
+        eventsAPI.registerObserver(for: telemetryObserver)
+    }
+
+    private func startPassiveNavigation() {
+        passiveLocationManager = PassiveLocationManager(directions: directions,
+                                                        systemLocationManager: locationManager,
+                                                        userInfo: userInfo)
+        updateLocation()
+    }
+
+    private func startActiveNavigation() {
+        navigationService?.start()
+        updateLocation()
+    }
+
+    private func configureActiveNavigation() {
+        navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
+                                                    customRoutingProvider: MapboxRoutingProvider(.offline),
+                                                    credentials: Fixture.credentials,
+                                                    locationSource: locationManager,
+                                                    simulating: .never,
+                                                    userInfo: userInfo)
+        navigationService.eventsManager.userInfo = userInfo
+    }
+
+    private func updateLocation() {
+        let firstLocation = locationManager.locations.first!
+        navigator.updateLocation(firstLocation) { _ in }
+    }
+
+    private func freeDriveEvent(eventType: String,
+                                coordinate: CLLocationCoordinate2D) -> Event {
+        let attributes: [String: Any] = [
+            "eventType": eventType,
+            "driverMode": "freeDrive",
+            "lat": coordinate.latitude,
+            "lng": coordinate.longitude,
+        ]
+        return event(with: "navigation.freeDrive",
+                     attributes: attributes,
+                     approximateValueCheckAttributes: [:],
+                     noValueCheckAttributesKeys: passiveNoValueCheckAttributesKeys)
+    }
+
+    private func activeNavigationEvent(eventName: String,
+                                       state: String? = nil,
+                                       routeProgress: RouteProgress,
+                                       coordinate: CLLocationCoordinate2D,
+                                       originalRoute: Route? = nil,
+                                       rerouteCount: Int = 0,
+                                       noValueCheckAttributesKeys: Set<String>? = nil) -> Event {
+        let route = routeProgress.route
+        let originalRoute = originalRoute ?? route
+        let lastCoordinate = route.shape!.coordinates.last!
+        let location = CLLocation(coordinate: coordinate)
+        var attributes: [String: Any] = [
+            "originalStepCount": originalRoute.legs.map({$0.steps.count}).reduce(0, +),
+            "stepCount": routeProgress.currentLeg.steps.count,
+            "voiceIndex": 0,
+            "bannerIndex": 0,
+            "driverMode": "trip",
+            "lat": coordinate.latitude,
+            "lng": coordinate.longitude,
+            "profile": "driving-traffic",
+            "originalGeometry": Polyline(coordinates: originalRoute.shape!.coordinates).encodedPolyline,
+            "originalGeometryFormat": "precision_6",
+            "geometry": Polyline(coordinates: route.shape!.coordinates).encodedPolyline,
+            "geometryFormat": "precision_6",
+            "stepIndex": routeProgress.currentLegProgress.stepIndex,
+            "legIndex": routeProgress.legIndex,
+            "legCount": routeProgress.route.legs.count,
+            "estimatedDuration": Int(route.expectedTravelTime),
+            "estimatedDistance": route.distance,
+            "rerouteCount": rerouteCount
+        ]
+        if let state = state {
+            attributes["state"] = state
+        }
+        let approximateValueCheckAttributes = [
+            "distanceCompleted": (routeProgress.distanceTraveled, 10.0),
+            "distanceRemaining": (routeProgress.distanceRemaining, 10.0),
+            "durationRemaining": (routeProgress.durationRemaining, 1.0),
+            "absoluteDistanceToDestination": (location.distance(from: CLLocation(latitude: lastCoordinate.latitude, longitude: lastCoordinate.longitude)), 10.0)
+        ]
+        let attributesKeys = noValueCheckAttributesKeys ?? activeNoValueCheckAttributesKeys
+        return event(with: eventName,
+                     attributes: attributes,
+                     approximateValueCheckAttributes: approximateValueCheckAttributes,
+                     noValueCheckAttributesKeys: attributesKeys)
+    }
+
+    private func event(with eventName: String,
+                       attributes: [String: Any],
+                       approximateValueCheckAttributes: [String: (Double, Double)],
+                       noValueCheckAttributesKeys: Set<String>) -> Event {
+        var eventAttributes: [String: Any] = [
+            "event": eventName
+        ]
+        eventAttributes.merge(navigationBaseAttributes) { _, new in new }
+        eventAttributes.merge(attributes) { _, new in new }
+        return Event(eventName: eventName,
+                     attributes: eventAttributes,
+                     approximateValueCheckAttributes: approximateValueCheckAttributes,
+                     noValueCheckAttributesKeys: noValueCheckAttributesKeys)
+    }
+}
+
+extension NativeTelemetryIntegrationTests.Event {
+    var approximateValueCheckAttributesKeys: Set<String> {
+        Set(approximateValueCheckAttributes.keys)
+    }
+    var specialCheckAttributesKeys: Set<String> {
+        noValueCheckAttributesKeys.union(approximateValueCheckAttributesKeys)
+    }
+
+    init(eventName: String,
+         attributes: [String: Any],
+         expectedEvent:  NativeTelemetryIntegrationTests.Event) {
+        let specialCheckAttributeKeys = expectedEvent.specialCheckAttributesKeys
+        let eventAttributes = attributes.filter { !specialCheckAttributeKeys.contains($0.key) }
+        let approximateValueCheckAttributes: [String: (Double, Double)] = attributes
+            .filter { expectedEvent.approximateValueCheckAttributesKeys.contains($0.key) }
+            .reduce(into: [:]) { result, element in
+                guard let doubleValue = element.value as? Double,
+                      let eps = expectedEvent.approximateValueCheckAttributes[element.key]?.1
+                else { return }
+
+                result[element.key] = (doubleValue, eps)
+            }
+        let noValueCheckAttributesKeys = attributes.keys.filter { expectedEvent.noValueCheckAttributesKeys.contains($0) }
+        self.init(eventName: eventName,
+                  attributes: eventAttributes,
+                  approximateValueCheckAttributes: approximateValueCheckAttributes,
+                  noValueCheckAttributesKeys: Set(noValueCheckAttributesKeys))
+    }
+}


### PR DESCRIPTION
* Adds the ability to pass userInfo to NavigationService to use app metadata in Telemetry even for the first sent event.
* Adds basic Native Telemetry integration tests.