### PR TITLE
Add `--allow-warnings` flag to cocoapods distribute script

### DIFF
--- a/scripts/distribute-version.py
+++ b/scripts/distribute-version.py
@@ -4,7 +4,7 @@ import time
 
 def push_pod(name, max_attempts):
     for attempt in range(0, max_attempts):
-        status = subprocess.run('pod repo update && pod trunk push ' + name + '.podspec', shell=True)
+        status = subprocess.run('pod repo update && pod trunk push ' + name + '.podspec --allow-warnings', shell=True)
         if status.returncode == 0:
             return
         time.sleep(60 * pow(2, attempt))


### PR DESCRIPTION
### Description
Fixes podspec uploading due to
```
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'MapboxMobileEvents' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'Solar-dev' from project 'Pods')
 ```