### PR TITLE
Add the ability to pass userInfo to NavigationService constructor

### DIFF
--- a/.breakage-allowlist
+++ b/.breakage-allowlist
@@ -1,1 +1,3 @@
 Func CarPlayManagerDelegate.carPlayManager(_:willPresent:) has been added as a protocol requirement
+Constructor MapboxNavigationService.init(history:customHistoryEventsListener:customRoutingProvider:credentials:eventsManagerType:routerType:customActivityType:) has been removed
+Constructor MapboxNavigationService.init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:) has been removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * MapboxCoreNavigation now requires [MapboxDirections v2.11.0-alpha.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.11.0-alpha.1). ([#4396](https://github.com/mapbox/mapbox-navigation-ios/pull/4396))
 * MapboxNavigation now requires [MapboxMaps v10.12.0-rc.1](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.12.0-rc.1). ([#4408](https://github.com/mapbox/mapbox-navigation-ios/pull/4408))
 
+### Routing
+* Added an optional `userInfo` argument to the `NavigationService(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)` and `NavigationService(history:customHistoryEventsListener:customRoutingProvider:credentials:eventsManagerType:routerType:customActivityType:userInfo:)`. ([#4395](https://github.com/mapbox/mapbox-navigation-ios/pull/4395))
+
 ### Visual instructions
 * Fixed duplication of the road name components in the road shield and the label. ([#4401](https://github.com/mapbox/mapbox-navigation-ios/pull/4401))
 * Added support for localized road shields. ([#4401](https://github.com/mapbox/mapbox-navigation-ios/pull/4401))

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		2CA6105429802ACF003E49A7 /* MonitorConnectivityTypeProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA6105329802ACF003E49A7 /* MonitorConnectivityTypeProviderTests.swift */; };
 		2CAEABD12930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAEABD02930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift */; };
 		2CAEABD32930D87B00DE851A /* RouterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAEABD22930D87B00DE851A /* RouterSpy.swift */; };
+		2CB2A22B29C320A60002A6B4 /* NativeTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2A22A29C320A60002A6B4 /* NativeTelemetryIntegrationTests.swift */; };
 		2CC3043529A3DCDE00A3318F /* NavigationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC3043429A3DCDE00A3318F /* NavigationStatusTests.swift */; };
 		2CDF5C972919628100C41082 /* NavigationLocationManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDF5C962919628100C41082 /* NavigationLocationManagerSpy.swift */; };
 		2CE25130291A56D900C0FA15 /* IdleTimerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2512E291A56CE00C0FA15 /* IdleTimerManagerTests.swift */; };
@@ -833,6 +834,7 @@
 		2CA6105329802ACF003E49A7 /* MonitorConnectivityTypeProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorConnectivityTypeProviderTests.swift; sourceTree = "<group>"; };
 		2CAEABD02930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapboxNavigationServiceIntegrationTests.swift; sourceTree = "<group>"; };
 		2CAEABD22930D87B00DE851A /* RouterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterSpy.swift; sourceTree = "<group>"; };
+		2CB2A22A29C320A60002A6B4 /* NativeTelemetryIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeTelemetryIntegrationTests.swift; sourceTree = "<group>"; };
 		2CC3043429A3DCDE00A3318F /* NavigationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStatusTests.swift; sourceTree = "<group>"; };
 		2CDF5C962919628100C41082 /* NavigationLocationManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLocationManagerSpy.swift; sourceTree = "<group>"; };
 		2CE2512E291A56CE00C0FA15 /* IdleTimerManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdleTimerManagerTests.swift; sourceTree = "<group>"; };
@@ -1580,6 +1582,7 @@
 		2C585154292521C20077A558 /* MapboxCoreNavigationIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				2CB2A22A29C320A60002A6B4 /* NativeTelemetryIntegrationTests.swift */,
 				2CAEABD02930D25300DE851A /* MapboxNavigationServiceIntegrationTests.swift */,
 				2C71DE01292F821E00620775 /* BillingHandlerIntegrationTests.swift */,
 				2C585166292531340077A558 /* PassiveLocationManagerIntegrationTests.swift */,
@@ -1588,16 +1591,6 @@
 			);
 			name = MapboxCoreNavigationIntegrationTests;
 			path = Tests/MapboxCoreNavigationIntegrationTests;
-			sourceTree = "<group>";
-		};
-		2CE89C29299E6C17000A2E34 /* EV */ = {
-			isa = PBXGroup;
-			children = (
-				2CE89C2A299E6C2A000A2E34 /* InterchangeTests.swift */,
-				2CE89C2C299E6D09000A2E34 /* JunctionTests.swift */,
-				2CE89C2E299E6E08000A2E34 /* RoadObjectKindTests.swift */,
-			);
-			path = EV;
 			sourceTree = "<group>";
 		};
 		2C856447297AD64C006EFCBB /* Telemetry */ = {
@@ -1625,6 +1618,16 @@
 				2CA6104C297EF78C003E49A7 /* DeviceSpy.swift */,
 			);
 			path = System;
+			sourceTree = "<group>";
+		};
+		2CE89C29299E6C17000A2E34 /* EV */ = {
+			isa = PBXGroup;
+			children = (
+				2CE89C2A299E6C2A000A2E34 /* InterchangeTests.swift */,
+				2CE89C2C299E6D09000A2E34 /* JunctionTests.swift */,
+				2CE89C2E299E6E08000A2E34 /* RoadObjectKindTests.swift */,
+			);
+			path = EV;
 			sourceTree = "<group>";
 		};
 		2CF3F8C92926D38A00BB2B9C /* Helper */ = {
@@ -3131,6 +3134,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C585167292531340077A558 /* PassiveLocationManagerIntegrationTests.swift in Sources */,
+				2CB2A22B29C320A60002A6B4 /* NativeTelemetryIntegrationTests.swift in Sources */,
 				2C71DE02292F821E00620775 /* BillingHandlerIntegrationTests.swift in Sources */,
 				2C9DDBE42934D8FD007F8CFD /* MapboxCoreNavigationIntegrationTests.swift in Sources */,
 				2C58515F292523670077A558 /* RouteControllerIntegrationTests.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/NavigationService.swift
+++ b/Sources/MapboxCoreNavigation/NavigationService.swift
@@ -317,7 +317,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -350,7 +350,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
      */
-    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)")
     public convenience init(routeResponse: RouteResponse,
                             routeIndex: Int,
                             routeOptions: RouteOptions,
@@ -384,17 +384,17 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter routerType: An optional router type to use for traversing the route.
      - parameter customActivityType: Custom `CLActivityType` to be used for location updates. If not specified, SDK will pick it automatically for current navigation profile.
      */
-    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:)")
+    @available(*, deprecated, renamed: "init(indexedRouteResponse:customRoutingProvider:credentials:locationSource:eventsManagerType:simulating:routerType:customActivityType:userInfo:)")
     required public convenience init(routeResponse: RouteResponse,
-                         routeIndex: Int,
-                         routeOptions: RouteOptions,
-                         customRoutingProvider: RoutingProvider? = nil,
-                         credentials: Credentials,
-                         locationSource: NavigationLocationManager? = nil,
-                         eventsManagerType: NavigationEventsManager.Type? = nil,
-                         simulating simulationMode: SimulationMode? = nil,
-                         routerType: Router.Type? = nil,
-                         customActivityType: CLActivityType? = nil) {
+                                     routeIndex: Int,
+                                     routeOptions: RouteOptions,
+                                     customRoutingProvider: RoutingProvider? = nil,
+                                     credentials: Credentials,
+                                     locationSource: NavigationLocationManager? = nil,
+                                     eventsManagerType: NavigationEventsManager.Type? = nil,
+                                     simulating simulationMode: SimulationMode? = nil,
+                                     routerType: Router.Type? = nil,
+                                     customActivityType: CLActivityType? = nil) {
         self.init(indexedRouteResponse: .init(routeResponse: routeResponse,
                                               routeIndex: routeIndex),
                   customRoutingProvider: customRoutingProvider,
@@ -405,7 +405,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
                   routerType: routerType,
                   customActivityType: customActivityType)
     }
