### PR TITLE
Fix non sent parameters for 'navigation.cancel' telemetry event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@
 ### Other changes
 
 * Fixed an issue where `ReplayLocationManager` init with `History` removed all custom history events. ([#4403](https://github.com/mapbox/mapbox-navigation-ios/pull/4403))
-* Fixed possible display negative remaining distance value. ([#4402](https://github.com/mapbox/mapbox-navigation-ios/pull/4402))
-* Fixed non-sent parameters for 'navigation.cancel' telemetry event. ([#4413](https://github.com/mapbox/mapbox-navigation-ios/pull/4413))
+* Fixed a potential issue where negative remaining distance values could be displayed.  ([#4402](https://github.com/mapbox/mapbox-navigation-ios/pull/4402))
+* Fixed a problem where certain parameters were not being sent for the 'navigation.cancel' telemetry event. ([#4413](https://github.com/mapbox/mapbox-navigation-ios/pull/4413))
 
 ## v2.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
 ### Other changes
 
 * Fixed an issue where `ReplayLocationManager` init with `History` removed all custom history events. ([#4403](https://github.com/mapbox/mapbox-navigation-ios/pull/4403))
-* Fixes possible display negative remaining distance value. ([#4402](https://github.com/mapbox/mapbox-navigation-ios/pull/4402))
+* Fixed possible display negative remaining distance value. ([#4402](https://github.com/mapbox/mapbox-navigation-ios/pull/4402))
+* Fixed non-sent parameters for 'navigation.cancel' telemetry event. ([#4413](https://github.com/mapbox/mapbox-navigation-ios/pull/4413))
 
 ## v2.11.0
 

--- a/Sources/MapboxCoreNavigation/Telemetry/NavigationCommonEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/Telemetry/NavigationCommonEventsManager.swift
@@ -209,7 +209,7 @@ class NavigationCommonEventsManager: NavigationTelemetryManager {
         sendFeedbackEvents([event.coreEvent])
     }
     
-    func navigationCancelEvent(rating potentialRating: Int? = nil, comment: String? = nil) -> ActiveNavigationEventDetails? {
+    func navigationCancelEvent(rating potentialRating: Int?, comment: String?) -> ActiveNavigationEventDetails? {
         guard let dataSource = activeNavigationDataSource else { return nil }
         
         let rating = potentialRating ?? EventRating.unrated
@@ -358,7 +358,7 @@ class NavigationCommonEventsManager: NavigationTelemetryManager {
         sendEvent(with: attributes)
     }
     
-    func sendCancelEvent(rating: Int? = nil, comment: String? = nil) {
+    func sendCancelEvent(rating: Int?, comment: String?) {
         guard let attributes = try? navigationCancelEvent(rating: rating, comment: comment)?.asDictionary() else { return }
         sendEvent(with: attributes)
     }

--- a/Sources/MapboxCoreNavigation/Telemetry/NavigationEventsManager.swift
+++ b/Sources/MapboxCoreNavigation/Telemetry/NavigationEventsManager.swift
@@ -225,7 +225,7 @@ open class NavigationEventsManager {
     }
 
     func sendCancelEvent(rating: Int? = nil, comment: String? = nil) {
-        commonEventsManager?.sendCancelEvent()
+        commonEventsManager?.sendCancelEvent(rating: rating, comment: comment)
     }
 
     func sendPassiveNavigationStart() {

--- a/Sources/TestHelper/NavigationEventsManagerTestDoubles.swift
+++ b/Sources/TestHelper/NavigationEventsManagerTestDoubles.swift
@@ -39,6 +39,8 @@ public class NavigationEventsManagerSpy: NavigationEventsManager {
     var passedPassiveNavigationType: PassiveNavigationFeedbackType?
     var passedDescription: String?
     var passedCompletionHandler: UserFeedbackCompletionHandler?
+    var passedRating: Int?
+    var passedComment: String?
 
     var returnedFeedbackEvent: FeedbackEvent? = Fixture.createFeedbackEvent()
 
@@ -140,8 +142,10 @@ public class NavigationEventsManagerSpy: NavigationEventsManager {
         sendRouteRetrievalEventCalled = true
     }
 
-    public override func sendCancelEvent(rating: Int? = nil, comment: String? = nil) {
+    public override func sendCancelEvent(rating: Int?, comment: String?) {
         sendCancelEventCalled = true
+        passedRating = rating
+        passedComment = comment
     }
 
     public override func sendPassiveNavigationStart() {

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -445,6 +445,8 @@ class NavigationServiceTests: TestCase {
         service.endNavigation(feedback: feedback)
 
         XCTAssertTrue(eventsManager.sendCancelEventCalled)
+        XCTAssertEqual(eventsManager.passedRating, 5)
+        XCTAssertEqual(eventsManager.passedComment, "comment")
         XCTAssertTrue(locationManager.stopUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.stopUpdatingLocationCalled)
 
@@ -477,6 +479,10 @@ class NavigationServiceTests: TestCase {
         service.endNavigation(feedback: feedback)
 
         XCTAssertTrue(eventsManager.sendCancelEventCalled)
+        XCTAssertEqual(eventsManager.passedRating, 5)
+        XCTAssertEqual(eventsManager.passedComment, "comment")
+        XCTAssertEqual(eventsManager.passedRating, 5)
+        XCTAssertEqual(eventsManager.passedComment, "comment")
         XCTAssertTrue(locationManager.stopUpdatingHeadingCalled)
         XCTAssertTrue(locationManager.stopUpdatingLocationCalled)
 

--- a/Tests/MapboxCoreNavigationTests/Telemetry/NavigationCommonEventsManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/Telemetry/NavigationCommonEventsManagerTests.swift
@@ -103,18 +103,18 @@ class NavigationCommonEventsManagerTests: TestCase {
 
     func testNoCancelEventIfNoDatasource() {
         eventManager.activeNavigationDataSource = nil
-        eventManager.sendCancelEvent()
+        eventManager.sendCancelEvent(rating: 5, comment: "comment")
         XCTAssertFalse(eventsAPI.hasQueuedEvent(with: EventType.cancel.rawValue))
     }
 
     func testSendCancelEventIfDelaysFlushing() {
-        eventManager.sendCancelEvent()
+        eventManager.sendCancelEvent(rating: 5, comment: "comment")
         XCTAssertTrue(eventsAPI.hasQueuedEvent(with: EventType.cancel.rawValue))
     }
 
     func testSendCancelEventIfDoesNotDelayFlushing() {
         eventManager.delaysEventFlushing = false
-        eventManager.sendCancelEvent()
+        eventManager.sendCancelEvent(rating: 5, comment: "comment")
         XCTAssertTrue(eventsAPI.hasImmediateEvent(with: EventType.cancel.rawValue))
     }
 

--- a/Tests/MapboxCoreNavigationTests/Telemetry/NavigationEventsManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/Telemetry/NavigationEventsManagerTests.swift
@@ -10,6 +10,7 @@ final class NavigationCommonEventsManagerSpy: NavigationCommonEventsManager {
     var sendPassiveNavigationFeedbackCalled = false
     var sendCarPlayConnectEventCalled = false
     var sendCarPlayDisconnectEventCalled = false
+    var sendCancelEventCalled = false
 
     var passedFeedbackEvent: FeedbackEvent?
     var passedSource: FeedbackSource?
@@ -17,6 +18,8 @@ final class NavigationCommonEventsManagerSpy: NavigationCommonEventsManager {
     var passedPassiveNavigationType: PassiveNavigationFeedbackType?
     var passedDescription: String?
     var passedCompletionHandler: UserFeedbackCompletionHandler?
+    var passedRating: Int?
+    var passedComment: String?
 
     var returnedFeedbackEvent: FeedbackEvent? = Fixture.createFeedbackEvent()
 
@@ -57,6 +60,12 @@ final class NavigationCommonEventsManagerSpy: NavigationCommonEventsManager {
 
     override func sendCarPlayDisconnectEvent() {
         sendCarPlayDisconnectEventCalled = true
+    }
+
+    override func sendCancelEvent(rating: Int?, comment: String?) {
+        sendCancelEventCalled = true
+        passedRating = rating
+        passedComment = comment
     }
 }
 
@@ -225,5 +234,13 @@ class NavigationEventsManagerTests: TestCase {
         let event = eventManager.createFeedback()
         XCTAssertEqual(navNativeEventsManager?.createFeedbackCalled, true)
         XCTAssertNotNil(event)
+    }
+
+    func testSendCancelNavigationEventIfDefault() {
+        configureEventsManager(useNavNative: false)
+        eventManager.sendCancelEvent(rating: 5, comment: "comment")
+        XCTAssertEqual(commonEventsManager?.sendCancelEventCalled, true)
+        XCTAssertEqual(commonEventsManager?.passedRating, 5)
+        XCTAssertEqual(commonEventsManager?.passedComment, "comment")
     }
 }


### PR DESCRIPTION
### Description
Fix non sent parameters for 'navigation.cancel' telemetry event