### PR TITLE
Fix unexpected camera jumps when showing the list of upcoming maneuvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 **Note:** The Mapbox Electronic Horizon feature of the Mapbox Navigation SDK is in public beta and is subject to changes, including its pricing. Use of the feature is subject to the beta product restrictions in the Mapbox Terms of Service. Mapbox reserves the right to eliminate any free tier or free evaluation offers at any time and require customers to place an order to purchase the Mapbox Electronic Horizon feature, regardless of the level of use of the feature.
 * Added`Interchange.identifier` and `Junction.identifier` fields. ([#4396](https://github.com/mapbox/mapbox-navigation-ios/pull/4396))
 
+### Camera
+
+* Fixes an issue where the camera's position was not calculated correctly when banners fully overlapped the map. ([#4400](https://github.com/mapbox/mapbox-navigation-ios/pull/4400))
+
 ## v2.11.0
 
 ### Packaging

--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -131,12 +131,9 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     private func updateNavigationCameraViewport() {
         if let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource {
             let newViewport = viewportPadding
-            let mapViewBounds = navigationMapView.mapView.bounds
+            let visibleRect = navigationMapView.mapView.bounds.inset(by: newViewport)
 
-            let visibleWidth = mapViewBounds.width - newViewport.left - newViewport.right
-            let visibleHeight = mapViewBounds.size.height - newViewport.top - newViewport.bottom
-
-            guard visibleWidth > 0, visibleHeight > 0 else {
+            guard visibleRect.size.width > 0, visibleRect.size.height > 0 else {
                 // The viewport padding is bigger than the map itself,
                 // this usually means that it is being fully overlapped by one of the banners
                 // In this case, we ignore new viewport to avoid unexpected camera jumps

--- a/Sources/MapboxNavigation/CameraController.swift
+++ b/Sources/MapboxNavigation/CameraController.swift
@@ -130,7 +130,20 @@ class CameraController: NavigationComponent, NavigationComponentDelegate {
     
     private func updateNavigationCameraViewport() {
         if let navigationViewportDataSource = navigationMapView.navigationCamera.viewportDataSource as? NavigationViewportDataSource {
-            navigationViewportDataSource.viewportPadding = viewportPadding
+            let newViewport = viewportPadding
+            let mapViewBounds = navigationMapView.mapView.bounds
+
+            let visibleWidth = mapViewBounds.width - newViewport.left - newViewport.right
+            let visibleHeight = mapViewBounds.size.height - newViewport.top - newViewport.bottom
+
+            guard visibleWidth > 0, visibleHeight > 0 else {
+                // The viewport padding is bigger than the map itself,
+                // this usually means that it is being fully overlapped by one of the banners
+                // In this case, we ignore new viewport to avoid unexpected camera jumps
+                return
+            }
+
+            navigationViewportDataSource.viewportPadding = newViewport
         }
     }
 


### PR DESCRIPTION
Fixes a camera jumping issue:

https://user-images.githubusercontent.com/1976216/223154902-524b1a6a-5edd-41f7-bfec-54e07f4a1612.mp4

Now we will ignore all invalid viewports and camera won't move at all.