### PR TITLE
Weekly snapshot pipeline refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,28 @@ commands:
           name: Install Dependencies
           command: carthage bootstrap --platform ios --cache-builds --configuration Debug --use-netrc --use-xcframeworks
 
+  pre-snapshot-check:
+    steps:
+      - run:
+          name: Pre-snapshot check
+          command: |
+            export GITHUB_TOKEN=$(./mbx-ci github writer private token)
+            python3 scripts/snapshot/pre-snapshot-check.py
+
+  prepare-snapshot:
+    steps:
+      - run:
+          name: Prepare snapshot
+          command: |
+            export GITHUB_TOKEN=$(./mbx-ci github writer private token)
+            python3 scripts/snapshot/prepare-snapshot.py
+
+  trigger-onetap:
+    steps:
+      - run:
+          name: Trigger onetap
+          command: python3 scripts/snapshot/trigger-onetap.py
+
 step-library:
   - &restore-cache
       restore_cache:
@@ -728,6 +750,31 @@ jobs:
       - *save-cache-podmaster
       - *save-cache-gems
 
+  pre-snapshot-check:
+    parameters:
+      xcode:
+        type: string
+        default: "13.4.1"
+    macos:
+      xcode: << parameters.xcode >>
+    steps:
+      - checkout
+      - install-mbx-ci
+      - pre-snapshot-check
+
+  release-weekly-snapshot:
+    parameters:
+      xcode:
+        type: string
+        default: "13.4.1"
+    macos:
+      xcode: << parameters.xcode >>
+    steps:
+      - checkout
+      - install-mbx-ci
+      - prepare-snapshot
+      - trigger-onetap
+
 workflows:
   extended-workflow:
     jobs:
@@ -877,3 +924,25 @@ workflows:
           filters:
             branches:
               only: /^trigger-distribute-version-.*/
+  weekly-snapshot-workflow:
+    # Run workflow every Friday at 23:59 UTC
+    triggers:
+      - schedule:
+          cron: "59 23 * * 5"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - release-weekly-snapshot
+  pre-snapshot-workflow:
+    # Run workflow every Thursday at 23:59 UTC
+    triggers:
+      - schedule:
+          cron: "59 23 * * 4"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - pre-snapshot-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,8 @@ commands:
       - run:
           name: Pre-snapshot check
           command: |
-            export GITHUB_TOKEN=$(./mbx-ci github writer private token)
+            export GITHUB_TOKEN=$(mbx-ci github writer private token)
+            pip3 install requests
             python3 scripts/snapshot/pre-snapshot-check.py
 
   prepare-snapshot:
@@ -165,14 +166,20 @@ commands:
       - run:
           name: Prepare snapshot
           command: |
-            export GITHUB_TOKEN=$(./mbx-ci github writer private token)
+            export GITHUB_TOKEN=$(mbx-ci github writer private token)
+            git remote set-url origin "https://x-access-token:$(mbx-ci github writer public token)@github.com/mapbox/mapbox-navigation-ios.git"
+            git config user.email "release-bot@mapbox.com"
+            git config user.name "Mapbox Releases"
+            pip3 install requests
             python3 scripts/snapshot/prepare-snapshot.py
 
   trigger-onetap:
     steps:
       - run:
           name: Trigger onetap
-          command: python3 scripts/snapshot/trigger-onetap.py
+          command: |
+            pip3 install requests
+            python3 scripts/snapshot/trigger-onetap.py
 
 step-library:
   - &restore-cache

