### PR TITLE
Time difference callouts fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 ### Other changes
 
 * Optimized performance of route response parsing for reroutes, continuous alternatives and similar use-cases. ([#4462](https://github.com/mapbox/mapbox-navigation-ios/pull/4462))
+* Fixed inconsistent time difference callouts positions for alternative routes. ([#4473](https://github.com/mapbox/mapbox-navigation-ios/pull/4473))
 * Fixed an issue with too high alternative route requests frequency in case of only one route being present in the route response.
-- Fixed an issue with positioning lag in tunnels.
+* Fixed an issue with positioning lag in tunnels.
 
 ## v2.13.0
 

--- a/Sources/MapboxNavigation/NavigationMapView+Annotations.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+Annotations.swift
@@ -112,9 +112,9 @@ extension NavigationMapView {
         
         for (index, alternativeRoute) in routes.enumerated() {
             guard let routeShape = alternativeRoute.indexedRouteResponse.currentRoute?.shape,
-                  let annotationCoordinate = routeShape.indexedCoordinateFromStart(distance: alternativeRoute.infoFromOrigin.distance
-                                                                                   - alternativeRoute.infoFromDeviationPoint.distance
-                                                                                   + continuousAlternativeDurationAnnotationOffset)?.coordinate else {
+                  let annotationCoordinate = routeShape.trimmed(from: alternativeRoute.alternativeRouteIntersection.location,
+                                                                distance: continuousAlternativeDurationAnnotationOffset)?.coordinates.last
+            else {
                 return
             }
             


### PR DESCRIPTION
### Description
Fixed method for picking time diff callout coordinate

### Implementation
Picking exact deviation point coordinate and adding a margin distance instead of calculating route distances.