### PR TITLE
Fix a possible crash that could happen when displaying the route with the same source, midpoint, and destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Map
 
-* Fixed a possible crash that could happen when displaying the route with the same source, midpoint, and destination. ([#4574](https://github.com/mapbox/mapbox-navigation-ios/pull/4574))
+* Fixed a possible crash that could happen when displaying the route with the same source, midpoint, and destination. ([#4576](https://github.com/mapbox/mapbox-navigation-ios/pull/4576))
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 ### Routing
 
-* `NavigationRouteOptions` and `NavigationMatchOptions` no longer include `.numericCongestionLevel` attribute by default for profiles other than `.automobileAvoidingTraffic`. 
+* `NavigationRouteOptions` and `NavigationMatchOptions` no longer include `.numericCongestionLevel` attribute by default for profiles other than `.automobileAvoidingTraffic`. ([#4564](https://github.com/mapbox/mapbox-navigation-ios/pull/4564))
+
+### Map
+
+* Fixed a possible crash that could happen when displaying the route with the same source, midpoint, and destination. ([#4574](https://github.com/mapbox/mapbox-navigation-ios/pull/4574))
 
 ### Other changes
 

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -353,7 +353,7 @@ extension NavigationMapView {
                     gradientStops[0.0] = associatedFeatureColor
                     
                     if index + 1 < routeLineFeatures.count {
-                        let segmentEndPercentTraveled = distanceTraveled / routeDistance
+                        let segmentEndPercentTraveled = (routeDistance > 0.0) ? distanceTraveled / routeDistance : 0
                         var currentGradientStop = lineSettings.isSoft ? segmentEndPercentTraveled - stopGap : Double(CGFloat(segmentEndPercentTraveled).nextDown)
                         currentGradientStop = min(max(currentGradientStop, 0.0), 1.0)
                         gradientStops[currentGradientStop] = associatedFeatureColor
@@ -367,7 +367,7 @@ extension NavigationMapView {
                     if associatedFeatureColor == lastRecordSegment.1 {
                         gradientStops[lastRecordSegment.0] = nil
                     } else {
-                        let segmentStartPercentTraveled = distanceTraveled / routeDistance
+                        let segmentStartPercentTraveled = (routeDistance > 0.0) ? distanceTraveled / routeDistance : 0
                         var currentGradientStop = lineSettings.isSoft ? segmentStartPercentTraveled + stopGap : Double(CGFloat(segmentStartPercentTraveled).nextUp)
                         currentGradientStop = min(max(currentGradientStop, 0.0), 1.0)
                         gradientStops[currentGradientStop] = associatedFeatureColor
@@ -379,14 +379,14 @@ extension NavigationMapView {
                 if associatedFeatureColor == lastRecordSegment.1 {
                     gradientStops[lastRecordSegment.0] = nil
                 } else {
-                    let segmentStartPercentTraveled = distanceTraveled / routeDistance
+                    let segmentStartPercentTraveled = (routeDistance > 0.0) ? distanceTraveled / routeDistance : 0
                     var currentGradientStop = lineSettings.isSoft ? segmentStartPercentTraveled + stopGap : Double(CGFloat(segmentStartPercentTraveled).nextUp)
                     currentGradientStop = min(max(currentGradientStop, 0.0), 1.0)
                     gradientStops[currentGradientStop] = associatedFeatureColor
                 }
                 
                 distanceTraveled = distanceTraveled + distance
-                let segmentEndPercentTraveled = distanceTraveled / routeDistance
+                let segmentEndPercentTraveled = (routeDistance > 0.0) ? distanceTraveled / routeDistance : 0
                 var currentGradientStop = lineSettings.isSoft ? segmentEndPercentTraveled - stopGap : Double(CGFloat(segmentEndPercentTraveled).nextDown)
                 currentGradientStop = min(max(currentGradientStop, 0.0), 1.0)
                 gradientStops[currentGradientStop] = associatedFeatureColor

--- a/Sources/MapboxNavigation/NavigationMapView.swift
+++ b/Sources/MapboxNavigation/NavigationMapView.swift
@@ -764,9 +764,11 @@ open class NavigationMapView: UIView {
                 let gradientStops = routeLineCongestionGradient(route,
                                                                 congestionFeatures: congestionFeatures,
                                                                 isSoft: crossfadesCongestionSegments)
-                defaultLineLayer.lineGradient = .expression((Expression.routeLineGradientExpression(gradientStops,
-                                                                                              lineBaseColor: trafficUnknownColor,
-                                                                                              isSoft: crossfadesCongestionSegments)))
+                defaultLineLayer.lineGradient = .expression(
+                    (Expression.routeLineGradientExpression(gradientStops,
+                                                            lineBaseColor: trafficUnknownColor,
+                                                            isSoft: crossfadesCongestionSegments))
+                )
             } else {
                 if showsCongestionForAlternativeRoutes {
                     let gradientStops = routeLineCongestionGradient(route,


### PR DESCRIPTION
### Description
Fixed a possible division by zero