### PR TITLE
 Add support for NN startNavigationSession/stopNavigationSession methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * Fixed an issue with route callouts being slightly displaced. ([#4427](https://github.com/mapbox/mapbox-navigation-ios/pull/4427))
 
+### Other changes
+
+* Added support for Native Telemetry `Navigator.startNavigationSession()` and `Navigator.stopNavigationSession()` for correct report of navigation session type to telemetry. ([#4435](https://github.com/mapbox/mapbox-navigation-ios/pull/4435))
+
 ## v2.12.0
 
 ### Packaging

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.4.0"
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "130.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "131.0.0"
 github "mapbox/mapbox-directions-swift" "v2.11.0-rc.1"
 github "mapbox/mapbox-events-ios" "v1.0.10"
 github "mapbox/turf-swift" "v2.6.1"

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
-          "version": "2.1.1"
+          "revision": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+          "version": "2.1.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-          "version": "2.1.0"
+          "revision": "a23ded2c91df9156628a6996ab4f347526f17b6b",
+          "version": "2.1.2"
         }
       },
       {

--- a/MapboxNavigation.xcodeproj/project.pbxproj
+++ b/MapboxNavigation.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		2C36D9022952256400EE37DF /* RouteProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C36D8FF2952256400EE37DF /* RouteProgressTests.swift */; };
 		2C4093B5292661FD0099FA0E /* RouteParserSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */; };
 		2C484CDA2979AD6F00EAAE78 /* EventsMetadataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C484CD92979AD6F00EAAE78 /* EventsMetadataProviderTests.swift */; };
+		2C4D0A2E29F6DC900063BF52 /* NavigationSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4D0A2D29F6DC900063BF52 /* NavigationSessionManager.swift */; };
 		2C585157292521C20077A558 /* MapboxCoreNavigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5ADFBC91DDCC7840011824B /* MapboxCoreNavigation.framework */; };
 		2C58515F292523670077A558 /* RouteControllerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */; };
 		2C585164292530AF0077A558 /* TestHelper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35CDA85E2190F2A30072B675 /* TestHelper.framework */; };
@@ -151,6 +152,8 @@
 		2CE89C2B299E6C2A000A2E34 /* InterchangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE89C2A299E6C2A000A2E34 /* InterchangeTests.swift */; };
 		2CE89C2D299E6D09000A2E34 /* JunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE89C2C299E6D09000A2E34 /* JunctionTests.swift */; };
 		2CE89C2F299E6E08000A2E34 /* RoadObjectKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE89C2E299E6E08000A2E34 /* RoadObjectKindTests.swift */; };
+		2CEC5C5629F71714001B5EC2 /* NavigationSessionManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEC5C5529F71714001B5EC2 /* NavigationSessionManagerSpy.swift */; };
+		2CEC5C5829F71D9A001B5EC2 /* NavigationSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEC5C5729F71D9A001B5EC2 /* NavigationSessionManagerTests.swift */; };
 		2CF3F8CB2926D3E600BB2B9C /* URLCacheSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF3F8CA2926D3E600BB2B9C /* URLCacheSpy.swift */; };
 		2CF3F8CD2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */; };
 		2CF5F5CA298155EC00B34C8C /* NavigationNativeEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF5F5C82981500E00B34C8C /* NavigationNativeEventsManagerTests.swift */; };
