### PR TITLE
Use upcomingRouteAlertUpdates instead of upcomingRouteAlerts

### DIFF
--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -110,6 +110,8 @@
 		2C585165292530B70077A558 /* MapboxNavigationNative.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; };
 		2C585167292531340077A558 /* PassiveLocationManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */; };
 		2C59B995298330F8003D4EA0 /* FeedbackMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C59B994298330F8003D4EA0 /* FeedbackMetadata.swift */; };
+		2C60D94829CCAC8900DE9FE7 /* route-with-road-objects-japan.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C60D94029CCAC8900DE9FE7 /* route-with-road-objects-japan.json */; };
+		2C60D94929CCAC8900DE9FE7 /* route-with-road-objects-japan.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C60D94029CCAC8900DE9FE7 /* route-with-road-objects-japan.json */; };
 		2C67751C290AC4A6009C5EE4 /* MapboxNavigationNative.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C1CDA6265E22B400E158E0 /* MapboxNavigationNative.xcframework */; };
 		2C71DE02292F821E00620775 /* BillingHandlerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C71DE01292F821E00620775 /* BillingHandlerIntegrationTests.swift */; };
 		2C7FAF96291ABE62000217A7 /* TestRouteProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FAF95291ABE62000217A7 /* TestRouteProvider.swift */; };
@@ -806,6 +808,7 @@
 		2C58516229252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxCoreNavigationIntegrationTests.swift; sourceTree = "<group>"; };
 		2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassiveLocationManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		2C59B994298330F8003D4EA0 /* FeedbackMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackMetadata.swift; sourceTree = "<group>"; };
+		2C60D94029CCAC8900DE9FE7 /* route-with-road-objects-japan.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "route-with-road-objects-japan.json"; sourceTree = "<group>"; };
 		2C71DE01292F821E00620775 /* BillingHandlerIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BillingHandlerIntegrationTests.swift; sourceTree = "<group>"; };
 		2C7FAF95291ABE62000217A7 /* TestRouteProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRouteProvider.swift; sourceTree = "<group>"; };
 		2C7FAF97291BB1CA000217A7 /* RerouteControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RerouteControllerSpy.swift; sourceTree = "<group>"; };
@@ -2258,6 +2261,7 @@
 		B47C1AE4261FD0A30078546C /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				2C60D94029CCAC8900DE9FE7 /* route-with-road-objects-japan.json */,
 				8AFCE2F92964E2EE00EBFC11 /* route-with-instruction-components-with-subtype.json */,
 				8A474195294BBFDA00F231F9 /* route-with-amenities.json */,
 				B4953F5628762CAF0090E4F8 /* route-with-straight-line.json */,
@@ -2983,6 +2987,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C60D94929CCAC8900DE9FE7 /* route-with-road-objects-japan.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3032,6 +3037,7 @@
 				E2D1497D265CFB5B008135A3 /* 878.gph.gz in Resources */,
 				B4A78D27261FD47700FDF212 /* DCA-Arboretum.json in Resources */,
 				8A474196294BBFDB00F231F9 /* route-with-amenities.json in Resources */,
+				2C60D94829CCAC8900DE9FE7 /* route-with-road-objects-japan.json in Resources */,
 				2B5F6C342912B9430062E3B5 /* DCA-Arboretum-duration-edited.json in Resources */,
 				2B45758B28F56A160074039A /* ag_history.pbf.gz in Resources */,
 				B4A78D28261FD47700FDF212 /* routeWithInstructions.json in Resources */,

