### PR TITLE
Missing replay events fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 * Fixes an issue where the camera's position was not calculated correctly when banners fully overlapped the map. ([#4400](https://github.com/mapbox/mapbox-navigation-ios/pull/4400))
 
 ### Other changes
+
+* Fixed an issue where `ReplayLocationManager` init with `History` removed all custom history events. ([#4403](https://github.com/mapbox/mapbox-navigation-ios/pull/4403))
 * Fixes possible display negative remaining distance value. ([#4402](https://github.com/mapbox/mapbox-navigation-ios/pull/4402))
 
 ## v2.11.0

--- a/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/ReplayLocationManager.swift
@@ -15,14 +15,19 @@ open class ReplayLocationManager: NavigationLocationManager {
      */
     public var speedMultiplier: TimeInterval = 1
     
+    private var _locations: [CLLocation]
     /**
      `locations` to be replayed.
      */
     public var locations: [CLLocation] {
-        didSet {
+        get {
+            _locations
+        }
+        set {
+            _locations = newValue
             currentIndex = 0
             verifyParameters()
-            self.events = locations.map { ReplayEvent(from: $0) }
+            self.events = _locations.map { ReplayEvent(from: $0) }
         }
     }
     
@@ -71,7 +76,7 @@ open class ReplayLocationManager: NavigationLocationManager {
     private var nextTickWorkItem: DispatchWorkItem?
     
     public init(locations: [CLLocation]) {
-        self.locations = locations.sorted { $0.timestamp < $1.timestamp }
+        self._locations = locations.sorted { $0.timestamp < $1.timestamp }
         self.events = locations.map { ReplayEvent(from: $0) }
         super.init()
         
@@ -80,7 +85,7 @@ open class ReplayLocationManager: NavigationLocationManager {
     }
     
     public init(history: History) {
-        self.locations = history.rawLocations.sorted { $0.timestamp < $1.timestamp }
+        self._locations = history.rawLocations.sorted { $0.timestamp < $1.timestamp }
         self.events = history.events.map { ReplayEvent(from: $0) }
         
         super.init()
@@ -201,7 +206,7 @@ open class ReplayLocationManager: NavigationLocationManager {
             
             previousNewLocationTimestamp = newTimestamp
         }
-        self.locations = advancedLocations
+        self._locations = advancedLocations
     }
 }
 

--- a/Tests/MapboxCoreNavigationTests/ReplayLocationManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/ReplayLocationManagerTests.swift
@@ -117,4 +117,33 @@ final class ReplayLocationManagerTests: TestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         XCTAssertGreaterThan(ticksCount, 1)
     }
+    
+    func testHistoryInitializationDoesNotLooseCustomEvents() {
+        let firstLocation = CLLocation(coordinate: .init(latitude: 0, longitude: 0),
+                                       altitude: 0,
+                                       horizontalAccuracy: 0,
+                                       verticalAccuracy: 0,
+                                       timestamp: Date())
+        let secondLocation = CLLocation(coordinate: .init(latitude: 1, longitude: 1),
+                                        altitude: 0,
+                                        horizontalAccuracy: 0,
+                                        verticalAccuracy: 0,
+                                        timestamp: Date())
+        
+        let manager = ReplayLocationManager(history: History(events: [
+            LocationUpdateHistoryEvent(timestamp: Date().timeIntervalSince1970,
+                                       location: firstLocation),
+            UserPushedHistoryEvent(timestamp: Date().timeIntervalSince1970,
+                                   type: "test",
+                                   properties: "properties"),
+            LocationUpdateHistoryEvent(timestamp: Date().timeIntervalSince1970,
+                                       location: secondLocation)
+        ]))
+        
+        XCTAssert(manager.events.contains {
+            guard case let .historyEvent(event) = $0.kind else { return false }
+            
+            return event is UserPushedHistoryEvent
+        })
+    }
 }


### PR DESCRIPTION
### Description
Fixed issue when initializing ReplayLocationManager with events removed all custom history events

### Implementation
Avoided `events` overwriting by separating an internal storage variable.