### PR TITLE
Correct `NavigationMatchOptions` congestion level in cycling profile

### DIFF
--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -91,7 +91,13 @@ open class NavigationMatchOptions: MatchOptions, OptimizedForNavigation {
         },
                    profileIdentifier: profileIdentifier,
                    queryItems: queryItems)
-        attributeOptions = [.numericCongestionLevel, .expectedTravelTime]
+        attributeOptions = [.expectedTravelTime]
+        if profileIdentifier == .cycling {
+            // https://github.com/mapbox/mapbox-navigation-ios/issues/3495
+            attributeOptions.update(with: .congestionLevel)
+        } else {
+            attributeOptions.update(with: .numericCongestionLevel)
+        }
         if profileIdentifier == .automobile || profileIdentifier == .automobileAvoidingTraffic {
             attributeOptions.insert(.maximumSpeedLimit)
         }


### PR DESCRIPTION
Correct the `.numericCongestionLevel` attribute to `.congestionLevel` when using the cycling profile. This is the same as https://github.com/mapbox/mapbox-navigation-ios/issues/3495 (https://github.com/mapbox/mapbox-navigation-ios/pull/3496) but for `NavigationMatchOptions` instead of `NavigationRouteOptions`.

https://github.com/mapbox/mapbox-navigation-ios/blob/ff4873f77bd91505820e6027f1a4a43efc4a7a3d/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift#L28-L34

This avoids the same error as the other issue but when using the map matching API:
```
The operation couldn’t be completed. annotations value must be one of duration, distance, speed, maxspeed, congestion
```