### PR TITLE
Fix race condition in `ImageDownloader`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ jobs:
                 command: xcodebuild -resolvePackageDependencies
             - run:
                 name: MapboxNavigation-Package
-                command: xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=<< parameters.device >>' -scheme MapboxNavigation-Package -configuration << parameters.configuration >> build <<# parameters.test >>test <</ parameters.test >> <<# parameters.codecoverage >>-enableCodeCoverage YES<</ parameters.codecoverage >> ENABLE_TESTABILITY=YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO"
+                command: xcodebuild -enableThreadSanitizer YES -run-tests-until-failure -test-repetition-relaunch-enabled YES -only-testing:MapboxNavigationTests/ImageDownloaderTests -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=<< parameters.iOS >>,name=<< parameters.device >>' -scheme MapboxNavigation-Package -configuration << parameters.configuration >> build <<# parameters.test >>test <</ parameters.test >> <<# parameters.codecoverage >>-enableCodeCoverage YES<</ parameters.codecoverage >> ENABLE_TESTABILITY=YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO"
       # FIXME: SPM test host is currently disabled, but we should run tests on the SPM test host job. When it is reenabled, delete this section that generates the code coverage report.
       - when:
           condition: << parameters.codecoverage >>

--- a/Sources/MapboxNavigation/ImageDownload.swift
+++ b/Sources/MapboxNavigation/ImageDownload.swift
@@ -52,7 +52,7 @@ final class ImageDownloadOperation: Operation, ImageDownload {
         return state == .finished
     }
 
-    override var isConcurrent: Bool {
+    override var isAsynchronous: Bool {
         return true
     }
 

--- a/Tests/MapboxNavigationTests/Helper/ReentrantImageDownloaderSpy.swift
+++ b/Tests/MapboxNavigationTests/Helper/ReentrantImageDownloaderSpy.swift
@@ -8,10 +8,10 @@ final class ReentrantImageDownloaderSpy: ReentrantImageDownloader {
     var returnedDownloadResults = [URL: Data]()
     var returnedOperation: ImageDownload?
 
-    func download(with url: URL, completion: CachedResponseCompletionHandler?) -> Void {
+    func download(with url: URL, completion: @escaping CachedResponseCompletionHandler) -> Void {
         passedDownloadUrl = url
         let response = cachedResponse(with: returnedDownloadResults[url], url: url)
-        completion?(response, response == nil ? DirectionsError.noData : nil)
+        completion(response, response == nil ? DirectionsError.noData : nil)
     }
 
     func activeOperation(with url: URL) -> ImageDownload? {

--- a/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -169,7 +169,7 @@ class ImageDownloaderTests: TestCase {
 
     func testDownloadWithImmidiateCancel() {
         let incorrectUrl = URL(fileURLWithPath: "/incorrect_url")
-        downloader.download(with: incorrectUrl, completion: nil)
+        downloader.download(with: incorrectUrl, completion: {_,_ in })
         let operation = (downloader.activeOperation(with: incorrectUrl) as! ImageDownloadOperation)
         operation.cancel()
         
@@ -181,7 +181,7 @@ class ImageDownloaderTests: TestCase {
 
     func testDownloadWithImmidiateCancelFromAnotherThread() {
         let incorrectUrl = URL(fileURLWithPath: "/incorrect_url")
-        downloader.download(with: incorrectUrl, completion: nil)
+        downloader.download(with: incorrectUrl, completion: {_,_ in })
         let operation = (downloader.activeOperation(with: incorrectUrl) as! ImageDownloadOperation)
         DispatchQueue.global().sync {
             operation.cancel()

--- a/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
+++ b/Tests/MapboxNavigationTests/ImageDownloaderTests.swift
@@ -169,7 +169,7 @@ class ImageDownloaderTests: TestCase {
 
     func testDownloadWithImmidiateCancel() {
         let incorrectUrl = URL(fileURLWithPath: "/incorrect_url")
-        downloader.download(with: incorrectUrl, completion: {_,_ in })
+        downloader.download(with: incorrectUrl, completion: { _,_ in })
         let operation = (downloader.activeOperation(with: incorrectUrl) as! ImageDownloadOperation)
         operation.cancel()
         
@@ -181,7 +181,7 @@ class ImageDownloaderTests: TestCase {
 
     func testDownloadWithImmidiateCancelFromAnotherThread() {
         let incorrectUrl = URL(fileURLWithPath: "/incorrect_url")
-        downloader.download(with: incorrectUrl, completion: {_,_ in })
+        downloader.download(with: incorrectUrl, completion: { _,_ in })
         let operation = (downloader.activeOperation(with: incorrectUrl) as! ImageDownloadOperation)
         DispatchQueue.global().sync {
             operation.cancel()


### PR DESCRIPTION
ImageDownloader uses a custom `NSOperation` subclass to asynchronously download images.

Instead of overriding [`isConcurrent`](https://developer.apple.com/documentation/foundation/operation/1411089-isconcurrent) flag, this subclass has to override [`isAsynchronous`](https://developer.apple.com/documentation/foundation/operation/1408275-isasynchronous) flag. `isConcurrent` is a legacy flag, from the tests I did it seems it's never called by the system.
It seems like right now the fact that we don't correctly set `isAsynchronous` can lead to crashes in some cases because by default all NSOperations are considered synchronous and iOS can deallocate them before the download is actually finished. This should be fixed by correctly marking our NSOperation as `isAsynchronous == true`.

I also fixed another potential issue in `ImageDownloader` where we add a completion handler to an operation only after adding this operation to a queue, in theory this might lead to a race, though I think this could never cause issues in production.


Another issue yet unfixed is:
> *** MapboxNavigation.ImageDownloadOperation 0x7b440028ff00 went isFinished=YES without being started by the queue it is in

It happens because our custom subclass of NSOperation doesn't handle correctly a state when it's cancelled before NSOperationQueue started it.