@@ -803,6 +806,7 @@
 		2C36D8FF2952256400EE37DF /* RouteProgressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteProgressTests.swift; sourceTree = "<group>"; };
 		2C4093B4292661FD0099FA0E /* RouteParserSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteParserSpy.swift; sourceTree = "<group>"; };
 		2C484CD92979AD6F00EAAE78 /* EventsMetadataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsMetadataProviderTests.swift; sourceTree = "<group>"; };
+		2C4D0A2D29F6DC900063BF52 /* NavigationSessionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationSessionManager.swift; sourceTree = "<group>"; };
 		2C585153292521C20077A558 /* MapboxCoreNavigationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxCoreNavigationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C58515E292523670077A558 /* RouteControllerIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteControllerIntegrationTests.swift; sourceTree = "<group>"; };
 		2C58516229252FE20077A558 /* MapboxCoreNavigationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxCoreNavigationIntegrationTests.swift; sourceTree = "<group>"; };
@@ -844,6 +848,8 @@
 		2CE89C2A299E6C2A000A2E34 /* InterchangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterchangeTests.swift; sourceTree = "<group>"; };
 		2CE89C2C299E6D09000A2E34 /* JunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JunctionTests.swift; sourceTree = "<group>"; };
 		2CE89C2E299E6E08000A2E34 /* RoadObjectKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadObjectKindTests.swift; sourceTree = "<group>"; };
+		2CEC5C5529F71714001B5EC2 /* NavigationSessionManagerSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationSessionManagerSpy.swift; sourceTree = "<group>"; };
+		2CEC5C5729F71D9A001B5EC2 /* NavigationSessionManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationSessionManagerTests.swift; sourceTree = "<group>"; };
 		2CF3F8CA2926D3E600BB2B9C /* URLCacheSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCacheSpy.swift; sourceTree = "<group>"; };
 		2CF3F8CC2926D5DE00BB2B9C /* BimodalImageCacheSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BimodalImageCacheSpy.swift; sourceTree = "<group>"; };
 		2CF5F5C82981500E00B34C8C /* NavigationNativeEventsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationNativeEventsManagerTests.swift; sourceTree = "<group>"; };
@@ -1571,6 +1577,7 @@
 		2C484CD82979AD5C00EAAE78 /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				2CEC5C5729F71D9A001B5EC2 /* NavigationSessionManagerTests.swift */,
 				2C856453297B1884006EFCBB /* NavigationCommonEventsManagerTests.swift */,
 				162039CE216C348500875F5C /* NavigationEventsManagerTests.swift */,
 				2C484CD92979AD6F00EAAE78 /* EventsMetadataProviderTests.swift */,
@@ -1599,6 +1606,7 @@
 		2C856447297AD64C006EFCBB /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				2C4D0A2D29F6DC900063BF52 /* NavigationSessionManager.swift */,
 				2C18A12D2988729C00750CEE /* EventStep.swift */,
 				2C18A12B29886F8C00750CEE /* EventFixLocation.swift */,
 				2C856450297AE0A6006EFCBB /* NavigationEventsManager.swift */,
