### PR TITLE
Match CocoaPods dependency rules to SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.18.3
+
+### Packaging
+
+* Fixed MapboxMaps version compatibility in CocoaPods to match SPM. MapboxNavigation in CocoaPods is now compatible with MapboxMaps starting from v10.17.0 to v11.0.0 not including.
+* Fixed MapboxDirections version compatibility in CocoaPods to match SPM. MapboxDirections in CocoaPods is now compatible with MapboxDirections starting from v2.12.0 to v3.0.0 not including.
+* Fixed MapboxNavigationNative version compatibility in CocoaPods to match SPM. MapboxNavigationNative in CocoaPods is now compatible with MapboxNavigationNative starting from v204.0.1 to v205.0.0 not including.
+
 ## v2.18.2
 
 ### CarPlay

--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -44,8 +44,8 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxCoreNavigation"
 
-  s.dependency "MapboxNavigationNative", "~> 204.0.1"
-  s.dependency "MapboxDirections", "~> 2.12.0"
+  s.dependency "MapboxNavigationNative", ">= 204.0.1", "< 205.0.0"
+  s.dependency "MapboxDirections", "~> 2.12"
 
   s.swift_version = "5.5"
 end

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
-          "version": "2.1.2"
+          "revision": "3ef6999c73b6938cc0da422f2c912d0158abb0a0",
+          "version": "2.2.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "a23ded2c91df9156628a6996ab4f347526f17b6b",
-          "version": "2.1.2"
+          "revision": "2ef56b2caf25f55fa7eef8784c30d5a767550f54",
+          "version": "2.2.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "696503304fe8807bd5af3abb23ef20c051dd8b12",
-          "version": "23.9.2"
+          "revision": "c2aa7022afdcf5a070ace4e3b608562101a04690",
+          "version": "23.10.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "255a3d159c710d33ab8a85d15a2842012462f581",
-          "version": "10.17.0"
+          "revision": "51f776b11bcff34ced88fcf14e4ed9c568257232",
+          "version": "10.18.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "dffb8fd7c8316ae8d9b79b694be933deba6f544e",
-          "version": "2.12.0"
+          "revision": "6512320ee7f0091a4c55abe2bc6414f078da88c8",
+          "version": "2.14.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "52bb5df80e4a6dd84d61bf9f4fc63a68b30c03e4",
-          "version": "10.17.0"
+          "revision": "8ef49bb140bbd5d51917f1e69d4c3949a176c009",
+          "version": "10.18.2"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-          "version": "1.2.3"
+          "revision": "41982a3656a71c768319979febd796c6fd111d5c",
+          "version": "1.5.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "f0afe204b4266337066a436becab62fdd2b32378",
-          "version": "2.7.0"
+          "revision": "213050191cfcb3d5aa76e1fa90c6ff1e182a42ca",
+          "version": "2.8.0"
         }
       }
     ]

--- a/MapboxNavigation.podspec
+++ b/MapboxNavigation.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.module_name = "MapboxNavigation"
 
   s.dependency "MapboxCoreNavigation", "#{s.version.to_s}"
-  s.dependency "MapboxMaps", "~> 10.17.0"
+  s.dependency "MapboxMaps", "~> 10.17"
   s.dependency "Solar-dev", "~> 3.0"
   s.dependency "MapboxSpeech", "~> 2.0"
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "696503304fe8807bd5af3abb23ef20c051dd8b12",
-          "version": "23.9.2"
+          "revision": "c2aa7022afdcf5a070ace4e3b608562101a04690",
+          "version": "23.10.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "255a3d159c710d33ab8a85d15a2842012462f581",
-          "version": "10.17.0"
+          "revision": "51f776b11bcff34ced88fcf14e4ed9c568257232",
+          "version": "10.18.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "dffb8fd7c8316ae8d9b79b694be933deba6f544e",
-          "version": "2.12.0"
+          "revision": "6512320ee7f0091a4c55abe2bc6414f078da88c8",
+          "version": "2.14.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "52bb5df80e4a6dd84d61bf9f4fc63a68b30c03e4",
-          "version": "10.17.0"
+          "revision": "8ef49bb140bbd5d51917f1e69d4c3949a176c009",
+          "version": "10.18.2"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "c8ed701b513cf5177118a175d85fbbbcd707ab41",
-          "version": "1.3.0"
+          "revision": "41982a3656a71c768319979febd796c6fd111d5c",
+          "version": "1.5.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "f0afe204b4266337066a436becab62fdd2b32378",
-          "version": "2.7.0"
+          "revision": "213050191cfcb3d5aa76e1fa90c6ff1e182a42ca",
+          "version": "2.8.0"
         }
       }
     ]

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
-  - MapboxCommon (23.9.2)
-  - MapboxCoreMaps (10.17.0):
-    - MapboxCommon (~> 23.9)
+  - MapboxCommon (23.10.1)
+  - MapboxCoreMaps (10.18.0):
+    - MapboxCommon (~> 23.10)
   - MapboxCoreNavigation (2.18.2):
