### PR TITLE
Add the ability to set locale for top and bottom banner views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 ### User interface
 
 * `SpeedLimitView` now shows a special "Limits no longer apply" sign on roads where speed limit is known to not exist. ([#4584](https://github.com/mapbox/mapbox-navigation-ios/pull/4584)) 
+* `TopBannerViewController.delegate` and `TopBannerViewController.instructionsBannerView` are now public. ([#4595](https://github.com/mapbox/mapbox-navigation-ios/pull/4595)) 
+* `BottomBannerViewController.dateFormatter`, `BottomBannerViewController.dateComponentsFormatter`, `BottomBannerViewController.distanceFormatter` and `InstructionsBannerView.distanceFormatter` are now public. ([#4595](https://github.com/mapbox/mapbox-navigation-ios/pull/4595))
 
 ### Other changes
 

--- a/Sources/MapboxNavigation/BottomBannerViewController.swift
+++ b/Sources/MapboxNavigation/BottomBannerViewController.swift
@@ -12,10 +12,15 @@ open class BottomBannerViewController: UIViewController, NavigationComponent {
     var previousProgress: RouteProgress?
     var timer: DispatchTimer?
     
-    let dateFormatter = DateFormatter()
-    let dateComponentsFormatter = DateComponentsFormatter()
-    let distanceFormatter = DistanceFormatter()
-    
+    /// Arrival date formatter for banner view.
+    public let dateFormatter = DateFormatter()
+
+    /// Date components formatter for banner view.
+    public let dateComponentsFormatter = DateComponentsFormatter()
+
+    /// Distance formatter for banner view.
+    public let distanceFormatter = DistanceFormatter()
+
     var verticalCompactConstraints = [NSLayoutConstraint]()
     var verticalRegularConstraints = [NSLayoutConstraint]()
     

--- a/Sources/MapboxNavigation/InstructionsBannerView.swift
+++ b/Sources/MapboxNavigation/InstructionsBannerView.swift
@@ -109,8 +109,9 @@ open class BaseInstructionsBannerView: UIControl {
     var centerYConstraints = [NSLayoutConstraint]()
     var baselineConstraints = [NSLayoutConstraint]()
     
-    let distanceFormatter = DistanceFormatter()
-    
+    /// Distance formatter for banner view.
+    public let distanceFormatter = DistanceFormatter()
+
     /**
      The remaining distance of current step in meters.
      */

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -13,8 +13,10 @@ open class TopBannerViewController: UIViewController {
     
     // MARK: Displaying Instructions
     
-    weak var delegate: TopBannerViewControllerDelegate? = nil
-    
+    /// The delegate for the view controller.
+    /// - seealso: TopBannerViewControllerDelegate
+    public weak var delegate: TopBannerViewControllerDelegate? = nil
+
     lazy var topPaddingView: TopBannerView = .forAutoLayout()
     
     var routeProgress: RouteProgress?
@@ -25,7 +27,8 @@ open class TopBannerViewController: UIViewController {
     
     lazy var informationStackView = UIStackView(orientation: .vertical, autoLayout: true)
     
-    lazy var instructionsBannerView: InstructionsBannerView = {
+    /// A banner view that contains the current step instructions and responds to tap and swipe gestures.
+    public private(set) lazy var instructionsBannerView: InstructionsBannerView = {
         let banner: InstructionsBannerView = .forAutoLayout()
         banner.heightAnchor.constraint(equalToConstant: instructionsBannerHeight).isActive = true
         banner.delegate = self


### PR DESCRIPTION
### Description
Closes #4581
https://mapbox.atlassian.net/browse/NAVIOS-1547

### Implementation
Makes properties public
<details>
  <summary>Usage example</summary>

  ```swift
let top = TopBannerViewController()
top.instructionsBannerView.distanceFormatter.locale = .init(identifier: "zh-Hans")
navigationOptions.topBanner = top

let bottom = BottomBannerViewController()
bottom.distanceFormatter.locale = .init(identifier: "zh-Hans")
bottom.dateFormatter.locale = .init(identifier: "zh-Hans")
navigationOptions.bottomBanner = bottom

let navigationViewController = NavigationViewController(for: indexedRouteResponse, navigationOptions: navigationOptions)
bottom.delegate = navigationViewController
top.delegate = navigationViewController
  ```
</details>