### PR TITLE
CarPlay alternative routes display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.15.0
+
+### Other changes
+
+* Fixed an issue when starting `NavigationViewController` with injected `NavigationService` (for example via CarPlay) could result in alternative routes not showing on the map. ([#4489](https://github.com/mapbox/mapbox-navigation-ios/pull/4489)) 
+
 ## v2.14.0
 
 ### Packaging

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -275,11 +275,15 @@ class ViewController: UIViewController {
     
     public func beginNavigationWithCarPlay(navigationService: NavigationService) {
         let navigationViewController = activeNavigationViewController ?? self.navigationViewController(navigationService: navigationService)
-        navigationViewController.didConnectToCarPlay()
 
-        guard activeNavigationViewController == nil else { return }
+        guard activeNavigationViewController == nil else {
+            activeNavigationViewController?.didConnectToCarPlay()
+            return
+        }
 
-        presentAndRemoveNavigationMapView(navigationViewController)
+        presentAndRemoveNavigationMapView(navigationViewController) {
+            navigationViewController.didConnectToCarPlay()
+        }
     }
     
     func beginCarPlayNavigation() {

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "972d8117e5a4ced65acf04c7239a4f1d8d5ddcc5",
-          "version": "137.0.0"
+          "revision": "d71a6000e41298afc61cebabf2f5d68d1151d322",
+          "version": "137.1.0"
         }
       },
       {

--- a/Sources/MapboxNavigation/NavigationViewController.swift
+++ b/Sources/MapboxNavigation/NavigationViewController.swift
@@ -491,6 +491,8 @@ open class NavigationViewController: UIViewController, NavigationStatusPresenter
         if usesNightStyleInDarkMode && self.traitCollection.userInterfaceStyle == .dark {
             styleManager.applyStyle(type: .night)
         }
+        
+        updateContinuousAlternatives()
     }
     
     open override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### Description
Added loading continuous alternatives on `NavigationViewController` startup, which previously resulted in showing only the main route when `NavigationService` was created beforehand. Fixed displaying route steps when starting navigation from CarPlay by correctly calling the connection handler