-    
+
     /**
      Intializes a new `NavigationService`.
      
@@ -416,6 +416,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
      - parameter simulationMode: The simulation mode desired.
      - parameter routerType: An optional router type to use for traversing the route.
+     - parameter customActivityType: Custom `CLActivityType` to be used for location updates. If not specified, SDK will pick it automatically for current navigation profile.     
+     - parameter userInfo: An optional metadata to be provided as initial value of `NavigationEventsManager.userInfo` property.
      */
     required public init(indexedRouteResponse: IndexedRouteResponse,
                          customRoutingProvider: RoutingProvider? = nil,
@@ -424,7 +426,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                          eventsManagerType: NavigationEventsManager.Type? = nil,
                          simulating simulationMode: SimulationMode? = nil,
                          routerType: Router.Type? = nil,
-                         customActivityType: CLActivityType? = nil) {
+                         customActivityType: CLActivityType? = nil,
+                         userInfo: [String: String?]? = nil) {
         nativeLocationSource = locationSource ?? NavigationLocationManager()
         self.credentials = credentials
         self.simulationMode = simulationMode ?? .inTunnels
@@ -442,14 +445,16 @@ public class MapboxNavigationService: NSObject, NavigationService {
                    indexedRouteResponse: indexedRouteResponse,
                    customRoutingProvider: customRoutingProvider,
                    eventsManagerType: eventsManagerType,
-                   customActivityType: customActivityType)
+                   customActivityType: customActivityType,
+                   userInfo: userInfo)
     }
 
     private func commonInit(routerType: Router.Type?,
                             indexedRouteResponse: IndexedRouteResponse,
                             customRoutingProvider: RoutingProvider?,
                             eventsManagerType: NavigationEventsManager.Type?,
-                            customActivityType: CLActivityType?) {
+                            customActivityType: CLActivityType?,
+                            userInfo: [String: String?]?) {
         resumeNotifications()
 
         let routerType = routerType ?? DefaultRouter.self
@@ -462,6 +467,7 @@ public class MapboxNavigationService: NSObject, NavigationService {
         let eventType = eventsManagerType ?? NavigationEventsManager.self
         _eventsManager = eventType.init(activeNavigationDataSource: self,
                                         accessToken: self.credentials.accessToken)
+        _eventsManager?.userInfo = userInfo
         locationManager.activityType = customActivityType ?? options.activityType
         bootstrapEvents()
         
@@ -481,6 +487,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
      - parameter credentials: Credentials to authorize additional data requests throughout the route.
      - parameter eventsManagerType: An optional events manager type to use while tracking the route.
      - parameter routerType: An optional router type to use for traversing the route.
+     - parameter customActivityType: Custom `CLActivityType` to be used for location updates. If not specified, SDK will pick it automatically for current navigation profile.
+     - parameter userInfo: An optional metadata to be provided as initial value of `NavigationEventsManager.userInfo` property.
      - returns `nil` if provided `historyFileDump` does not contain valid initial route.
      */
     public convenience init?(history: History,
@@ -489,7 +497,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                              credentials: Credentials,
                              eventsManagerType: NavigationEventsManager.Type? = nil,
                              routerType: Router.Type? = nil,
-                             customActivityType: CLActivityType? = nil) {
+                             customActivityType: CLActivityType? = nil,
+                             userInfo: [String: String?]? = nil) {
         guard let routeResponse = history.initialRoute else {
             return nil
         }
@@ -502,7 +511,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                   locationSource: replayLocationManager,
                   eventsManagerType: eventsManagerType,
                   routerType: routerType,
-                  customActivityType: customActivityType)
+                  customActivityType: customActivityType,
+                  userInfo: userInfo)
         
         if customHistoryEventsListener == nil {
             replayLocationManager.eventsListener = self
@@ -518,7 +528,9 @@ public class MapboxNavigationService: NSObject, NavigationService {
          routerType: Router.Type?,
          customActivityType: CLActivityType?,
          simulatedLocationSourceType: SimulatedLocationManager.Type,
-         poorGPSTimer: DispatchTimer) {
+         poorGPSTimer: DispatchTimer,
+         userInfo: [String: String?]? = nil
+    ) {
         self.nativeLocationSource = locationSource
         self.credentials = credentials
         self.simulationMode = simulationMode
@@ -530,7 +542,8 @@ public class MapboxNavigationService: NSObject, NavigationService {
                    indexedRouteResponse: indexedRouteResponse,
                    customRoutingProvider: customRoutingProvider,
                    eventsManagerType: eventsManagerType,
-                   customActivityType: customActivityType)
+                   customActivityType: customActivityType,
+                   userInfo: userInfo)
     }
     
     deinit {

--- a/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/MapboxNavigationServiceIntegrationTests.swift
@@ -57,7 +57,7 @@ class MapboxNavigationServiceIntegrationTests: TestCase {
         delegate = NavigationServiceDelegateSpy()
         routeResponse = makeRouteResponse()
         route = routeResponse.routes!.first!
-        initialRouteResponse = IndexedRouteResponse.init(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions), routeIndex: 0)
+        initialRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions), routeIndex: 0)
 
         alternateRouteResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
         alternateRoute = Fixture.route(from: jsonFileName, options: routeOptions)