--- a/Sources/MapboxCoreNavigation/RouteAlert.swift
+++ b/Sources/MapboxCoreNavigation/RouteAlert.swift
@@ -18,8 +18,8 @@ public struct RouteAlert {
      */
     public let distanceToStart: CLLocationDistance
     
-    init(_ native: UpcomingRouteAlert) {
+    init(_ native: UpcomingRouteAlert, distanceToStart: CLLocationDistance) {
         self.roadObject = RoadObject(native.roadObject)
-        self.distanceToStart = native.distanceToStart
+        self.distanceToStart = distanceToStart
     }
 }

--- a/Sources/TestHelper/Fixtures/route-with-road-objects-japan.json
+++ b/Sources/TestHelper/Fixtures/route-with-road-objects-japan.json
@@ -1,0 +1,23060 @@
+{
+  "routes": [
+    {
+      "weight_typical": 4633.226,
+      "duration_typical": 4104.587,
+      "weight_name": "auto",
+      "weight": 4623.631,
+      "duration": 4113.889,
+      "distance": 74785.734,
+      "legs": [
+        {
+          "via_waypoints": [],
+          "admins": [
+            {
+              "iso_3166_1_alpha3": "JPN",
+              "iso_3166_1": "JP"
+            }
+          ],
+          "annotation": {
+            "maxspeed": [
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              }
+            ],
+            "congestion_numeric": [
+              0,
+              0,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0
+            ],
+            "speed": [
+              26.2,
+              25.8,
+              22.9,
+              22.9,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5
+            ],
+            "distance": [
+              113.3,
+              107,
+              35.7,
+              46.7,
+              81.4,
+              114.3,
+              75.7,
+              28.6,
+              25.3,
+              12.9,
+              25.5,
+              15.5,
+              14.4,
+              16.5,
+              17,
+              15.2,
+              13.4,
+              17.1,
+              16.3,
+              21.2,
+              25.5,
+              35.7,
+              192.8,
+              46.8,
+              117.9,
+              33.9,
+              24,
+              41.6,
+              28.5,
+              29.3,
+              26.3,
+              11.3
+            ],
+            "duration": [
+              4.328,
+              4.142,
+              1.573,
+              2.039,
+              3.529,
+              4.957,
+              3.283,
+              1.238,
+              1.097,
+              0.561,
+              1.105,
+              0.672,
+              0.624,
+              0.715,
+              0.736,
+              0.658,
+              0.581,
+              0.744,
+              0.705,
+              0.919,
+              1.105,
+              1.55,
+              8.357,
+              2.111,
+              5.244,
+              1.504,
+              1.069,
+              1.846,
+              1.27,
+              1.301,
+              1.167,
+              0.502
+            ]
+          },
+          "weight_typical": 101.983,
+          "duration_typical": 89.828,
+          "weight": 72.189,
+          "duration": 61.234,
+          "steps": [
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive southwest on <say-as interpret-as=\"address\">Expwy Wangan Line</say-as>. Then Keep left at <say-as interpret-as=\"address\">Ariake JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Drive southwest on Expwy Wangan Line. Then Keep left at Ariake JCT.",
+                  "distanceAlongGeometry": 220.274
+                }
+              ],
+              "intersections": [
+                {
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "bearings": [
+                    236
+                  ],
+                  "duration": 4.328,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 4.328,
+                  "geometry_index": 0,
+                  "location": [
+                    139.790845,
+                    35.634688
+                  ]
+                },
+                {
+                  "bearings": [
+                    56,
+                    237
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 1,
+                  "location": [
+                    139.789811,
+                    35.634114
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA069301?arrow_ids=CA06930A",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "銀座"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "銀座"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ariake JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "11",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "11"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Ariake JCT / 11"
+                  },
+                  "distanceAlongGeometry": 220.274
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "depart",
+                "instruction": "Drive southwest on Expwy Wangan Line.",
+                "bearing_after": 236,
+                "bearing_before": 0,
+                "location": [
+                  139.790845,
+                  35.634688
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Expwy Wangan Line",
+              "weight_typical": 10.566,
+              "duration_typical": 10.566,
+              "duration": 8.47,
+              "distance": 220.274,
+              "driving_side": "left",
+              "weight": 8.47,
+              "mode": "driving",
+              "geometry": "__~}bAy~csiGzb@r_A~_@v|@"
+            },
+            {
+              "mode": "driving",
+              "weight": 63.72,
+              "distance": 1206.318,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06930A"
+                  ],
+                  "base_id": "CA069301",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 79.262,
+              "weight_typical": 91.417,
+              "name": "Expwy No.11 Line Daiba Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep left at Ariake JCT toward 銀座.",
+                "modifier": "slight left",
+                "bearing_after": 228,
+                "bearing_before": 237,
+                "location": [
+                  139.788823,
+                  35.633586
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "11: 銀座",
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "You will arrive at your destination"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight",
+                    "text": "You will arrive at your destination"
+                  },
+                  "distanceAlongGeometry": 1206.318
+                },
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "You have arrived at your destination"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight",
+                    "text": "You have arrived at your destination"
+                  },
+                  "distanceAlongGeometry": 83.333
+                }
+              ],
+              "geometry": "cz{}bAm``siGhLnQjPbW`Ydm@fb@~`AvVjj@bG~OjErNfAnGnB`PPtI?|HQjJiAjJ{AzH{ApGgD|HeDfHqFhJkIbKaNhOeqAruA}TvP_v@ll@aNfMkIrIyOzRyHrNmIrNoFrNeBvE",
+              "duration": 52.764,
+              "junction_name": "Ariake JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 1 kilometer.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 1 kilometer.",
+                  "distanceAlongGeometry": 1189.652
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, You will arrive at your destination.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, You will arrive at your destination.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>",
+                  "announcement": "You have arrived at your destination.",
+                  "distanceAlongGeometry": 83.333
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.788823,
+                    35.633586
+                  ],
+                  "geometry_index": 2,
+                  "admin_index": 0,
+                  "weight": 1.561,
+                  "is_urban": false,
+                  "duration": 1.573,
+                  "bearings": [
+                    57,
+                    228,
+                    237
+                  ],
+                  "jct": {
+                    "name": "Ariake JCT"
+                  },
+                  "out": 1,
+                  "in": 0,
+                  "turn_duration": 0.012,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    48,
+                    228
+                  ],
+                  "duration": 2.039,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 2.039,
+                  "geometry_index": 3,
+                  "location": [
+                    139.788527,
+                    35.633373
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    48,
+                    235
+                  ],
+                  "duration": 33.137,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 33.137,
+                  "geometry_index": 4,
+                  "location": [
+                    139.788141,
+                    35.633095
+                  ]
+                },
+                {
+                  "bearings": [
+                    139,
+                    145,
+                    327
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "turn_weight": 11,
+                  "turn_duration": 0.033,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 2,
+                  "geometry_index": 23,
+                  "location": [
+                    139.781403,
+                    35.633549
+                  ]
+                }
+              ]
+            },
+            {
+              "voiceInstructions": [],
+              "intersections": [
+                {
+                  "bearings": [
+                    120
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "admin_index": 0,
+                  "geometry_index": 32,
+                  "location": [
+                    139.778818,
+                    35.635951
+                  ]
+                }
+              ],
+              "bannerInstructions": [],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "arrive",
+                "instruction": "You have arrived at your destination.",
+                "bearing_after": 0,
+                "bearing_before": 300,
+                "location": [
+                  139.778818,
+                  35.635951
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Expwy No.11 Line Daiba Line",
+              "weight_typical": 0,
+              "duration_typical": 0,
+              "duration": 0,
+              "distance": 0,
+              "driving_side": "left",
+              "weight": 0,
+              "mode": "driving",
+              "geometry": "}m`~bAcolriG??"
+            }
+          ],
+          "distance": 1426.592,
+          "summary": "Expwy Wangan Line, Expwy No.11 Line Daiba Line"
+        },
+        {
+          "via_waypoints": [],
+          "admins": [
+            {
+              "iso_3166_1_alpha3": "JPN",
+              "iso_3166_1": "JP"
+            }
+          ],
+          "incidents": [
+            {
+              "id": "12908017811954018",
+              "type": "construction",
+              "creation_time": "2023-03-15T12:25:00Z",
+              "start_time": "2023-03-15T12:25:00Z",
+              "end_time": "2023-03-15T12:40:00Z",
+              "iso_3166_1_alpha2": "JP",
+              "iso_3166_1_alpha3": "JPN",
+              "description": "Pavement work",
+              "sub_type": "construction",
+              "sub_type_description": "Lane restriction",
+              "alertc_codes": [
+                410,
+                40
+              ],
+              "lanes_blocked": [],
+              "length": 353,
+              "south": 35.662555,
+              "west": 139.761886,
+              "north": 35.665405,
+              "east": 139.763168,
+              "congestion": {
+                "value": 101
+              },
+              "geometry_index_start": 159,
+              "geometry_index_end": 169,
+              "affected_road_names": [
+                "海岸通り/Kaigan St./都道３１６号線/Todou No.316 Line"
+              ]
+            },
+            {
+              "id": "7193651434730766",
+              "type": "construction",
+              "creation_time": "2023-03-15T12:25:00Z",
+              "start_time": "2023-03-15T12:25:00Z",
+              "end_time": "2023-03-15T12:40:00Z",
+              "iso_3166_1_alpha2": "JP",
+              "iso_3166_1_alpha3": "JPN",
+              "description": "Pavement work",
+              "sub_type": "construction",
+              "sub_type_description": "Lane restriction",
+              "alertc_codes": [
+                410,
+                40
+              ],
+              "lanes_blocked": [],
+              "length": 301,
+              "south": 35.662658,
+              "west": 139.762405,
+              "north": 35.665107,
+              "east": 139.763473,
+              "congestion": {
+                "value": 101
+              },
+              "geometry_index_start": 181,
+              "geometry_index_end": 185,
+              "affected_road_names": [
+                "海岸通り/Kaigan St./都道３１６号線/Todou No.316 Line"
+              ]
+            }
+          ],
+          "annotation": {
+            "maxspeed": [
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 60,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              }
+            ],
+            "congestion_numeric": [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0
+            ],
+            "speed": [
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              13.1,
+              13.1,
+              13.1,
+              13.1,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              13.1,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              13.7,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13.6,
+              13,
+              13,
+              13,
+              13.1,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              6.7,
+              6.7,
+              6.6,
+              6.7,
+              6.6,
+              6.6,
+              6.9,
+              7,
+              7,
+              7,
+              7,
+              7.1,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              5.2,
+              3.8,
+              3.6,
+              6.6,
+              8,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.4,
+              4.4,
+              4.5,
+              13.6,
+              13.7,
+              14.6,
+              15.1,
+              14.7,
+              14.7,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.2,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              16.1,
+              16.1,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              15.8,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              16.4,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              22,
+              20.6,
+              20.6,
+              20.6,
+              20.6,
+              20.6,
+              21.6,
+              21.6,
+              21.6,
+              21.7,
+              21.1,
+              21.1,
+              21.1,
+              21.1,
+              21.1,
+              21.1,
+              19.1,
+              19.2,
+              19.2,
+              19,
+              18,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              18.6,
+              20.5,
+              20.5,
+              20.5,
+              20.5,
+              20.5,
+              20.5,
+              20.6,
+              20.6,
+              20.6,
+              20.5,
+              20.5,
+              20.5,
+              20.5,
+              20.7,
+              20.5,
+              20.5,
+              20.3,
+              20.3,
+              20.3,
+              20.3,
+              20.3,
+              20.3,
+              20.3,
+              20.3,
+              20.3,
+              19.9,
+              20.6,
+              20.1,
+              20.8,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.4,
+              22.4,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.2,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8
+            ],
+            "distance": [
+              17.3,
+              36.4,
+              35.1,
+              32.9,
+              27.2,
+              29.3,
+              37,
+              28.8,
+              29.9,
+              32.1,
+              43.9,
+              33.7,
+              29,
+              35.5,
+              28.6,
+              57.3,
+              23.5,
+              67.2,
+              45.1,
+              35.9,
+              30.4,
+              36.5,
+              27.3,
+              23.2,
+              30.3,
+              26.7,
+              7.1,
+              13.5,
+              21.7,
+              30.1,
+              24,
+              25.4,
+              27.1,
+              38.7,
+              82.7,
+              80.4,
+              67.8,
+              109.4,
+              84.6,
+              90.5,
+              76.3,
+              101.1,
+              38.9,
+              61.8,
+              24.4,
+              15.7,
+              13.4,
+              19.5,
+              15.3,
+              16.1,
+              21.8,
+              13.1,
+              23.2,
+              13.4,
+              14.8,
+              22.8,
+              11.5,
+              18.7,
+              18.6,
+              40.2,
+              43.3,
+              55.7,
+              50.5,
+              61.8,
+              45.3,
+              71.2,
+              12.3,
+              30,
+              70,
+              62.9,
+              52.5,
+              23.8,
+              15.6,
+              17.2,
+              17.3,
+              28.7,
+              3,
+              33,
+              19,
+              19.1,
+              15.8,
+              11.4,
+              13.4,
+              14.5,
+              13.5,
+              19.3,
+              26.4,
+              27.8,
+              18.9,
+              30,
+              36.1,
+              23.5,
+              16.6,
+              10.1,
+              5.5,
+              4.7,
+              7.5,
+              21.2,
+              30.1,
+              23.9,
+              18,
+              13.4,
+              147.4,
+              4.6,
+              29.1,
+              37.9,
+              32.3,
+              30,
+              15.7,
+              34.3,
+              9.7,
+              25.8,
+              9.5,
+              9.3,
+              25.7,
+              31,
+              29.9,
+              20.6,
+              22.7,
+              35,
+              32,
+              83.5,
+              23.7,
+              39.2,
+              40.2,
+              73.2,
+              35,
+              22.7,
+              16.6,
+              11.5,
+              15,
+              29.9,
+              28.2,
+              29.9,
+              15.7,
+              16,
+              17.6,
+              13.4,
+              12.5,
+              15.4,
+              18,
+              66,
+              51.8,
+              46.8,
+              40.9,
+              52,
+              16,
+              18.3,
+              17.7,
+              10,
+              13.2,
+              14.8,
+              27.4,
+              20.9,
+              31.3,
+              29.3,
+              13.4,
+              11.1,
+              21.2,
+              7.8,
+              28.3,
+              24.6,
+              8,
+              8.9,
+              11.5,
+              6.9,
+              5.6,
+              16.3,
+              19.7,
+              4.2,
+              2.3,
+              3.7,
+              2.3,
+              2.4,
+              3.2,
+              3.2,
+              3.1,
+              2.1,
+              3.2,
+              3.7,
+              4.4,
+              23.7,
+              52.2,
+              8.9,
+              51.7,
+              15.7,
+              8.3,
+              10.2,
+              11,
+              10.2,
+              43.8,
+              34.2,
+              58.4,
+              17.3,
+              18.5,
+              36.5,
+              14.9,
+              16.3,
+              126.8,
+              50.1,
+              49.9,
+              12.1,
+              13.4,
+              17.9,
+              13.4,
+              15.5,
+              13.8,
+              15,
+              13.8,
+              35.9,
+              35.1,
+              15.7,
+              10.4,
+              12.5,
+              20.7,
+              34.9,
+              50.6,
+              51.5,
+              31,
+              20.6,
+              58.7,
+              56.7,
+              60.8,
+              20.6,
+              13.5,
+              13.4,
+              20.6,
+              13.4,
+              13.5,
+              11.4,
+              11.3,
+              16.6,
+              15.5,
+              14.8,
+              13,
+              20.9,
+              16.7,
+              56.4,
+              24.5,
+              26.8,
+              41.5,
+              87.8,
+              37.9,
+              93.7,
+              33.3,
+              130.7,
+              19.8,
+              13.8,
+              17.6,
+              53.1,
+              15.4,
+              9.7,
+              16.1,
+              10.5,
+              11.4,
+              11.4,
+              12.3,
+              9.5,
+              10.7,
+              18.6,
+              16.7,
+              22.1,
+              24.1,
+              22.9,
+              22.2,
+              17.8,
+              34,
+              21.7,
+              59.8,
+              30.8,
+              37.2,
+              48.4,
+              69.1,
+              59.7,
+              58.8,
+              48.4,
+              120.6,
+              20.6,
+              19.8,
+              23.9,
+              13.9,
+              23.1,
+              12,
+              17.7,
+              11.8,
+              11.6,
+              12.4,
+              12.4,
+              8.8,
+              14.9,
+              13.8,
+              11.5,
+              16.6,
+              21.2,
+              35.5,
+              53.5,
+              127,
+              84,
+              78.5,
+              86.9,
+              66.4,
+              95.7,
+              59,
+              81.8,
+              43.9,
+              19.5,
+              22.4,
+              18.3,
+              17.8,
+              29,
+              25.7,
+              3.8,
+              27.1,
+              23.7,
+              24,
+              19,
+              20.2,
+              18.5,
+              23.2,
+              20.2,
+              70.9,
+              48.3,
+              58.5,
+              51.7,
+              34.3,
+              38.7,
+              34.4,
+              41.2,
+              28.2,
+              31.1,
+              27,
+              24.6,
+              27.8,
+              21.6,
+              25.9,
+              20.7,
+              27.5,
+              37.7,
+              32.3,
+              25.8,
+              28,
+              29.1,
+              27.2,
+              32.2,
+              42.2,
+              51.3,
+              167.7,
+              64.3,
+              97.1,
+              66.3,
+              23.1,
+              37.5,
+              16.3,
+              32,
+              22.8,
+              24.2,
+              28,
+              22.9,
+              29.9,
+              59.7,
+              126.9,
+              91.3,
+              21.4,
+              70.7,
+              43.7,
+              51.6,
+              20.7,
+              141.2,
+              134.5,
+              98.7,
+              26,
+              35.7,
+              54.9,
+              77.5,
+              172.5,
+              172.7,
+              56.1,
+              89.5,
+              461.2,
+              850.3,
+              13.9,
+              121.6,
+              29.9,
+              26.1,
+              39.4,
+              31.8,
+              28.8,
+              40.3,
+              47.9,
+              32.3,
+              35.9,
+              32.3,
+              35.9,
+              13.8,
+              55.2,
+              43.4,
+              45.4,
+              35,
+              154.6,
+              325.7,
+              119.5,
+              150.6,
+              8.4,
+              11.2,
+              40.2,
+              75.3,
+              100,
+              39.2,
+              126.8,
+              94.8,
+              17.6,
+              45.3,
+              195.8,
+              198.2,
+              169.8,
+              75.2,
+              169,
+              173.2,
+              105.1,
+              28.8,
+              15.5,
+              45.3,
+              87.9,
+              83.9,
+              6.3,
+              17.1,
+              85.9,
+              53,
+              126.8,
+              182.9,
+              86.2,
+              137.2,
+              132.2,
+              63.6,
+              190.2,
+              81,
+              50.2,
+              195.7,
+              86.5,
+              66,
+              59.6,
+              73.4,
+              40,
+              70,
+              45.4,
+              47.3,
+              10.2,
+              41.6,
+              73.3,
+              159.1,
+              217.9,
+              158.7,
+              239.9,
+              14.2,
+              125.3,
+              13.4,
+              144,
+              448.4,
+              118.2,
+              33,
+              225.8,
+              45.8,
+              42.6,
+              102,
+              77.2,
+              116.6,
+              73.9,
+              44.3,
+              212,
+              6.9,
+              118.6,
+              161.3
+            ],
+            "duration": [
+              0.77,
+              1.617,
+              1.558,
+              1.463,
+              1.212,
+              1.299,
+              1.645,
+              1.279,
+              1.33,
+              1.427,
+              1.953,
+              1.499,
+              1.288,
+              1.577,
+              1.271,
+              2.548,
+              1.045,
+              2.987,
+              2.005,
+              1.595,
+              1.351,
+              1.621,
+              1.215,
+              1.031,
+              1.346,
+              1.187,
+              0.314,
+              0.599,
+              0.966,
+              2.374,
+              1.883,
+              1.984,
+              2.121,
+              3.027,
+              6.477,
+              6.288,
+              5.306,
+              8.559,
+              6.623,
+              7.077,
+              5.969,
+              7.918,
+              3.036,
+              4.839,
+              1.911,
+              1.223,
+              1.05,
+              1.522,
+              1.204,
+              1.254,
+              1.712,
+              1.024,
+              1.814,
+              1.047,
+              1.158,
+              1.782,
+              0.902,
+              1.463,
+              1.455,
+              3.144,
+              3.388,
+              4.355,
+              3.954,
+              4.833,
+              3.546,
+              5.565,
+              0.967,
+              2.363,
+              5.485,
+              4.927,
+              4.117,
+              1.859,
+              1.223,
+              1.329,
+              1.317,
+              2.193,
+              0.23,
+              2.579,
+              1.487,
+              1.502,
+              1.235,
+              0.893,
+              1.046,
+              1.136,
+              1.059,
+              1.509,
+              2.066,
+              2.178,
+              1.481,
+              2.352,
+              2.823,
+              1.839,
+              1.304,
+              0.791,
+              0.433,
+              0.361,
+              0.59,
+              1.664,
+              2.352,
+              1.871,
+              1.411,
+              1.054,
+              11.273,
+              0.338,
+              2.015,
+              2.623,
+              2.233,
+              2.079,
+              1.088,
+              2.369,
+              0.676,
+              1.78,
+              0.663,
+              0.643,
+              1.78,
+              2.142,
+              2.072,
+              1.425,
+              1.572,
+              2.419,
+              2.216,
+              6.124,
+              1.74,
+              2.875,
+              2.948,
+              5.368,
+              2.573,
+              1.668,
+              1.211,
+              0.847,
+              1.103,
+              2.193,
+              2.069,
+              2.19,
+              1.154,
+              1.176,
+              1.291,
+              0.983,
+              0.918,
+              1.127,
+              1.32,
+              4.845,
+              4.004,
+              3.597,
+              3.14,
+              3.983,
+              2.254,
+              2.528,
+              2.457,
+              1.383,
+              1.815,
+              2.052,
+              3.785,
+              2.89,
+              4.331,
+              4.043,
+              1.854,
+              1.645,
+              3.155,
+              3.236,
+              4.236,
+              3.738,
+              1.22,
+              3.314,
+              3.654,
+              0.995,
+              0.791,
+              2.334,
+              2.809,
+              1.635,
+              0.434,
+              0.705,
+              0.45,
+              0.44,
+              0.616,
+              0.616,
+              0.586,
+              0.396,
+              0.616,
+              0.699,
+              0.834,
+              9.219,
+              14.441,
+              3.492,
+              8.473,
+              3.413,
+              1.757,
+              2.143,
+              2.325,
+              2.175,
+              9.264,
+              7.736,
+              13.189,
+              3.825,
+              1.429,
+              2.664,
+              1.019,
+              1.087,
+              8.617,
+              3.405,
+              3.218,
+              0.777,
+              0.858,
+              1.155,
+              0.861,
+              0.997,
+              0.888,
+              0.961,
+              0.887,
+              2.31,
+              2.253,
+              1.011,
+              0.671,
+              0.797,
+              1.331,
+              2.248,
+              3.249,
+              3.313,
+              1.989,
+              1.324,
+              3.778,
+              3.642,
+              3.993,
+              1.381,
+              0.899,
+              0.889,
+              1.372,
+              0.894,
+              0.901,
+              0.757,
+              0.757,
+              1.108,
+              1.033,
+              0.988,
+              0.868,
+              1.393,
+              1.111,
+              3.763,
+              1.635,
+              1.786,
+              2.771,
+              5.856,
+              2.528,
+              6.25,
+              2.075,
+              8.112,
+              1.269,
+              0.872,
+              1.111,
+              3.356,
+              0.97,
+              0.615,
+              1.012,
+              0.666,
+              0.72,
+              0.717,
+              0.78,
+              0.597,
+              0.675,
+              1.179,
+              1.051,
+              1.398,
+              1.521,
+              1.443,
+              1.402,
+              1.128,
+              2.145,
+              1.371,
+              3.775,
+              1.948,
+              2.348,
+              3.058,
+              4.359,
+              3.775,
+              3.712,
+              3.058,
+              7.613,
+              1.302,
+              1.252,
+              1.505,
+              0.882,
+              1.454,
+              0.76,
+              1.113,
+              0.747,
+              0.735,
+              0.781,
+              0.781,
+              0.56,
+              0.94,
+              0.871,
+              0.727,
+              1.048,
+              1.339,
+              2.239,
+              3.38,
+              8.021,
+              5.303,
+              4.956,
+              5.484,
+              4.197,
+              6.043,
+              3.726,
+              5.16,
+              2.771,
+              1.235,
+              1.413,
+              1.156,
+              1.12,
+              1.834,
+              1.579,
+              0.226,
+              1.656,
+              1.446,
+              1.462,
+              1.159,
+              1.232,
+              1.131,
+              1.412,
+              1.233,
+              4.325,
+              2.947,
+              3.568,
+              3.158,
+              2.089,
+              2.361,
+              2.099,
+              2.514,
+              1.719,
+              1.899,
+              1.645,
+              1.501,
+              1.694,
+              1.321,
+              1.578,
+              1.267,
+              1.677,
+              2.298,
+              1.969,
+              1.573,
+              1.713,
+              1.773,
+              1.658,
+              1.962,
+              2.576,
+              3.132,
+              10.231,
+              2.949,
+              4.423,
+              3.018,
+              1.054,
+              1.706,
+              0.743,
+              1.458,
+              1.038,
+              1.1,
+              1.278,
+              1.039,
+              1.363,
+              2.718,
+              5.784,
+              4.158,
+              1.04,
+              3.436,
+              2.125,
+              2.514,
+              1.004,
+              6.536,
+              6.212,
+              4.569,
+              1.2,
+              1.686,
+              2.6,
+              3.67,
+              8.168,
+              8.171,
+              2.657,
+              4.715,
+              24.069,
+              44.383,
+              0.73,
+              6.757,
+              1.627,
+              1.399,
+              2.112,
+              1.706,
+              1.546,
+              2.16,
+              2.573,
+              1.735,
+              1.927,
+              1.734,
+              1.928,
+              0.742,
+              2.696,
+              2.115,
+              2.213,
+              1.703,
+              7.532,
+              15.877,
+              5.803,
+              7.313,
+              0.408,
+              0.548,
+              1.958,
+              3.666,
+              4.872,
+              1.897,
+              6.199,
+              4.62,
+              0.875,
+              2.235,
+              9.659,
+              9.775,
+              8.371,
+              3.711,
+              8.35,
+              8.537,
+              5.196,
+              1.45,
+              0.75,
+              2.25,
+              4.224,
+              3.843,
+              0.288,
+              0.779,
+              3.917,
+              2.416,
+              5.779,
+              8.34,
+              3.932,
+              6.255,
+              6.029,
+              2.824,
+              8.451,
+              3.6,
+              2.233,
+              8.693,
+              3.844,
+              2.897,
+              2.618,
+              3.222,
+              1.755,
+              3.076,
+              1.992,
+              2.077,
+              0.447,
+              1.828,
+              3.217,
+              6.986,
+              9.687,
+              7.06,
+              10.665,
+              0.633,
+              5.579,
+              0.599,
+              6.406,
+              19.939,
+              5.256,
+              1.465,
+              10.17,
+              2.034,
+              1.871,
+              4.477,
+              3.391,
+              5.119,
+              3.243,
+              1.945,
+              9.309,
+              0.301,
+              5.208,
+              7.084
+            ]
+          },
+          "weight_typical": 1481.755,
+          "duration_typical": 1267.39,
+          "weight": 1542.786,
+          "duration": 1350.628,
+          "steps": [
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive northwest for 3 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Drive northwest for 3 kilometers.",
+                  "distanceAlongGeometry": 3444.871
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Keep right at <say-as interpret-as=\"address\">Hamazakibashi JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Keep right at Hamazakibashi JCT.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Hamazakibashi JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ｷﾞﾝｻﾞ\">銀座</phoneme>, <phoneme alphabet=\"jeita\" ph=\"ﾊｺｻﾞｷ%\">箱崎</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Hamazakibashi JCT toward 銀座, 箱崎.",
+                  "distanceAlongGeometry": 80
+                }
+              ],
+              "intersections": [
+                {
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "bearings": [
+                    299
+                  ],
+                  "duration": 40.995,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 40.995,
+                  "geometry_index": 0,
+                  "location": [
+                    139.778818,
+                    35.635951
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.769097,
+                    35.634798
+                  ],
+                  "geometry_index": 29,
+                  "admin_index": 0,
+                  "weight": 67.222,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 65.605,
+                  "bearings": [
+                    95,
+                    101,
+                    278
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.022,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    111,
+                    292
+                  ],
+                  "duration": 58.148,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 61.055,
+                  "geometry_index": 42,
+                  "location": [
+                    139.760416,
+                    35.63739
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.757711,
+                    35.642889
+                  ],
+                  "geometry_index": 67,
+                  "admin_index": 0,
+                  "weight": 20.954,
+                  "is_urban": false,
+                  "duration": 19.974,
+                  "bearings": [
+                    0,
+                    180,
+                    349
+                  ],
+                  "rest_stop": {
+                    "amenities": [
+                      {
+                        "type": "toilet"
+                      },
+                      {
+                        "type": "info"
+                      },
+                      {
+                        "type": "baby_care"
+                      },
+                      {
+                        "type": "facilities_for_disabled"
+                      },
+                      {
+                        "type": "telephone"
+                      }
+                    ],
+                    "name": "芝浦ＰＡ",
+                    "type": "rest_area"
+                  },
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.757654,
+                    35.645176
+                  ],
+                  "geometry_index": 73,
+                  "admin_index": 0,
+                  "weight": 6.934,
+                  "is_urban": true,
+                  "turn_weight": 1.5,
+                  "duration": 5.07,
+                  "bearings": [
+                    174,
+                    182,
+                    343
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.014,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    159,
+                    336
+                  ],
+                  "duration": 37.017,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 40.719,
+                  "geometry_index": 77,
+                  "location": [
+                    139.757414,
+                    35.645738
+                  ]
+                },
+                {
+                  "bearings": [
+                    23,
+                    201,
+                    212
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 2,
+                  "turn_weight": 6,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "turn_duration": 0.014,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 102,
+                  "location": [
+                    139.758552,
+                    35.649694
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "銀座"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "箱崎"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "銀座 / 箱崎"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Hamazakibashi JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "C1",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "C1"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Hamazakibashi JCT / C1"
+                  },
+                  "distanceAlongGeometry": 3444.871
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA064301?arrow_ids=CA06430E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight right",
+                        "active": true,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight right",
+                        "active": true,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "銀座"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "箱崎"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "銀座 / 箱崎"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Hamazakibashi JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "C1",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "C1"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Hamazakibashi JCT / C1"
+                  },
+                  "distanceAlongGeometry": 400
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "depart",
+                "instruction": "Drive northwest on Expwy No.11 Line Daiba Line.",
+                "bearing_after": 299,
+                "bearing_before": 0,
+                "location": [
+                  139.778818,
+                  35.635951
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Expwy No.11 Line Daiba Line",
+              "weight_typical": 208.179,
+              "duration_typical": 192.365,
+              "duration": 238.083,
+              "distance": 3444.871,
+              "driving_side": "left",
+              "weight": 256.548,
+              "mode": "driving",
+              "geometry": "}m`~bAcolriG}ChIuGvU{EtUuC~T{AnQ{AzRQpX?zRb@rShA~TrCx\\`CvUrCdRxDlVvDlQrJ|c@dD|M`Npi@jIl[bGtU|EdRnFlVfDvPzArNzArSRlQ?zC?hHe@|MiApSiAjOmB~OuCxPaGxWyOht@eOxr@oMhj@oUheAyOtu@oQdy@sN`p@gSh`AcGzWwKvf@eDrNmB|HaCxFyDjJeDnGkExFuGtIwDrD_JpG}EpBqFfCcK~CkEj@mIl@kIl@qU?iW?g^Tk[?ua@?mXV}f@?}E?yO?if@Tib@?o\\TiLVuGl@gHnBgHpBaNbFq@X}ObH{H|CkIpBuGbAkEVoF?cGWoFm@mIoB{LkEoMcFyH_DsNyFqQ}HcKkEuGgCeDyA{Am@iAm@aCm@_JuDsNyFcKaFuGkEkE_DkkAaf@"
+            },
+            {
+              "mode": "driving",
+              "weight": 99.995,
+              "distance": 1058.358,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06430E"
+                  ],
+                  "base_id": "CA064301",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 61.833,
+              "weight_typical": 83.486,
+              "name": "Expwy Inner Circular Route",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Hamazakibashi JCT toward 銀座/箱崎.",
+                "modifier": "slight right",
+                "bearing_after": 24,
+                "bearing_before": 23,
+                "location": [
+                  139.759177,
+                  35.650916
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "C1: 銀座, 箱崎",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "汐留"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "汐留"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Shiodome JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "KK",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "KK"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Shiodome JCT / KK"
+                  },
+                  "distanceAlongGeometry": 1058.358
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA065101?arrow_ids=CA06510A",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "汐留"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "汐留"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Shiodome JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "KK",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "KK"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Shiodome JCT / KK"
+                  },
+                  "distanceAlongGeometry": 400
+                }
+              ],
+              "geometry": "gu}~bAqcfqiGiAm@aNyFuR}HwOoGsNyFcGgC}PoGeDeA{L}CgDm@eDUmM?kP?yO?qJ?wK?sR?}Pl@{m@WiL?_U?qU?ah@l@uR?wKUgHTkEl@cGxA_NfH}LfH_NdHcGfCuGzAyHl@oFW}Ek@cGqBgH_Dy^mV",
+              "duration": 75.859,
+              "junction_name": "Hamazakibashi JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 1 kilometer.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 1 kilometer.",
+                  "distanceAlongGeometry": 1043.358
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Keep left at <say-as interpret-as=\"address\">Shiodome JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Keep left at Shiodome JCT.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep left at <say-as interpret-as=\"address\">Shiodome JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ｼｵﾄﾞﾒ\">汐留</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep left at Shiodome JCT toward 汐留.",
+                  "distanceAlongGeometry": 94.444
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.759177,
+                    35.650916
+                  ],
+                  "geometry_index": 103,
+                  "admin_index": 0,
+                  "weight": 34.633,
+                  "is_urban": true,
+                  "duration": 30.135,
+                  "bearings": [
+                    18,
+                    24,
+                    203
+                  ],
+                  "jct": {
+                    "name": "Hamazakibashi JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.019,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.760074,
+                    35.654684
+                  ],
+                  "geometry_index": 121,
+                  "admin_index": 0,
+                  "weight": 18.165,
+                  "is_urban": true,
+                  "turn_weight": 11,
+                  "duration": 6.124,
+                  "bearings": [
+                    1,
+                    176,
+                    182
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.026,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    0,
+                    181
+                  ],
+                  "duration": 12.931,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 15.193,
+                  "geometry_index": 122,
+                  "location": [
+                    139.760086,
+                    35.655434
+                  ]
+                },
+                {
+                  "bearings": [
+                    0,
+                    178
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 126,
+                  "location": [
+                    139.760063,
+                    35.657017
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 18.015,
+              "distance": 191.445,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06510A"
+                  ],
+                  "base_id": "CA065101",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 17.298,
+              "weight_typical": 21.168,
+              "name": "",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep left at Shiodome JCT toward 汐留.",
+                "modifier": "slight left",
+                "bearing_after": 31,
+                "bearing_before": 31,
+                "location": [
+                  139.759961,
+                  35.660063
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "KK: 汐留",
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CB202101?arrow_ids=CB20210E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight right",
+                        "active": true,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight right",
+                        "active": true,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Shiodome"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-metropolitan-road",
+                          "display_ref": "316",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "Todou No.316 Line"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Shiodome / Todou No.316 Line"
+                  },
+                  "distanceAlongGeometry": 191.445
+                }
+              ],
+              "geometry": "}po_cAqtgqiG}WmQ}TwPcRsNiW{R",
+              "duration": 14.724,
+              "junction_name": "Shiodome JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 200 meters, Keep right at the fork.</prosody></amazon:effect></speak>",
+                  "announcement": "In 200 meters, Keep right at the fork.",
+                  "distanceAlongGeometry": 178.112
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at the fork.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at the fork.",
+                  "distanceAlongGeometry": 66.667
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.759961,
+                    35.660063
+                  ],
+                  "geometry_index": 142,
+                  "admin_index": 0,
+                  "weight": 9.289,
+                  "is_urban": true,
+                  "duration": 7.601,
+                  "bearings": [
+                    31,
+                    38,
+                    211
+                  ],
+                  "jct": {
+                    "name": "Shiodome JCT"
+                  },
+                  "out": 0,
+                  "in": 2,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    34,
+                    213
+                  ],
+                  "duration": 3.14,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 3.847,
+                  "geometry_index": 144,
+                  "location": [
+                    139.76054,
+                    35.660813
+                  ]
+                },
+                {
+                  "bearings": [
+                    34,
+                    214
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 145,
+                  "location": [
+                    139.76079,
+                    35.661119
+                  ]
+                }
+              ]
+            },
+            {
+              "ref": "Todou No.316 Line",
+              "mode": "driving",
+              "weight": 81.553,
+              "distance": 382.205,
+              "geometry": "gkr_cAg|iqiGkEyFaGyFcGcFwCuBgEyC}EuDuKuI{HyF_NiJ}LuIkE}CwD{AqJoBaCcAiLuIqJgHoBoBaCqBwDqBoBcA{Am@uGqB_Jl@",
+              "duration": 60.517,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CB20210E"
+                  ],
+                  "base_id": "CB202101",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 72.313,
+              "weight_typical": 96.004,
+              "name": "Kaigan St.",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at the fork.",
+                "modifier": "slight right",
+                "bearing_after": 43,
+                "bearing_before": 34,
+                "location": [
+                  139.761108,
+                  35.661508
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "Shiodome",
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-metropolitan-road",
+                          "display_ref": "316",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "Todou No.316 Line"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "Todou No.316 Line"
+                  },
+                  "distanceAlongGeometry": 382.205
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Turn right to stay on <say-as interpret-as=\"address\">Todou No.316 Line</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Turn right to stay on Todou No.316 Line.",
+                  "distanceAlongGeometry": 368.872
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right to stay on <say-as interpret-as=\"address\">Todou No.316 Line</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Turn right to stay on Todou No.316 Line.",
+                  "distanceAlongGeometry": 76
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.761108,
+                    35.661508
+                  ],
+                  "geometry_index": 146,
+                  "admin_index": 0,
+                  "weight": 10.516,
+                  "is_urban": true,
+                  "mapbox_streets_v8": {
+                    "class": "primary_link"
+                  },
+                  "duration": 8.623,
+                  "bearings": [
+                    34,
+                    43,
+                    214
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.038,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    33,
+                    214
+                  ],
+                  "duration": 20.769,
+                  "mapbox_streets_v8": {
+                    "class": "primary_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 25.442,
+                  "geometry_index": 150,
+                  "location": [
+                    139.761531,
+                    35.661945
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    18,
+                    212
+                  ],
+                  "duration": 4.8,
+                  "mapbox_streets_v8": {
+                    "class": "primary_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.88,
+                  "geometry_index": 157,
+                  "location": [
+                    139.762426,
+                    35.663082
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "location": [
+                    139.762528,
+                    35.663359
+                  ],
+                  "geometry_index": 159,
+                  "admin_index": 0,
+                  "weight": 12.47,
+                  "is_urban": true,
+                  "traffic_signal": true,
+                  "turn_duration": 2.036,
+                  "turn_weight": 11,
+                  "duration": 3.236,
+                  "bearings": [
+                    23,
+                    194,
+                    210
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    33,
+                    203,
+                    335
+                  ],
+                  "duration": 4.236,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "left",
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "turn_duration": 0.036,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.145,
+                  "geometry_index": 160,
+                  "location": [
+                    139.762562,
+                    35.663424
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    33,
+                    59,
+                    213
+                  ],
+                  "duration": 4.957,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "turn_duration": 0.007,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 6.064,
+                  "geometry_index": 161,
+                  "location": [
+                    139.762733,
+                    35.663637
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "location": [
+                    139.762937,
+                    35.663878
+                  ],
+                  "geometry_index": 163,
+                  "admin_index": 0,
+                  "weight": 3.588,
+                  "is_urban": true,
+                  "traffic_signal": true,
+                  "turn_duration": 2.018,
+                  "turn_weight": 2,
+                  "duration": 3.314,
+                  "bearings": [
+                    35,
+                    96,
+                    104,
+                    215,
+                    267
+                  ],
+                  "out": 0,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "location": [
+                    139.762994,
+                    35.663943
+                  ],
+                  "geometry_index": 164,
+                  "admin_index": 0,
+                  "weight": 9.056,
+                  "is_urban": true,
+                  "traffic_signal": true,
+                  "turn_duration": 2.014,
+                  "turn_weight": 2,
+                  "duration": 7.774,
+                  "bearings": [
+                    26,
+                    108,
+                    122,
+                    215,
+                    267
+                  ],
+                  "out": 0,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "bearings": [
+                    101,
+                    199,
+                    354
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "turn_duration": 0.04,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 2,
+                  "geometry_index": 168,
+                  "location": [
+                    139.763165,
+                    35.664276
+                  ]
+                }
+              ]
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 200 meters, Take the <say-as interpret-as=\"address\">Shiodome</say-as> ramp on the right.</prosody></amazon:effect></speak>",
+                  "announcement": "In 200 meters, Take the Shiodome ramp on the right.",
+                  "distanceAlongGeometry": 164.04
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Take the <say-as interpret-as=\"address\">Shiodome</say-as> ramp on the right.</prosody></amazon:effect></speak>",
+                  "announcement": "Take the Shiodome ramp on the right.",
+                  "distanceAlongGeometry": 68
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    47,
+                    174,
+                    353
+                  ],
+                  "duration": 8.028,
+                  "turn_duration": 0.828,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 8.82,
+                  "geometry_index": 169,
+                  "location": [
+                    139.763142,
+                    35.664452
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    177,
+                    284,
+                    355
+                  ],
+                  "duration": 9.219,
+                  "turn_weight": 5,
+                  "turn_duration": 3.048,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 12.56,
+                  "geometry_index": 181,
+                  "location": [
+                    139.76346,
+                    35.664517
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    189,
+                    245,
+                    357
+                  ],
+                  "duration": 14.441,
+                  "turn_duration": 0.041,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 17.64,
+                  "geometry_index": 182,
+                  "location": [
+                    139.763472,
+                    35.664304
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "location": [
+                    139.763381,
+                    35.663841
+                  ],
+                  "geometry_index": 183,
+                  "admin_index": 0,
+                  "weight": 3.654,
+                  "is_urban": true,
+                  "traffic_signal": true,
+                  "turn_duration": 2.142,
+                  "turn_weight": 2,
+                  "duration": 3.492,
+                  "bearings": [
+                    9,
+                    115,
+                    215,
+                    267,
+                    276,
+                    289
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "bearings": [
+                    35,
+                    113,
+                    215,
+                    293,
+                    303
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "turn_weight": 2,
+                  "turn_duration": 2.018,
+                  "traffic_signal": true,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 2,
+                  "geometry_index": 184,
+                  "location": [
+                    139.763324,
+                    35.663776
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/entrance/13i00031_o20d?arrow_ids=13i00031_o21a",
+                        "subType": "entrance",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "slight right",
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Shiodome"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "C1",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "C1"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "slight right",
+                    "text": "Shiodome / C1"
+                  },
+                  "distanceAlongGeometry": 174.373
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "continue",
+                "instruction": "Turn right to stay on Todou No.316 Line.",
+                "modifier": "right",
+                "bearing_after": 47,
+                "bearing_before": 354,
+                "location": [
+                  139.763142,
+                  35.664452
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "",
+              "weight_typical": 52.581,
+              "duration_typical": 43.653,
+              "duration": 43.653,
+              "distance": 174.373,
+              "driving_side": "left",
+              "weight": 52.581,
+              "mode": "driving",
+              "ref": "Todou No.316 Line",
+              "geometry": "gcx_cAk{mqiGiAUc@Ww@k@Sm@Qm@QcAQcA?cA?m@PcAb@cAv@cAhLW|[tD`CpBvVrS"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 1 kilometer.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 1 kilometer.",
+                  "distanceAlongGeometry": 1118.71
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Keep left at <say-as interpret-as=\"address\">Hamazakibashi JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Keep left at Hamazakibashi JCT.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep left at <say-as interpret-as=\"address\">Hamazakibashi JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾜﾝｶﾞ&ﾝｾﾝ\">湾岸線</phoneme>, <phoneme alphabet=\"jeita\" ph=\"ﾖｺﾊﾏ\">横浜</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep left at Hamazakibashi JCT toward 湾岸線, 横浜.",
+                  "distanceAlongGeometry": 100
+                }
+              ],
+              "intersections": [
+                {
+                  "mapbox_streets_v8": {
+                    "class": "primary_link"
+                  },
+                  "location": [
+                    139.762994,
+                    35.663396
+                  ],
+                  "geometry_index": 185,
+                  "admin_index": 0,
+                  "weight": 23.82,
+                  "is_urban": true,
+                  "turn_weight": 15,
+                  "duration": 7.313,
+                  "bearings": [
+                    35,
+                    213,
+                    239
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.113,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    53,
+                    219
+                  ],
+                  "duration": 13.765,
+                  "mapbox_streets_v8": {
+                    "class": "primary_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 16.862,
+                  "geometry_index": 188,
+                  "location": [
+                    139.762687,
+                    35.663221
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    30,
+                    213
+                  ],
+                  "duration": 20.925,
+                  "mapbox_streets_v8": {
+                    "class": "primary_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 25.633,
+                  "geometry_index": 191,
+                  "location": [
+                    139.762301,
+                    35.66273
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    32,
+                    197
+                  ],
+                  "duration": 3.825,
+                  "mapbox_streets_v8": {
+                    "class": "primary_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 4.686,
+                  "geometry_index": 193,
+                  "location": [
+                    139.761756,
+                    35.662026
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.761699,
+                    35.661878
+                  ],
+                  "geometry_index": 194,
+                  "admin_index": 0,
+                  "weight": 2.801,
+                  "is_urban": true,
+                  "turn_weight": 1.125,
+                  "duration": 1.429,
+                  "bearings": [
+                    17,
+                    32,
+                    213
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.061,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "payment_methods": [
+                        "general",
+                        "etc"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "payment_methods": [
+                        "general",
+                        "etc"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.761586,
+                    35.661739
+                  ],
+                  "geometry_index": 195,
+                  "admin_index": 0,
+                  "weight": 18.263,
+                  "is_urban": true,
+                  "toll_collection": {
+                    "name": "Shiodome Tollgate",
+                    "type": "toll_booth"
+                  },
+                  "turn_weight": 15,
+                  "duration": 2.664,
+                  "bearings": [
+                    33,
+                    212
+                  ],
+                  "out": 1,
+                  "in": 0,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    32,
+                    214
+                  ],
+                  "duration": 1.019,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 1.248,
+                  "geometry_index": 196,
+                  "location": [
+                    139.76137,
+                    35.661462
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    34,
+                    215
+                  ],
+                  "duration": 1.087,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 1.331,
+                  "geometry_index": 197,
+                  "location": [
+                    139.761279,
+                    35.661351
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    35,
+                    214
+                  ],
+                  "duration": 12.023,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 14.728,
+                  "geometry_index": 198,
+                  "location": [
+                    139.761176,
+                    35.66123
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.760063,
+                    35.659924
+                  ],
+                  "geometry_index": 200,
+                  "admin_index": 0,
+                  "weight": 57.209,
+                  "is_urban": true,
+                  "turn_weight": 11,
+                  "duration": 38.516,
+                  "bearings": [
+                    31,
+                    36,
+                    212
+                  ],
+                  "out": 2,
+                  "in": 1,
+                  "turn_duration": 0.009,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "bearings": [
+                    0,
+                    179
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 222,
+                  "location": [
+                    139.760211,
+                    35.654749
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "湾岸線"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "横浜"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "湾岸線 / 横浜"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Hamazakibashi JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "1",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "1"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Hamazakibashi JCT / 1"
+                  },
+                  "distanceAlongGeometry": 1132.043
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA064201?arrow_ids=CA06420A",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "湾岸線"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "横浜"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "湾岸線 / 横浜"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Hamazakibashi JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "1",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "1"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Hamazakibashi JCT / 1"
+                  },
+                  "distanceAlongGeometry": 400
+                }
+              ],
+              "destinations": "C1: 首都高速都心環状線",
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "on ramp",
+                "instruction": "Take the Shiodome ramp on the right.",
+                "modifier": "slight right",
+                "bearing_after": 239,
+                "bearing_before": 215,
+                "location": [
+                  139.762994,
+                  35.663396
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Expwy Inner Circular Route",
+              "weight_typical": 198.605,
+              "duration_typical": 116.561,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "13i00031_o21a"
+                  ],
+                  "base_id": "13i00031_o20d",
+                  "type": "entrance",
+                  "data_id": "727833600"
+                }
+              ],
+              "duration": 106.558,
+              "distance": 1132.043,
+              "driving_side": "left",
+              "weight": 171.272,
+              "mode": "driving",
+              "geometry": "gav_cAcrmqiGrCdHhA~C~B~CtC|CrCfCjT|MdOvKxZhTfHpBtG`FhPnL|EtDpFlE~y@~o@rUpStVlQxDhC|EnBxHzAnFTtGUpFcA`G{A|EgC|PkJjPkJbGgCvDk@|EWrJ?rRVj[W|[?jP?pJ?~_@?x^?ba@U"
+            },
+            {
+              "mode": "driving",
+              "weight": 67.338,
+              "distance": 747.77,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06420A"
+                  ],
+                  "base_id": "CA064201",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 55.17,
+              "weight_typical": 81.553,
+              "name": "Expwy No.1 Line Haneda Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep left at Hamazakibashi JCT toward 湾岸線/横浜.",
+                "modifier": "slight left",
+                "bearing_after": 177,
+                "bearing_before": 179,
+                "location": [
+                  139.760222,
+                  35.654203
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "1: 湾岸線, 横浜",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "湾岸線"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "湾岸線"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Shibaura JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Shibaura JCT"
+                  },
+                  "distanceAlongGeometry": 747.77
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA067101?arrow_ids=CA06710A",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "湾岸線"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "湾岸線"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Shibaura JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Shibaura JCT"
+                  },
+                  "distanceAlongGeometry": 400
+                }
+              ],
+              "geometry": "ubd_cA{dhqiGpJWpFUnF?pJUnFWpFUjE?jE?fHl@rGj@bGdA|ExA~I~CtGfCn\\dMvKjEzLbFlThJtl@vUtR|Hpo@zWjPnGtbAxa@",
+              "duration": 49.128,
+              "junction_name": "Hamazakibashi JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 700 meters.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 700 meters.",
+                  "distanceAlongGeometry": 732.77
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Keep left at <say-as interpret-as=\"address\">Shibaura JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Keep left at Shibaura JCT.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep left at <say-as interpret-as=\"address\">Shibaura JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾜﾝｶﾞ&ﾝｾﾝ\">湾岸線</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep left at Shibaura JCT toward 湾岸線.",
+                  "distanceAlongGeometry": 94.444
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.760222,
+                    35.654203
+                  ],
+                  "geometry_index": 223,
+                  "admin_index": 0,
+                  "weight": 5.327,
+                  "is_urban": true,
+                  "duration": 4.541,
+                  "bearings": [
+                    177,
+                    182,
+                    359
+                  ],
+                  "jct": {
+                    "name": "Hamazakibashi JCT"
+                  },
+                  "out": 0,
+                  "in": 2,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    176,
+                    358
+                  ],
+                  "duration": 34.4,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 39.56,
+                  "geometry_index": 227,
+                  "location": [
+                    139.760256,
+                    35.653592
+                  ]
+                },
+                {
+                  "bearings": [
+                    23,
+                    32,
+                    202
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "turn_weight": 11,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 2,
+                  "geometry_index": 244,
+                  "location": [
+                    139.758461,
+                    35.649241
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 225.7,
+              "distance": 3420.729,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06710A"
+                  ],
+                  "base_id": "CA067101",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 176.435,
+              "weight_typical": 187.872,
+              "name": "Expwy No.11 Line Daiba Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep left at Shibaura JCT toward 湾岸線.",
+                "modifier": "slight left",
+                "bearing_after": 190,
+                "bearing_before": 203,
+                "location": [
+                  139.757768,
+                  35.64788
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "湾岸線",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "横浜"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "空港中央"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "横浜 / 空港中央"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ariake JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "B",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "B"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Ariake JCT / B"
+                  },
+                  "distanceAlongGeometry": 3420.729
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA069101?arrow_ids=CA06910E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight right",
+                        "active": true,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight right",
+                        "active": true,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "横浜"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "空港中央"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "横浜 / 空港中央"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ariake JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "B",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "B"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Ariake JCT / B"
+                  },
+                  "distanceAlongGeometry": 400
+                }
+              ],
+              "geometry": "oww~bAokcqiG~IbApFbAfHfCvZnLbGpBdDbAtGzAxDj@jETjE?|E?dDk@vDcAzHiCtGgCpJsDtKwDdK}CbKqBzHcA`RUdK?p`@?hPWzS?dZ?ve@Up`@?~_@?dZ?tbAWpJU~IcAvK_DnFyApJcFxDgC`GaFfD_DrCuDrCkErCkEzA_DrCqGnBoGzAcFnBsIrCoLnFuUpJca@`YupAjP}t@dOmq@jPaw@zLsi@`Ry|@vKsd@vOqs@tGk[nByKlB{M|AcKv@aKfA{RRwP?qA?wQe@iOiAiOiAyK{AoLoBaKsC}MsCwKeOwk@_Jo]iL}c@mIk`@}EaUkEqXwDuUeDwZ}AcRiAiTw@oQ?_P?eRR}Mt@wPv@eMnBoQjEyWzEsSxDiOnFaPtG_PfH}MpJaPxOqSpUaU|kAwaA",
+              "duration": 213.262,
+              "junction_name": "Shibaura JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 3 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 3 kilometers.",
+                  "distanceAlongGeometry": 3400.729
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Keep right at <say-as interpret-as=\"address\">Ariake JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Keep right at Ariake JCT.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Ariake JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾖｺﾊﾏ\">横浜</phoneme>, <phoneme alphabet=\"jeita\" ph=\"ｸｰｺｰ ﾁｭｰｵｰ\">空港中央</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Ariake JCT toward 横浜, 空港中央.",
+                  "distanceAlongGeometry": 120
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.757768,
+                    35.64788
+                  ],
+                  "geometry_index": 246,
+                  "admin_index": 0,
+                  "weight": 93.195,
+                  "is_urban": true,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "turn_duration": 0.017,
+                  "turn_weight": 5,
+                  "duration": 82.059,
+                  "bearings": [
+                    23,
+                    190,
+                    201
+                  ],
+                  "jct": {
+                    "name": "Shibaura JCT"
+                  },
+                  "out": 1,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    111,
+                    293
+                  ],
+                  "duration": 52.421,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 53.732,
+                  "geometry_index": 296,
+                  "location": [
+                    139.760439,
+                    35.637483
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.769029,
+                    35.634891
+                  ],
+                  "geometry_index": 310,
+                  "admin_index": 0,
+                  "weight": 65.41,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 65.42,
+                  "bearings": [
+                    86,
+                    92,
+                    278
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.01,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "bearings": [
+                    142,
+                    315
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 345,
+                  "location": [
+                    139.780073,
+                    35.635252
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 205.632,
+              "distance": 3851.134,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06910E"
+                  ],
+                  "base_id": "CA069101",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 188.437,
+              "weight_typical": 203.038,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Ariake JCT toward 横浜/空港中央.",
+                "modifier": "slight right",
+                "bearing_after": 145,
+                "bearing_before": 145,
+                "location": [
+                  139.781494,
+                  35.63366
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "B: 横浜, 空港中央",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "空港中央"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "空港中央"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Oi JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Oi JCT"
+                  },
+                  "distanceAlongGeometry": 3851.134
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA070301?arrow_ids=CA07030E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "空港中央"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "空港中央"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Oi JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Oi JCT"
+                  },
+                  "distanceAlongGeometry": 400
+                }
+              ],
+              "geometry": "w~{}bAkvqriGp\\qXrh@ij@dZg^~IoG|PoLtGqB|Pk@vKj@vKtDzLdHjIfH~IrN|Pxa@jf@bhAh[ps@|E`KhS|h@zLzW`Nn]dDvKjj@tpAth@llAr]xw@`G~M`JnS`Rx\\xZdh@|`AhvAlaAxuApTf[ta@vk@jnDhiF|iIhfLfD`Fln@j{@vJxMfIzKvOvPnMxKhLhJ`R|MhWdMvOpGbRxFjPjErRtDpFbA",
+              "duration": 191.263,
+              "junction_name": "Ariake JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 4 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 4 kilometers.",
+                  "distanceAlongGeometry": 3834.468
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Keep right at <say-as interpret-as=\"address\">Oi JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Keep right at Oi JCT.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Oi JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ｸｰｺｰ ﾁｭｰｵｰ\">空港中央</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Oi JCT toward 空港中央.",
+                  "distanceAlongGeometry": 132.222
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.781494,
+                    35.63366
+                  ],
+                  "geometry_index": 347,
+                  "admin_index": 0,
+                  "weight": 33.813,
+                  "is_urban": false,
+                  "duration": 33.83,
+                  "bearings": [
+                    139,
+                    145,
+                    325
+                  ],
+                  "jct": {
+                    "name": "Ariake JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    56,
+                    235
+                  ],
+                  "duration": 4.476,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 4.476,
+                  "geometry_index": 362,
+                  "location": [
+                    139.780301,
+                    35.628855
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    59,
+                    236
+                  ],
+                  "duration": 5.643,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 5.502,
+                  "geometry_index": 364,
+                  "location": [
+                    139.779437,
+                    35.628419
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.778347,
+                    35.627873
+                  ],
+                  "geometry_index": 367,
+                  "admin_index": 0,
+                  "weight": 23.42,
+                  "is_urban": false,
+                  "turn_weight": 11,
+                  "duration": 12.749,
+                  "bearings": [
+                    56,
+                    63,
+                    237
+                  ],
+                  "out": 2,
+                  "in": 1,
+                  "turn_duration": 0.01,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    56,
+                    236
+                  ],
+                  "duration": 4.569,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 4.569,
+                  "geometry_index": 369,
+                  "location": [
+                    139.775801,
+                    35.626512
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    56,
+                    237
+                  ],
+                  "duration": 1.2,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 1.2,
+                  "geometry_index": 370,
+                  "location": [
+                    139.774892,
+                    35.626022
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    57,
+                    236
+                  ],
+                  "duration": 26.953,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 26.953,
+                  "geometry_index": 371,
+                  "location": [
+                    139.774652,
+                    35.625893
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.76995,
+                    35.622503
+                  ],
+                  "geometry_index": 377,
+                  "admin_index": 0,
+                  "weight": 5.446,
+                  "is_urban": false,
+                  "turn_weight": 0.75,
+                  "duration": 4.715,
+                  "bearings": [
+                    47,
+                    52,
+                    226
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.019,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "tunnel_name": "Tokyoko Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    46,
+                    227
+                  ],
+                  "duration": 68.452,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 70.163,
+                  "geometry_index": 378,
+                  "location": [
+                    139.769234,
+                    35.621948
+                  ]
+                },
+                {
+                  "tunnel_name": "Tokyoko Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    46,
+                    228
+                  ],
+                  "duration": 0.73,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 0.767,
+                  "geometry_index": 380,
+                  "location": [
+                    139.758712,
+                    35.613847
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    48,
+                    226
+                  ],
+                  "duration": 6.757,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 7.095,
+                  "geometry_index": 381,
+                  "location": [
+                    139.758599,
+                    35.613763
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.757633,
+                    35.613004
+                  ],
+                  "geometry_index": 382,
+                  "admin_index": 0,
+                  "weight": 11.058,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 10.55,
+                  "bearings": [
+                    46,
+                    217,
+                    226
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.019,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "bearings": [
+                    32,
+                    205
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 388,
+                  "location": [
+                    139.756281,
+                    35.611634
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 146.146,
+              "distance": 2751.995,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA07030E"
+                  ],
+                  "base_id": "CA070301",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 126.629,
+              "weight_typical": 137.455,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Oi JCT toward 空港中央.",
+                "modifier": "slight right",
+                "bearing_after": 189,
+                "bearing_before": 193,
+                "location": [
+                  139.755565,
+                  35.609958
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "空港中央, 横浜",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "空港中央"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "空港中央"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Tokai JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Tokai JCT"
+                  },
+                  "distanceAlongGeometry": 2751.995
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA061101?arrow_ids=CA06110E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "空港中央"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "空港中央"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Tokai JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Tokai JCT"
+                  },
+                  "distanceAlongGeometry": 1500
+                }
+              ],
+              "geometry": "kum|bAya_qiGr]tDhWbAnXTrR?xuA?zuDl@`bAm@nsA{AtCUhE?pUUfi@Wbw@bA~TTdfAdAdt@xAzH?lX?|lB?fnBJh~AHfi@?z}Aj@f`B?~y@?dO?tG?lX?dp@}C",
+              "duration": 134.802,
+              "junction_name": "Oi JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 3 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 3 kilometers.",
+                  "distanceAlongGeometry": 2728.662
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep right at <say-as interpret-as=\"address\">Tokai JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep right at Tokai JCT.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep right at <say-as interpret-as=\"address\">Tokai JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep right at Tokai JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Tokai JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ｸｰｺｰ ﾁｭｰｵｰ\">空港中央</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Tokai JCT toward 空港中央.",
+                  "distanceAlongGeometry": 151.111
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755565,
+                    35.609958
+                  ],
+                  "geometry_index": 394,
+                  "admin_index": 0,
+                  "weight": 17.061,
+                  "is_urban": false,
+                  "duration": 16.258,
+                  "bearings": [
+                    13,
+                    177,
+                    189
+                  ],
+                  "jct": {
+                    "name": "Oi JCT"
+                  },
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.009,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.755429,
+                    35.606968
+                  ],
+                  "geometry_index": 399,
+                  "admin_index": 0,
+                  "weight": 16.652,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 15.877,
+                  "bearings": [
+                    0,
+                    170,
+                    180
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    0,
+                    179
+                  ],
+                  "duration": 13.524,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 14.201,
+                  "geometry_index": 400,
+                  "location": [
+                    139.755406,
+                    35.604042
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    179,
+                    357
+                  ],
+                  "duration": 11.043,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 11.595,
+                  "geometry_index": 403,
+                  "location": [
+                    139.755486,
+                    35.601542
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    2,
+                    181
+                  ],
+                  "duration": 1.897,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 2.04,
+                  "geometry_index": 407,
+                  "location": [
+                    139.755475,
+                    35.599506
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755464,
+                    35.599154
+                  ],
+                  "geometry_index": 408,
+                  "admin_index": 0,
+                  "weight": 12.61,
+                  "is_urban": true,
+                  "turn_weight": 1,
+                  "duration": 10.819,
+                  "bearings": [
+                    1,
+                    6,
+                    181
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.019,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755384,
+                    35.597164
+                  ],
+                  "geometry_index": 410,
+                  "admin_index": 0,
+                  "weight": 24.227,
+                  "is_urban": true,
+                  "duration": 22.544,
+                  "bearings": [
+                    2,
+                    172,
+                    180
+                  ],
+                  "rest_stop": {
+                    "amenities": [
+                      {
+                        "type": "toilet"
+                      },
+                      {
+                        "type": "info"
+                      },
+                      {
+                        "type": "baby_care"
+                      },
+                      {
+                        "type": "facilities_for_disabled"
+                      },
+                      {
+                        "type": "telephone"
+                      }
+                    ],
+                    "name": "大井ＰＡ",
+                    "type": "rest_area"
+                  },
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.007,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 12.082,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 12.988,
+                  "geometry_index": 414,
+                  "location": [
+                    139.755378,
+                    35.59306
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755373,
+                    35.590859
+                  ],
+                  "geometry_index": 416,
+                  "admin_index": 0,
+                  "weight": 19.131,
+                  "is_urban": true,
+                  "turn_weight": 1,
+                  "duration": 16.886,
+                  "bearings": [
+                    0,
+                    6,
+                    181
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.021,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755351,
+                    35.587785
+                  ],
+                  "geometry_index": 418,
+                  "admin_index": 0,
+                  "weight": 6.316,
+                  "is_urban": true,
+                  "turn_weight": 0.75,
+                  "duration": 5.196,
+                  "bearings": [
+                    0,
+                    6,
+                    180
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 1.45,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 1.559,
+                  "geometry_index": 419,
+                  "location": [
+                    139.755351,
+                    35.586841
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 0.75,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 0.806,
+                  "geometry_index": 420,
+                  "location": [
+                    139.755351,
+                    35.586582
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 2.25,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 2.419,
+                  "geometry_index": 421,
+                  "location": [
+                    139.755351,
+                    35.586443
+                  ]
+                },
+                {
+                  "bearings": [
+                    0,
+                    175
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 422,
+                  "location": [
+                    139.755351,
+                    35.586036
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 218.005,
+              "distance": 5004.626,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06110E"
+                  ],
+                  "base_id": "CA061101",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 216.696,
+              "weight_typical": 211.814,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Tokai JCT toward 空港中央.",
+                "modifier": "slight right",
+                "bearing_after": 174,
+                "bearing_before": 175,
+                "location": [
+                  139.75543,
+                  35.585249
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "空港中央, 大黒ふ頭",
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination will be on the left"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left",
+                    "text": "Your destination will be on the left"
+                  },
+                  "distanceAlongGeometry": 5004.626
+                },
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination is on the left"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left",
+                    "text": "Your destination is on the left"
+                  },
+                  "distanceAlongGeometry": 111.111
+                }
+              ],
+              "geometry": "am}zbAky~piGzm@uDnBUnHu@vn@iG|[oGzcA_UnbBg^zm@}MriAmVvfAmVva@}HpfB__@~j@eMdZgHliBk`@zm@sNzb@kJx^yKxe@_PdSaK~_@iYtR{RnQmV`C}CrNkTlXwf@ln@a|An}@g`Cfm@u|A`eAklC~BoGnc@{hA`CyFrh@gtAdaC{gGng@s_ApJwPjvA}oBnRqSbQeRbl@ij@ta@__@pv@qi@zb@qX~TgMleBqiAlBcAzx@og@lmAwv@",
+              "duration": 222.78,
+              "junction_name": "Tokai JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 5 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 5 kilometers.",
+                  "distanceAlongGeometry": 4977.959
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Your destination will be on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Your destination will be on the left.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Your destination will be on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Your destination will be on the left.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Your destination is on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "Your destination is on the left.",
+                  "distanceAlongGeometry": 111.111
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.75543,
+                    35.585249
+                  ],
+                  "geometry_index": 423,
+                  "admin_index": 0,
+                  "weight": 43.637,
+                  "is_urban": false,
+                  "duration": 41.577,
+                  "bearings": [
+                    170,
+                    174,
+                    355
+                  ],
+                  "jct": {
+                    "name": "Tokai JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    167,
+                    345
+                  ],
+                  "duration": 29.644,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 30.385,
+                  "geometry_index": 433,
+                  "location": [
+                    139.757669,
+                    35.577278
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    166,
+                    345
+                  ],
+                  "duration": 30.117,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 30.117,
+                  "geometry_index": 439,
+                  "location": [
+                    139.759499,
+                    35.571473
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukokita Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    121,
+                    302
+                  ],
+                  "duration": 28.044,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 27.343,
+                  "geometry_index": 450,
+                  "location": [
+                    139.764011,
+                    35.566826
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukokita Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    121,
+                    301
+                  ],
+                  "duration": 6.178,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.869,
+                  "geometry_index": 454,
+                  "location": [
+                    139.769976,
+                    35.563901
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukokita Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    121,
+                    302
+                  ],
+                  "duration": 33.067,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 30.587,
+                  "geometry_index": 456,
+                  "location": [
+                    139.771283,
+                    35.563252
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    134,
+                    309
+                  ],
+                  "duration": 10.17,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 9.407,
+                  "geometry_index": 460,
+                  "location": [
+                    139.778203,
+                    35.55967
+                  ]
+                },
+                {
+                  "bearings": [
+                    125,
+                    139,
+                    314
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 2,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "turn_duration": 0.026,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 461,
+                  "location": [
+                    139.78001,
+                    35.558272
+                  ]
+                }
+              ]
+            },
+            {
+              "voiceInstructions": [],
+              "intersections": [
+                {
+                  "bearings": [
+                    330
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "admin_index": 0,
+                  "geometry_index": 472,
+                  "location": [
+                    139.785936,
+                    35.550703
+                  ]
+                }
+              ],
+              "bannerInstructions": [],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "arrive",
+                "instruction": "Your destination is on the left.",
+                "modifier": "left",
+                "bearing_after": 0,
+                "bearing_before": 150,
+                "location": [
+                  139.785936,
+                  35.550703
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Expwy Wangan Line",
+              "weight_typical": 0,
+              "duration_typical": 0,
+              "duration": 0,
+              "distance": 0,
+              "driving_side": "left",
+              "weight": 0,
+              "mode": "driving",
+              "geometry": "}}yxbA_lzriG??"
+            }
+          ],
+          "distance": 22159.551,
+          "summary": "Expwy No.11 Line Daiba Line, Expwy Wangan Line"
+        },
+        {
+          "via_waypoints": [],
+          "admins": [
+            {
+              "iso_3166_1_alpha3": "JPN",
+              "iso_3166_1": "JP"
+            },
+            {
+              "iso_3166_1_alpha3": "JPN",
+              "iso_3166_1": "JP"
+            },
+            {
+              "iso_3166_1_alpha3": "JPN",
+              "iso_3166_1": "JP"
+            }
+          ],
+          "annotation": {
+            "maxspeed": [
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 70,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 80,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              }
+            ],
+            "congestion_numeric": [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              79,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "speed": [
+              22.8,
+              22.8,
+              22.8,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              24.8,
+              24.8,
+              24.8,
+              24.9,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.7,
+              24.8,
+              24.8,
+              24.3,
+              19.5,
+              19.5,
+              19.5,
+              19.4,
+              19.4,
+              19.4,
+              21.9,
+              20.5,
+              20.5,
+              20.5,
+              20.5,
+              19.6,
+              19.6,
+              19.6,
+              19.6,
+              19.6,
+              19.5,
+              19.5,
+              15.3,
+              15.3,
+              15.3,
+              15.3,
+              15.3,
+              15.3,
+              15.3,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              15.6,
+              12.4,
+              12.9,
+              12.9,
+              12.9,
+              12.9,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              11.4,
+              11.7,
+              5,
+              5,
+              13,
+              13,
+              13,
+              2.5,
+              15,
+              11.2,
+              15.6,
+              15.5,
+              15.5,
+              15.5,
+              15.5,
+              15.5,
+              15.5,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.4,
+              14.2,
+              14.2,
+              14.2,
+              14.2,
+              14.2,
+              14.2,
+              14.2,
+              14.2,
+              14.2,
+              11.7,
+              11.7,
+              11.7,
+              11.7,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              11.4,
+              19.6,
+              19.8,
+              20.7,
+              20.5,
+              20.5,
+              20.5,
+              21.9,
+              13.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.5,
+              19.4,
+              19.4,
+              19.4,
+              19.4,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.9,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              19.2,
+              22,
+              22,
+              22,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              22.2,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              20.2,
+              20.2,
+              20.2,
+              20.4,
+              19.6,
+              20.1,
+              19.3,
+              19.7,
+              20.5,
+              20.5,
+              20.5,
+              20.6,
+              20.6,
+              20.3,
+              20.3,
+              20.3,
+              20.3,
+              20.8,
+              20.8,
+              20.8,
+              20.8,
+              20.8,
+              20.5,
+              21.5,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              20.8,
+              20.8,
+              20.8,
+              20.8,
+              20.9,
+              20.9,
+              20.9,
+              20.3,
+              20.6,
+              20.6,
+              19.8,
+              20.6,
+              20.6,
+              21.9,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.4,
+              21.3,
+              21.4,
+              21.4,
+              21.3,
+              21.4,
+              21.6,
+              21.6,
+              21.4,
+              22,
+              22,
+              23.1,
+              22.8,
+              23,
+              22.8,
+              22.4,
+              22.4,
+              21.6,
+              21.6,
+              23.1,
+              23.1,
+              21.6,
+              21.6,
+              21.7,
+              21.7,
+              21.7,
+              21.7,
+              21.7,
+              21.7,
+              21.7,
+              21.6,
+              21.6,
+              21.6,
+              21.7,
+              21.7,
+              21.7,
+              21.7,
+              22,
+              22.7,
+              22.7,
+              22.7,
+              23.3,
+              23.3,
+              23.2,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.7,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              23.1,
+              22.5,
+              22.5,
+              22.5,
+              22.5,
+              22.3,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.1,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.6,
+              23.6,
+              23.6,
+              23.6,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23,
+              23.1,
+              23.1,
+              22.7,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              23,
+              23,
+              23,
+              22.6,
+              22.5,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              22,
+              22,
+              22,
+              22,
+              21.9,
+              21.9,
+              21.9,
+              21.9,
+              23.1,
+              23.1,
+              23,
+              23,
+              23.1,
+              23.1,
+              23.1,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              22.8,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              13.3,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              12.8,
+              23.3,
+              23.3,
+              23.3,
+              23.3,
+              23,
+              23,
+              23,
+              23.1,
+              23.1,
+              23.1,
+              23,
+              23,
+              23,
+              23,
+              23,
+              23,
+              23,
+              23,
+              23,
+              23.1,
+              23.1,
+              22.5,
+              22.5,
+              22.5,
+              23.3,
+              22.2,
+              16.9,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              16.1,
+              16.1,
+              16.1,
+              16.1,
+              11.1,
+              11.1,
+              13.8,
+              13.8,
+              13.9,
+              13.9,
+              13.9,
+              13.9,
+              13.6,
+              5,
+              13.5,
+              13.3,
+              4.7,
+              13.9,
+              13.9,
+              13.9,
+              12.5,
+              12.5,
+              12.4,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              11.1,
+              17,
+              16.1,
+              16.1,
+              16.1,
+              16.1
+            ],
+            "distance": [
+              48.2,
+              86.8,
+              160.2,
+              64.2,
+              82.1,
+              20.3,
+              5.9,
+              94.3,
+              92.2,
+              254.8,
+              131.7,
+              65.5,
+              141.8,
+              80.5,
+              94.1,
+              144.3,
+              41.1,
+              83.2,
+              49.7,
+              102.5,
+              60.5,
+              34.3,
+              41.6,
+              44.4,
+              42.4,
+              7.3,
+              39.2,
+              46.4,
+              47.4,
+              46.5,
+              48.7,
+              49.8,
+              72,
+              48.3,
+              49.3,
+              189.3,
+              102.6,
+              230.4,
+              315.3,
+              286.2,
+              51.9,
+              53.3,
+              51.9,
+              53.7,
+              78.1,
+              60.9,
+              48.3,
+              21.7,
+              73.5,
+              21.6,
+              71,
+              42.9,
+              41.5,
+              34.4,
+              48.9,
+              34.5,
+              16.7,
+              16.9,
+              12.7,
+              17.8,
+              10.5,
+              13,
+              12.9,
+              13.2,
+              14.4,
+              10.7,
+              19.6,
+              10.8,
+              11.2,
+              14.8,
+              51.1,
+              60.1,
+              89.2,
+              80.4,
+              39.7,
+              35,
+              16.1,
+              17.2,
+              15.8,
+              13.6,
+              4.2,
+              6.1,
+              8.3,
+              13.7,
+              16.4,
+              13.8,
+              19.3,
+              45.5,
+              71.2,
+              29.1,
+              14.6,
+              43.1,
+              77.2,
+              29.1,
+              50.8,
+              75.7,
+              60.8,
+              24.7,
+              187.1,
+              58.3,
+              64,
+              2.4,
+              34.8,
+              35.8,
+              21.9,
+              29.4,
+              29.5,
+              28.9,
+              27,
+              33.8,
+              28.1,
+              17.1,
+              25.4,
+              19.3,
+              11.4,
+              15.5,
+              14.5,
+              53.5,
+              49.8,
+              67,
+              48.9,
+              79.6,
+              26.7,
+              25.2,
+              43.2,
+              22.6,
+              16.4,
+              14.5,
+              20.8,
+              14.4,
+              10.5,
+              13.3,
+              11.6,
+              12.4,
+              12.4,
+              11,
+              12.9,
+              13.5,
+              12.4,
+              9.7,
+              11.6,
+              29.4,
+              22.8,
+              50.2,
+              34.2,
+              5.2,
+              74.1,
+              75.6,
+              7.4,
+              57.5,
+              70.1,
+              56.5,
+              52.4,
+              52.2,
+              53.6,
+              52.1,
+              284.5,
+              315.2,
+              231.8,
+              290.7,
+              48.6,
+              49.3,
+              73,
+              47.8,
+              48.6,
+              47.5,
+              47.5,
+              45.3,
+              45.4,
+              43.4,
+              43.4,
+              41.6,
+              28.3,
+              65.2,
+              58.8,
+              47.3,
+              42.5,
+              82.4,
+              119.6,
+              73.3,
+              144.3,
+              105.3,
+              109.4,
+              145.4,
+              27.2,
+              227.7,
+              97.9,
+              70.3,
+              58.6,
+              128.3,
+              164.3,
+              57.3,
+              80.2,
+              254,
+              23,
+              8.2,
+              234.2,
+              82.7,
+              78.1,
+              31.8,
+              18.1,
+              22.8,
+              109.6,
+              65.3,
+              56.1,
+              53.1,
+              53.2,
+              129.1,
+              38.1,
+              107.7,
+              116.9,
+              203.2,
+              147.6,
+              128,
+              14.3,
+              72,
+              51.8,
+              13.4,
+              98.9,
+              250.8,
+              54.2,
+              120.8,
+              63.3,
+              30.9,
+              153.2,
+              76.6,
+              48.3,
+              48.1,
+              58.6,
+              68.5,
+              46.9,
+              100.4,
+              98.3,
+              44.8,
+              56.2,
+              158.7,
+              136.5,
+              115.5,
+              120.4,
+              36.3,
+              268.9,
+              45.5,
+              87,
+              80.8,
+              124.2,
+              95,
+              18.8,
+              44.1,
+              63.8,
+              13.8,
+              43.5,
+              18.6,
+              25.8,
+              69.2,
+              48.5,
+              15.4,
+              28.9,
+              93.7,
+              28.6,
+              157,
+              145.2,
+              98,
+              379.3,
+              74.1,
+              128.9,
+              64.9,
+              75.4,
+              61.8,
+              80.4,
+              88.7,
+              96.9,
+              164.9,
+              160.8,
+              73.3,
+              137,
+              139.2,
+              154.5,
+              27.8,
+              46.5,
+              45.5,
+              44.4,
+              32.6,
+              40.2,
+              28.1,
+              33,
+              33.7,
+              39.9,
+              43.9,
+              43.7,
+              90.6,
+              153.1,
+              964.1,
+              361.2,
+              5.8,
+              71.5,
+              34.8,
+              5.1,
+              106.2,
+              86.7,
+              185.1,
+              73.8,
+              59.1,
+              37.1,
+              110.8,
+              214.2,
+              107.1,
+              171.6,
+              186.8,
+              212.8,
+              463.5,
+              29.7,
+              147.5,
+              112.2,
+              152.1,
+              75.9,
+              49.4,
+              633.2,
+              49.2,
+              31.5,
+              121.8,
+              207,
+              55.2,
+              152.2,
+              102.9,
+              154.7,
+              114,
+              67.4,
+              110.8,
+              146.3,
+              72.8,
+              65.2,
+              127,
+              49.4,
+              98.2,
+              27,
+              18.6,
+              58.1,
+              75.5,
+              229.2,
+              267.1,
+              46.7,
+              101.3,
+              21.7,
+              405.7,
+              448.9,
+              70.5,
+              101.6,
+              27.7,
+              30.9,
+              65.7,
+              266.1,
+              98.8,
+              290.7,
+              309.2,
+              116.5,
+              74.1,
+              38.2,
+              370.2,
+              57.9,
+              48.5,
+              40.6,
+              50.6,
+              52.7,
+              87.5,
+              504.9,
+              274.3,
+              273.4,
+              76,
+              71.3,
+              39.7,
+              24.8,
+              298.6,
+              256,
+              255.1,
+              2.3,
+              99.7,
+              38.1,
+              74.7,
+              83.9,
+              58.7,
+              96.8,
+              43.7,
+              38.9,
+              34.1,
+              38.8,
+              51,
+              5,
+              48.4,
+              43.7,
+              39.1,
+              24.9,
+              33,
+              75.5,
+              136.1,
+              53.2,
+              628.2,
+              59,
+              395.9,
+              194.4,
+              355.2,
+              124.5,
+              26.9,
+              216.2,
+              4.3,
+              169.7,
+              100.3,
+              268.7,
+              102.6,
+              141.2,
+              13.2,
+              171.7,
+              211,
+              13.2,
+              170.2,
+              132.3,
+              590.4,
+              228.1,
+              121.2,
+              108.4,
+              133.9,
+              385.4,
+              268.7,
+              206.7,
+              122.3,
+              85.3,
+              196.4,
+              170.3,
+              67.2,
+              88.4,
+              73.9,
+              76.2,
+              224.6,
+              234.5,
+              44.8,
+              238.3,
+              31.4,
+              181.3,
+              440.5,
+              160.5,
+              29.6,
+              76.2,
+              117.7,
+              44.4,
+              48.4,
+              57.3,
+              36.9,
+              12.6,
+              62.5,
+              93.7,
+              73,
+              45.3,
+              75.9,
+              97.6,
+              54.3,
+              98.2,
+              60.5,
+              116.9,
+              18.2,
+              301.3,
+              301,
+              38.9,
+              292.2,
+              322.1,
+              308.8,
+              323,
+              49.7,
+              272,
+              60.4,
+              74,
+              51.6,
+              97.1,
+              74.6,
+              340.8,
+              47.4,
+              126.9,
+              59.4,
+              107.3,
+              47.6,
+              55.5,
+              48.7,
+              24.8,
+              24.1,
+              23.5,
+              40.5,
+              19.8,
+              48.2,
+              26.8,
+              33.2,
+              59.5,
+              126.7,
+              132.1,
+              52,
+              48.4,
+              35.5,
+              48.5,
+              64.9,
+              48.3,
+              64,
+              37.1,
+              78.2,
+              14,
+              74.4,
+              283.1,
+              35.9,
+              345.9,
+              487.8,
+              129.6,
+              64.1,
+              48,
+              182.2,
+              82.7,
+              92,
+              28.3,
+              105,
+              149.1,
+              126.2,
+              153.4,
+              223.5,
+              36.5,
+              103.1,
+              35.8,
+              12,
+              2.2,
+              199.1,
+              158.2,
+              102.2,
+              22.6,
+              65.8,
+              12.6,
+              10.6,
+              149.1,
+              27.6,
+              83.9,
+              28.9,
+              131.8,
+              7.4,
+              54.7,
+              17.7,
+              49.2,
+              12.4,
+              20.6,
+              63.1,
+              55.9,
+              20,
+              33.6,
+              2.1,
+              3.2,
+              9.2,
+              8.3,
+              21.2,
+              35.9,
+              225.9,
+              69.7
+            ],
+            "duration": [
+              2.11,
+              3.806,
+              7.026,
+              2.772,
+              3.517,
+              0.868,
+              0.256,
+              4.04,
+              3.954,
+              10.929,
+              5.78,
+              2.878,
+              6.223,
+              3.537,
+              4.129,
+              6.334,
+              1.807,
+              3.388,
+              2.008,
+              4.14,
+              2.427,
+              1.389,
+              1.684,
+              1.796,
+              1.716,
+              0.293,
+              1.588,
+              1.878,
+              1.915,
+              1.882,
+              1.97,
+              2.015,
+              2.914,
+              1.955,
+              1.994,
+              7.656,
+              4.149,
+              9.319,
+              12.747,
+              11.575,
+              2.099,
+              2.153,
+              2.099,
+              2.172,
+              3.158,
+              2.457,
+              1.952,
+              0.89,
+              3.785,
+              1.11,
+              3.651,
+              2.21,
+              2.136,
+              1.773,
+              2.233,
+              1.681,
+              0.817,
+              0.823,
+              0.62,
+              0.908,
+              0.539,
+              0.664,
+              0.658,
+              0.677,
+              0.734,
+              0.552,
+              1.49,
+              0.708,
+              0.731,
+              0.973,
+              3.343,
+              3.939,
+              5.846,
+              5.169,
+              2.55,
+              2.252,
+              1.031,
+              1.109,
+              1.013,
+              1.096,
+              0.319,
+              0.475,
+              0.647,
+              1.063,
+              1.275,
+              1.079,
+              1.51,
+              3.556,
+              5.563,
+              2.278,
+              1.308,
+              3.686,
+              15.401,
+              5.808,
+              5.912,
+              5.825,
+              4.691,
+              17.622,
+              18.952,
+              7.227,
+              4.126,
+              0.152,
+              2.24,
+              2.304,
+              1.409,
+              1.895,
+              1.9,
+              1.998,
+              1.871,
+              2.347,
+              1.946,
+              1.184,
+              1.839,
+              1.36,
+              0.804,
+              1.091,
+              1.022,
+              3.774,
+              3.517,
+              4.722,
+              3.447,
+              6.805,
+              2.277,
+              2.146,
+              3.698,
+              1.983,
+              1.436,
+              1.269,
+              1.827,
+              1.258,
+              0.924,
+              1.167,
+              1.01,
+              1.089,
+              1.091,
+              0.957,
+              1.132,
+              1.185,
+              1.083,
+              0.854,
+              1.014,
+              2.582,
+              1.237,
+              2.535,
+              1.654,
+              0.25,
+              3.608,
+              3.682,
+              0.341,
+              4.275,
+              3.287,
+              2.643,
+              2.451,
+              2.441,
+              2.504,
+              2.439,
+              13.301,
+              14.74,
+              10.837,
+              13.595,
+              2.268,
+              2.306,
+              3.414,
+              2.236,
+              2.272,
+              2.222,
+              2.218,
+              2.119,
+              2.126,
+              2.027,
+              2.029,
+              1.947,
+              1.324,
+              3.039,
+              3.023,
+              2.435,
+              2.184,
+              4.238,
+              5.391,
+              3.297,
+              6.489,
+              4.738,
+              4.921,
+              6.539,
+              1.185,
+              10.01,
+              4.299,
+              3.083,
+              2.574,
+              5.633,
+              7.217,
+              2.514,
+              3.524,
+              13.258,
+              1.202,
+              0.428,
+              12.22,
+              4.316,
+              4.076,
+              1.662,
+              0.94,
+              1.191,
+              5.719,
+              3.408,
+              2.926,
+              2.427,
+              2.419,
+              5.871,
+              1.712,
+              4.844,
+              5.257,
+              9.14,
+              6.635,
+              5.756,
+              0.642,
+              3.239,
+              2.328,
+              0.604,
+              4.445,
+              11.282,
+              2.439,
+              5.431,
+              2.847,
+              1.392,
+              6.893,
+              3.447,
+              2.176,
+              2.166,
+              2.634,
+              3.084,
+              2.112,
+              4.519,
+              4.423,
+              2.013,
+              2.531,
+              7.136,
+              6.138,
+              5.194,
+              5.418,
+              1.631,
+              12.085,
+              2.045,
+              3.971,
+              3.684,
+              5.664,
+              4.333,
+              0.858,
+              2.012,
+              2.91,
+              0.63,
+              2.175,
+              0.92,
+              1.271,
+              3.403,
+              2.469,
+              0.771,
+              1.491,
+              4.766,
+              1.398,
+              7.642,
+              7.071,
+              4.783,
+              18.442,
+              3.667,
+              6.362,
+              3.196,
+              3.708,
+              2.978,
+              3.862,
+              4.255,
+              4.656,
+              7.92,
+              7.832,
+              3.413,
+              6.411,
+              6.51,
+              7.229,
+              1.301,
+              2.172,
+              2.125,
+              2.08,
+              1.521,
+              1.882,
+              1.374,
+              1.585,
+              1.622,
+              1.923,
+              2.102,
+              2.097,
+              4.345,
+              7.587,
+              46.891,
+              17.568,
+              0.292,
+              3.468,
+              1.689,
+              0.262,
+              4.956,
+              4.055,
+              8.656,
+              3.453,
+              2.766,
+              1.735,
+              5.19,
+              10.005,
+              5.01,
+              8.042,
+              8.743,
+              9.831,
+              21.415,
+              1.385,
+              6.706,
+              5.104,
+              6.593,
+              3.344,
+              2.151,
+              27.79,
+              2.195,
+              1.405,
+              5.645,
+              9.561,
+              2.416,
+              6.586,
+              4.774,
+              7.151,
+              5.262,
+              3.107,
+              5.108,
+              6.747,
+              3.361,
+              3.005,
+              5.856,
+              2.286,
+              4.542,
+              1.248,
+              0.857,
+              2.68,
+              3.484,
+              10.564,
+              12.186,
+              2.07,
+              4.455,
+              0.956,
+              17.395,
+              19.248,
+              3.051,
+              4.455,
+              1.219,
+              1.354,
+              2.886,
+              11.673,
+              4.338,
+              12.754,
+              13.591,
+              5.119,
+              3.257,
+              1.679,
+              16.269,
+              2.565,
+              2.152,
+              1.804,
+              2.251,
+              2.346,
+              3.892,
+              21.93,
+              12.193,
+              12.149,
+              3.377,
+              3.169,
+              1.799,
+              1.077,
+              12.952,
+              11.108,
+              11.065,
+              0.1,
+              4.322,
+              1.65,
+              3.241,
+              3.636,
+              2.545,
+              4.195,
+              1.893,
+              1.686,
+              1.479,
+              1.682,
+              2.196,
+              0.212,
+              2.074,
+              1.874,
+              1.676,
+              1.07,
+              1.411,
+              3.236,
+              5.836,
+              2.279,
+              26.617,
+              2.498,
+              16.778,
+              8.235,
+              15.235,
+              5.34,
+              1.154,
+              9.283,
+              0.188,
+              7.374,
+              4.362,
+              11.651,
+              4.522,
+              6.202,
+              0.576,
+              7.543,
+              9.267,
+              0.58,
+              7.474,
+              5.807,
+              25.617,
+              9.898,
+              5.256,
+              4.8,
+              5.956,
+              17.569,
+              12.24,
+              9.421,
+              5.572,
+              3.882,
+              8.95,
+              7.758,
+              3.06,
+              4.027,
+              3.367,
+              3.47,
+              10.235,
+              10.164,
+              1.944,
+              10.347,
+              1.364,
+              7.86,
+              19.102,
+              6.956,
+              1.324,
+              3.348,
+              5.171,
+              1.949,
+              2.126,
+              2.519,
+              1.619,
+              0.554,
+              2.747,
+              7.06,
+              5.473,
+              3.398,
+              5.693,
+              7.325,
+              4.072,
+              7.367,
+              4.533,
+              8.773,
+              1.364,
+              22.598,
+              22.579,
+              2.918,
+              21.92,
+              24.157,
+              23.161,
+              24.228,
+              3.732,
+              20.402,
+              4.528,
+              5.556,
+              3.865,
+              7.284,
+              5.596,
+              25.567,
+              3.556,
+              9.939,
+              4.66,
+              8.405,
+              3.737,
+              4.346,
+              3.817,
+              1.087,
+              1.031,
+              1.008,
+              1.739,
+              0.861,
+              2.096,
+              1.163,
+              1.438,
+              2.573,
+              5.488,
+              5.729,
+              2.257,
+              2.1,
+              1.542,
+              2.106,
+              2.813,
+              2.096,
+              2.778,
+              1.611,
+              3.385,
+              0.606,
+              3.302,
+              12.564,
+              1.6,
+              14.829,
+              21.96,
+              7.672,
+              5.773,
+              4.318,
+              16.38,
+              22.446,
+              8.278,
+              2.546,
+              9.45,
+              9.272,
+              7.828,
+              9.544,
+              13.873,
+              3.31,
+              9.304,
+              2.596,
+              0.868,
+              0.187,
+              14.342,
+              11.4,
+              7.362,
+              3.677,
+              20.352,
+              8.961,
+              0.792,
+              33.561,
+              1.991,
+              6.019,
+              2.078,
+              10.525,
+              0.595,
+              4.41,
+              1.603,
+              4.425,
+              1.119,
+              1.857,
+              5.677,
+              5.029,
+              1.797,
+              3.025,
+              0.187,
+              0.291,
+              0.828,
+              0.503,
+              1.313,
+              2.228,
+              14.022,
+              4.33
+            ]
+          },
+          "weight_typical": 3049.488,
+          "duration_typical": 2747.369,
+          "weight": 3008.656,
+          "duration": 2702.027,
+          "steps": [
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive southeast on <say-as interpret-as=\"address\">Expwy Wangan Line</say-as> for 4 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Drive southeast on Expwy Wangan Line for 4 kilometers.",
+                  "distanceAlongGeometry": 4065.065
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep left at <say-as interpret-as=\"address\">Kawasakiukishima JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep left at Kawasakiukishima JCT.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep left at <say-as interpret-as=\"address\">Kawasakiukishima JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep left at Kawasakiukishima JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep left at <say-as interpret-as=\"address\">Kawasakiukishima JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾄｰｷｮ'ｰﾜﾝ ｱｸｱﾗｲﾝ\">東京湾アクアライン</phoneme>, <phoneme alphabet=\"jeita\" ph=\"ｷ%ｻﾗﾂﾞ\">木更津</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep left at Kawasakiukishima JCT toward 東京湾アクアライン, 木更津.",
+                  "distanceAlongGeometry": 160
+                }
+              ],
+              "intersections": [
+                {
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "bearings": [
+                    150
+                  ],
+                  "duration": 12.942,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 11.971,
+                  "geometry_index": 0,
+                  "location": [
+                    139.785936,
+                    35.550703
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.787577,
+                    35.548412
+                  ],
+                  "geometry_index": 3,
+                  "admin_index": 0,
+                  "weight": 14.232,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 15.406,
+                  "bearings": [
+                    150,
+                    330,
+                    334
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.021,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukominami Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    149,
+                    331
+                  ],
+                  "duration": 10.929,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 10.109,
+                  "geometry_index": 9,
+                  "location": [
+                    139.789532,
+                    35.545607
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    149,
+                    329
+                  ],
+                  "duration": 30.688,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 27.619,
+                  "geometry_index": 10,
+                  "location": [
+                    139.790998,
+                    35.543654
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.794623,
+                    35.538117
+                  ],
+                  "geometry_index": 17,
+                  "admin_index": 0,
+                  "weight": 9.305,
+                  "is_urban": false,
+                  "turn_weight": 0.75,
+                  "duration": 9.536,
+                  "bearings": [
+                    163,
+                    336,
+                    344
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.03,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    171,
+                    347
+                  ],
+                  "duration": 2.427,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 2.184,
+                  "geometry_index": 20,
+                  "location": [
+                    139.795271,
+                    35.536071
+                  ]
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    172,
+                    351
+                  ],
+                  "duration": 6.876,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 6.189,
+                  "geometry_index": 21,
+                  "location": [
+                    139.795373,
+                    35.535534
+                  ]
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    177,
+                    357
+                  ],
+                  "duration": 25.766,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 23.834,
+                  "geometry_index": 26,
+                  "location": [
+                    139.795566,
+                    35.534016
+                  ]
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    13,
+                    193
+                  ],
+                  "duration": 49.47,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 44.523,
+                  "geometry_index": 36,
+                  "location": [
+                    139.794623,
+                    35.528369
+                  ]
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    23,
+                    204
+                  ],
+                  "duration": 4.409,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 3.968,
+                  "geometry_index": 45,
+                  "location": [
+                    139.791294,
+                    35.517731
+                  ]
+                },
+                {
+                  "bearings": [
+                    26,
+                    205
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "geometry_index": 47,
+                  "location": [
+                    139.790783,
+                    35.516842
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東京湾アクアライン"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "木更津"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "東京湾アクアライン / 木更津"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Kawasakiukishima JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "K6",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "K6"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Kawasakiukishima JCT / K6"
+                  },
+                  "distanceAlongGeometry": 4065.065
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA100211?arrow_ids=CA10021A",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東京湾アクアライン"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "木更津"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "東京湾アクアライン / 木更津"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Kawasakiukishima JCT"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "K6",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "K6"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Kawasakiukishima JCT / K6"
+                  },
+                  "distanceAlongGeometry": 1500
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "depart",
+                "instruction": "Drive southeast on Expwy Wangan Line.",
+                "bearing_after": 150,
+                "bearing_before": 0,
+                "location": [
+                  139.785936,
+                  35.550703
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Expwy Wangan Line",
+              "weight_typical": 161.466,
+              "duration_typical": 176.77,
+              "duration": 169.339,
+              "distance": 4065.065,
+              "driving_side": "left",
+              "weight": 154.734,
+              "mode": "driving",
+              "geometry": "}}yxbA_lzriGjVsOfi@{\\plAaw@f^aUng@_ZxHaFzAcAvl@u_@bl@g^`yBszAt~@cm@x^wUzcA_p@zf@gYzm@{\\zhA{g@`TuJpk@aPdZyFbw@sNp`@kE`RoBdVqBxW{AvVcA`C?~Tm@`Y?pYV`YbAdZpBvZfC|f@xFrYjEdZjEpfBb\\dw@rNb}Bnb@lkD~o@f{Cdm@h[nG|[dHxZtIh[vKng@rSf^`PhWzM~IjE"
+            },
+            {
+              "mode": "driving",
+              "weight": 23.006,
+              "distance": 507.128,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA10021A"
+                  ],
+                  "base_id": "CA100211",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 43.06,
+              "weight_typical": 38.746,
+              "name": "",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep left at Kawasakiukishima JCT toward 東京湾アクアライン/木更津.",
+                "modifier": "slight left",
+                "bearing_after": 202,
+                "bearing_before": 205,
+                "location": [
+                  139.790681,
+                  35.516666
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "K6: 東京湾アクアライン, 木更津, 川崎",
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA100271?arrow_ids=CA10027E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight right",
+                        "active": true,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東京湾アクアライン"
+                      },
+                      {
+                        "type": "text",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "木更津"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東京湾アクアライン / 木更津"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ukishima"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Ukishima"
+                  },
+                  "distanceAlongGeometry": 507.128
+                }
+              ],
+              "geometry": "snwvbAqtcsiGde@dR|IlE|b@fTlTnLdSfM`NzMpUdR`N|MjEnGvDfHv@nGv@`Ke@bFiAnGmBxFyDtD}E~CyD`A",
+              "duration": 25.571,
+              "junction_name": "Kawasakiukishima JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 500 meters, Keep right toward <phoneme alphabet=\"jeita\" ph=\"ﾄｰｷｮ'ｰﾜﾝ ｱｸｱﾗｲﾝ\">東京湾アクアライン</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 500 meters, Keep right toward 東京湾アクアライン.",
+                  "distanceAlongGeometry": 493.795
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right toward <phoneme alphabet=\"jeita\" ph=\"ﾄｰｷｮ'ｰﾜﾝ ｱｸｱﾗｲﾝ\">東京湾アクアライン</phoneme>, <phoneme alphabet=\"jeita\" ph=\"ｷ%ｻﾗﾂﾞ\">木更津</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right toward 東京湾アクアライン, 木更津.",
+                  "distanceAlongGeometry": 66.667
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.790681,
+                    35.516666
+                  ],
+                  "geometry_index": 48,
+                  "admin_index": 1,
+                  "weight": 4.397,
+                  "is_urban": false,
+                  "duration": 4.895,
+                  "bearings": [
+                    25,
+                    202,
+                    210
+                  ],
+                  "jct": {
+                    "name": "Kawasakiukishima JCT"
+                  },
+                  "out": 1,
+                  "in": 0,
+                  "turn_duration": 0.009,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    25,
+                    206
+                  ],
+                  "duration": 3.651,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 3.286,
+                  "geometry_index": 50,
+                  "location": [
+                    139.790271,
+                    35.51588
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    26,
+                    207
+                  ],
+                  "duration": 6.12,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 5.508,
+                  "geometry_index": 51,
+                  "location": [
+                    139.789931,
+                    35.515305
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    39,
+                    215
+                  ],
+                  "duration": 2.233,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 2.01,
+                  "geometry_index": 54,
+                  "location": [
+                    139.789249,
+                    35.514398
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    35,
+                    219
+                  ],
+                  "duration": 3.941,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 3.546,
+                  "geometry_index": 55,
+                  "location": [
+                    139.788942,
+                    35.514037
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    65,
+                    265
+                  ],
+                  "duration": 3.446,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 3.101,
+                  "geometry_index": 59,
+                  "location": [
+                    139.788283,
+                    35.513574
+                  ]
+                },
+                {
+                  "bearings": [
+                    131,
+                    335
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "geometry_index": 64,
+                  "location": [
+                    139.787624,
+                    35.51375
+                  ]
+                }
+              ]
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 300 meters, Keep left at the fork.</prosody></amazon:effect></speak>",
+                  "announcement": "In 300 meters, Keep left at the fork.",
+                  "distanceAlongGeometry": 243.474
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep left at the fork.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep left at the fork.",
+                  "distanceAlongGeometry": 66.667
+                }
+              ],
+              "intersections": [
+                {
+                  "bearings": [
+                    0,
+                    8,
+                    156
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 2,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid_indication": "slight right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "turn_duration": 0.207,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "geometry_index": 66,
+                  "location": [
+                    139.787511,
+                    35.513954
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CB298201?arrow_ids=CB29820A",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ukishima"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "Ukishima"
+                  },
+                  "distanceAlongGeometry": 256.808
+                }
+              ],
+              "destinations": "東京湾アクアライン, 木更津",
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right toward 東京湾アクアライン/木更津.",
+                "modifier": "slight right",
+                "bearing_after": 8,
+                "bearing_before": 336,
+                "location": [
+                  139.787511,
+                  35.513954
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "",
+              "weight_typical": 15.14,
+              "duration_typical": 17.029,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA10027E"
+                  ],
+                  "base_id": "CA100271",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "duration": 17.029,
+              "distance": 256.808,
+              "driving_side": "left",
+              "weight": 15.14,
+              "mode": "driving",
+              "geometry": "cervbAmn}riG}Ik@yDcAyD{A}EuDkTmVsYoXog@gc@"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 600 meters, Continue at <phoneme alphabet=\"jeita\" ph=\"ｳｷ%ｼﾏｺｰｴﾝﾏｴ\">浮島公園前</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 600 meters, Continue at 浮島公園前.",
+                  "distanceAlongGeometry": 596.032
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue at <phoneme alphabet=\"jeita\" ph=\"ｳｷ%ｼﾏｺｰｴﾝﾏｴ\">浮島公園前</phoneme> toward <phoneme alphabet=\"jeita\" ph=\"ｶﾜｻｷ%ｼｶﾞ&ｲ\">川崎市街</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue at 浮島公園前 toward 川崎市街.",
+                  "distanceAlongGeometry": 66.667
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "location": [
+                    139.789067,
+                    35.515842
+                  ],
+                  "geometry_index": 73,
+                  "admin_index": 1,
+                  "weight": 11.803,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "duration": 13.124,
+                  "bearings": [
+                    29,
+                    37,
+                    216
+                  ],
+                  "out": 0,
+                  "in": 2,
+                  "turn_duration": 0.01,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    9,
+                    193
+                  ],
+                  "duration": 1.096,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 0.986,
+                  "geometry_index": 79,
+                  "location": [
+                    139.790078,
+                    35.517471
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    189,
+                    357
+                  ],
+                  "duration": 2.504,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 2.254,
+                  "geometry_index": 80,
+                  "location": [
+                    139.790101,
+                    35.517592
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    173,
+                    339
+                  ],
+                  "duration": 15.261,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 13.735,
+                  "geometry_index": 84,
+                  "location": [
+                    139.790067,
+                    35.517879
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "location": [
+                    139.788919,
+                    35.519351
+                  ],
+                  "geometry_index": 90,
+                  "admin_index": 1,
+                  "weight": 1.657,
+                  "is_urban": false,
+                  "turn_weight": 0.5,
+                  "duration": 1.308,
+                  "bearings": [
+                    138,
+                    146,
+                    321
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.022,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    141,
+                    318
+                  ],
+                  "duration": 3.686,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 3.317,
+                  "geometry_index": 91,
+                  "location": [
+                    139.788817,
+                    35.519453
+                  ]
+                },
+                {
+                  "bearings": [
+                    125,
+                    138,
+                    314
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.009,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 2,
+                  "geometry_index": 92,
+                  "location": [
+                    139.788499,
+                    35.51974
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/exit/14o00026_o10d?arrow_ids=14o00026_o11a",
+                        "subType": "exit",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "straight",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "left",
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "浮島公園前"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "straight",
+                    "text": "浮島公園前"
+                  },
+                  "distanceAlongGeometry": 609.366
+                }
+              ],
+              "destinations": "Ukishima",
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep left at the fork.",
+                "modifier": "slight left",
+                "bearing_after": 29,
+                "bearing_before": 36,
+                "location": [
+                  139.789067,
+                  35.515842
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "",
+              "weight_typical": 53.332,
+              "duration_typical": 58.188,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CB29820A"
+                  ],
+                  "base_id": "CB298201",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "duration": 58.188,
+              "distance": 609.366,
+              "driving_side": "left",
+              "weight": 53.332,
+              "mode": "driving",
+              "geometry": "c{uvbAuo`siGkf@_ZaReMkPkJaG}CgHqBuGcAqFm@iA?mB?uC?oFbAuGpB}EfCyHtDmT`P_`@tZcKnLkEjE}PzRa]je@_JzM"
+            },
+            {
+              "bannerInstructions": [
+                {
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "right",
+                        "active": true,
+                        "directions": [
+                          "right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-national-route",
+                          "display_ref": "409",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "National Road No.409 Line"
+                      }
+                    ],
+                    "driving_side": "left",
+                    "type": "turn",
+                    "modifier": "uturn",
+                    "text": "National Road No.409 Line"
+                  },
+                  "distanceAlongGeometry": 187.287
+                }
+              ],
+              "ref": "National Road No.409 Line",
+              "mode": "driving",
+              "weight": 20.46,
+              "distance": 187.287,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "14o00026_o11a"
+                  ],
+                  "base_id": "14o00026_o10d",
+                  "type": "exit",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 16.428,
+              "weight_typical": 20.46,
+              "name": "",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "new name",
+                "instruction": "Continue at 浮島公園前 toward 川崎市街.",
+                "modifier": "straight",
+                "bearing_after": 308,
+                "bearing_before": 312,
+                "location": [
+                  139.787647,
+                  35.520397
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "川崎市街",
+              "geometry": "yw~vbA}v}riGkPvZmXzh@mTr_@",
+              "duration": 16.428,
+              "junction_name": "浮島公園前",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 200 meters, Make a right U-turn to stay on <say-as interpret-as=\"address\">National Road No.409 Line</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 200 meters, Make a right U-turn to stay on National Road No.409 Line.",
+                  "distanceAlongGeometry": 170.62
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Make a right U-turn to stay on <say-as interpret-as=\"address\">National Road No.409 Line</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Make a right U-turn to stay on National Road No.409 Line.",
+                  "distanceAlongGeometry": 127.778
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "left",
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "location": [
+                    139.787647,
+                    35.520397
+                  ],
+                  "geometry_index": 94,
+                  "admin_index": 1,
+                  "weight": 16.255,
+                  "is_urban": false,
+                  "traffic_signal": true,
+                  "turn_duration": 2.009,
+                  "turn_weight": 7.5,
+                  "duration": 11.737,
+                  "bearings": [
+                    39,
+                    132,
+                    222,
+                    308
+                  ],
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "bearings": [
+                    127,
+                    220,
+                    309
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "turn_duration": 0.019,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 2,
+                  "geometry_index": 96,
+                  "location": [
+                    139.786533,
+                    35.521082
+                  ]
+                }
+              ]
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 200 meters, Stay straight to take the <say-as interpret-as=\"address\">Ukishima</say-as> ramp.</prosody></amazon:effect></speak>",
+                  "announcement": "In 200 meters, Stay straight to take the Ukishima ramp.",
+                  "distanceAlongGeometry": 207.115
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Stay straight to take the <say-as interpret-as=\"address\">Ukishima</say-as> ramp. Then Keep left toward <phoneme alphabet=\"jeita\" ph=\"ﾄｰｷｮｰ\">東京</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Stay straight to take the Ukishima ramp. Then Keep left toward 東京.",
+                  "distanceAlongGeometry": 105.556
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid_indication": "right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "location": [
+                    139.786011,
+                    35.521425
+                  ],
+                  "geometry_index": 97,
+                  "admin_index": 1,
+                  "weight": 92.75,
+                  "is_urban": false,
+                  "traffic_signal": true,
+                  "turn_duration": 7.622,
+                  "turn_weight": 83.75,
+                  "duration": 17.622,
+                  "bearings": [
+                    42,
+                    129,
+                    310
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "bearings": [
+                    37,
+                    125,
+                    222,
+                    304
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "turn_weight": 22.5,
+                  "turn_duration": 6.486,
+                  "traffic_signal": true,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "geometry_index": 98,
+                  "location": [
+                    139.786192,
+                    35.521591
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "left",
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ukishima"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-urban-expressway",
+                          "display_ref": "B",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "B"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "straight",
+                    "text": "Ukishima / B"
+                  },
+                  "distanceAlongGeometry": 211.782
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "continue",
+                "instruction": "Make a right U-turn to stay on National Road No.409 Line.",
+                "modifier": "uturn",
+                "bearing_after": 125,
+                "bearing_before": 309,
+                "location": [
+                  139.786011,
+                  35.521425
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "",
+              "weight_typical": 126.47,
+              "duration_typical": 36.574,
+              "duration": 36.574,
+              "distance": 211.782,
+              "driving_side": "left",
+              "weight": 126.47,
+              "mode": "driving",
+              "ref": "National Road No.409 Line",
+              "geometry": "ax`wbAupzriGkIiJb{@yhB"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep left toward <phoneme alphabet=\"jeita\" ph=\"ﾄｰｷｮｰ\">東京</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep left toward 東京.",
+                  "distanceAlongGeometry": 45.026
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "left",
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "location": [
+                    139.787885,
+                    35.520629
+                  ],
+                  "geometry_index": 99,
+                  "admin_index": 1,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "traffic_signal": true,
+                  "turn_weight": 15,
+                  "out": 1,
+                  "in": 3,
+                  "turn_duration": 2.007,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "bearings": [
+                    35,
+                    126,
+                    220,
+                    305
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東京"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "left",
+                    "text": "東京"
+                  },
+                  "distanceAlongGeometry": 58.359
+                }
+              ],
+              "destinations": "B: 首都高速湾岸線",
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "on ramp",
+                "instruction": "Stay straight to take the Ukishima ramp.",
+                "modifier": "straight",
+                "bearing_after": 126,
+                "bearing_before": 125,
+                "location": [
+                  139.787885,
+                  35.520629
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "",
+              "weight_typical": 19.698,
+              "duration_typical": 7.227,
+              "duration": 7.227,
+              "distance": 58.359,
+              "driving_side": "left",
+              "weight": 19.698,
+              "mode": "driving",
+              "geometry": "if_wbAye~riGbRu_@"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Keep right toward <phoneme alphabet=\"jeita\" ph=\"ﾄｰｷｮｰ\">東京</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Keep right toward 東京.",
+                  "distanceAlongGeometry": 339.289
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right toward <phoneme alphabet=\"jeita\" ph=\"ﾄｰｷｮｰ\">東京</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right toward 東京.",
+                  "distanceAlongGeometry": 62.222
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    118,
+                    128,
+                    306
+                  ],
+                  "duration": 4.126,
+                  "turn_duration": 0.012,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 3.703,
+                  "geometry_index": 100,
+                  "location": [
+                    139.788408,
+                    35.520323
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    110,
+                    298
+                  ],
+                  "duration": 9.9,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 8.91,
+                  "geometry_index": 101,
+                  "location": [
+                    139.789033,
+                    35.520055
+                  ]
+                },
+                {
+                  "bearings": [
+                    125,
+                    299
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "geometry_index": 107,
+                  "location": [
+                    139.790601,
+                    35.519536
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/tollbranch/CRZ41101?arrow_ids=CRZ4110E",
+                        "subType": "tollbranch",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東京"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東京"
+                  },
+                  "distanceAlongGeometry": 352.622
+                }
+              ],
+              "destinations": "東京, 首都高速, 横浜",
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep left toward 東京.",
+                "modifier": "slight left",
+                "bearing_after": 118,
+                "bearing_before": 126,
+                "location": [
+                  139.788408,
+                  35.520323
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "",
+              "weight_typical": 21.024,
+              "duration_typical": 23.372,
+              "duration": 23.372,
+              "distance": 352.622,
+              "driving_side": "left",
+              "weight": 21.024,
+              "mode": "driving",
+              "geometry": "es~vbAof_siGvOaf@Rm@jEuUhEmV`CgM|EmQbGwPfHiOxHeM`NgMvKkJ`GkE"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 11 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 11 kilometers.",
+                  "distanceAlongGeometry": 11452.569
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep right at <say-as interpret-as=\"address\">Oi JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep right at Oi JCT.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep right at <say-as interpret-as=\"address\">Oi JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep right at Oi JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Oi JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾋｶﾞ&ｼ%ｶﾝﾄｰﾄﾞｰ\">東関東道</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Oi JCT toward 東関東道.",
+                  "distanceAlongGeometry": 151.111
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    149,
+                    159,
+                    326
+                  ],
+                  "duration": 6.115,
+                  "turn_duration": 0.045,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 5.464,
+                  "geometry_index": 112,
+                  "location": [
+                    139.791601,
+                    35.518657
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    5,
+                    199
+                  ],
+                  "duration": 15.459,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 13.913,
+                  "geometry_index": 117,
+                  "location": [
+                    139.791749,
+                    35.517907
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    28,
+                    209
+                  ],
+                  "duration": 11.229,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 1,
+                  "weight": 10.106,
+                  "geometry_index": 121,
+                  "location": [
+                    139.790794,
+                    35.516101
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "location": [
+                    139.790044,
+                    35.515092
+                  ],
+                  "geometry_index": 124,
+                  "admin_index": 1,
+                  "weight": 3.817,
+                  "is_urban": false,
+                  "turn_weight": 0.5,
+                  "duration": 3.698,
+                  "bearings": [
+                    20,
+                    35,
+                    205
+                  ],
+                  "out": 2,
+                  "in": 1,
+                  "turn_duration": 0.013,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "payment_methods": [
+                        "general",
+                        "etc"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "payment_methods": [
+                        "etc"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "location": [
+                    139.78984,
+                    35.514741
+                  ],
+                  "geometry_index": 125,
+                  "admin_index": 1,
+                  "weight": 34.677,
+                  "is_urban": false,
+                  "toll_collection": {
+                    "name": "Wangan-ukishima Tollgate",
+                    "type": "toll_booth"
+                  },
+                  "turn_weight": 15,
+                  "duration": 21.863,
+                  "bearings": [
+                    25,
+                    210
+                  ],
+                  "out": 1,
+                  "in": 0,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "location": [
+                    139.788658,
+                    35.51512
+                  ],
+                  "geometry_index": 142,
+                  "admin_index": 1,
+                  "weight": 2.175,
+                  "is_urban": false,
+                  "turn_weight": 1.125,
+                  "duration": 1.237,
+                  "bearings": [
+                    54,
+                    216,
+                    227
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.071,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    53,
+                    234
+                  ],
+                  "duration": 2.535,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 2.282,
+                  "geometry_index": 143,
+                  "location": [
+                    139.788862,
+                    35.51524
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    49,
+                    233
+                  ],
+                  "duration": 1.654,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 1.489,
+                  "geometry_index": 144,
+                  "location": [
+                    139.789306,
+                    35.515509
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    35,
+                    229
+                  ],
+                  "duration": 7.541,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 6.786,
+                  "geometry_index": 145,
+                  "location": [
+                    139.78959,
+                    35.515712
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    33,
+                    209
+                  ],
+                  "duration": 0.341,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 0.306,
+                  "geometry_index": 148,
+                  "location": [
+                    139.790499,
+                    35.516888
+                  ]
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    36,
+                    213
+                  ],
+                  "duration": 4.275,
+                  "mapbox_streets_v8": {
+                    "class": "motorway_link"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 3.847,
+                  "geometry_index": 149,
+                  "location": [
+                    139.790544,
+                    35.516944
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.790919,
+                    35.51736
+                  ],
+                  "geometry_index": 150,
+                  "admin_index": 1,
+                  "weight": 14.695,
+                  "is_urban": false,
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "turn_duration": 0.014,
+                  "turn_weight": 11.75,
+                  "duration": 3.287,
+                  "bearings": [
+                    24,
+                    207,
+                    216
+                  ],
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "tunnel_name": "Tamagawa Tunnel"
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    21,
+                    204
+                  ],
+                  "duration": 93.46,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 1,
+                  "out": 0,
+                  "weight": 84.114,
+                  "geometry_index": 151,
+                  "location": [
+                    139.791237,
+                    35.517934
+                  ]
+                },
+                {
+                  "tunnel_name": "Tamagawa Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    169,
+                    349
+                  ],
+                  "duration": 3.039,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 2.735,
+                  "geometry_index": 173,
+                  "location": [
+                    139.795214,
+                    35.535469
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    169,
+                    349
+                  ],
+                  "duration": 11.88,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 10.692,
+                  "geometry_index": 174,
+                  "location": [
+                    139.795077,
+                    35.536044
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.794452,
+                    35.538052
+                  ],
+                  "geometry_index": 178,
+                  "admin_index": 0,
+                  "weight": 28.229,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 31.375,
+                  "bearings": [
+                    162,
+                    329,
+                    337
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.01,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukominami Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    150,
+                    331
+                  ],
+                  "duration": 1.185,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 1.096,
+                  "geometry_index": 184,
+                  "location": [
+                    139.790827,
+                    35.54357
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukominami Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    151,
+                    329
+                  ],
+                  "duration": 10.01,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 9.259,
+                  "geometry_index": 185,
+                  "location": [
+                    139.79068,
+                    35.543783
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    149,
+                    330
+                  ],
+                  "duration": 28.844,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 26.681,
+                  "geometry_index": 186,
+                  "location": [
+                    139.789396,
+                    35.545542
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.785771,
+                    35.550653
+                  ],
+                  "geometry_index": 193,
+                  "admin_index": 0,
+                  "weight": 47.489,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 51.347,
+                  "bearings": [
+                    151,
+                    315,
+                    330
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.779976,
+                    35.558105
+                  ],
+                  "geometry_index": 205,
+                  "admin_index": 0,
+                  "weight": 10.656,
+                  "is_urban": false,
+                  "turn_weight": 0.75,
+                  "duration": 10.717,
+                  "bearings": [
+                    137,
+                    145,
+                    314
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukokita Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    132,
+                    309
+                  ],
+                  "duration": 33.345,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 30.844,
+                  "geometry_index": 208,
+                  "location": [
+                    139.778089,
+                    35.559559
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukokita Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    122,
+                    301
+                  ],
+                  "duration": 6.21,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 5.899,
+                  "geometry_index": 214,
+                  "location": [
+                    139.771192,
+                    35.563132
+                  ]
+                },
+                {
+                  "tunnel_name": "Kukokita Tunnel",
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    121,
+                    302
+                  ],
+                  "duration": 28.44,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 27.729,
+                  "geometry_index": 217,
+                  "location": [
+                    139.769885,
+                    35.563771
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    120,
+                    302
+                  ],
+                  "duration": 31.455,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 31.455,
+                  "geometry_index": 224,
+                  "location": [
+                    139.763908,
+                    35.566705
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    165,
+                    345
+                  ],
+                  "duration": 30.06,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 30.812,
+                  "geometry_index": 233,
+                  "location": [
+                    139.759317,
+                    35.571436
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    165,
+                    346
+                  ],
+                  "duration": 14.13,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 14.836,
+                  "geometry_index": 240,
+                  "location": [
+                    139.757476,
+                    35.57725
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    167,
+                    344
+                  ],
+                  "duration": 24.061,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 25.264,
+                  "geometry_index": 242,
+                  "location": [
+                    139.756635,
+                    35.57999
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755305,
+                    35.584601
+                  ],
+                  "geometry_index": 250,
+                  "admin_index": 0,
+                  "weight": 5.665,
+                  "is_urban": true,
+                  "turn_weight": 1,
+                  "duration": 4.366,
+                  "bearings": [
+                    168,
+                    177,
+                    353
+                  ],
+                  "out": 2,
+                  "in": 0,
+                  "turn_duration": 0.026,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    178,
+                    357
+                  ],
+                  "duration": 3.403,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 3.658,
+                  "geometry_index": 253,
+                  "location": [
+                    139.755226,
+                    35.585387
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    177,
+                    359
+                  ],
+                  "duration": 2.469,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 2.654,
+                  "geometry_index": 254,
+                  "location": [
+                    139.75518,
+                    35.586008
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    0,
+                    179
+                  ],
+                  "duration": 0.771,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 0.829,
+                  "geometry_index": 255,
+                  "location": [
+                    139.755169,
+                    35.586443
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 1.491,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 1.603,
+                  "geometry_index": 256,
+                  "location": [
+                    139.755169,
+                    35.586582
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    1,
+                    180
+                  ],
+                  "duration": 4.766,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.124,
+                  "geometry_index": 257,
+                  "location": [
+                    139.755169,
+                    35.586841
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.75518,
+                    35.587683
+                  ],
+                  "geometry_index": 258,
+                  "admin_index": 0,
+                  "weight": 17.31,
+                  "is_urban": true,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 16.111,
+                  "bearings": [
+                    0,
+                    181,
+                    351
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755203,
+                    35.590655
+                  ],
+                  "geometry_index": 261,
+                  "admin_index": 0,
+                  "weight": 24.946,
+                  "is_urban": true,
+                  "duration": 23.225,
+                  "bearings": [
+                    1,
+                    180,
+                    352
+                  ],
+                  "rest_stop": {
+                    "amenities": [
+                      {
+                        "type": "toilet"
+                      },
+                      {
+                        "type": "info"
+                      },
+                      {
+                        "type": "baby_care"
+                      },
+                      {
+                        "type": "facilities_for_disabled"
+                      },
+                      {
+                        "type": "telephone"
+                      },
+                      {
+                        "type": "picnic_shelter"
+                      }
+                    ],
+                    "name": "大井ＰＡ",
+                    "type": "rest_area"
+                  },
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.019,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755191,
+                    35.594942
+                  ],
+                  "geometry_index": 263,
+                  "admin_index": 0,
+                  "weight": 4.923,
+                  "is_urban": true,
+                  "turn_weight": 1,
+                  "duration": 3.667,
+                  "bearings": [
+                    0,
+                    180,
+                    187
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 6.362,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 6.839,
+                  "geometry_index": 264,
+                  "location": [
+                    139.755191,
+                    35.595608
+                  ]
+                },
+                {
+                  "bearings": [
+                    1,
+                    180
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 265,
+                  "location": [
+                    139.755202,
+                    35.596766
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Oi JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Oi JCT"
+                  },
+                  "distanceAlongGeometry": 11465.902
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA070111?arrow_ids=CA07011E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Oi JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Oi JCT"
+                  },
+                  "distanceAlongGeometry": 1500
+                }
+              ],
+              "destinations": "東京",
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right toward 東京.",
+                "modifier": "slight right",
+                "bearing_after": 159,
+                "bearing_before": 146,
+                "location": [
+                  139.791601,
+                  35.518657
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Expwy Wangan Line",
+              "weight_typical": 589.261,
+              "duration_typical": 586.023,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CRZ4110E"
+                  ],
+                  "base_id": "CRZ41101",
+                  "type": "tollbranch",
+                  "data_id": "727833600"
+                }
+              ],
+              "duration": 562.327,
+              "distance": 11465.902,
+              "driving_side": "left",
+              "weight": 568.319,
+              "mode": "driving",
+              "geometry": "ak{vbAanesiGhLkElIqBjEUtG?`Gj@j[bK~XvKda@dRhWrNhf@fYdKtIpJ|H|TvK~IxFpFlEvD`FjE`KzAfHd@bF?dHe@xF{AxFsClEsC|CkEfCoFl@}E?eDcAyDqBiLaKoFwKyOwZuKwPiAcAea@c\\_d@qXoByA_YmV{b@{Rq\\eMwZaKyZkJ}[_Ii[eHszCak@mkD_p@w}Bec@c~Cwk@sYaFeZmEog@yFsYgCeZyAsYcAsYUmX?oXj@iWl@gWxAcVfCsNpB}b@pGk_@xFaYjEcVbF}j@vP}|@|^ad@~TcfArn@}q@|c@gt@rd@qeAlq@iLdH}lBfoAmn@ba@ea@bWi[rSo}@~j@{nAxw@wZ|Rkf@|YgzB`wAqJbF_CxAmpBtpA}f@b\\sd@tZsNtIuGjEkIfHep@ll@}[tZcVfYyShYmTpXso@`aAiLpSqd@fy@ea@zcA_z@`wBuh@~vAqd@hjAaCnGySri@aNp]aCxF{[fy@ohAtrCwOf^m_@dhAaRzc@uGnQwl@nxAmXri@wOfYgS~T}WhYk_@pXuVdMgt@vUgt@vPiWxFu]fHeuAtZaiAbWa~@nQk`AhTuRjEkqCll@{WbF{m@`P_k@nLubApSas@fMkIhAkWnDgb@xFqFbAgWnBmIVmMTye@zAeZTuG?eO?ss@UaOCcwAQqpAW_v@U}sEl@sh@?kgAUmc@Wgi@cA"
+            },
+            {
+              "mode": "driving",
+              "weight": 207.839,
+              "distance": 4176.07,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA07011E"
+                  ],
+                  "base_id": "CA070111",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 190.651,
+              "weight_typical": 198.474,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Oi JCT toward 東関東道.",
+                "modifier": "slight right",
+                "bearing_after": 2,
+                "bearing_before": 2,
+                "location": [
+                  139.755248,
+                  35.598025
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "東関東道",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ariake JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Ariake JCT"
+                  },
+                  "distanceAlongGeometry": 4176.07
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA069201?arrow_ids=CA06920E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Ariake JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Ariake JCT"
+                  },
+                  "distanceAlongGeometry": 1500
+                }
+              ],
+              "geometry": "qkv{bA_n~piGua@{@cl@kAwp@Umu@?q{AzAgyAxAch@G}kAMcmAWwuA?sN?aYk@oXm@yWqB}PgC_UkEaNuDkPyFkPgHeSaKmT{MgSaPah@}c@oy@mlA{qJ_dN{iCytDiAyAa[kb@sLePw@yAkh@ys@y`@aj@_eAm}AsYaf@cRk`@qJiT{b@o}@k`Ag{B",
+              "duration": 199.768,
+              "junction_name": "Oi JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 4 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 4 kilometers.",
+                  "distanceAlongGeometry": 4149.403
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep right at <say-as interpret-as=\"address\">Ariake JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep right at Ariake JCT.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep right at <say-as interpret-as=\"address\">Ariake JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep right at Ariake JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Ariake JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾋｶﾞ&ｼ%ｶﾝﾄｰﾄﾞｰ\">東関東道</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Ariake JCT toward 東関東道.",
+                  "distanceAlongGeometry": 151.111
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755248,
+                    35.598025
+                  ],
+                  "geometry_index": 267,
+                  "admin_index": 0,
+                  "weight": 24.847,
+                  "is_urban": false,
+                  "duration": 23.671,
+                  "bearings": [
+                    2,
+                    182,
+                    351
+                  ],
+                  "jct": {
+                    "name": "Oi JCT"
+                  },
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.007,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    179,
+                    359
+                  ],
+                  "duration": 7.832,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 8.224,
+                  "geometry_index": 272,
+                  "location": [
+                    139.755281,
+                    35.60245
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    0,
+                    179
+                  ],
+                  "duration": 3.413,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 3.584,
+                  "geometry_index": 273,
+                  "location": [
+                    139.755236,
+                    35.603894
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 20.151,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 21.158,
+                  "geometry_index": 274,
+                  "location": [
+                    139.75524,
+                    35.604552
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    0,
+                    180
+                  ],
+                  "duration": 11.081,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 11.635,
+                  "geometry_index": 277,
+                  "location": [
+                    139.755259,
+                    35.608421
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.755531,
+                    35.610532
+                  ],
+                  "geometry_index": 283,
+                  "admin_index": 0,
+                  "weight": 7.804,
+                  "is_urban": false,
+                  "turn_weight": 1,
+                  "duration": 6.504,
+                  "bearings": [
+                    17,
+                    193,
+                    201
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.024,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    29,
+                    206
+                  ],
+                  "duration": 8.544,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 8.971,
+                  "geometry_index": 287,
+                  "location": [
+                    139.756088,
+                    35.611652
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.75719,
+                    35.612976
+                  ],
+                  "geometry_index": 290,
+                  "admin_index": 0,
+                  "weight": 9.047,
+                  "is_urban": false,
+                  "turn_weight": 1.125,
+                  "duration": 7.587,
+                  "bearings": [
+                    47,
+                    216,
+                    222
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.041,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "tunnel_name": "Tokyoko Tunnel",
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "tunnel",
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    47,
+                    227
+                  ],
+                  "duration": 64.459,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 66.071,
+                  "geometry_index": 291,
+                  "location": [
+                    139.758429,
+                    35.613912
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    45,
+                    227
+                  ],
+                  "duration": 0.292,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 0.292,
+                  "geometry_index": 293,
+                  "location": [
+                    139.769098,
+                    35.622068
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    46,
+                    225
+                  ],
+                  "duration": 5.157,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.157,
+                  "geometry_index": 294,
+                  "location": [
+                    139.769143,
+                    35.622105
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.769984,
+                    35.622772
+                  ],
+                  "geometry_index": 296,
+                  "admin_index": 0,
+                  "weight": 0.234,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 0.262,
+                  "bearings": [
+                    37,
+                    53,
+                    226
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.028,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    46,
+                    233
+                  ],
+                  "duration": 4.956,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 4.956,
+                  "geometry_index": 297,
+                  "location": [
+                    139.770029,
+                    35.6228
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    46,
+                    226
+                  ],
+                  "duration": 20.665,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 20.665,
+                  "geometry_index": 298,
+                  "location": [
+                    139.770874,
+                    35.623462
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    55,
+                    236
+                  ],
+                  "duration": 5.19,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.19,
+                  "geometry_index": 303,
+                  "location": [
+                    139.774574,
+                    35.62604
+                  ]
+                },
+                {
+                  "bearings": [
+                    57,
+                    235
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 304,
+                  "location": [
+                    139.775574,
+                    35.626614
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 73.813,
+              "distance": 1583.249,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06920E"
+                  ],
+                  "base_id": "CA069201",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 71.495,
+              "weight_typical": 72.48,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Ariake JCT toward 東関東道.",
+                "modifier": "slight right",
+                "bearing_after": 57,
+                "bearing_before": 57,
+                "location": [
+                  139.777562,
+                  35.62766
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "東関東道, 浦安",
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA174201?arrow_ids=CA17420E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Shinonome JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Shinonome JCT"
+                  },
+                  "distanceAlongGeometry": 1583.249
+                }
+              ],
+              "geometry": "wgp}bAs`jriG_`@y|@gt@waBmy@ejBoaAcyBipCshGgHaPgm@osAwa@s_Amn@kvA",
+              "duration": 72.828,
+              "junction_name": "Ariake JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep right at <say-as interpret-as=\"address\">Shinonome JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep right at Shinonome JCT.",
+                  "distanceAlongGeometry": 1556.582
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep right at <say-as interpret-as=\"address\">Shinonome JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep right at Shinonome JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Shinonome JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾋｶﾞ&ｼ%ｶﾝﾄｰﾄﾞｰ\">東関東道</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Shinonome JCT toward 東関東道.",
+                  "distanceAlongGeometry": 151.111
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.777562,
+                    35.62766
+                  ],
+                  "geometry_index": 305,
+                  "admin_index": 0,
+                  "weight": 5.003,
+                  "is_urban": false,
+                  "duration": 5.01,
+                  "bearings": [
+                    51,
+                    57,
+                    237
+                  ],
+                  "jct": {
+                    "name": "Ariake JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.007,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    56,
+                    237
+                  ],
+                  "duration": 8.042,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 8.042,
+                  "geometry_index": 306,
+                  "location": [
+                    139.778551,
+                    35.628188
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    56,
+                    236
+                  ],
+                  "duration": 8.743,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 8.743,
+                  "geometry_index": 307,
+                  "location": [
+                    139.780131,
+                    35.62904
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    56,
+                    236
+                  ],
+                  "duration": 9.831,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 9.831,
+                  "geometry_index": 308,
+                  "location": [
+                    139.781846,
+                    35.629975
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    56,
+                    236
+                  ],
+                  "duration": 21.415,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 21.415,
+                  "geometry_index": 309,
+                  "location": [
+                    139.7838,
+                    35.631039
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    56,
+                    236
+                  ],
+                  "duration": 1.385,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 1.385,
+                  "geometry_index": 310,
+                  "location": [
+                    139.78805,
+                    35.633364
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.788323,
+                    35.633512
+                  ],
+                  "geometry_index": 311,
+                  "admin_index": 0,
+                  "weight": 7.699,
+                  "is_urban": false,
+                  "turn_weight": 1,
+                  "duration": 6.706,
+                  "bearings": [
+                    56,
+                    236,
+                    242
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.007,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    57,
+                    236
+                  ],
+                  "duration": 5.104,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.104,
+                  "geometry_index": 312,
+                  "location": [
+                    139.789675,
+                    35.634252
+                  ]
+                },
+                {
+                  "bearings": [
+                    56,
+                    237
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 313,
+                  "location": [
+                    139.790709,
+                    35.634808
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 63.015,
+              "distance": 1375.453,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA17420E"
+                  ],
+                  "base_id": "CA174201",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 61.346,
+              "weight_typical": 63.274,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Shinonome JCT toward 東関東道.",
+                "modifier": "slight right",
+                "bearing_after": 57,
+                "bearing_before": 56,
+                "location": [
+                  139.792107,
+                  35.635567
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "東関東道, 浦安, 箱崎",
+              "bannerInstructions": [
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA068301?arrow_ids=CA06830E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Tatsumi JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Tatsumi JCT"
+                  },
+                  "distanceAlongGeometry": 1375.453
+                }
+              ],
+              "geometry": "}u_~bAumfsiGeV_k@mMc\\oeE{iJoNe[}H_Qwa@mgAku@k}BwKya@k_@i`B",
+              "duration": 61.093,
+              "junction_name": "Shinonome JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep right at <say-as interpret-as=\"address\">Tatsumi JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep right at Tatsumi JCT.",
+                  "distanceAlongGeometry": 1348.786
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep right at <say-as interpret-as=\"address\">Tatsumi JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep right at Tatsumi JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Tatsumi JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾋｶﾞ&ｼ%ｶﾝﾄｰﾄﾞｰ\">東関東道</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Tatsumi JCT toward 東関東道.",
+                  "distanceAlongGeometry": 151.111
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.792107,
+                    35.635567
+                  ],
+                  "geometry_index": 314,
+                  "admin_index": 0,
+                  "weight": 3.337,
+                  "is_urban": false,
+                  "duration": 3.344,
+                  "bearings": [
+                    51,
+                    57,
+                    236
+                  ],
+                  "jct": {
+                    "name": "Shinonome JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.007,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    59,
+                    237
+                  ],
+                  "duration": 2.151,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 2.151,
+                  "geometry_index": 315,
+                  "location": [
+                    139.792811,
+                    35.635938
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    56,
+                    239
+                  ],
+                  "duration": 27.79,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 27.79,
+                  "geometry_index": 316,
+                  "location": [
+                    139.793277,
+                    35.636169
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    56,
+                    236
+                  ],
+                  "duration": 3.6,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 3.6,
+                  "geometry_index": 317,
+                  "location": [
+                    139.799083,
+                    35.639345
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.799822,
+                    35.639752
+                  ],
+                  "geometry_index": 319,
+                  "admin_index": 0,
+                  "weight": 15.935,
+                  "is_urban": false,
+                  "turn_weight": 0.75,
+                  "duration": 15.205,
+                  "bearings": [
+                    59,
+                    236,
+                    244
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.021,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "bearings": [
+                    66,
+                    242,
+                    252
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "turn_weight": 1,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "turn_duration": 0.024,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 321,
+                  "location": [
+                    139.803003,
+                    35.641178
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 169.111,
+              "distance": 3760.463,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06830E"
+                  ],
+                  "base_id": "CA068301",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 165.99,
+              "weight_typical": 166.956,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Tatsumi JCT toward 東関東道.",
+                "modifier": "slight right",
+                "bearing_after": 68,
+                "bearing_before": 68,
+                "location": [
+                  139.805117,
+                  35.6419
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "東関東道, 浦安",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Kasai JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Kasai JCT"
+                  },
+                  "distanceAlongGeometry": 3760.463
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA066201?arrow_ids=CA06620E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Kasai JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Kasai JCT"
+                  },
+                  "distanceAlongGeometry": 1500
+                }
+              ],
+              "geometry": "wal~bAyz_tiGmT_aAy^mbBwVchA{Lij@cVafAu]w|AaNym@iL}h@_YupAyH}^qQ{~@sCwPmBcKqFaf@eDyr@yO}{C}PgvDcB__@uEodAe@}MsYkuGi[esHgDio@}EsdA?eR?iTPml@pJgvD`CccApJigE",
+              "duration": 168.073,
+              "junction_name": "Tatsumi JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 4 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 4 kilometers.",
+                  "distanceAlongGeometry": 3733.796
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep right at <say-as interpret-as=\"address\">Kasai JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep right at Kasai JCT.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep right at <say-as interpret-as=\"address\">Kasai JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep right at Kasai JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Kasai JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾋｶﾞ&ｼ%ｶﾝﾄｰﾄﾞｰ\">東関東道</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Kasai JCT toward 東関東道.",
+                  "distanceAlongGeometry": 151.111
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.805117,
+                    35.6419
+                  ],
+                  "geometry_index": 323,
+                  "admin_index": 0,
+                  "weight": 12.205,
+                  "is_urban": false,
+                  "duration": 11.925,
+                  "bearings": [
+                    61,
+                    68,
+                    248
+                  ],
+                  "jct": {
+                    "name": "Tatsumi JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    68,
+                    249
+                  ],
+                  "duration": 5.262,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.393,
+                  "geometry_index": 325,
+                  "location": [
+                    139.807764,
+                    35.642752
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    68,
+                    248
+                  ],
+                  "duration": 8.215,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 8.421,
+                  "geometry_index": 326,
+                  "location": [
+                    139.808934,
+                    35.643132
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    68,
+                    248
+                  ],
+                  "duration": 18.969,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 19.443,
+                  "geometry_index": 328,
+                  "location": [
+                    139.810764,
+                    35.643724
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    69,
+                    249
+                  ],
+                  "duration": 8.077,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 8.279,
+                  "geometry_index": 332,
+                  "location": [
+                    139.814991,
+                    35.645085
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    72,
+                    252
+                  ],
+                  "duration": 17.585,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 17.585,
+                  "geometry_index": 335,
+                  "location": [
+                    139.816808,
+                    35.645613
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.820967,
+                    35.646141
+                  ],
+                  "geometry_index": 339,
+                  "admin_index": 0,
+                  "weight": 13.167,
+                  "is_urban": false,
+                  "turn_weight": 1,
+                  "duration": 12.186,
+                  "bearings": [
+                    83,
+                    262,
+                    270
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.019,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.823899,
+                    35.646428
+                  ],
+                  "geometry_index": 340,
+                  "admin_index": 0,
+                  "weight": 7.463,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 7.481,
+                  "bearings": [
+                    79,
+                    83,
+                    263
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.018,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    83,
+                    264
+                  ],
+                  "duration": 36.643,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 35.727,
+                  "geometry_index": 343,
+                  "location": [
+                    139.825762,
+                    35.646604
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.835147,
+                    35.647483
+                  ],
+                  "geometry_index": 345,
+                  "admin_index": 0,
+                  "weight": 3.717,
+                  "is_urban": false,
+                  "turn_weight": 0.75,
+                  "duration": 3.051,
+                  "bearings": [
+                    82,
+                    264,
+                    276
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "bearings": [
+                    83,
+                    262
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 346,
+                  "location": [
+                    139.83592,
+                    35.647567
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 533.51,
+              "distance": 11085.791,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA06620E"
+                  ],
+                  "base_id": "CA066201",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 482.778,
+              "weight_typical": 530.29,
+              "name": "Expwy Wangan Line",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Kasai JCT toward 東関東道.",
+                "modifier": "slight right",
+                "bearing_after": 94,
+                "bearing_before": 94,
+                "location": [
+                  139.845636,
+                  35.647234
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "東関東道, 浦安",
+              "bannerInstructions": [
+                {
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Koya JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Koya JCT"
+                  },
+                  "distanceAlongGeometry": 11085.791
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CA277201?arrow_ids=CA27720E",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "straight",
+                        "active": true,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "secondary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "東関東道"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "東関東道"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Koya JCT"
+                      }
+                    ],
+                    "type": "fork",
+                    "modifier": "right",
+                    "text": "Koya JCT"
+                  },
+                  "distanceAlongGeometry": 1500
+                }
+              ],
+              "geometry": "cov~bAg_oviGhL_tEdDgoAhAcr@v@iYvO}}FnBwf@hAk`@nBwZhEaa@tGya@`Nox@ltBo|Hn}@glDr~@{jDxOgo@vOwk@lIeWvDsNdfAwyDzx@}`Dzx@e`DPm@xS}~@|E{WfHkq@xDox@v@og@}AwaAmB{\\uCgYeDuUkEsXgHk`@e@cBoJg]_J_Z_JkV_F}MqJwP_Yeh@as@{cAmTqX_}FclHwVk[c~Ca~DcmAw|A}mCcjDkq@sz@}IyKkvAufBw@cAqaAyrAog@go@ykBq_Csh@_p@ix@mbAeDmEmdAkqAatAodBgDmEmhAgjAaz@kv@ifG{vFgdBq_Bor@uu@}j@yr@ku@}~@w~CurDomBk}BosA_aBwp@gy@ib@wf@ynAw|AqaAosAiWob@y^{m@_Yyf@sYeh@kkAqzB",
+              "duration": 485.802,
+              "junction_name": "Kasai JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 11 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 11 kilometers.",
+                  "distanceAlongGeometry": 11059.124
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Keep right at <say-as interpret-as=\"address\">Koya JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Keep right at Koya JCT.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Keep right at <say-as interpret-as=\"address\">Koya JCT</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Keep right at Koya JCT.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Keep right at <say-as interpret-as=\"address\">Koya JCT</say-as> toward <phoneme alphabet=\"jeita\" ph=\"ﾋｶﾞ&ｼ%ｶﾝﾄｰﾄﾞｰ\">東関東道</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Keep right at Koya JCT toward 東関東道.",
+                  "distanceAlongGeometry": 151.111
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.845636,
+                    35.647234
+                  ],
+                  "geometry_index": 353,
+                  "admin_index": 0,
+                  "weight": 18.235,
+                  "is_urban": false,
+                  "duration": 18.71,
+                  "bearings": [
+                    83,
+                    94,
+                    274
+                  ],
+                  "jct": {
+                    "name": "Kasai JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.007,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    93,
+                    275
+                  ],
+                  "duration": 21.205,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 21.205,
+                  "geometry_index": 355,
+                  "location": [
+                    139.850328,
+                    35.646938
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.855646,
+                    35.646605
+                  ],
+                  "geometry_index": 358,
+                  "admin_index": 0,
+                  "weight": 3.61,
+                  "is_urban": false,
+                  "turn_weight": 1,
+                  "duration": 2.565,
+                  "bearings": [
+                    96,
+                    275,
+                    284
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.019,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    95,
+                    276
+                  ],
+                  "duration": 3.956,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 4.054,
+                  "geometry_index": 359,
+                  "location": [
+                    139.856282,
+                    35.646549
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    103,
+                    279
+                  ],
+                  "duration": 8.489,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 8.701,
+                  "geometry_index": 361,
+                  "location": [
+                    139.85726,
+                    35.646456
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.859282,
+                    35.645975
+                  ],
+                  "geometry_index": 364,
+                  "admin_index": 0,
+                  "weight": 22.999,
+                  "is_urban": false,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 21.93,
+                  "bearings": [
+                    107,
+                    114,
+                    288
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.026,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    114,
+                    294
+                  ],
+                  "duration": 30.889,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 32.433,
+                  "geometry_index": 365,
+                  "location": [
+                    139.864362,
+                    35.644096
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.871372,
+                    35.641541
+                  ],
+                  "geometry_index": 369,
+                  "admin_index": 0,
+                  "weight": 2.661,
+                  "is_urban": true,
+                  "turn_weight": 0.75,
+                  "duration": 1.798,
+                  "bearings": [
+                    118,
+                    295,
+                    303
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.021,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    114,
+                    298
+                  ],
+                  "duration": 36.304,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 39.026,
+                  "geometry_index": 370,
+                  "location": [
+                    139.871759,
+                    35.641374
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    112,
+                    294
+                  ],
+                  "duration": 26.328,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 28.302,
+                  "geometry_index": 375,
+                  "location": [
+                    139.88019,
+                    35.638282
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.886724,
+                    35.637931
+                  ],
+                  "geometry_index": 385,
+                  "admin_index": 2,
+                  "weight": 24.043,
+                  "is_urban": true,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 21.866,
+                  "bearings": [
+                    63,
+                    71,
+                    253
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    44,
+                    224
+                  ],
+                  "duration": 54.127,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 63.599,
+                  "geometry_index": 395,
+                  "location": [
+                    139.891291,
+                    35.640523
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    44,
+                    224
+                  ],
+                  "duration": 21.729,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 26.074,
+                  "geometry_index": 399,
+                  "location": [
+                    139.90112,
+                    35.648763
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    44,
+                    224
+                  ],
+                  "duration": 9.471,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 11.366,
+                  "geometry_index": 402,
+                  "location": [
+                    139.905017,
+                    35.652031
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    46,
+                    224
+                  ],
+                  "duration": 7.374,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 8.664,
+                  "geometry_index": 404,
+                  "location": [
+                    139.90671,
+                    35.653457
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.908051,
+                    35.654522
+                  ],
+                  "geometry_index": 405,
+                  "admin_index": 2,
+                  "weight": 19.556,
+                  "is_urban": true,
+                  "turn_weight": 0.75,
+                  "duration": 16.013,
+                  "bearings": [
+                    44,
+                    226,
+                    234
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    44,
+                    224
+                  ],
+                  "duration": 4.522,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 5.2,
+                  "geometry_index": 407,
+                  "location": [
+                    139.91088,
+                    35.656911
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    44,
+                    224
+                  ],
+                  "duration": 37.449,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 42.13,
+                  "geometry_index": 408,
+                  "location": [
+                    139.911664,
+                    35.657577
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    37,
+                    217
+                  ],
+                  "duration": 40.771,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 43.829,
+                  "geometry_index": 415,
+                  "location": [
+                    139.917981,
+                    35.663253
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    44,
+                    221
+                  ],
+                  "duration": 4.8,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 5.16,
+                  "geometry_index": 418,
+                  "location": [
+                    139.924367,
+                    35.66991
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    44,
+                    224
+                  ],
+                  "duration": 5.956,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 6.402,
+                  "geometry_index": 419,
+                  "location": [
+                    139.925196,
+                    35.670613
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    139.926219,
+                    35.671483
+                  ],
+                  "geometry_index": 420,
+                  "admin_index": 2,
+                  "weight": 48.155,
+                  "is_urban": true,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "duration": 44.803,
+                  "bearings": [
+                    32,
+                    42,
+                    224
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.008,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    42,
+                    224
+                  ],
+                  "duration": 23.651,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 25.424,
+                  "geometry_index": 424,
+                  "location": [
+                    139.933616,
+                    35.677955
+                  ]
+                },
+                {
+                  "bearings": [
+                    50,
+                    230
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "geometry_index": 428,
+                  "location": [
+                    139.937672,
+                    35.681251
+                  ]
+                }
+              ]
+            },
+            {
+              "mode": "driving",
+              "weight": 553.733,
+              "distance": 8357.659,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CA27720E"
+                  ],
+                  "base_id": "CA277201",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 510.168,
+              "weight_typical": 566.966,
+              "name": "Higashikanto Expwy(Koya To Itako)",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "fork",
+                "instruction": "Keep right at Koya JCT toward 東関東道.",
+                "modifier": "slight right",
+                "bearing_after": 53,
+                "bearing_before": 53,
+                "location": [
+                  139.941695,
+                  35.683824
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "東関東道, 千葉, 成田",
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Wangannarashino IC"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-national-route",
+                          "display_ref": "357",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "National Road No.357 Line"
+                      }
+                    ],
+                    "type": "off ramp",
+                    "modifier": "left",
+                    "text": "Wangannarashino IC / National Road No.357 Line"
+                  },
+                  "distanceAlongGeometry": 8357.659
+                },
+                {
+                  "view": {
+                    "components": [
+                      {
+                        "imageURL": "https://api.mapbox.com/guidance-views/v1/727833600/jct/CB999101?arrow_ids=CB99910A",
+                        "subType": "jct",
+                        "type": "guidance-view",
+                        "text": ""
+                      }
+                    ],
+                    "type": "off ramp",
+                    "modifier": "left",
+                    "text": ""
+                  },
+                  "sub": {
+                    "components": [
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "slight left",
+                        "active": true,
+                        "directions": [
+                          "slight left"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Wangannarashino IC"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-national-route",
+                          "display_ref": "357",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "National Road No.357 Line"
+                      }
+                    ],
+                    "type": "off ramp",
+                    "modifier": "left",
+                    "text": "Wangannarashino IC / National Road No.357 Line"
+                  },
+                  "distanceAlongGeometry": 1500
+                }
+              ],
+              "geometry": "_~}`cA}rj|iGumA}`CaN{WgoAwbCqIkP}|@mbBitCyqFet@oxAgHaPqUwk@g^ufAiHm[aG}^aGke@uCyWg@qGgEqi@{Au_APmq@hAe^jE{r@zLi`AzHob@vOu_AlIwf@xSukAzAaKbs@ceEnr@eeE|EoXvp@o_Ebw@srEft@cjEbw@isEtGu_@zm@}qDhLke@|Pem@zLg^dZey@xSwk@|}AqkEhLk[lc@ijAxOob@j_@o}@dOgYzSm[rRmVlIkJjIsIlI}HnQiOtGqGpUmQhLqGxO}Hr]iObbAc\\`eAy\\pY}MhW}MjPaKbVwPn\\gYzSiT~Xq]nMmQvZ{h@rCyF|Wgh@z}A}{CbK{RdrBm_EpaDinGxi@mgA",
+              "duration": 498.138,
+              "junction_name": "Koya JCT",
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 8 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 8 kilometers.",
+                  "distanceAlongGeometry": 8330.992
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1.5 kilometers, Take the <say-as interpret-as=\"address\">Wangannarashino IC</say-as> exit on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "In 1.5 kilometers, Take the Wangannarashino IC exit on the left.",
+                  "distanceAlongGeometry": 1500
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 800 meters, Take the <say-as interpret-as=\"address\">Wangannarashino IC</say-as> exit on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "In 800 meters, Take the Wangannarashino IC exit on the left.",
+                  "distanceAlongGeometry": 800
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Take the <say-as interpret-as=\"address\">Wangannarashino IC</say-as> exit on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "Take the Wangannarashino IC exit on the left.",
+                  "distanceAlongGeometry": 160
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.941695,
+                    35.683824
+                  ],
+                  "geometry_index": 432,
+                  "admin_index": 2,
+                  "weight": 18.009,
+                  "is_urban": true,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "turn_duration": 0.007,
+                  "turn_weight": 5,
+                  "duration": 12.109,
+                  "bearings": [
+                    42,
+                    53,
+                    233
+                  ],
+                  "jct": {
+                    "name": "Koya JCT"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    53,
+                    233
+                  ],
+                  "duration": 11.711,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 12.589,
+                  "geometry_index": 434,
+                  "location": [
+                    139.944172,
+                    35.685324
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    53,
+                    233
+                  ],
+                  "duration": 33.918,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 36.462,
+                  "geometry_index": 436,
+                  "location": [
+                    139.946558,
+                    35.686777
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.953466,
+                    35.691008
+                  ],
+                  "geometry_index": 439,
+                  "admin_index": 2,
+                  "weight": 23.937,
+                  "is_urban": true,
+                  "turn_weight": 1,
+                  "duration": 21.357,
+                  "bearings": [
+                    56,
+                    234,
+                    246
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.021,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    139.958397,
+                    35.692619
+                  ],
+                  "geometry_index": 448,
+                  "admin_index": 2,
+                  "weight": 305.093,
+                  "is_urban": true,
+                  "turn_weight": 0.75,
+                  "duration": 276.705,
+                  "bearings": [
+                    87,
+                    260,
+                    265
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "turn_duration": 0.03,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    121,
+                    300
+                  ],
+                  "duration": 9.939,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 11.182,
+                  "geometry_index": 474,
+                  "location": [
+                    139.996747,
+                    35.681999
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    120,
+                    301
+                  ],
+                  "duration": 24.965,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 28.086,
+                  "geometry_index": 475,
+                  "location": [
+                    139.997952,
+                    35.681416
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "location": [
+                    140.00077,
+                    35.679722
+                  ],
+                  "geometry_index": 480,
+                  "admin_index": 2,
+                  "weight": 5.448,
+                  "is_urban": true,
+                  "duration": 4.865,
+                  "bearings": [
+                    128,
+                    138,
+                    316
+                  ],
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "ic": {
+                    "name": "Yatsufunabashi IC"
+                  },
+                  "out": 1,
+                  "in": 2,
+                  "turn_duration": 0.022,
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    142,
+                    324
+                  ],
+                  "duration": 4.12,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 4.635,
+                  "geometry_index": 484,
+                  "location": [
+                    140.001542,
+                    35.678926
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    154,
+                    332
+                  ],
+                  "duration": 9.499,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 10.449,
+                  "geometry_index": 487,
+                  "location": [
+                    140.002111,
+                    35.678213
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    161,
+                    341
+                  ],
+                  "duration": 23.031,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 25.334,
+                  "geometry_index": 490,
+                  "location": [
+                    140.002997,
+                    35.67638
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    129,
+                    314
+                  ],
+                  "duration": 3.99,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 4.389,
+                  "geometry_index": 499,
+                  "location": [
+                    140.005974,
+                    35.672343
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    127,
+                    307
+                  ],
+                  "duration": 15.867,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 17.453,
+                  "geometry_index": 501,
+                  "location": [
+                    140.006769,
+                    35.671825
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    127,
+                    307
+                  ],
+                  "duration": 1.6,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 1.76,
+                  "geometry_index": 503,
+                  "location": [
+                    140.00994,
+                    35.669908
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    126,
+                    307
+                  ],
+                  "duration": 14.829,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 16.312,
+                  "geometry_index": 504,
+                  "location": [
+                    140.010258,
+                    35.669714
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    126,
+                    306
+                  ],
+                  "duration": 21.96,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 24.156,
+                  "geometry_index": 505,
+                  "location": [
+                    140.013337,
+                    35.667871
+                  ]
+                },
+                {
+                  "bearings": [
+                    126,
+                    306
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll",
+                    "motorway"
+                  ],
+                  "in": 1,
+                  "mapbox_streets_v8": {
+                    "class": "motorway"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "geometry_index": 506,
+                  "location": [
+                    140.017678,
+                    35.66527
+                  ]
+                }
+              ]
+            },
+            {
+              "ref": "National Road No.357 Line",
+              "mode": "driving",
+              "weight": 138.562,
+              "distance": 1254.431,
+              "geometry": "qkx_cAihaajG|Pke@zLm[ts@{jBxScr@dOk{@lDkQ`SgcAta@w|AvZgoAda@i`Bjj@{oC",
+              "duration": 109.708,
+              "guidance_views": [
+                {
+                  "overlay_ids": [
+                    "CB99910A"
+                  ],
+                  "base_id": "CB999101",
+                  "type": "jct",
+                  "data_id": "727833600"
+                }
+              ],
+              "driving_side": "left",
+              "duration_typical": 109.708,
+              "weight_typical": 138.562,
+              "name": "Tokyowangan Road",
+              "speedLimitSign": "vienna",
+              "maneuver": {
+                "type": "off ramp",
+                "instruction": "Take the Wangannarashino IC exit on the left.",
+                "modifier": "slight left",
+                "bearing_after": 120,
+                "bearing_before": 126,
+                "location": [
+                  140.018837,
+                  35.664585
+                ]
+              },
+              "speedLimitUnit": "km/h",
+              "destinations": "Wangannarashino IC",
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-national-route",
+                          "display_ref": "357",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "National Road No.357 Line"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "type": "text",
+                        "text": "Tokyowangan Road"
+                      }
+                    ],
+                    "type": "off ramp",
+                    "modifier": "left",
+                    "text": "National Road No.357 Line / Tokyowangan Road"
+                  },
+                  "distanceAlongGeometry": 1254.431
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 1.5 kilometers.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 1.5 kilometers.",
+                  "distanceAlongGeometry": 1241.097
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Take the exit on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Take the exit on the left.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Take the exit on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "Take the exit on the left.",
+                  "distanceAlongGeometry": 88.889
+                }
+              ],
+              "intersections": [
+                {
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "location": [
+                    140.018837,
+                    35.664585
+                  ],
+                  "geometry_index": 507,
+                  "admin_index": 2,
+                  "weight": 11.088,
+                  "is_urban": true,
+                  "duration": 10.09,
+                  "bearings": [
+                    120,
+                    125,
+                    306
+                  ],
+                  "lanes": [
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "slight left"
+                      ],
+                      "valid_indication": "slight left",
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    }
+                  ],
+                  "ic": {
+                    "name": "Wangannarashino IC"
+                  },
+                  "out": 0,
+                  "in": 2,
+                  "turn_duration": 0.01,
+                  "classes": [
+                    "toll"
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    121,
+                    301
+                  ],
+                  "duration": 16.38,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 18.018,
+                  "geometry_index": 509,
+                  "location": [
+                    140.019906,
+                    35.664076
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "payment_methods": [
+                        "general"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "payment_methods": [
+                        "general"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "payment_methods": [
+                        "etc"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    },
+                    {
+                      "payment_methods": [
+                        "etc"
+                      ],
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "location": [
+                    140.021632,
+                    35.663233
+                  ],
+                  "geometry_index": 510,
+                  "admin_index": 2,
+                  "weight": 35.097,
+                  "is_urban": true,
+                  "toll_collection": {
+                    "name": "Wangannarashino Tollgate",
+                    "type": "toll_booth"
+                  },
+                  "turn_weight": 15,
+                  "classes": [
+                    "toll"
+                  ],
+                  "turn_duration": 15,
+                  "duration": 33.27,
+                  "bearings": [
+                    117,
+                    301
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "classes": [
+                    "toll"
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    110,
+                    290
+                  ],
+                  "duration": 9.45,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 10.631,
+                  "geometry_index": 513,
+                  "location": [
+                    140.02371,
+                    35.662554
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    114,
+                    290,
+                    296
+                  ],
+                  "duration": 9.272,
+                  "turn_weight": 18.2,
+                  "turn_duration": 0.024,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 28.604,
+                  "geometry_index": 514,
+                  "location": [
+                    140.024802,
+                    35.662233
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    113,
+                    137,
+                    294
+                  ],
+                  "duration": 7.828,
+                  "turn_duration": 0.007,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 8.798,
+                  "geometry_index": 515,
+                  "location": [
+                    140.026302,
+                    35.661678
+                  ]
+                },
+                {
+                  "bearings": [
+                    113,
+                    277,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "turn_duration": 0.018,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "geometry_index": 516,
+                  "location": [
+                    140.027586,
+                    35.661234
+                  ]
+                }
+              ]
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Continue for 700 meters.</prosody></amazon:effect></speak>",
+                  "announcement": "Continue for 700 meters.",
+                  "distanceAlongGeometry": 658.353
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 meters, Turn right at <phoneme alphabet=\"jeita\" ph=\"ﾊﾏﾀﾞ\">浜田</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "In 400 meters, Turn right at 浜田.",
+                  "distanceAlongGeometry": 400
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right at <phoneme alphabet=\"jeita\" ph=\"ﾊﾏﾀﾞ\">浜田</phoneme>. Then Turn right at <phoneme alphabet=\"jeita\" ph=\"ﾊﾏﾀﾞ\">浜田</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Turn right at 浜田. Then Turn right at 浜田.",
+                  "distanceAlongGeometry": 115.653
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    100,
+                    118,
+                    290
+                  ],
+                  "duration": 12.614,
+                  "turn_duration": 0.014,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 14.175,
+                  "geometry_index": 518,
+                  "location": [
+                    140.031461,
+                    35.659993
+                  ]
+                },
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "left",
+                        "straight"
+                      ],
+                      "valid_indication": "straight",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "location": [
+                    140.032927,
+                    35.659613
+                  ],
+                  "geometry_index": 520,
+                  "admin_index": 2,
+                  "weight": 13.288,
+                  "is_urban": true,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "turn_duration": 0.008,
+                  "turn_weight": 9.4,
+                  "duration": 3.464,
+                  "bearings": [
+                    32,
+                    109,
+                    290
+                  ],
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    114,
+                    289,
+                    351
+                  ],
+                  "duration": 33.29,
+                  "turn_duration": 0.026,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 0,
+                  "weight": 37.422,
+                  "geometry_index": 522,
+                  "location": [
+                    140.033427,
+                    35.659475
+                  ]
+                },
+                {
+                  "bearings": [
+                    31,
+                    120,
+                    120,
+                    208,
+                    299
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 4,
+                  "turn_weight": 3.75,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "left",
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid_indication": "right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "turn_duration": 2.021,
+                  "traffic_signal": true,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 1,
+                  "geometry_index": 526,
+                  "location": [
+                    140.038017,
+                    35.657669
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "浜田"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-prefectural-road",
+                          "display_ref": "15",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "Kendou No.15 Line"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "浜田 / Kendou No.15 Line"
+                  },
+                  "distanceAlongGeometry": 671.686
+                },
+                {
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "left",
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "right",
+                        "active": true,
+                        "directions": [
+                          "right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "浜田"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-prefectural-road",
+                          "display_ref": "15",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "Kendou No.15 Line"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "浜田 / Kendou No.15 Line"
+                  },
+                  "distanceAlongGeometry": 400
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "off ramp",
+                "instruction": "Take the exit on the left.",
+                "modifier": "slight left",
+                "bearing_after": 100,
+                "bearing_before": 110,
+                "location": [
+                  140.031461,
+                  35.659993
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Tokyowangan Road",
+              "weight_typical": 70.54,
+              "duration_typical": 53.044,
+              "duration": 53.044,
+              "distance": 671.686,
+              "driving_side": "left",
+              "weight": 70.54,
+              "mode": "driving",
+              "ref": "National Road No.357 Line",
+              "geometry": "qlo_cAi}yajGnB{WfSwaAjEmVfAyFPk@~j@m}Bng@i`BxZw|@jEoL"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right at <phoneme alphabet=\"jeita\" ph=\"ﾊﾏﾀﾞ\">浜田</phoneme>.</prosody></amazon:effect></speak>",
+                  "announcement": "Turn right at 浜田.",
+                  "distanceAlongGeometry": 52.536
+                }
+              ],
+              "intersections": [
+                {
+                  "bearings": [
+                    32,
+                    122,
+                    209,
+                    300,
+                    301
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "turn_weight": 30,
+                  "lanes": [
+                    {
+                      "indications": [
+                        "left",
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid_indication": "right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "turn_duration": 7.152,
+                  "traffic_signal": true,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 2,
+                  "geometry_index": 527,
+                  "location": [
+                    140.038233,
+                    35.657567
+                  ]
+                }
+              ],
+              "junction_name": "浜田",
+              "bannerInstructions": [
+                {
+                  "sub": {
+                    "components": [
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active": false,
+                        "directions": [
+                          "straight"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      },
+                      {
+                        "active_direction": "right",
+                        "active": true,
+                        "directions": [
+                          "right"
+                        ],
+                        "type": "lane",
+                        "text": ""
+                      }
+                    ],
+                    "text": ""
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "浜田"
+                      },
+                      {
+                        "type": "delimiter",
+                        "text": "/"
+                      },
+                      {
+                        "mapbox_shield": {
+                          "text_color": "white",
+                          "name": "jp-national-route",
+                          "display_ref": "357",
+                          "base_url": "https://api.mapbox.com/styles/v1"
+                        },
+                        "type": "icon",
+                        "text": "National Road No.357 Line"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "浜田 / National Road No.357 Line"
+                  },
+                  "distanceAlongGeometry": 65.869
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "turn",
+                "instruction": "Turn right at 浜田.",
+                "modifier": "right",
+                "bearing_after": 209,
+                "bearing_before": 120,
+                "location": [
+                  140.038233,
+                  35.657567
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "",
+              "weight_typical": 44.85,
+              "duration_typical": 20.352,
+              "duration": 20.352,
+              "distance": 65.869,
+              "driving_side": "left",
+              "weight": 44.85,
+              "mode": "driving",
+              "ref": "Kendou No.15 Line",
+              "geometry": "}tj_cAqdgbjGj_@~T"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 500 meters, Stay straight to take the ramp.</prosody></amazon:effect></speak>",
+                  "announcement": "In 500 meters, Stay straight to take the ramp.",
+                  "distanceAlongGeometry": 466.71
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Stay straight to take the ramp.</prosody></amazon:effect></speak>",
+                  "announcement": "Stay straight to take the ramp.",
+                  "distanceAlongGeometry": 80
+                }
+              ],
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "straight"
+                      ],
+                      "valid": false,
+                      "active": false
+                    },
+                    {
+                      "indications": [
+                        "right"
+                      ],
+                      "valid_indication": "right",
+                      "valid": true,
+                      "active": true
+                    }
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "location": [
+                    140.037881,
+                    35.657049
+                  ],
+                  "geometry_index": 528,
+                  "admin_index": 2,
+                  "weight": 11.053,
+                  "is_urban": true,
+                  "traffic_signal": true,
+                  "turn_duration": 8.024,
+                  "turn_weight": 10,
+                  "duration": 8.96,
+                  "bearings": [
+                    29,
+                    120,
+                    204,
+                    303,
+                    305
+                  ],
+                  "out": 4,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    125,
+                    299
+                  ],
+                  "duration": 0.792,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 1,
+                  "weight": 0.891,
+                  "geometry_index": 529,
+                  "location": [
+                    140.037767,
+                    35.657114
+                  ]
+                },
+                {
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "location": [
+                    140.037665,
+                    35.65716
+                  ],
+                  "geometry_index": 530,
+                  "admin_index": 2,
+                  "weight": 39.897,
+                  "is_urban": true,
+                  "traffic_signal": true,
+                  "turn_duration": 2.008,
+                  "turn_weight": 4.4,
+                  "duration": 33.561,
+                  "bearings": [
+                    30,
+                    119,
+                    122,
+                    204,
+                    299
+                  ],
+                  "out": 4,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    false,
+                    true
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    119,
+                    208,
+                    297
+                  ],
+                  "duration": 10.088,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 2,
+                  "weight": 11.34,
+                  "geometry_index": 531,
+                  "location": [
+                    140.036222,
+                    35.657808
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    113,
+                    288
+                  ],
+                  "duration": 11.12,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 1,
+                  "weight": 12.51,
+                  "geometry_index": 534,
+                  "location": [
+                    140.034802,
+                    35.658317
+                  ]
+                },
+                {
+                  "bearings": [
+                    107,
+                    225,
+                    282
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "turn_duration": 0.01,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 2,
+                  "geometry_index": 536,
+                  "location": [
+                    140.033336,
+                    35.658697
+                  ]
+                }
+              ],
+              "junction_name": "浜田",
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Stay straight to take the ramp"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "straight",
+                    "text": "Stay straight to take the ramp"
+                  },
+                  "distanceAlongGeometry": 506.525
+                }
+              ],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "turn",
+                "instruction": "Turn right at 浜田.",
+                "modifier": "right",
+                "bearing_after": 299,
+                "bearing_before": 209,
+                "location": [
+                  140.037881,
+                  35.657049
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Tokyowangan Road",
+              "weight_typical": 80.641,
+              "duration_typical": 68.931,
+              "duration": 68.931,
+              "distance": 506.525,
+              "driving_side": "left",
+              "weight": 80.641,
+              "mode": "driving",
+              "ref": "National Road No.357 Line",
+              "geometry": "qti_cAqnfbjGaCbF{AjEog@dyA}E`PqQft@iElQqUtuAe@|CkE|c@"
+            },
+            {
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 600 meters, You will arrive at your destination.</prosody></amazon:effect></speak>",
+                  "announcement": "In 600 meters, You will arrive at your destination.",
+                  "distanceAlongGeometry": 634.738
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>",
+                  "announcement": "You have arrived at your destination.",
+                  "distanceAlongGeometry": 69.444
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "bearings": [
+                    102,
+                    170,
+                    280
+                  ],
+                  "duration": 25.837,
+                  "turn_duration": 0.007,
+                  "mapbox_streets_v8": {
+                    "class": "trunk_link"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 2,
+                  "weight": 28.413,
+                  "geometry_index": 537,
+                  "location": [
+                    140.032745,
+                    35.658799
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    94,
+                    108,
+                    277
+                  ],
+                  "duration": 0.503,
+                  "turn_weight": 17.825,
+                  "turn_duration": 0.014,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 2,
+                  "weight": 18.362,
+                  "geometry_index": 548,
+                  "location": [
+                    140.02962,
+                    35.659206
+                  ]
+                },
+                {
+                  "bearings": [
+                    97,
+                    284
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "mapbox_streets_v8": {
+                    "class": "trunk"
+                  },
+                  "is_urban": true,
+                  "admin_index": 2,
+                  "out": 1,
+                  "geometry_index": 549,
+                  "location": [
+                    140.029529,
+                    35.659215
+                  ]
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "You will arrive at your destination"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight",
+                    "text": "You will arrive at your destination"
+                  },
+                  "distanceAlongGeometry": 648.072
+                },
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "You have arrived at your destination"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight",
+                    "text": "You have arrived at your destination"
+                  },
+                  "distanceAlongGeometry": 69.444
+                }
+              ],
+              "destinations": "国道３５７号線: 東京湾岸道路",
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "on ramp",
+                "instruction": "Stay straight to take the ramp.",
+                "modifier": "straight",
+                "bearing_after": 280,
+                "bearing_before": 282,
+                "location": [
+                  140.032745,
+                  35.658799
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Tokyowangan Road",
+              "weight_typical": 70.858,
+              "duration_typical": 48.234,
+              "duration": 48.234,
+              "distance": 648.072,
+              "driving_side": "left",
+              "weight": 70.858,
+              "mode": "driving",
+              "ref": "National Road No.357 Line",
+              "geometry": "}am_cAqm|ajGw@`KeDj`@QpGe@dM_Chj@oBje@iAnLaCtU?l@QbAiAtDQtD{AdMuCbWul@rpCeNlk@"
+            },
+            {
+              "voiceInstructions": [],
+              "intersections": [
+                {
+                  "bearings": [
+                    113
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "admin_index": 2,
+                  "geometry_index": 553,
+                  "location": [
+                    140.025875,
+                    35.66031
+                  ]
+                }
+              ],
+              "bannerInstructions": [],
+              "speedLimitUnit": "km/h",
+              "maneuver": {
+                "type": "arrive",
+                "instruction": "You have arrived at your destination.",
+                "bearing_after": 0,
+                "bearing_before": 293,
+                "location": [
+                  140.025875,
+                  35.66031
+                ]
+              },
+              "speedLimitSign": "vienna",
+              "name": "Tokyowangan Road",
+              "weight_typical": 0,
+              "duration_typical": 0,
+              "duration": 0,
+              "distance": 0,
+              "driving_side": "left",
+              "weight": 0,
+              "mode": "driving",
+              "ref": "National Road No.357 Line",
+              "geometry": "k`p_cAe`oajG??"
+            }
+          ],
+          "distance": 51199.59,
+          "summary": "Expwy Wangan Line, Higashikanto Expwy(Koya To Itako)"
+        }
+      ],
+      "geometry": "__~}bAy~csiGzb@r_A~_@v|@hLnQjPbW`Ydm@fb@~`AvVjj@bG~OjErNfAnGnB`PPtI?|HQjJiAjJ{AzH{ApGgD|HeDfHqFhJkIbKaNhOeqAruA}TvP_v@ll@aNfMkIrIyOzRyHrNmIrNoFrNeBvE}ChIuGvU{EtUuC~T{AnQ{AzRQpX?zRb@rShA~TrCx\\`CvUrCdRxDlVvDlQrJ|c@dD|M`Npi@jIl[bGtU|EdRnFlVfDvPzArNzArSRlQ?zC?hHe@|MiApSiAjOmB~OuCxPaGxWyOht@eOxr@oMhj@oUheAyOtu@oQdy@sN`p@gSh`AcGzWwKvf@eDrNmB|HaCxFyDjJeDnGkExFuGtIwDrD_JpG}EpBqFfCcK~CkEj@mIl@kIl@qU?iW?g^Tk[?ua@?mXV}f@?}E?yO?if@Tib@?o\\TiLVuGl@gHnBgHpBaNbFq@X}ObH{H|CkIpBuGbAkEVoF?cGWoFm@mIoB{LkEoMcFyH_DsNyFqQ}HcKkEuGgCeDyA{Am@iAm@aCm@_JuDsNyFcKaFuGkEkE_DkkAaf@iAm@aNyFuR}HwOoGsNyFcGgC}PoGeDeA{L}CgDm@eDUmM?kP?yO?qJ?wK?sR?}Pl@{m@WiL?_U?qU?ah@l@uR?wKUgHTkEl@cGxA_NfH}LfH_NdHcGfCuGzAyHl@oFW}Ek@cGqBgH_Dy^mV}WmQ}TwPcRsNiW{RkEyFaGyFcGcFwCuBgEyC}EuDuKuI{HyF_NiJ}LuIkE}CwD{AqJoBaCcAiLuIqJgHoBoBaCqBwDqBoBcA{Am@uGqB_Jl@iAUc@Ww@k@Sm@Qm@QcAQcA?cA?m@PcAb@cAv@cAhLW|[tD`CpBvVrSrCdHhA~C~B~CtC|CrCfCjT|MdOvKxZhTfHpBtG`FhPnL|EtDpFlE~y@~o@rUpStVlQxDhC|EnBxHzAnFTtGUpFcA`G{A|EgC|PkJjPkJbGgCvDk@|EWrJ?rRVj[W|[?jP?pJ?~_@?x^?ba@UpJWpFUnF?pJUnFWpFUjE?jE?fHl@rGj@bGdA|ExA~I~CtGfCn\\dMvKjEzLbFlThJtl@vUtR|Hpo@zWjPnGtbAxa@~IbApFbAfHfCvZnLbGpBdDbAtGzAxDj@jETjE?|E?dDk@vDcAzHiCtGgCpJsDtKwDdK}CbKqBzHcA`RUdK?p`@?hPWzS?dZ?ve@Up`@?~_@?dZ?tbAWpJU~IcAvK_DnFyApJcFxDgC`GaFfD_DrCuDrCkErCkEzA_DrCqGnBoGzAcFnBsIrCoLnFuUpJca@`YupAjP}t@dOmq@jPaw@zLsi@`Ry|@vKsd@vOqs@tGk[nByKlB{M|AcKv@aKfA{RRwP?qA?wQe@iOiAiOiAyK{AoLoBaKsC}MsCwKeOwk@_Jo]iL}c@mIk`@}EaUkEqXwDuUeDwZ}AcRiAiTw@oQ?_P?eRR}Mt@wPv@eMnBoQjEyWzEsSxDiOnFaPtG_PfH}MpJaPxOqSpUaU|kAwaAp\\qXrh@ij@dZg^~IoG|PoLtGqB|Pk@vKj@vKtDzLdHjIfH~IrN|Pxa@jf@bhAh[ps@|E`KhS|h@zLzW`Nn]dDvKjj@tpAth@llAr]xw@`G~M`JnS`Rx\\xZdh@|`AhvAlaAxuApTf[ta@vk@jnDhiF|iIhfLfD`Fln@j{@vJxMfIzKvOvPnMxKhLhJ`R|MhWdMvOpGbRxFjPjErRtDpFbAr]tDhWbAnXTrR?xuA?zuDl@`bAm@nsA{AtCUhE?pUUfi@Wbw@bA~TTdfAdAdt@xAzH?lX?|lB?fnBJh~AHfi@?z}Aj@f`B?~y@?dO?tG?lX?dp@}Czm@uDnBUnHu@vn@iG|[oGzcA_UnbBg^zm@}MriAmVvfAmVva@}HpfB__@~j@eMdZgHliBk`@zm@sNzb@kJx^yKxe@_PdSaK~_@iYtR{RnQmV`C}CrNkTlXwf@ln@a|An}@g`Cfm@u|A`eAklC~BoGnc@{hA`CyFrh@gtAdaC{gGng@s_ApJwPjvA}oBnRqSbQeRbl@ij@ta@__@pv@qi@zb@qX~TgMleBqiAlBcAzx@og@lmAwv@jVsOfi@{\\plAaw@f^aUng@_ZxHaFzAcAvl@u_@bl@g^`yBszAt~@cm@x^wUzcA_p@zf@gYzm@{\\zhA{g@`TuJpk@aPdZyFbw@sNp`@kE`RoBdVqBxW{AvVcA`C?~Tm@`Y?pYV`YbAdZpBvZfC|f@xFrYjEdZjEpfBb\\dw@rNb}Bnb@lkD~o@f{Cdm@h[nG|[dHxZtIh[vKng@rSf^`PhWzM~IjEde@dR|IlE|b@fTlTnLdSfM`NzMpUdR`N|MjEnGvDfHv@nGv@`Ke@bFiAnGmBxFyDtD}E~CyD`A}Ik@yDcAyD{A}EuDkTmVsYoXog@gc@kf@_ZaReMkPkJaG}CgHqBuGcAqFm@iA?mB?uC?oFbAuGpB}EfCyHtDmT`P_`@tZcKnLkEjE}PzRa]je@_JzMkPvZmXzh@mTr_@kIiJb{@yhBbRu_@vOaf@Rm@jEuUhEmV`CgM|EmQbGwPfHiOxHeM`NgMvKkJ`GkEhLkElIqBjEUtG?`Gj@j[bK~XvKda@dRhWrNhf@fYdKtIpJ|H|TvK~IxFpFlEvD`FjE`KzAfHd@bF?dHe@xF{AxFsClEsC|CkEfCoFl@}E?eDcAyDqBiLaKoFwKyOwZuKwPiAcAea@c\\_d@qXoByA_YmV{b@{Rq\\eMwZaKyZkJ}[_Ii[eHszCak@mkD_p@w}Bec@c~Cwk@sYaFeZmEog@yFsYgCeZyAsYcAsYUmX?oXj@iWl@gWxAcVfCsNpB}b@pGk_@xFaYjEcVbF}j@vP}|@|^ad@~TcfArn@}q@|c@gt@rd@qeAlq@iLdH}lBfoAmn@ba@ea@bWi[rSo}@~j@{nAxw@wZ|Rkf@|YgzB`wAqJbF_CxAmpBtpA}f@b\\sd@tZsNtIuGjEkIfHep@ll@}[tZcVfYyShYmTpXso@`aAiLpSqd@fy@ea@zcA_z@`wBuh@~vAqd@hjAaCnGySri@aNp]aCxF{[fy@ohAtrCwOf^m_@dhAaRzc@uGnQwl@nxAmXri@wOfYgS~T}WhYk_@pXuVdMgt@vUgt@vPiWxFu]fHeuAtZaiAbWa~@nQk`AhTuRjEkqCll@{WbF{m@`P_k@nLubApSas@fMkIhAkWnDgb@xFqFbAgWnBmIVmMTye@zAeZTuG?eO?ss@UaOCcwAQqpAW_v@U}sEl@sh@?kgAUmc@Wgi@cAua@{@cl@kAwp@Umu@?q{AzAgyAxAch@G}kAMcmAWwuA?sN?aYk@oXm@yWqB}PgC_UkEaNuDkPyFkPgHeSaKmT{MgSaPah@}c@oy@mlA{qJ_dN{iCytDiAyAa[kb@sLePw@yAkh@ys@y`@aj@_eAm}AsYaf@cRk`@qJiT{b@o}@k`Ag{B_`@y|@gt@waBmy@ejBoaAcyBipCshGgHaPgm@osAwa@s_Amn@kvAeV_k@mMc\\oeE{iJoNe[}H_Qwa@mgAku@k}BwKya@k_@i`BmT_aAy^mbBwVchA{Lij@cVafAu]w|AaNym@iL}h@_YupAyH}^qQ{~@sCwPmBcKqFaf@eDyr@yO}{C}PgvDcB__@uEodAe@}MsYkuGi[esHgDio@}EsdA?eR?iTPml@pJgvD`CccApJigEhL_tEdDgoAhAcr@v@iYvO}}FnBwf@hAk`@nBwZhEaa@tGya@`Nox@ltBo|Hn}@glDr~@{jDxOgo@vOwk@lIeWvDsNdfAwyDzx@}`Dzx@e`DPm@xS}~@|E{WfHkq@xDox@v@og@}AwaAmB{\\uCgYeDuUkEsXgHk`@e@cBoJg]_J_Z_JkV_F}MqJwP_Yeh@as@{cAmTqX_}FclHwVk[c~Ca~DcmAw|A}mCcjDkq@sz@}IyKkvAufBw@cAqaAyrAog@go@ykBq_Csh@_p@ix@mbAeDmEmdAkqAatAodBgDmEmhAgjAaz@kv@ifG{vFgdBq_Bor@uu@}j@yr@ku@}~@w~CurDomBk}BosA_aBwp@gy@ib@wf@ynAw|AqaAosAiWob@y^{m@_Yyf@sYeh@kkAqzBumA}`CaN{WgoAwbCqIkP}|@mbBitCyqFet@oxAgHaPqUwk@g^ufAiHm[aG}^aGke@uCyWg@qGgEqi@{Au_APmq@hAe^jE{r@zLi`AzHob@vOu_AlIwf@xSukAzAaKbs@ceEnr@eeE|EoXvp@o_Ebw@srEft@cjEbw@isEtGu_@zm@}qDhLke@|Pem@zLg^dZey@xSwk@|}AqkEhLk[lc@ijAxOob@j_@o}@dOgYzSm[rRmVlIkJjIsIlI}HnQiOtGqGpUmQhLqGxO}Hr]iObbAc\\`eAy\\pY}MhW}MjPaKbVwPn\\gYzSiT~Xq]nMmQvZ{h@rCyF|Wgh@z}A}{CbK{RdrBm_EpaDinGxi@mgA|Pke@zLm[ts@{jBxScr@dOk{@lDkQ`SgcAta@w|AvZgoAda@i`Bjj@{oCnB{WfSwaAjEmVfAyFPk@~j@m}Bng@i`BxZw|@jEoLj_@~TaCbF{AjEog@dyA}E`PqQft@iElQqUtuAe@|CkE|c@w@`KeDj`@QpGe@dM_Chj@oBje@iAnLaCtU?l@QbAiAtDQtD{AdMuCbWul@rpCeNlk@",
+      "voiceLocale": "en-US"
+    }
+  ],
+  "waypoints": [
+    {
+      "distance": 0,
+      "name": "B",
+      "location": [
+        139.790845,
+        35.634688
+      ]
+    },
+    {
+      "distance": 0.041,
+      "name": "11",
+      "location": [
+        139.778818,
+        35.635951
+      ]
+    },
+    {
+      "distance": 3.618,
+      "name": "B",
+      "location": [
+        139.785936,
+        35.550703
+      ]
+    },
+    {
+      "distance": 0.023,
+      "name": "国道３５７号線",
+      "location": [
+        140.025875,
+        35.66031
+      ]
+    }
+  ],
+  "code": "Ok",
+  "uuid": "route_with_road_objects_japan"
+}


### PR DESCRIPTION
Feature parity with Android mapbox/mapbox-navigation-android#7030

NN change was introduced for Android in order to 
> Fixed "global reference table overflow" by reducing the amount of objects transferred through the JNI on every route progress update.