### PR TITLE
[Cherry pick] Fixed the possible situation when the upcoming route leg is rendered above the active route leg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Added PrivacyInfo.xcprivacy support. ([#4573](https://github.com/mapbox/mapbox-navigation-ios/pull/4573))
 * Removed `NavigationEventsManager.init(activeNavigationDataSource:passiveNavigationDataSource:accessToken:mobileEventsManager:)` in favor of `NavigationEventsManager.init(activeNavigationDataSource:passiveNavigationDataSource:accessToken:)`. ([#4572](https://github.com/mapbox/mapbox-navigation-ios/pull/4572))
 * Fixed a rare issue that could lead to memory corruption under specific conditions. This was resolved by replacing the internal image downloader with brand new actor-based implementation. ([#4588](https://github.com/mapbox/mapbox-navigation-ios/pull/4588))
+* Fixed the possible situation when the upcoming route leg is rendered above the active route leg. ([#4588](https://github.com/mapbox/mapbox-navigation-ios/pull/4588))
 
 ## v2.17.0
 

--- a/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
+++ b/Sources/MapboxNavigation/NavigationMapView+VanishingRouteLine.swift
@@ -433,8 +433,8 @@ extension NavigationMapView {
                         return self.congestionColor(for: nil, isMain: isMain)
                     }
                 }
-                
-                return self.routeCasingColor
+
+                return .clear
             }
         })
         

--- a/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
+++ b/Tests/MapboxNavigationTests/NavigationMapViewTests.swift
@@ -426,6 +426,27 @@ class NavigationMapViewTests: TestCase {
         XCTAssertEqual(routeLineGradient[0.0], navigationMapView.trafficLowColor)
     }
 
+    func testGenerateRouteLineGradientWithMultilegRoute() {
+        let coordinates: [CLLocationCoordinate2D] = [
+            CLLocationCoordinate2D(latitude: 37.798, longitude: -122.398),
+            CLLocationCoordinate2D(latitude: 37.795, longitude: -122.398),
+            CLLocationCoordinate2D(latitude: 37.795, longitude: -122.395),
+        ]
+        let congestionSegment: CongestionSegment = (coordinates, CongestionLevel.low)
+        var feature = Feature(geometry: .lineString(LineString(congestionSegment.0)))
+        feature.properties = [
+            CongestionAttribute: .string(String(describing: congestionSegment.1)),
+            CurrentLegAttribute: false
+        ]
+        let congestionFeatures = [feature]
+
+        let routeLineGradient = navigationMapView.routeLineCongestionGradient(congestionFeatures: congestionFeatures,
+                                                                              isMain: true,
+                                                                              isSoft: false)
+        XCTAssertEqual(routeLineGradient.count, 1)
+        XCTAssertEqual(routeLineGradient[0.0], .clear)
+    }
+
     func testGenerateRouteLineRestrictedGradient() {
         let coordinates: [CLLocationCoordinate2D] = [
             CLLocationCoordinate2D(latitude: 1, longitude: 0),


### PR DESCRIPTION
### Description
Cherry pick of #4589 into 2.18