### PR TITLE
Correcting setRoutes reason

### DIFF
--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -148,12 +148,17 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
                             routeOptions: RouteOptions?,
                             completion: ((Bool) -> Void)?) {
         guard !hasFinishedRouting else { return }
-        updateRoute(with: indexedRouteResponse, routeOptions: routeOptions, isProactive: false, completion: completion)
+        updateRoute(with: indexedRouteResponse,
+                    routeOptions: routeOptions,
+                    isProactive: false,
+                    isAlternative: false,
+                    completion: completion)
     }
 
     func updateRoute(with indexedRouteResponse: IndexedRouteResponse,
                      routeOptions: RouteOptions?,
                      isProactive: Bool,
+                     isAlternative: Bool,
                      completion: ((Bool) -> Void)?) {
         guard let route = indexedRouteResponse.currentRoute else {
             preconditionFailure("`indexedRouteResponse` does not contain route for index `\(indexedRouteResponse.routeIndex)` when updating route.")
@@ -502,7 +507,10 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
             case let .success(indexedResponse):
                 let response = indexedResponse.routeResponse
                 guard case let .route(options) = response.options else { return }
-                self.updateRoute(with: indexedResponse, routeOptions: options, isProactive: false) { success in
+                self.updateRoute(with: indexedResponse,
+                                 routeOptions: options,
+                                 isProactive: false,
+                                 isAlternative: false) { success in
                     self.isRerouting = false
                 }
             }

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -317,6 +317,7 @@ protocol InternalRouter: AnyObject {
     func updateRoute(with indexedRouteResponse: IndexedRouteResponse,
                      routeOptions: RouteOptions?,
                      isProactive: Bool,
+                     isAlternative: Bool,
                      completion: ((Bool) -> Void)?)
 }
 
@@ -457,7 +458,8 @@ extension InternalRouter where Self: Router {
                     // Prefer the most optimal route (the first one) over the route that matched the original choice.
                     self.updateRoute(with: indexedResponse,
                                      routeOptions: routeOptions ?? self.routeProgress.routeOptions,
-                                     isProactive: true) { [weak self] success in
+                                     isProactive: true,
+                                     isAlternative: false) { [weak self] success in
                         self?.isRerouting = false
                     }
                 }

--- a/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RouteControllerTests.swift
@@ -706,7 +706,11 @@ class RouteControllerTests: TestCase {
             return
         }
         navigationSessionManagerSpy.reset()
-        routeController.updateRoute(with: response, routeOptions: routeOptions, isProactive: false, completion: nil)
+        routeController.updateRoute(with: response,
+                                    routeOptions: routeOptions,
+                                    isProactive: false,
+                                    isAlternative: false,
+                                    completion: nil)
 
         XCTAssertTrue(navigatorSpy.setRoutesCalled)
         XCTAssertEqual(navigatorSpy.passedUuid, routeController.sessionUUID)
@@ -725,7 +729,11 @@ class RouteControllerTests: TestCase {
     func testUpdateRouteIfShouldNotStartNewBillingSession() {
         let response = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
         routingProvider.returnedRoutesResult = .success(response)
-        routeController.updateRoute(with: response, routeOptions: options, isProactive: false, completion: nil)
+        routeController.updateRoute(with: response,
+                                    routeOptions: options,
+                                    isProactive: false,
+                                    isAlternative: false,
+                                    completion: nil)
 
         XCTAssertTrue(navigatorSpy.setRoutesCalled)
         XCTAssertEqual(navigatorSpy.passedUuid, routeController.sessionUUID)
@@ -743,7 +751,11 @@ class RouteControllerTests: TestCase {
     func testUpdateRouteIfFasterRoute() {
         let response = IndexedRouteResponse(routeResponse: singleRouteResponse, routeIndex: 0)
         routingProvider.returnedRoutesResult = .success(response)
-        routeController.updateRoute(with: response, routeOptions: options, isProactive: true, completion: nil)
+        routeController.updateRoute(with: response,
+                                    routeOptions: options,
+                                    isProactive: true,
+                                    isAlternative: false,
+                                    completion: nil)
 
         XCTAssertTrue(navigatorSpy.setRoutesCalled)
         XCTAssertEqual(navigatorSpy.passedUuid, routeController.sessionUUID)


### PR DESCRIPTION
### Description
Corrected provided reason to update route when switching to alternative route. This is important to correct logging and Navigator internal functioning.

### Implementation
Just added a parameter to `InternalRouter`'s method instead of introducing one more (3rd) enum with cases for proactive rerouting or switching to alternative.
This is an internal change, so no need for a CHANGELOG entry.