### PR TITLE
Fix ci release v2 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ parameters:
 commands:
   install-mbx-ci:
     steps:
+      - macos/install-rosetta
       - run:
           name: "Install MBX CI"
           command: |


### PR DESCRIPTION
### Description
The CI build failed with the error:

> Bad CPU type in executable