### PR TITLE
Fix SystemSpeechSynthesizer related main thread hang on NavigationViewController creation

### DIFF
--- a/Sources/MapboxNavigation/SystemSpeechSynthesizer.swift
+++ b/Sources/MapboxNavigation/SystemSpeechSynthesizer.swift
@@ -13,7 +13,7 @@ open class SystemSpeechSynthesizer: NSObject, SpeechSynthesizing {
     public weak var delegate: SpeechSynthesizingDelegate?
     public var muted: Bool = false {
         didSet {
-            if isSpeaking {
+            if muted, isSpeaking {
                 interruptSpeaking()
             }
         }


### PR DESCRIPTION
### Description
There is an old iOS issue with AVSpeechSynthesizer: each access to it triggers XPC communication, which hangs the thread on which the object is accessed, up to a few seconds: https://stackoverflow.com/questions/53912072/avspeechsynthesizer-freezes-ios-app-for-a-few-seconds.

Xcode 15.3 now highlights this issue with console warnings like: 
<details>
  <summary>Warning example</summary>
  
  ```
  Thread Performance Checker: Thread running at User-interactive quality-of-service class waiting on a lower QoS thread running at Default quality-of-service class. Investigate ways to avoid priority inversions
PID: 13043, TID: 7057855
Backtrace
=================================================================
3   Foundation                          0x000000018888e37c 5623831D-5719-33A9-9691-759F47D714D1 + 7627644
4   Foundation                          0x00000001882426e4 5623831D-5719-33A9-9691-759F47D714D1 + 1025764
5   Foundation                          0x000000018826974c 5623831D-5719-33A9-9691-759F47D714D1 + 1185612
6   TextToSpeech                        0x00000001a9c78878 TTSSpeechTransformTextWithLanguageAndVoiceIdentifier + 5132
7   TextToSpeech                        0x00000001a9c7df20 AXAVSpeechSynthesisVoiceFromTTSSpeechVoice + 13132
8   TextToSpeech                        0x00000001a9c76020 _TTSIdentifierForVoiceInformation + 17508
9   MyAwesomeApp                  0x00000001051f78f4 $s16MapboxNavigation23SystemSpeechSynthesizerC10isSpeakingSbvg + 44
10  MyAwesomeApp                  0x00000001051f728c $s16MapboxNavigation23SystemSpeechSynthesizerC5mutedSbvW + 60
11  MyAwesomeApp                  0x00000001051f73a8 $s16MapboxNavigation23SystemSpeechSynthesizerC5mutedSbvs + 120
12  MyAwesomeApp                  0x00000001051f9ef4 $s16MapboxNavigation23SystemSpeechSynthesizerCAA0D12SynthesizingA2aDP5mutedSbvsTW + 40
13  MyAwesomeApp                  0x0000000105088934 $s16MapboxNavigation28MultiplexedSpeechSynthesizerC9applyMute33_C78A32105F77292EE97E3E9C94F947E2LLyyFyAA0D12Synthesizing_pXEfU_ + 128
  ```
</details>

While we can't fix this problem in Apple system library, we only access AVSpeechSynthesizer when it's really necessary. Right now `NavigationViewController.viewDidLoad` leads to a mutation of `SystemSpeechSynthesizer.muted` property, which in turn accesses AVSpeechSynthesizer, even though it's not really used.

### Implementation
When mutating `SystemSpeechSynthesizer.muted`, we only try to interrupt it when `muted == true`, skipping `isSpeaking` getter.