### PR TITLE
Reset Polish by default in v2 samples

### DIFF
--- a/MapboxNavigation-SPM.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/MapboxNavigation-SPM.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -64,7 +64,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = "pl"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
### Description
The Polish language was mistakenly set by default in the sample app for the v2 SDK in #4582