### PR TITLE
Fix navigation integration tests

### DIFF
--- a/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
+++ b/Tests/MapboxCoreNavigationIntegrationTests/RouteControllerIntegrationTests.swift
@@ -490,6 +490,8 @@ extension MapboxCoreNavigation.RoadObject.Kind {
             return .ic
         case .jct:
             return .jct
+        case .notification:
+            return .notification
         }
     }
 }


### PR DESCRIPTION
### Description
Fixed [the build error](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-ios/11295/workflows/71acceab-2a39-4dab-a6b6-50b20612907a/jobs/109354)
```
RouteControllerIntegrationTests.swift:470:9: error: switch must be exhaustive
        switch self {
```