@@ -2221,6 +2229,7 @@
 		B47C1ACE261FD0A30078546C /* TestHelper */ = {
 			isa = PBXGroup;
 			children = (
+				2CEC5C5529F71714001B5EC2 /* NavigationSessionManagerSpy.swift */,
 				2CA61049297EF6D9003E49A7 /* System */,
 				2C2880A2291AB7240063E5B7 /* NavNative */,
 				2C9006C9291927850012CCEA /* DummyRoute.swift */,
@@ -3487,6 +3496,7 @@
 				E23A76C62715E76A0098C23C /* ReplayLocationManager+TestSupport.swift in Sources */,
 				B47C1B59261FD3B70078546C /* DummyLocationManager.swift in Sources */,
 				B456A8EC2620D26B00FD86D8 /* LeakTest.swift in Sources */,
+				2CEC5C5629F71714001B5EC2 /* NavigationSessionManagerSpy.swift in Sources */,
 				B47C1B1E261FD3290078546C /* CoreLocation.swift in Sources */,
 				E2F08C70269DB17C002EFDC5 /* AccessToken.swift in Sources */,
 				2C9006CA291927850012CCEA /* RoutingProviderSpy.swift in Sources */,
@@ -3575,6 +3585,7 @@
 				118D883826F8CA0700B2ED7B /* PassiveNavigationFeedbackType.swift in Sources */,
 				2BBED92F265E2C7D00F90032 /* NativeHandlersFactory.swift in Sources */,
 				4303A3992332CD6200B5737D /* UnimplementedLogging.swift in Sources */,
+				2C4D0A2E29F6DC900063BF52 /* NavigationSessionManager.swift in Sources */,
 				2C295ACA299BF76000FC74E8 /* Junction.swift in Sources */,
 				2E6656F9264EC912009463EE /* Result+Expected.swift in Sources */,
 				8A7B69922947AA0F00FFC3F5 /* AmenityType.swift in Sources */,
@@ -3657,6 +3668,7 @@
 				E23D8B6B269D7EE90094CEFA /* TilesetDescriptorFactoryTests.swift in Sources */,
 				2C36D9002952256400EE37DF /* RouteLegProgressTests.swift in Sources */,
 				2CA6105429802ACF003E49A7 /* MonitorConnectivityTypeProviderTests.swift in Sources */,
+				2CEC5C5829F71D9A001B5EC2 /* NavigationSessionManagerTests.swift in Sources */,
 				2C36D9012952256400EE37DF /* RouteStepProgressTests.swift in Sources */,
 				359A8AED1FA78D3000BDB486 /* DistanceFormatterTests.swift in Sources */,
 				5A43FC8B24B488DC00BF7943 /* PassiveLocationManagerTests.swift in Sources */,

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -365,7 +365,6 @@ final class Navigator: CoreNavigator {
     
     deinit {
         unsubscribeNavigator()
-        
     }
 }
 

--- a/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
+++ b/Sources/MapboxCoreNavigation/CoreNavigationNavigator.swift
@@ -116,7 +116,7 @@ final class Navigator: CoreNavigator {
                     completion(.failure(NavigatorError.failedToUpdateRoutes(reason: "Unexpected internal response")))
                 }
             }
-        }, alternativeRoutesSetupHandler: {[weak self] routes, completion in
+        }, alternativeRoutesSetupHandler: { [weak self] routes, completion in
             self?.navigator.setAlternativeRoutesForRoutes(routes, callback: { result in
                 if result.isValue(),
                    let alternatives = result.value as? [RouteAlternative] {
@@ -152,7 +152,7 @@ final class Navigator: CoreNavigator {
     static var isSharedInstanceCreated: Bool {
         _navigator != nil
     }
-    
+
     private static weak var _navigator: Navigator?
     
     /**
@@ -195,6 +195,7 @@ final class Navigator: CoreNavigator {
      */
     func restartNavigator(forcing version: String? = nil) {
         unsubscribeNavigator()
+        let previousNavigationSessionState = navigator.storeNavigationSession()
         navigator.shutdown()
         
         let factory = NativeHandlersFactory(tileStorePath: NavigationSettings.shared.tileStoreConfiguration.navigatorLocation.tileStoreURL?.path ?? "",
@@ -211,7 +212,8 @@ final class Navigator: CoreNavigator {
         roadObjectStore.native = navigator.roadObjectStore()
         roadObjectMatcher.native = MapboxNavigationNative.RoadObjectMatcher(cache: cacheHandle)
         rerouteController = RerouteController(navigator, config: NativeHandlersFactory.configHandle())
-        
+
+        navigator.restoreNavigationSession(for: previousNavigationSessionState)
         subscribeNavigator()
         setupAlternativesControllerIfNeeded()
     }
@@ -363,6 +365,7 @@ final class Navigator: CoreNavigator {
     
     deinit {
         unsubscribeNavigator()
+        
     }
 }
 

--- a/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/PassiveLocationManager.swift
@@ -62,6 +62,8 @@ open class PassiveLocationManager: NSObject {
     }()
 
     private let navigatorType: CoreNavigator.Type
+
+    private let navigationSessionManager: NavigationSessionManager
     
     /**
      The underlying navigator that performs map matching.
@@ -260,10 +262,12 @@ open class PassiveLocationManager: NSObject {
          eventsManagerType: NavigationEventsManager.Type?,
          userInfo: [String: String?]?,
          datasetProfileIdentifier: ProfileIdentifier?,
-         navigatorType: CoreNavigator.Type) {
+         navigatorType: CoreNavigator.Type,
+         navigationSessionManager: NavigationSessionManager) {
         self.navigatorType = navigatorType
         self.directions = directions
         self.systemLocationManager = systemLocationManager
+        self.navigationSessionManager = navigationSessionManager
 
         super.init()
 
@@ -294,6 +298,7 @@ open class PassiveLocationManager: NSObject {
         self.navigatorType = Navigator.self
         self.directions = directions
         self.systemLocationManager = systemLocationManager ?? NavigationLocationManager()
+        self.navigationSessionManager = NavigationSessionManagerImp.shared
 
         super.init()
 
@@ -326,10 +331,12 @@ open class PassiveLocationManager: NSObject {
         subscribeNotifications()
 
         BillingHandler.shared.beginBillingSession(for: .freeDrive, uuid: sessionUUID)
+        navigationSessionManager.reportStartNavigation()
     }
     
     deinit {
         BillingHandler.shared.stopBillingSession(with: sessionUUID)
+        navigationSessionManager.reportStopNavigation()
         eventsManager.withBackupDataSource(active: nil, passive: self) {
             if self.rawLocation != nil {
                 self.eventsManager.sendPassiveNavigationStop()

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -242,6 +242,7 @@ open class RouteController: NSObject {
 
     private let navigatorType: CoreNavigator.Type
     private let routeParserType: RouteParser.Type
+    private let navigationSessionManager: NavigationSessionManager
 
     var navigator: MapboxNavigationNative.Navigator {
         return sharedNavigator.navigator
@@ -369,6 +370,7 @@ open class RouteController: NSObject {
     public func finishRouting() {
         guard !hasFinishedRouting else { return }
         hasFinishedRouting = true
+        navigationSessionManager.reportStopNavigation()
         removeRoutes(completion: nil)
         BillingHandler.shared.stopBillingSession(with: sessionUUID)
         unsubscribeNotifications()
@@ -658,6 +660,7 @@ open class RouteController: NSObject {
 
         self.navigatorType = Navigator.self
         self.routeParserType = RouteParser.self
+        self.navigationSessionManager = NavigationSessionManagerImp.shared
         self.indexedRouteResponse = indexedRouteResponse
         self.dataSource = source
 
@@ -681,7 +684,8 @@ open class RouteController: NSObject {
          customRoutingProvider: RoutingProvider?,
          dataSource source: RouterDataSource,
          navigatorType: CoreNavigator.Type,
-         routeParserType: RouteParser.Type) {
+         routeParserType: RouteParser.Type,
+         navigationSessionManager: NavigationSessionManager) {
         Self.checkUniqueInstance()
 
         self.navigatorType = navigatorType
@@ -690,6 +694,7 @@ open class RouteController: NSObject {
         self.dataSource = source
         let options = indexedRouteResponse.validatedRouteOptions
         self.routeProgress = RouteProgress(route: indexedRouteResponse.currentRoute!, options: options)
+        self.navigationSessionManager = navigationSessionManager
 
         super.init()
 
@@ -714,6 +719,7 @@ open class RouteController: NSObject {
                         fromLegIndex: 0,
                         reason: .startNewRoute) { [weak self] _ in
             self?.isInitialized = true
+            self?.navigationSessionManager.reportStartNavigation()
         }
     }
     

--- a/Sources/MapboxCoreNavigation/Telemetry/NavigationSessionManager.swift
+++ b/Sources/MapboxCoreNavigation/Telemetry/NavigationSessionManager.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MapboxNavigationNative
+
+protocol NavigationSessionManager {
+    static var shared: Self { get }
+
+    func reportStartNavigation()
+    func reportStopNavigation()
+}
+
+final class NavigationSessionManagerImp: NavigationSessionManager {
+    private let lock: NSLock = .init()
+
+    private var sessionCount: Int = 0
+
+    private let navigatorType: CoreNavigator.Type
+
+    private var navigator: MapboxNavigationNative.Navigator {
+        return navigatorType.shared.navigator
+    }
+
+    func reportStartNavigation() {
+        guard NavigationTelemetryConfiguration.useNavNativeTelemetryEvents else { return }
+
+        var shouldStart = false
+        lock {
+            shouldStart = sessionCount == 0
+            sessionCount += 1
+        }
+        if shouldStart {
+            navigator.startNavigationSession()
+        }
+    }
+
+    func reportStopNavigation() {
+        guard NavigationTelemetryConfiguration.useNavNativeTelemetryEvents else { return }
+
+        var shouldStop = false
+        lock {
+            shouldStop = sessionCount == 1
+            sessionCount = max(sessionCount - 1, 0)
+        }
+        if shouldStop {
+            navigator.stopNavigationSession()
+        }
+    }
+
+    /// Shared manager instance. There is no other instances of `NavigationSessionManager`.
+    static let shared: NavigationSessionManagerImp = .init()
+
+    init(navigatorType: CoreNavigator.Type = Navigator.self) {
+        self.navigatorType = navigatorType
+    }
+}

--- a/Sources/TestHelper/NavNative/NativeNavigatorSpy.swift
+++ b/Sources/TestHelper/NavNative/NativeNavigatorSpy.swift
@@ -19,6 +19,9 @@ public class NativeNavigatorSpy: MapboxNavigationNative.Navigator {
     public var rerouteController: RerouteControllerInterface!
     public var rerouteDetector: RerouteDetectorInterface!
 
+    public var startNavigationSessionCalled = false
+    public var stopNavigationSessionCalled = false
+
     public init() {
         let factory = NativeHandlersFactory(tileStorePath: "", credentials: DirectionsSpy.shared.credentials)
         super.init(config: NativeHandlersFactory.configHandle(),
@@ -69,5 +72,13 @@ public class NativeNavigatorSpy: MapboxNavigationNative.Navigator {
 
     @_implementationOnly public override func getRerouteDetector() -> RerouteDetectorInterface {
         return rerouteDetector ?? RerouteDetectorSpy()
+    }
+
+    public override func startNavigationSession() {
+        startNavigationSessionCalled = true
+    }
+
+    public override func stopNavigationSession() {
+        stopNavigationSessionCalled = true
     }
 }

--- a/Sources/TestHelper/NavigationSessionManagerSpy.swift
+++ b/Sources/TestHelper/NavigationSessionManagerSpy.swift
@@ -1,0 +1,22 @@
+import Foundation
+@testable import MapboxCoreNavigation
+
+public final class NavigationSessionManagerSpy: NavigationSessionManager {
+    public static var shared: NavigationSessionManagerSpy = .init()
+
+    public var reportStartNavigationCalled = false
+    public var reportStopNavigationCalled = false
+
+    public func reportStartNavigation() {
+        reportStartNavigationCalled = true
+    }
+
+    public func reportStopNavigation() {
+        reportStopNavigationCalled = true
+    }
+
+    public func reset() {
+        reportStartNavigationCalled = false
+        reportStopNavigationCalled = false
+    }
+}

--- a/Tests/MapboxCoreNavigationTests/Telemetry/NavigationSessionManagerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/Telemetry/NavigationSessionManagerTests.swift
@@ -1,0 +1,56 @@
+@testable @_spi(MapboxInternal) import MapboxCoreNavigation
+@testable import TestHelper
+import XCTest
+
+final class NavigationSessionManagerTests: TestCase {
+    private var manager: NavigationSessionManager!
+    private var coreNavigator: CoreNavigatorSpy!
+    private var navigator: NativeNavigatorSpy!
+
+    override func setUp() {
+        super.setUp()
+
+        coreNavigator = CoreNavigatorSpy.shared
+        navigator = coreNavigator.navigatorSpy
+        manager = NavigationSessionManagerImp(navigatorType: CoreNavigatorSpy.self)
+        NavigationTelemetryConfiguration.useNavNativeTelemetryEvents = true
+    }
+
+    override func tearDown() {
+        NavigationTelemetryConfiguration.useNavNativeTelemetryEvents = false
+        super.tearDown()
+    }
+
+    func testDoNotStartAndStopIfNonNativeTelemetry() {
+        NavigationTelemetryConfiguration.useNavNativeTelemetryEvents = false
+        manager.reportStopNavigation()
+        manager.reportStartNavigation()
+        XCTAssertFalse(navigator.startNavigationSessionCalled)
+        XCTAssertFalse(navigator.stopNavigationSessionCalled)
+    }
+
+    func testStopSessionIfNotStartedIfNativeTelemetry() {
+        manager.reportStopNavigation()
+        XCTAssertFalse(navigator.stopNavigationSessionCalled, "Should not report stop if not started")
+
+        manager.reportStartNavigation()
+        XCTAssertTrue(navigator.startNavigationSessionCalled)
+        manager.reportStopNavigation()
+        XCTAssertTrue(navigator.stopNavigationSessionCalled)
+    }
+
+    func testStartAndStopSessionIfTwoSessionStartedIfNativeTelemetry() {
+        manager.reportStartNavigation()
+        XCTAssertTrue(navigator.startNavigationSessionCalled, "Should report start if not started")
+
+        navigator.startNavigationSessionCalled = false
+        manager.reportStartNavigation()
+        XCTAssertFalse(navigator.startNavigationSessionCalled, "Should not report start if already started")
+
+        manager.reportStopNavigation()
+        XCTAssertFalse(navigator.stopNavigationSessionCalled, "Should not report stop if more session running")
+
+        manager.reportStopNavigation()
+        XCTAssertTrue(navigator.stopNavigationSessionCalled, "Should report stop if no more session running")
+    }
+}


### PR DESCRIPTION
### Description
Closes [NAVIOS-983](https://mapbox.atlassian.net/browse/NAVIOS-983)

Implemented logic is:
* iOS SDK calls startNavigationSession if the session was not started yet, and either an instance of PassiveLocationManager is created (free drive) or the callback of Navigator.setRoutesData was called (active guidance)
* it calls stopNavigationSession when no more session running (could be deinitialization of PassiveLocationManager or Navigator.setRoutesData(null))
* it calls storeNavigationSession before switching to offline or switching back to online. And SDK calls restoreNavigationSessionForState when switching finished