### PR TITLE
Correct `NavigationMatchOptions` congestion level in cycling profile …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## main
+
+### Routing
+
+* `NavigationRouteOptions` and `NavigationMatchOptions` no longer include `.numericCongestionLevel` attribute by default for profiles other than `.automobileAvoidingTraffic`. 
+
 ## v2.17.0
 
 ### Packaging

--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -92,10 +92,7 @@ open class NavigationMatchOptions: MatchOptions, OptimizedForNavigation {
                    profileIdentifier: profileIdentifier,
                    queryItems: queryItems)
         attributeOptions = [.expectedTravelTime]
-        if profileIdentifier == .cycling {
-            // https://github.com/mapbox/mapbox-navigation-ios/issues/3495
-            attributeOptions.update(with: .congestionLevel)
-        } else {
+        if profileIdentifier == .automobileAvoidingTraffic {
             attributeOptions.update(with: .numericCongestionLevel)
         }
         if profileIdentifier == .automobile || profileIdentifier == .automobileAvoidingTraffic {

--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -26,10 +26,7 @@ open class NavigationRouteOptions: RouteOptions, OptimizedForNavigation {
                    queryItems: queryItems)
         includesAlternativeRoutes = true
         attributeOptions = [.expectedTravelTime, .maximumSpeedLimit]
-        if profileIdentifier == .cycling {
-            // https://github.com/mapbox/mapbox-navigation-ios/issues/3495
-            attributeOptions.update(with: .congestionLevel)
-        } else {
+        if profileIdentifier == .automobileAvoidingTraffic {
             attributeOptions.update(with: .numericCongestionLevel)
         }
         includesExitRoundaboutManeuver = true

--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -91,7 +91,13 @@ open class NavigationMatchOptions: MatchOptions, OptimizedForNavigation {
         },
                    profileIdentifier: profileIdentifier,
                    queryItems: queryItems)
-        attributeOptions = [.numericCongestionLevel, .expectedTravelTime]
+        attributeOptions = [.expectedTravelTime]
+        if profileIdentifier == .cycling {
+            // https://github.com/mapbox/mapbox-navigation-ios/issues/3495
+            attributeOptions.update(with: .congestionLevel)
+        } else {
+            attributeOptions.update(with: .numericCongestionLevel)
+        }
         if profileIdentifier == .automobile || profileIdentifier == .automobileAvoidingTraffic {
             attributeOptions.insert(.maximumSpeedLimit)
         }

--- a/Tests/MapboxCoreNavigationTests/OptionsTests.swift
+++ b/Tests/MapboxCoreNavigationTests/OptionsTests.swift
@@ -30,15 +30,15 @@ class OptionsTests: TestCase {
         XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates).attributeOptions,
                        [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
         XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .automobile).attributeOptions,
-                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+                       [.expectedTravelTime, .maximumSpeedLimit])
         XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .automobileAvoidingTraffic).attributeOptions,
                        [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
         // https://github.com/mapbox/mapbox-navigation-ios/issues/3495
         XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .cycling).attributeOptions,
-                       [.congestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+                       [.expectedTravelTime, .maximumSpeedLimit])
         XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .walking).attributeOptions,
-                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+                       [.expectedTravelTime, .maximumSpeedLimit])
         XCTAssertEqual(NavigationRouteOptions(coordinates: coordinates, profileIdentifier: .init(rawValue: "mapbox/unicycling")).attributeOptions,
-                       [.numericCongestionLevel, .expectedTravelTime, .maximumSpeedLimit])
+                       [.expectedTravelTime, .maximumSpeedLimit])
     }
 }


### PR DESCRIPTION
Briding changes from (#4563) to main.

Correct the `.numericCongestionLevel` attribute to `.congestionLevel` when using the cycling profile. This is the same as https://github.com/mapbox/mapbox-navigation-ios/issues/3495 (https://github.com/mapbox/mapbox-navigation-ios/pull/3496) but for `NavigationMatchOptions` instead of `NavigationRouteOptions`.

https://github.com/mapbox/mapbox-navigation-ios/blob/ff4873f77bd91505820e6027f1a4a43efc4a7a3d/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift#L28-L34