### PR TITLE
[Cherry-pick][2.13.0] Fix possible crash when Navigator.removeRerouteObserver(for:) was called twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Other changes
 
 * Added support for Native Telemetry `Navigator.startNavigationSession()` and `Navigator.stopNavigationSession()` for correct report of navigation session type to telemetry. ([#4435](https://github.com/mapbox/mapbox-navigation-ios/pull/4435))
+* Fixed a possible crash that could happen while configuring predictive cache before navigation started. ([#4444](https://github.com/mapbox/mapbox-navigation-ios/pull/4444))
 
 ## v2.12.0
 

--- a/Sources/MapboxCoreNavigation/RerouteController.swift
+++ b/Sources/MapboxCoreNavigation/RerouteController.swift
@@ -76,6 +76,7 @@ class RerouteController {
     private var reroutingRequest: NavigationProviderRequest?
     private var latestRouteResponse: (response: RouteResponse, options: RouteOptions)?
     private var isCancelled = false
+    private var isInvalidated = false
     
     private weak var navigator: MapboxNavigationNative.Navigator?
 
@@ -98,6 +99,9 @@ class RerouteController {
     }
 
     func invalidate() {
+        guard !isInvalidated else { return }
+
+        isInvalidated = true
         navigator?.removeRerouteObserver(for: self)
         navigator?.setRerouteControllerForController(defaultRerouteController.nativeInterface)
     }

--- a/Tests/MapboxCoreNavigationTests/RerouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RerouteControllerTests.swift
@@ -140,4 +140,12 @@ final class RerouteControllerTests: TestCase {
         XCTAssertTrue(navigatorSpy.passedRemovedRerouteObserver === rerouteController)
     }
 
+    func testDoNotInvalidateTwice() {
+        rerouteController.invalidate()
+        navigatorSpy.passedRemovedRerouteObserver = nil
+
+        rerouteController.invalidate()
+        XCTAssertNil(navigatorSpy.passedRemovedRerouteObserver)
+    }
+
 }


### PR DESCRIPTION
### Description
Cherry-pick #4444 #4453