### PR TITLE
Add archive step to speed up the job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,8 +714,11 @@ jobs:
             cp -a "$OUTPUT" /tmp/generated-docs
       - *save-cache-podmaster
       - *save-cache-gems
+      - run:
+          name: Compress Docs
+          command: tar -cvzf /tmp/docs.tar /tmp/generated-docs
       - store_artifacts:
-          path: /tmp/generated-docs
+          path: /tmp/docs.tar
           destination: docs
       - when:
           condition: << pipeline.git.tag >>


### PR DESCRIPTION
Archiving the docs folder before uploading it to arctifact storage should drastically speed up the "publish documentation" job.
Right now the upload takes 7 minutes. 

[Before](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-ios/11679/workflows/92ac3d61-babc-44f3-a517-1db7e6c3648a/jobs/113305):
<img width="603" alt="image" src="https://github.com/mapbox/mapbox-navigation-ios/assets/1976216/429668be-0cdf-41b1-a32c-97bb322a6f65">

[After](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-ios/11683/workflows/d99cbd10-5a3c-499d-b142-92e193c337b9/jobs/113372): 
<img width="637" alt="image" src="https://github.com/mapbox/mapbox-navigation-ios/assets/1976216/8baabd87-cf7a-4e35-ac64-e3b9f23950c7">

