### PR TITLE
Use camera options to calculate zoom for overview camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Map
 
 * Fixed a possible crash that could happen when displaying the route with the same source, midpoint, and destination. ([#4576](https://github.com/mapbox/mapbox-navigation-ios/pull/4576))
+* Fixed an incorrect viewport padding in the overview route camera. ([#4593](https://github.com/mapbox/mapbox-navigation-ios/pull/4593))
 
 ### User interface
 

--- a/Sources/MapboxNavigation/NavigationViewportDataSource.swift
+++ b/Sources/MapboxNavigation/NavigationViewportDataSource.swift
@@ -370,7 +370,11 @@ public class NavigationViewportDataSource: ViewportDataSource {
             .map({ $0.shape?.coordinates })
         let untraveledCoordinatesOnCurrentStep = routeProgress.currentLegProgress.currentStepProgress.remainingStepCoordinates()
         let remainingCoordinatesOnRoute = coordinatesAfterCurrentStep.flatten() + untraveledCoordinatesOnCurrentStep
-        let carPlayCameraPadding = mapView.safeArea + UIEdgeInsets.centerEdgeInsets
+
+        var carPlayCameraPadding = mapView.safeArea + UIEdgeInsets.centerEdgeInsets
+        // NOTE: We need this extra padding in CarPlay to avoid overlap of the route, street name labels, and control buttons.
+        carPlayCameraPadding.top += 20 // destination pin
+        carPlayCameraPadding.bottom += 38.0 // way name view
         let overviewCameraOptions = options.overviewCameraOptions
         
         if overviewCameraOptions.pitchUpdatesAllowed || overviewMobileCamera.pitch == nil {
@@ -423,12 +427,11 @@ public class NavigationViewportDataSource: ViewportDataSource {
                                                            bearing: overviewMobileCamera.bearing,
                                                            edgeInsets: viewportPadding,
                                                            maxZoomLevel: overviewCameraOptions.maximumZoomLevel)
-
-            // NOTE: zoom method adds some extra padding to the viewport. We need this extra padding in CarPlay
-            // to avoid overlap of the route, street name labels, and control buttons.
-            overviewCarPlayCamera.zoom = zoom(remainingCoordinatesOnRoute,
-                                              edgeInsets: carPlayCameraPadding,
-                                              maxZoomLevel: overviewCameraOptions.maximumZoomLevel)
+            overviewCarPlayCamera.zoom = overviewCameraZoom(remainingCoordinatesOnRoute,
+                                                            pitch: overviewCarPlayCamera.pitch,
+                                                            bearing: overviewCarPlayCamera.bearing,
+                                                            edgeInsets: carPlayCameraPadding,
+                                                            maxZoomLevel: overviewCameraOptions.maximumZoomLevel)
         }
         
         if overviewCameraOptions.paddingUpdatesAllowed || overviewMobileCamera.padding == nil {

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,67 +2,92 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }


### PR DESCRIPTION
### Description
https://mapbox.atlassian.net/browse/NAVIOS-1537

### Implementation
Fixes the issue on iOS where navigation routes didn't take the whole available viewport because of incorrectly calculated zoom level.
Note: the viewport does not take the whole screen, it is calculated to take into account the padding to the control elements.
Note: the old implementation is still used for CarPlay to avoid hardcoding the size of the control elements to avoid the views overlap.

### Screenshots or Gifs
<details>
  <summary>Screenshots</summary>

| Before |  After |
|:--:|:--:|
|![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 12 18 13](https://github.com/mapbox/mapbox-navigation-ios/assets/3630656/5e3d595e-b604-41b2-98df-9d83a9622a9d)|![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 12 14 30](https://github.com/mapbox/mapbox-navigation-ios/assets/3630656/ec6ebb89-b691-4a21-80cd-99c1c963d794)|
</details>