--- a/Tests/MapboxCoreNavigationIntegrationTests/NativeTelemetryIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/NativeTelemetryIntegrationTests.swift
@@ -1,0 +1,539 @@
+import XCTest
+import MapboxDirections
+import MapboxNavigationNative
+import CoreLocation
+import AVFoundation
+import Polyline
+@testable import TestHelper
+@_implementationOnly import MapboxCommon_Private
+@testable @_spi(MapboxInternal) import MapboxCoreNavigation
+
+class NativeTelemetryIntegrationTests: TestCase {
+    let expectationsTimeout: Double = 2
+    var navigationService: NavigationService!
+    var locationManager: ReplayLocationManager!
+    var passiveLocationManager: PassiveLocationManager!
+
+    var indexedRouteResponse: IndexedRouteResponse!
+    var route: Route!
+    var routeResponse: RouteResponse!
+    var alternateRouteResponse: RouteResponse!
+    var alternateRoute: Route!
+
+    var directions: Directions!
+    var navigator: MapboxCoreNavigation.Navigator!
+    var eventsAPI: EventsService!
+    var telemetryObserver: TelemetryObserver!
+    let userInfo = [
+        "userId": "user_id_value",
+        "sessionId": "session_id_value",
+        "name": "name_value",
+        "version": "version_value",
+    ]
+    var dictionaryUserInfo: NSDictionary {
+        NSDictionary(dictionary: userInfo)
+    }
+
+    private var device: UIDevice { UIDevice.current }
+    private var screenBrightness: Int { Int(UIScreen.main.brightness * 100) }
+    private var deviceString: String { "\(device.model) (\(cpu); Simulator)" }
+    private var platformName: String { device.systemName }
+    private var platformVersion: String { ProcessInfo.processInfo.operatingSystemVersionString }
+    private var volumeLevel: Int { Int(AVAudioSession.sharedInstance().outputVolume * 100) }
+    private var batteryPluggedIn: Bool { [.charging, .full].contains(UIDevice.current.batteryState) }
+
+    override func setUp() {
+        NavigationTelemetryConfiguration.useNavNativeTelemetryEvents = true
+        directions = .mocked
+        configureEventsObserver()
+
+        let routeOptions = NavigationRouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 9.519172, longitude: 47.210823),
+            CLLocationCoordinate2D(latitude: 9.52222, longitude: 47.214268),
+            CLLocationCoordinate2D(latitude: 47.212326, longitude: 9.512569),
+        ])
+        routeOptions.includesAlternativeRoutes = false
+        let jsonFileName = "multileg-route"
+        routeResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+        route = routeResponse.routes!.first!
+        indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
+        alternateRouteResponse = Fixture.routeResponse(from: jsonFileName, options: routeOptions)
+        alternateRoute = Fixture.route(from: jsonFileName, options: routeOptions)
+
+        let customConfig = ["telemetry": ["eventsPriority": "Immediate"]]
+        UserDefaults.standard.set(customConfig, forKey: customConfigKey)
+
+        UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationWhenInUseUsageDescription")
+        UserDefaults.standard.set("Location Usage Description", forKey: "NSLocationAlwaysAndWhenInUseUsageDescription")
+
+        Navigator.shared.rerouteController.reroutesProactively = false
+
+        let steps = route.legs[0].steps
+        var coordinates: [CLLocationCoordinate2D] = []
+        if let firstStep = steps[0].shape, let secondStep = steps[1].shape {
+            coordinates = firstStep.coordinates + secondStep.coordinates.prefix(1)
+        }
+
+        locationManager = ReplayLocationManager(locations: coordinates
+            .map { CLLocation(coordinate: $0) }
+            .shiftedToPresent())
+
+        locationManager.speedMultiplier = 10
+        navigator = .shared
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+        NavigationTelemetryConfiguration.useNavNativeTelemetryEvents = false
+        Navigator.shared.rerouteController.reroutesProactively = true
+        navigationService = nil
+        passiveLocationManager = nil
+        navigator = nil
+        UserDefaults.resetStandardUserDefaults()
+        eventsAPI.unregisterObserver(for: telemetryObserver)
+        telemetryObserver = nil
+
+        super.tearDown()
+    }
+
+    func testStartFreeDrive() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+    }
+
+    func testStartActiveNavigation() {
+        updateLocation()
+        let firstLocation = locationManager.locations.first!
+        configureActiveNavigation()
+
+
+        // TODO: do not skip events after fix in NN
+        telemetryObserver.shouldSkipEventsCount = 2
+
+        var activeAttributesKeys = activeNoValueCheckAttributesKeys
+        activeAttributesKeys.insert("locationsAfter")
+        telemetryObserver.expectedEvents = [
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.depart",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate,
+                                  noValueCheckAttributesKeys: activeAttributesKeys),
+        ]
+        startActiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: 5)
+    }
+
+    func testStartActiveNavigationAfterFreeRide() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+        telemetryObserver.reset()
+
+        configureActiveNavigation()
+
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "stop", coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+        ]
+        startActiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+    }
+
+    func testFinishRoute() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+        telemetryObserver.reset()
+
+        configureActiveNavigation()
+
+        var activeAttributesKeys = activeNoValueCheckAttributesKeys
+        activeAttributesKeys.insert("locationsAfter")
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "stop", coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.depart",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate,
+                                  noValueCheckAttributesKeys: activeAttributesKeys),
+// TODO: enable after fix in NN
+//            activeNavigationEvent(eventName: "navigation.arrive",
+//                                  routeProgress: navigationService.routeProgress,
+//                                  coordinate: firstLocation.coordinate,
+//                                  noValueCheckAttributesKeys: activeAttributesKeys)
+        ]
+        startActiveNavigation()
+
+        let navigationFinished = expectation(description: "Navigation finished")
+        locationManager.replayCompletionHandler = { [weak self] _ in
+            navigationFinished.fulfill()
+            self?.navigationService.endNavigation(feedback: nil)
+            return false
+        }
+
+        wait(for: [telemetryObserver.expectation, navigationFinished], timeout: 5)
+    }
+
+    func testStartFreeRideAfterActiveNavigation() {
+        let firstLocation = locationManager.locations.first!
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate)
+        ]
+
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+
+        telemetryObserver.reset()
+        configureActiveNavigation()
+
+        telemetryObserver.expectedEvents = [
+            freeDriveEvent(eventType: "stop", coordinate: firstLocation.coordinate),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_started",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+        ]
+        startActiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+
+        telemetryObserver.reset()
+
+        var activeAttributesKeys = activeNoValueCheckAttributesKeys
+        activeAttributesKeys.insert("locationsBefore")
+        telemetryObserver.expectedEvents = [
+            activeNavigationEvent(eventName: "navigation.cancel",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate,
+                                 noValueCheckAttributesKeys: activeAttributesKeys),
+            activeNavigationEvent(eventName: "navigation.navigationStateChanged",
+                                  state: "navigation_ended",
+                                  routeProgress: navigationService.routeProgress,
+                                  coordinate: firstLocation.coordinate),
+            freeDriveEvent(eventType: "start", coordinate: firstLocation.coordinate),
+        ]
+        navigationService.router.finishRouting()
+        startPassiveNavigation()
+
+        wait(for: [telemetryObserver.expectation], timeout: expectationsTimeout)
+    }
+
+    struct Event: Equatable {
+        let eventName: String
+        let attributes: [String: Any]
+        let approximateValueCheckAttributes: [String: (Double, Double)]
+        let noValueCheckAttributesKeys: Set<String>
+
+        static func ==(lhs: NativeTelemetryIntegrationTests.Event, rhs: NativeTelemetryIntegrationTests.Event) -> Bool {
+            lhs.eventName == rhs.eventName &&
+            lhs.attributes.count == rhs.attributes.count &&
+            lhs.noValueCheckAttributesKeys == rhs.noValueCheckAttributesKeys &&
+            lhs.approximateValueCheckAttributes.count == rhs.approximateValueCheckAttributes.count &&
+            lhs.approximateValueCheckAttributes.allSatisfy { key, value in
+                guard let rightValue = rhs.approximateValueCheckAttributes[key] else { return false }
+                return abs(value.0 - rightValue.0) <= value.1
+            }
+        }
+    }
+
+    final class TelemetryObserver: EventsServiceObserver {
+        var actualEvents: [Event] = []
+        var expectedEvents: [Event] = []
+
+        var shouldSkipEventsCount: Int = 0
+        private(set) var skippedEventsCount: Int = 0
+
+        var expectation = XCTestExpectation(description: "Events sent expectation")
+
+        func reset() {
+            actualEvents = []
+            expectation = XCTestExpectation(description: "Events sent expectation")
+        }
+
+        func didEncounterError(forError error: EventsServiceError, events: Any) {
+            DispatchQueue.main.async { [weak self] in
+                self?.handleEvents(events)
+            }
+        }
+
+        func didSendEvents(forEvents events: Any) {
+            DispatchQueue.main.async { [weak self] in
+                self?.handleEvents(events)
+            }
+        }
+
+        private func handleEvents(_ events: Any) {
+            guard let eventAttributes = events as? [[String: Any]] else {
+                return XCTFail("Events has incorrect type")
+            }
+            for event in eventAttributes {
+                handleEvent(event)
+            }
+        }
+
+        private func handleEvent(_ event: [String: Any]) {
+            guard skippedEventsCount >= shouldSkipEventsCount else {
+                skippedEventsCount += 1
+                return
+            }
+
+            guard let eventName = event["event"] as? String else {
+                return XCTFail("Event \(event) has no name")
+            }
+
+            guard actualEvents.count < expectedEvents.count else {
+                return XCTFail("Event \(eventName) was not expected")
+            }
+
+            print("\(eventName) event revieved. Details \(event)")
+            let expectedEvent = expectedEvents[actualEvents.count]
+            let typedEvent = Event(eventName: eventName,
+                                   attributes: event,
+                                   expectedEvent: expectedEvent)
+            actualEvents.append(typedEvent)
+            XCTAssertEqual(typedEvent, expectedEvent)
+
+            if expectedEvents.count == actualEvents.count {
+                expectation.fulfill()
+            }
+        }
+    }
+
+    fileprivate var navigationBaseAttributes: [String: Any] {
+        [
+            "connectivity": "WiFi",
+            "sdkIdentifier": "mapbox-navigation-ios",
+            "eventVersion": 2.4,
+            "version": 2.4,
+            "operatingSystem": "\(platformName) \(platformVersion)",
+            "device": deviceString,
+            "simulation": 0,
+            "locationEngine": "sim:0,acc:0",
+            "volumeLevel": volumeLevel,
+            "audioType": "speaker",
+            "screenBrightness": screenBrightness,
+            "percentTimeInForeground": 100,
+            "percentTimeInPortrait": 100,
+            "batteryPluggedIn": batteryPluggedIn as NSNumber,
+            "appMetadata": dictionaryUserInfo
+        ]
+    }
+
+    private var passiveNoValueCheckAttributesKeys: Set<String> {
+        [
+            "created",
+            "createdMonotime",
+            "driverModeStartTimestamp",
+            "driverModeStartTimestampMonotime",
+            "driverModeId"
+        ]
+    }
+
+    private var activeNoValueCheckAttributesKeys: Set<String> {
+        let attributes: Set<String> = [
+            "originalRequestIdentifier",
+            "requestIdentifier"
+        ]
+        return attributes.union(passiveNoValueCheckAttributesKeys)
+    }
+
+    private var cpu: String {
+#if arch(x86_64)
+        return "x86_64"
+#elseif arch(arm)
+        return "arm"
+#elseif arch(arm64)
+        return "arm64"
+#else
+        return ""
+#endif
+    }
+
+    private func stepLocations(legIndex: Int = 0, stepIndex: Int = 0) -> [CLLocation] {
+        guard let shape = route.legs[legIndex].steps[stepIndex].shape else { return [] }
+        let now = Date()
+        return shape.coordinates.enumerated().map {
+            CLLocation(coordinate: $0.element,
+                       altitude: -1,
+                       horizontalAccuracy: 10,
+                       verticalAccuracy: -1,
+                       course: -1,
+                       speed: 10,
+                       timestamp: now + $0.offset)
+        }
+    }
+
+    private func configureEventsObserver() {
+        let accessToken = Fixture.credentials.accessToken ?? ""
+        let options = EventsServerOptions(
+            token: accessToken,
+            userAgentFragment: MapboxNavigationNative.Navigator.getUserAgentFragment(),
+            deferredDeliveryServiceOptions: nil
+        )
+        eventsAPI = EventsService.getOrCreate(for: options)
+        telemetryObserver = TelemetryObserver()
+        eventsAPI.registerObserver(for: telemetryObserver)
+    }
+
+    private func startPassiveNavigation() {
+        passiveLocationManager = PassiveLocationManager(directions: directions,
+                                                        systemLocationManager: locationManager,
+                                                        userInfo: userInfo)
+        updateLocation()
+    }
+
+    private func startActiveNavigation() {
+        navigationService?.start()
+        updateLocation()
+    }
+
+    private func configureActiveNavigation() {
+        navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
+                                                    customRoutingProvider: MapboxRoutingProvider(.offline),
+                                                    credentials: Fixture.credentials,
+                                                    locationSource: locationManager,
+                                                    simulating: .never,
+                                                    userInfo: userInfo)
+        navigationService.eventsManager.userInfo = userInfo
+    }
+
+    private func updateLocation() {
+        let firstLocation = locationManager.locations.first!
+        navigator.updateLocation(firstLocation) { _ in }
+    }
+
+    private func freeDriveEvent(eventType: String,
+                                coordinate: CLLocationCoordinate2D) -> Event {
+        let attributes: [String: Any] = [
+            "eventType": eventType,
+            "driverMode": "freeDrive",
+            "lat": coordinate.latitude,
+            "lng": coordinate.longitude,
+        ]
+        return event(with: "navigation.freeDrive",
+                     attributes: attributes,
+                     approximateValueCheckAttributes: [:],
+                     noValueCheckAttributesKeys: passiveNoValueCheckAttributesKeys)
+    }
+
+    private func activeNavigationEvent(eventName: String,
+                                       state: String? = nil,
+                                       routeProgress: RouteProgress,
+                                       coordinate: CLLocationCoordinate2D,
+                                       originalRoute: Route? = nil,
+                                       rerouteCount: Int = 0,
+                                       noValueCheckAttributesKeys: Set<String>? = nil) -> Event {
+        let route = routeProgress.route
+        let originalRoute = originalRoute ?? route
+        let lastCoordinate = route.shape!.coordinates.last!
+        let location = CLLocation(coordinate: coordinate)
+        var attributes: [String: Any] = [
+            "originalStepCount": originalRoute.legs.map({$0.steps.count}).reduce(0, +),
+            "stepCount": routeProgress.currentLeg.steps.count,
+            "voiceIndex": 0,
+            "bannerIndex": 0,
+            "driverMode": "trip",
+            "lat": coordinate.latitude,
+            "lng": coordinate.longitude,
+            "profile": "driving-traffic",
+            "originalGeometry": Polyline(coordinates: originalRoute.shape!.coordinates).encodedPolyline,
+            "originalGeometryFormat": "precision_6",
+            "geometry": Polyline(coordinates: route.shape!.coordinates).encodedPolyline,
+            "geometryFormat": "precision_6",
+            "stepIndex": routeProgress.currentLegProgress.stepIndex,
+            "legIndex": routeProgress.legIndex,
+            "legCount": routeProgress.route.legs.count,
+            "estimatedDuration": Int(route.expectedTravelTime),
+            "estimatedDistance": route.distance,
+            "rerouteCount": rerouteCount
+        ]
+        if let state = state {
+            attributes["state"] = state
+        }
+        let approximateValueCheckAttributes = [
+            "distanceCompleted": (routeProgress.distanceTraveled, 10.0),
+            "distanceRemaining": (routeProgress.distanceRemaining, 10.0),
+            "durationRemaining": (routeProgress.durationRemaining, 1.0),
+            "absoluteDistanceToDestination": (location.distance(from: CLLocation(latitude: lastCoordinate.latitude, longitude: lastCoordinate.longitude)), 10.0)
+        ]
+        let attributesKeys = noValueCheckAttributesKeys ?? activeNoValueCheckAttributesKeys
+        return event(with: eventName,
+                     attributes: attributes,
+                     approximateValueCheckAttributes: approximateValueCheckAttributes,
+                     noValueCheckAttributesKeys: attributesKeys)
+    }
+
+    private func event(with eventName: String,
+                       attributes: [String: Any],
+                       approximateValueCheckAttributes: [String: (Double, Double)],
+                       noValueCheckAttributesKeys: Set<String>) -> Event {
+        var eventAttributes: [String: Any] = [
+            "event": eventName
+        ]
+        eventAttributes.merge(navigationBaseAttributes) { _, new in new }
+        eventAttributes.merge(attributes) { _, new in new }
+        return Event(eventName: eventName,
+                     attributes: eventAttributes,
+                     approximateValueCheckAttributes: approximateValueCheckAttributes,
+                     noValueCheckAttributesKeys: noValueCheckAttributesKeys)
+    }
+}
+
+extension NativeTelemetryIntegrationTests.Event {
+    var approximateValueCheckAttributesKeys: Set<String> {
+        Set(approximateValueCheckAttributes.keys)
+    }
+    var specialCheckAttributesKeys: Set<String> {
+        noValueCheckAttributesKeys.union(approximateValueCheckAttributesKeys)
+    }
+
+    init(eventName: String,
+         attributes: [String: Any],
+         expectedEvent:  NativeTelemetryIntegrationTests.Event) {
+        let specialCheckAttributeKeys = expectedEvent.specialCheckAttributesKeys
+        let eventAttributes = attributes.filter { !specialCheckAttributeKeys.contains($0.key) }
+        let approximateValueCheckAttributes: [String: (Double, Double)] = attributes
+            .filter { expectedEvent.approximateValueCheckAttributesKeys.contains($0.key) }
+            .reduce(into: [:]) { result, element in
+                guard let doubleValue = element.value as? Double,
+                      let eps = expectedEvent.approximateValueCheckAttributes[element.key]?.1
+                else { return }
+
+                result[element.key] = (doubleValue, eps)
+            }
+        let noValueCheckAttributesKeys = attributes.keys.filter { expectedEvent.noValueCheckAttributesKeys.contains($0) }
+        self.init(eventName: eventName,
+                  attributes: eventAttributes,
+                  approximateValueCheckAttributes: approximateValueCheckAttributes,
+                  noValueCheckAttributesKeys: Set(noValueCheckAttributesKeys))
+    }
+}

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -41,6 +41,7 @@ class NavigationServiceTests: TestCase {
     let indexedRouteResponse = IndexedRouteResponse.init(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions), routeIndex: 0)
     var location: CLLocation!
     var lastLocation: CLLocation!
