### PR TITLE
Up dependencies to NN to 128.0.0, Maps to 10.12.0-rc.1, Common to 23.4.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Packaging
 
-* MapboxCoreNavigation now requires [MapboxNavigationNative v127._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/127.0.0). ([#4396](https://github.com/mapbox/mapbox-navigation-ios/pull/4396))
+* MapboxCoreNavigation now requires [MapboxNavigationNative v128._x_](https://github.com/mapbox/mapbox-navigation-native-ios/releases/tag/128.0.0). ([#4408](https://github.com/mapbox/mapbox-navigation-ios/pull/4408))
 * MapboxCoreNavigation now requires [MapboxDirections v2.11.0-alpha.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.11.0-alpha.1). ([#4396](https://github.com/mapbox/mapbox-navigation-ios/pull/4396))
-* MapboxNavigation now requires [MapboxMaps v10.12.0-beta.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.12.0-beta.1). ([#4396](https://github.com/mapbox/mapbox-navigation-ios/pull/4396))
+* MapboxNavigation now requires [MapboxMaps v10.12.0-rc.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.12.0-rc.1). ([#4408](https://github.com/mapbox/mapbox-navigation-ios/pull/4408))
 
 ### Visual instructions
 * Fixed duplication of the road name components in the road shield and the label. ([#4401](https://github.com/mapbox/mapbox-navigation-ios/pull/4401))

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.4.0-beta.1
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 127.1.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" == 23.4.0-rc.1
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" ~> 128.0.0
 github "mapbox/mapbox-directions-swift" == 2.11.0-alpha.1
 github "mapbox/mapbox-events-ios" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.4.0-beta.1"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "127.1.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.4.0-rc.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "128.0.0"
 github "mapbox/mapbox-directions-swift" "v2.11.0-alpha.1"
 github "mapbox/mapbox-events-ios" "v1.0.10"
 github "mapbox/turf-swift" "v2.6.1"

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 127.1.0"
+  s.dependency "MapboxNavigationNative", "~> 128.0.0"
   s.dependency "MapboxDirections-pre", "2.11.0-alpha.1"
   s.dependency "MapboxMobileEvents", "~> 1.0"
 

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "185d791e7478cc5da7cc2b4756ecd0d0bd387eac",
-          "version": "23.4.0-beta.1"
+          "revision": "d38abed1cfca3843308d478450c3d8b07a797c5a",
+          "version": "23.4.0-rc.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "81b929488b5bbc467df4cf294ceffa0ae98ef0e0",
-          "version": "10.12.0-beta.1"
+          "revision": "82706a65bf7a51818d943c91f014d17588b0f65e",
+          "version": "10.12.0-rc.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "246fa104e4eec0fb913c036cb0505723e26a9a2e",
-          "version": "10.12.0-beta.1"
+          "revision": "e47d5d6f2b55b0decd9d60b47b3c9c9b6c726fa3",
+          "version": "10.12.0-rc.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "1abcb34ef6d3463a73ff517edd128db8d2ea4856",
-          "version": "127.1.0"
+          "revision": "b876a849063ff8f8d5aa4f151532b7480b06a918",
+          "version": "128.0.0"
         }
       },
       {

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", "~> 10.12.0-beta.1"
+  s.dependency "MapboxMaps", "~> 10.12.0-rc.1"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech", "~> 2.0"
   s.dependency "MapboxMobileEvents", "~> 1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "185d791e7478cc5da7cc2b4756ecd0d0bd387eac",
-          "version": "23.4.0-beta.1"
+          "revision": "d38abed1cfca3843308d478450c3d8b07a797c5a",
+          "version": "23.4.0-rc.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "81b929488b5bbc467df4cf294ceffa0ae98ef0e0",
-          "version": "10.12.0-beta.1"
+          "revision": "82706a65bf7a51818d943c91f014d17588b0f65e",
+          "version": "10.12.0-rc.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "246fa104e4eec0fb913c036cb0505723e26a9a2e",
-          "version": "10.12.0-beta.1"
+          "revision": "e47d5d6f2b55b0decd9d60b47b3c9c9b6c726fa3",
+          "version": "10.12.0-rc.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "1abcb34ef6d3463a73ff517edd128db8d2ea4856",
-          "version": "127.1.0"
+          "revision": "b876a849063ff8f8d5aa4f151532b7480b06a918",
+          "version": "128.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
     dependencies: [
         .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", .exact("2.11.0-alpha.1")),
         .package(name: "MapboxMobileEvents", url: "https://github.com/mapbox/mapbox-events-ios.git", from: "1.0.0"),
-        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "127.1.0"),
-        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.12.0-beta.1"),
+        .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "128.0.0"),
+        .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.12.0-rc.1"),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),
         .package(name: "MapboxSpeech", url: "https://github.com/mapbox/mapbox-speech-swift.git", from: "2.0.0"),
         .package(name: "CwlPreconditionTesting", url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -430,8 +430,6 @@ extension TileEndpointConfiguration {
                   dataset: datasetProfileIdentifier.rawValue,
                   version: tilesVersion,
                   token: accessToken,
-                  userAgent: URLSession.userAgent,
-                  navigatorVersion: "",
                   isFallback: targetVersion != nil,
                   versionBeforeFallback: targetVersion ?? tilesVersion,
                   minDiffInDaysToConsiderServerVersion: minimumDaysToPersistVersion as NSNumber?)

--- a/Sources/TestHelper/NavNative/TestNavigationStatusProvider.swift
+++ b/Sources/TestHelper/NavNative/TestNavigationStatusProvider.swift
@@ -17,7 +17,8 @@ public final class TestNavigationStatusProvider {
                                               voiceInstruction: VoiceInstruction? = nil,
                                               bannerInstruction: BannerInstruction? = nil,
                                               speedLimit: SpeedLimit? = nil,
-                                              activeGuidanceInfo: ActiveGuidanceInfo? = nil) -> NavigationStatus {
+                                              activeGuidanceInfo: ActiveGuidanceInfo? = nil,
+                                              upcomingRouteAlertUpdates: [UpcomingRouteAlertUpdate] = []) -> NavigationStatus {
         let fixLocation = FixLocation(location ?? CLLocation(latitude: 37.788443, longitude: -122.4020258))
         let shield = Shield(baseUrl: "shield_url", displayRef: "ref", name: "shield", textColor: "")
         let road = MapboxNavigationNative.RoadName(text: "name", language: "lang", imageBaseUrl: "base_image_url", shield: shield)
@@ -46,6 +47,7 @@ public final class TestNavigationStatusProvider {
                      offRoadProba: 0,
                      activeGuidanceInfo: activeGuidanceInfo,
                      upcomingRouteAlerts: [],
+                     upcomingRouteAlertUpdates: upcomingRouteAlertUpdates,
                      nextWaypointIndex: 0,
                      layer: nil)
     }

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - MapboxCoreNavigation (2.12.0-beta.1):
     - MapboxDirections-pre (= 2.11.0-alpha.1)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (~> 127.1.0)
+    - MapboxNavigationNative (~> 128.0.0)
   - MapboxDirections-pre (2.11.0-alpha.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.6.1)
@@ -17,12 +17,12 @@ PODS:
   - MapboxMobileEvents (1.0.10)
   - MapboxNavigation (2.12.0-beta.1):
     - MapboxCoreNavigation (= 2.12.0-beta.1)
-    - MapboxMaps (~> 10.12.0-beta.1)
+    - MapboxMaps (~> 10.12.0-rc.1)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (127.1.0):
-    - MapboxCommon (~> 23.4.0-beta.1)
+  - MapboxNavigationNative (128.0.0):
+    - MapboxCommon (~> 23.4.0-rc.1)
   - MapboxSpeech (2.1.1)
   - Polyline (5.1.0)
   - Solar-dev (3.0.1)
@@ -54,12 +54,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 43d22459a736a031d84ec878c919c3e0c7b5e6c3
   MapboxCoreMaps: 639f3264678fb3cb0ed455a7ff40d8c507f8855f
-  MapboxCoreNavigation: 78d033ded2e2bca1ac8e643141bed5462a0d39f9
+  MapboxCoreNavigation: 0fc00274b20ec43fd2b723234d5aa7e5a9176f19
   MapboxDirections-pre: 2741f1147b69240915d9ab8963c4c0aff53abcb4
   MapboxMaps: 758d7eff723c49fd00f2f8480366e0e06867393f
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
-  MapboxNavigation: f990b4c000f0c808e5bdecab24d66d2e37939517
-  MapboxNavigationNative: c926c6aea4413d6a1323e970eef42305edb6d255
+  MapboxNavigation: 13ba850325f9a52cbaf87255ab8f24162a9b1ca5
+  MapboxNavigationNative: 57689b079975d787c2402c2a19b548ac6c10c4db
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77
   Polyline: 2a1f29f87f8d9b7de868940f4f76deb8c678a5b1
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
@@ -67,4 +67,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 20f356205cc7a366d6b3c177155b683e2d62b354
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/Tests/MapboxCoreNavigationTests/Progress/RouteProgressTests.swift
+++ b/Tests/MapboxCoreNavigationTests/Progress/RouteProgressTests.swift
@@ -340,6 +340,7 @@ class RouteProgressTests: TestCase {
                     step: .init(distanceTraveled: stepDistanceTraveled, fractionTraveled: 0, remainingDistance: 0, remainingDuration: 0)
                 ),
                 upcomingRouteAlerts: [],
+                upcomingRouteAlertUpdates: [],
                 nextWaypointIndex: 0,
                 layer: nil
             )


### PR DESCRIPTION
Updates only dependency version. The migration to `upcomingRouteAlertUpdates` should be completed after some fixes in NN in the next release.