--- a/scripts/snapshot/pre-snapshot-check.py
+++ b/scripts/snapshot/pre-snapshot-check.py
@@ -1,0 +1,61 @@
+import json
+import os
+
+import requests
+
+from utils import is_snapshot_week, get_dependency_version, get_latest_tag, get_snapshot_branch
+
+github_token = os.getenv("GITHUB_TOKEN")
+headers = {"Authorization": "Bearer " + github_token}
+
+
+def build_message():
+    message = '@navigation-ios '
+
+    releases_url = "https://api.github.com/repos/mapbox/mapbox-navigation-ios/releases"
+    releases = requests.get(releases_url).json()
+    if is_snapshot_week(releases):
+        message += 'Navigation SDK snapshot must be released today (rc or GA release was not released this week).\n'
+    else:
+        message += 'Navigation SDK snapshot must not be released today (rc or GA release was released this week).\n'
+        return message
+
+    maps_releases = requests.get(
+        'https://api.github.com/repos/mapbox/mapbox-maps-ios/releases',
+        headers=headers
+    ).json()
+    maps_version = get_dependency_version(maps_releases)
+    if maps_version:
+        message += ':white_check_mark: Maps ' + maps_version + ' is ready.\n'
+    else:
+        message += ':siren: Expected Maps release was not released.\n'
+
+    nav_native_releases = requests.get(
+        'https://api.github.com/repos/mapbox/mapbox-navigation-native/releases',
+        headers=headers
+    ).json()
+    nav_native_version = get_dependency_version(nav_native_releases)
+    if nav_native_version:
+        message += ':white_check_mark: Nav Native ' + nav_native_version + ' is ready.\n'
+    else:
+        message += ':siren: Expected Nav Native release was not released.\n'
+
+    tags = requests.get('https://api.github.com/repos/mapbox/mapbox-navigation-ios/git/refs/tags').json()
+    latest_tag = get_latest_tag(tags)
+    snapshot_branch = get_snapshot_branch(latest_tag)
+
+    message += 'Snapshot branch is *' + snapshot_branch + '*.\n'
+
+    message += '*Release time is today night.*\n'
+
+    return message
+
+
+def send_message(message):
+    payload = {'text': message, 'link_names': 1}
+    slack_url = os.getenv("SLACK_WEBHOOK")
+    requests.post(slack_url, data=json.dumps(payload))
+
+
+message = build_message()
+send_message(message)

--- a/scripts/snapshot/prepare-snapshot.py
+++ b/scripts/snapshot/prepare-snapshot.py
@@ -20,12 +20,12 @@ latest_tag = get_latest_tag(tags)
 print('Latest no-patch release is ' + latest_tag)
 
 snapshot_base_branch = get_snapshot_branch(latest_tag)
-print('Snapshot branch is ' + snapshot_base_branch)
+print('Snapshot base branch is ' + snapshot_base_branch)
 subprocess.run("git checkout " + snapshot_base_branch, shell=True, check=True)
 
 snapshot_branch = 'snapshot_' + str(datetime.date.today())