+    var userInfo: [String: String?] = ["key": "value"]
 
     var delegate: NavigationServiceDelegateSpy!
     var locationManager: NavigationLocationManagerSpy!
@@ -103,7 +104,8 @@ class NavigationServiceTests: TestCase {
                                                         routerType: RouterSpy.self,
                                                         customActivityType: .automotiveNavigation,
                                                         simulatedLocationSourceType: SimulatedLocationManagerSpy.self,
-                                                        poorGPSTimer: poorGPSTimer)
+                                                        poorGPSTimer: poorGPSTimer,
+                                                        userInfo: userInfo)
         navigationService.delegate = delegate
         return navigationService
     }
@@ -120,6 +122,11 @@ class NavigationServiceTests: TestCase {
         } else {
             XCTAssertFalse(usesDefaultUserInterface, "MapboxCoreNavigationTests shouldn't have an implicit dependency on MapboxNavigation due to removing the Example application target as the test host.")
         }
+    }
+
+    func testSetUserInfoToEventsManager() {
+        service = makeService()
+        XCTAssertEqual(eventsManager.userInfo, userInfo)
     }
 
     func testStartIfNeverSimulation() {


### PR DESCRIPTION
### Description
* Adds the ability to pass userInfo to NavigationService to use app metadata in Telemetry even for the first sent event.
* Adds basic Native Telemetry integration tests.