### PR TITLE
Move json alternative parsing away from the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.20.0
+
+### Routing
+
+* Move alternative route parsing to the background thread. ([#4729](https://github.com/mapbox/mapbox-navigation-ios/pull/4729))
+
 ## v2.19.0
 
 ### Packaging
@@ -12,6 +18,7 @@
 * Added handling `RouteResponse.refreshTTL` into account when refreshing a route. Now it will no longer be possible to attmept to refresh and outdated route, and `Router` will inform that current route has expired using `RouterDelegate.routerDidFailToRefreshExpiredRoute(:_)` method. ([#4672](https://github.com/mapbox/mapbox-navigation-ios/pull/4672))
 
 ### Other changes
+
 * Fixed next banner view correctly appearing when steps list view is expanded. ([#4708](https://github.com/mapbox/mapbox-navigation-ios/pull/4708))
 * Fixed rare route simulation issue where user's speed was calculated and NaN and the puck did not move. ([#4708](https://github.com/mapbox/mapbox-navigation-ios/pull/4708))
 * Fixed a possibly not-updating `StepsViewController` after reroutes when using a custom top bar. ([#4716](https://github.com/mapbox/mapbox-navigation-ios/pull/4716))

--- a/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
+++ b/Tests/MapboxCoreNavigationTests/NavigationServiceTests.swift
@@ -38,7 +38,7 @@ class NavigationServiceTests: TestCase {
 
     let expectationsTimeout = 1.0
 
-    let indexedRouteResponse = IndexedRouteResponse.init(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions), routeIndex: 0)
+    var indexedRouteResponse: IndexedRouteResponse!
     var location: CLLocation!
     var lastLocation: CLLocation!
     var userInfo: [String: String?] = ["key": "value"]
@@ -73,6 +73,7 @@ class NavigationServiceTests: TestCase {
     override func setUp() {
         super.setUp()
 
+        indexedRouteResponse = IndexedRouteResponse(routeResponse: Fixture.routeResponse(from: jsonFileName, options: routeOptions), routeIndex: 0)
         delegate = NavigationServiceDelegateSpy()
         locationManager = NavigationLocationManagerSpy()
         customRoutingProvider = RoutingProviderSpy()

--- a/Tests/MapboxCoreNavigationTests/RerouteControllerTests.swift
+++ b/Tests/MapboxCoreNavigationTests/RerouteControllerTests.swift
@@ -71,7 +71,10 @@ final class RerouteControllerTests: TestCase {
         customRoutingProvider = .init()
         delegate = .init()
 
-        rerouteController = .init(navigatorSpy, config: configHandle)
+        rerouteController = RerouteController(
+            navigatorSpy,
+            config: configHandle,
+            parsingQueue: .main)
         rerouteController.delegate = delegate
     }
 


### PR DESCRIPTION
### Description
Previously, the SDK parsed continuous alternatives each time method `show(routeResponse)` was called on the main thread. Also, each reroute callback was totally handled on the main thread, including parsing. 