-    - MapboxDirections (~> 2.12.0)
-    - MapboxNavigationNative (~> 204.0.1)
-  - MapboxDirections (2.12.0):
+    - MapboxDirections (~> 2.12)
+    - MapboxNavigationNative (< 205.0.0, >= 204.0.1)
+  - MapboxDirections (2.14.0):
     - Polyline (~> 5.0)
-    - Turf (~> 2.7.0)
-  - MapboxMaps (10.17.0):
-    - MapboxCommon (= 23.9.2)
-    - MapboxCoreMaps (= 10.17.0)
+    - Turf (~> 2.8.0)
+  - MapboxMaps (10.18.2):
+    - MapboxCommon (= 23.10.1)
+    - MapboxCoreMaps (= 10.18.0)
     - MapboxMobileEvents (= 1.0.10)
-    - Turf (= 2.7.0)
+    - Turf (= 2.8.0)
   - MapboxMobileEvents (1.0.10)
   - MapboxNavigation (2.18.2):
     - MapboxCoreNavigation (= 2.18.2)
-    - MapboxMaps (~> 10.17.0)
+    - MapboxMaps (~> 10.17)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
   - MapboxNavigationNative (204.0.1):
@@ -24,7 +24,7 @@ PODS:
   - MapboxSpeech (2.1.1)
   - Polyline (5.1.0)
   - Solar-dev (3.0.1)
-  - Turf (2.7.0)
+  - Turf (2.8.0)
 
 DEPENDENCIES:
   - MapboxCoreNavigation (from `../../../`)
@@ -50,19 +50,19 @@ EXTERNAL SOURCES:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  MapboxCommon: 768660d6fca8193529ecf82eb6f5f9ae7a5acdf9
-  MapboxCoreMaps: be412ff97b16aa7820922c818115a9a0d8211caa
-  MapboxCoreNavigation: ae88fed601889eb833537b9c25a2adae6523e639
-  MapboxDirections: 4676f626df320732dcf74612223e568d39588320
-  MapboxMaps: 87ef0003e6db46e45e7a16939f29ae87e38e7ce2
+  MapboxCommon: 0ff437e44988da6856e280d00ffb266564ed0487
+  MapboxCoreMaps: f1bd9405f5b9d3e343f2fe4138775299699a22fb
+  MapboxCoreNavigation: 46ef12de2938888605d3fbddbc80588bd55b1188
+  MapboxDirections: 3d468327d3e2ac52ae1be2176004976580cf6fd9
+  MapboxMaps: e76b14f52c54c40b76ddecd04f40448e6f35a864
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
-  MapboxNavigation: b420c01711bb29d69b24964436da36c481e1504e
+  MapboxNavigation: 433a4c18757dc74953c321cdf80993ab8cddea74
   MapboxNavigationNative: cf3640d04da6e67b701f76b1c502954286efee06
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77
   Polyline: 2a1f29f87f8d9b7de868940f4f76deb8c678a5b1
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
-  Turf: 13d1a92d969ca0311bbc26e8356cca178ce95da2
+  Turf: aa2ede4298009639d10db36aba1a7ebaad072a5e
 
 PODFILE CHECKSUM: bde8103af0e9b326531ee57cf1fa935cbd5f2e18
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.15.2


### PR DESCRIPTION
### Description

Supports Maps 10.18.2 in CocoaPods, that was supported in SPM