### PR TITLE
Steps table blank space fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added handling `RouteResponse.refreshTTL` into account when refreshing a route. Now it will no longer be possible to attmept to refresh and outdated route, and `Router` will inform that current route has expired using `RouterDelegate.routerDidFailToRefreshExpiredRoute(:_)` method. ([#4672](https://github.com/mapbox/mapbox-navigation-ios/pull/4672))
 
+### Other changes
+* Fixed next banner view correctly appearing when steps list view is exapnded. ([#4708](https://github.com/mapbox/mapbox-navigation-ios/pull/4708))
+* Fixed rare route simulation issue where user's speed was calculated and NaN and the puck did not move. ([#4708](https://github.com/mapbox/mapbox-navigation-ios/pull/4708))
+
 ## v2.18.4
 
 ### Packaging

--- a/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
+++ b/Sources/MapboxCoreNavigation/SimulatedLocationManager.swift
@@ -232,7 +232,7 @@ open class SimulatedLocationManager: NavigationLocationManager {
            let nextCoordinateOnRoute = originalShape.coordinates.after(index: closestCoordinateOnRouteIndex),
            let time = expectedSegmentTravelTimes.optional[closestCoordinateOnRouteIndex] {
             let distance = originalShape.coordinates[closestCoordinateOnRouteIndex].distance(to: nextCoordinateOnRoute)
-            currentSpeed = min(max(distance / time, minimumSpeed), maximumSpeed)
+            currentSpeed = min(max(distance / max(time, 1.0), minimumSpeed), maximumSpeed)
             slicedIndex = max(closestCoordinateOnRouteIndex - 1, 0)
         } else {
             let closestLocation = locations[closestCoordinateOnRouteIndex]

--- a/Sources/MapboxNavigation/TopBannerViewController.swift
+++ b/Sources/MapboxNavigation/TopBannerViewController.swift
@@ -59,10 +59,10 @@ open class TopBannerViewController: UIViewController {
     private let instructionsBannerHeight: CGFloat = 100.0
     
     private var informationChildren: [UIView] {
-        return [instructionsBannerView] + secondaryChildren + [lanesView]
+        return [instructionsBannerView] + secondaryChildren + [lanesView, nextBannerView]
     }
     private var secondaryChildren: [UIView] {
-        return [nextBannerView, statusView, junctionView]
+        return [statusView, junctionView]
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -112,7 +112,7 @@ open class TopBannerViewController: UIViewController {
     
     private func setupInformationStackView() {
         addInstructionsBanner()
-        let subviews = [lanesView] + secondaryChildren
+        let subviews = [lanesView, nextBannerView] + secondaryChildren
         informationStackView.addArrangedSubviews(subviews)
         for child in informationChildren {
             child.leadingAnchor.constraint(equalTo: informationStackView.leadingAnchor).isActive = true


### PR DESCRIPTION
### Description

Fixes blank space appearing in steps list table when next banner view should be shown. Also fixes rare issue with route simulation when puck could become stuck.

### Implementation

Blank space is fixed by resolving logic of next banner view which was controlled by itself and the TopBannerViewController, which resulted in conflicting visibility config.
Route simulation could sometimes become stuck in one place when expected segment travel time was not set, which resulted in simulated speed value to be calculated as NaN, which kept the puck in place.