-print(snapshot_branch)
-subprocess.run("git checkout -b " + snapshot_base_branch, shell=True, check=True)
+print('Snapshot branch is ' + snapshot_branch)
+subprocess.run("git checkout -b " + snapshot_branch, shell=True, check=True)
 
 maps_releases = requests.get(
     'https://api.github.com/repos/mapbox/mapbox-maps-android-internal/releases',

--- a/scripts/snapshot/prepare-snapshot.py
+++ b/scripts/snapshot/prepare-snapshot.py
@@ -1,0 +1,45 @@
+import datetime
+import os
+import subprocess
+import sys
+
+import requests
+
+from utils import get_latest_tag, get_snapshot_branch, is_snapshot_week, get_dependency_version
+
+github_token = os.getenv("GITHUB_TOKEN")
+headers = {"Authorization": "Bearer " + github_token}
+
+releases = requests.get('https://api.github.com/repos/mapbox/mapbox-navigation-android/releases').json()
+if not is_snapshot_week(releases):
+    print('Navigation SDK snapshot must not be released today (rc or GA release was released this week).')
+    sys.exit(1)
+
+tags = requests.get('https://api.github.com/repos/mapbox/mapbox-navigation-android/git/refs/tags').json()
+latest_tag = get_latest_tag(tags)
+print('Latest no-patch release is ' + latest_tag)
+
+snapshot_base_branch = get_snapshot_branch(latest_tag)
+print('Snapshot branch is ' + snapshot_base_branch)
+subprocess.run("git checkout " + snapshot_base_branch, shell=True, check=True)
+
+snapshot_branch = 'snapshot_' + str(datetime.date.today())
+print(snapshot_branch)
+subprocess.run("git checkout -b " + snapshot_base_branch, shell=True, check=True)
+
+maps_releases = requests.get(
+    'https://api.github.com/repos/mapbox/mapbox-maps-android-internal/releases',
+    headers=headers
+).json()
+maps_version = get_dependency_version(maps_releases)
+
+nav_native_releases = requests.get(
+    'https://api.github.com/repos/mapbox/mapbox-navigation-native/releases',
+    headers=headers
+).json()
+nav_native_version = get_dependency_version(nav_native_releases)
+
+# TODO update dependencies
+
+subprocess.run('git add . && git commit -m "Bump dependencies" && git push -u origin ' + snapshot_branch, shell=True,
+               check=True)

--- a/scripts/snapshot/trigger-onetap.py
+++ b/scripts/snapshot/trigger-onetap.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import datetime
+import json
+import os
+import sys
+
+import requests
+
+token = os.getenv("CIRCLE_TOKEN")
+
+if token is None:
+    print("Error triggering because CIRCLE_TOKEN is not set")
+    sys.exit(1)
+
+snapshot_branch = 'snapshot_' + str(datetime.date.today())
+print("Snapshot branch " + snapshot_branch)
+
+url = "https://circleci.com/api/v2/project/github/mapbox/1tap-ios/pipeline"
+
+headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
+
+data = {
+    "parameters": {
+        "run_weekly_snapshot": True,
+        "navigation_sdk_snapshot_branch": snapshot_branch
+    }
+}
+
+response = requests.post(url, auth=(token, ""), headers=headers, json=data)
+
+if response.status_code != 201 and response.status_code != 200:
+    print("Error triggering the CircleCI: %s." % response.json()["message"])
+    sys.exit(1)
+else:
+    response_dict = json.loads(response.text)
+    print("Started run_weekly_snapshot: %s" % response_dict)

--- a/scripts/snapshot/utils-tests.py
+++ b/scripts/snapshot/utils-tests.py
@@ -1,0 +1,132 @@
+import unittest
+
+from freezegun import freeze_time
+
+import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_get_latest_tag(self):
+        tags = [
+            {'ref': 'refs/tags/v2.12.0-beta.3'},
+            {'ref': 'refs/tags/v2.12.0-rc.1'},
+            {'ref': 'refs/tags/androidauto-v0.22.0'},
+            {'ref': 'refs/tags/v2.11.1'},
+        ]
+        self.assertEqual(utils.get_latest_tag(tags), 'v2.12.0-rc.1')
+
+    def test_get_snapshot_branch_with_latest_alpha_tag(self):
+        self.assertEqual(utils.get_snapshot_branch('v2.12.0-alpha.1'), 'main')
+
+    def test_get_snapshot_branch_with_latest_beta_tag(self):
+        self.assertEqual(utils.get_snapshot_branch('v2.12.0-beta.1'), 'main')
+
+    def test_get_snapshot_branch_with_latest_rc_tag(self):
+        self.assertEqual(utils.get_snapshot_branch('v2.12.0-rc.1'), 'release-v2.12')
+
+    def test_get_snapshot_branch_with_latest_stable_tag(self):
+        self.assertEqual(utils.get_snapshot_branch('v2.12.0'), 'main')
+
+    def test_is_rc_or_ga_true_rc(self):
+        self.assertEqual(utils.is_rc_or_ga('v1.1.0-rc.100'), True)
+
+    def test_is_rc_or_ga_true_ga(self):
+        self.assertEqual(utils.is_rc_or_ga('v1.1.0'), True)
+
+    def test_is_rc_or_ga_false_beta(self):
+        self.assertEqual(utils.is_rc_or_ga('v1.1.0-beta.123'), False)
+
+    def test_is_patch_true(self):
+        self.assertEqual(utils.is_patch('v1.1.100'), True)
+
+    def test_is_patch_false_ga(self):
+        self.assertEqual(utils.is_patch('v1.1.0'), False)
+
+    def test_is_patch_false_rc(self):
+        self.assertEqual(utils.is_patch('v1.1.0-rc.1'), False)
+
+    @freeze_time("2023-04-14")
+    def test_is_current_week_true(self):
+        self.assertEqual(utils.is_current_week('2023-04-12T12:24:15Z'), True)
+
+    @freeze_time("2023-04-14")
+    def test_is_current_week_false(self):
+        self.assertEqual(utils.is_current_week('2023-03-12T12:24:15Z'), False)
+
+    @freeze_time("2023-04-14")
+    def test_is_snapshot_week_alpha_true(self):
+        releases = [
+            {'name': '1.1.0-alpha.1', 'created_at': '2023-04-12T12:24:15Z'},
+            {'name': '1.0.0', 'created_at': '2023-04-02T12:24:15Z'},
+        ]
+        self.assertEqual(utils.is_snapshot_week(releases), True)
+
+    @freeze_time("2023-04-14")
+    def test_is_snapshot_week_beta_true(self):
+        releases = [
+            {'name': '1.1.0-beta.1', 'created_at': '2023-04-12T12:24:15Z'},
+            {'name': '1.0.0', 'created_at': '2023-04-02T12:24:15Z'},
+            {'name': '1.0.0-rc.1', 'created_at': '2023-04-01T12:24:15Z'},
+        ]
+        self.assertEqual(utils.is_snapshot_week(releases), True)
+
+    @freeze_time("2023-04-14")
+    def test_is_snapshot_week_patch_true(self):
+        releases = [
+            {'name': '1.1.1', 'created_at': '2023-04-12T12:24:15Z'},
+            {'name': '2.0.0', 'created_at': '2023-04-02T12:24:15Z'},
+        ]
+        self.assertEqual(utils.is_snapshot_week(releases), True)
+
+    @freeze_time("2023-04-14")
+    def test_is_snapshot_week_rc_false(self):
+        releases = [
+            {'name': '1.1.0-rc.1', 'created_at': '2023-04-12T12:24:15Z'},
+            {'name': '1.0.0', 'created_at': '2023-04-02T12:24:15Z'},
+        ]
+        self.assertEqual(utils.is_snapshot_week(releases), False)
+
+    @freeze_time("2023-04-14")
+    def test_is_snapshot_week_ga_false(self):
+        releases = [
+            {'name': '1.1.0', 'created_at': '2023-04-12T12:24:15Z'},
+            {'name': '1.0.0', 'created_at': '2023-04-02T12:24:15Z'},
+        ]
+        self.assertEqual(utils.is_snapshot_week(releases), False)
+
+    @freeze_time("2023-04-14")
+    def test_get_dependency_version_beta(self):
+        releases = [
+            {'name': '1.2.0-beta.1-private', 'created_at': '2023-04-13T12:24:15Z'},
+            {'name': '1.1.0-beta.1', 'created_at': '2023-04-12T12:24:15Z'},
+        ]
+        self.assertEqual(utils.get_dependency_version(releases), '1.1.0-beta.1')
+
+    @freeze_time("2023-04-14")
+    def test_get_dependency_version_rc(self):
+        releases = [
+            {'name': '1.1.1', 'created_at': '2023-04-13T12:24:15Z'},
+            {'name': '1.1.0-rc.1', 'created_at': '2023-04-12T12:24:15Z'},
+        ]
+        self.assertEqual(utils.get_dependency_version(releases), '1.1.0-rc.1')
+
+    @freeze_time("2023-04-14")
+    def test_get_dependency_version_ga(self):
+        releases = [
+            {'name': '1.2.0', 'created_at': '2023-04-12T12:24:15Z'},
+            {'name': '1.1.0', 'created_at': '2023-04-03T12:24:15Z'},
+        ]
+        self.assertEqual(utils.get_dependency_version(releases), '1.2.0')
+
+    @freeze_time("2023-04-14")
+    def test_get_dependency_version_no_release(self):
+        releases = [
+            {'name': '1.2.0-beta.1-private', 'created_at': '2023-03-13T12:24:15Z'},
+            {'name': '1.1.0-beta.1', 'created_at': '2023-03-12T12:24:15Z'},
+        ]
+        self.assertEqual(utils.get_dependency_version(releases), None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/snapshot/utils.py
+++ b/scripts/snapshot/utils.py
@@ -1,0 +1,50 @@
+import datetime
+
+
+def is_rc_or_ga(release_name):
+    return 'rc' in release_name or release_name.endswith('.0')
+
+
+def is_patch(release_name):
+    return not ('alpha' in release_name or 'beta' in release_name or 'rc' in release_name or release_name.endswith(
+        '.0'))
+
+
+def is_current_week(release_created_date):
+    created_date = datetime.date.fromisoformat(release_created_date.partition('T')[0])
+    today = datetime.date.today()
+    return created_date + datetime.timedelta(days=5) > today
+
+
+def is_snapshot_week(releases):
+    for release in releases:
+        if is_current_week(release['created_at']) and is_rc_or_ga(release['name']):
+            return False
+    return True
+
+
+def get_dependency_version(releases):
+    for release in releases:
+        if is_current_week(release['created_at']) and not is_patch(
+                release['name']) and not ('private' in release['name']):
+            return release['name'].replace('v', '')
+    return None
+
+
+def get_latest_tag(tags):
+    for tag in reversed(tags):
+        tag_name = tag['ref'].replace('refs/tags/', '')
+        if tag_name.startswith('v') and tag_name.partition('-')[0].endswith('.0'):
+            return tag_name
+
+
+# latest tag alpha - future version alpha or beta - main branch
+# latest tag beta - future version beta or rc - main branch
+# latest tag rc - future version rc or stable - release branch
+# latest tag stable - future version alpha or beta - main branch
+def get_snapshot_branch(latest_tag):
+    if 'beta' in latest_tag or 'alpha' in latest_tag \
+            or ('rc' not in latest_tag and 'beta' not in latest_tag and 'alpha' not in latest_tag):
+        return 'main'
+    else:
+        return 'release-' + latest_tag.partition('.0')[0]


### PR DESCRIPTION
# How it worked before
Every Friday-Saturday night CI build 1tap snapshot with release or main branch of Nav SDK

# New workflow
## 1. Every Thursday-Friday night CI makes checks about snapshot build
- Check that now is snapshot week. Snapshot week - is a week without RC or GA releases
- Check that Maps SDK was released this week
- Check that Nav Native SDK was released this week
- Check on which branch snapshot will be built

## After checks generate a message:

### This week is not snapshot week
<img width="704" alt="Screenshot 2023-04-18 at 14 23 12" src="https://user-images.githubusercontent.com/25399022/232708232-657e9f07-b32a-4b2e-a10f-aadddd5a15c3.png">

### This week is snapshot week
<img width="716" alt="Screenshot 2023-04-18 at 14 23 29" src="https://user-images.githubusercontent.com/25399022/232708120-9e0570d4-6f4d-421f-8dce-68b7b26b192f.png">

If release manager notice a problem with dependencies they will have a day to fix it.

## 2. Every Friday-Saturday night CI build snapshot if it is a snapshot week (week without RC or GA releases)
- Checkout release or main branch
- Create a snapshot branch
- Get the latest no patch no private release Maps SDK on this week and update
- Get the latest no patch release Nav Native SDK on this week and update
- Build 1tap with this snapshot branch

https://mapbox.atlassian.net/wiki/spaces/NAVSDK/pages/206864394/Nav+SDK+v2+Release+Cadence