### PR TITLE
Use use resource_bundle instead of resource in Core Podspec

### DIFF
--- a/MapboxCoreNavigation.podspec
+++ b/MapboxCoreNavigation.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.resources = ['Sources/MapboxCoreNavigation/Resources/*/*', 'Sources/MapboxCoreNavigation/Resources/*']
+  s.resource_bundle = { 'MapboxCoreNavigationResources' => ['Sources/MapboxCoreNavigation/Resources/*/*', 'Sources/MapboxCoreNavigation/Resources/*'] }
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/Sources/MapboxCoreNavigation/BundleAdditions.swift
+++ b/Sources/MapboxCoreNavigation/BundleAdditions.swift
@@ -32,8 +32,8 @@ extension Bundle {
         get {
             #if SWIFT_PACKAGE
             return .module
-            #else
-            var frameworkBundle = Bundle(for: RouteController.self)
+            #elseif COCOAPODS
+            let frameworkBundle = Bundle(for: RouteController.self)
 
             guard let resourceBundleURL = frameworkBundle.url(
                 forResource: "MapboxCoreNavigationResources", withExtension: "bundle")
@@ -43,6 +43,8 @@ extension Bundle {
             else { fatalError("Cannot access MapboxCoreNavigationResources.bundle!") }
 
             return resourceBundle
+            #else
+            return Bundle(for: RouteController.self)
             #endif
         }
     }

--- a/Sources/MapboxCoreNavigation/BundleAdditions.swift
+++ b/Sources/MapboxCoreNavigation/BundleAdditions.swift
@@ -33,7 +33,16 @@ extension Bundle {
             #if SWIFT_PACKAGE
             return .module
             #else
-            return Bundle(for: RouteController.self)
+            var frameworkBundle = Bundle(for: RouteController.self)
+
+            guard let resourceBundleURL = frameworkBundle.url(
+                forResource: "MapboxCoreNavigationResources", withExtension: "bundle")
+            else { fatalError("MapboxCoreNavigationResources.bundle not found!") }
+
+            guard let resourceBundle = Bundle(url: resourceBundleURL)
+            else { fatalError("Cannot access MapboxCoreNavigationResources.bundle!") }
+
+            return resourceBundle
             #endif
         }
     }

--- a/Sources/MapboxNavigation/Bundle.swift
+++ b/Sources/MapboxNavigation/Bundle.swift
@@ -11,9 +11,9 @@ extension Bundle {
         get {
             #if SWIFT_PACKAGE
             return .module
-            #else
-            var frameworkBundle = Bundle(for: NavigationViewController.self)
-            
+            #elseif COCOAPODS
+            let frameworkBundle = Bundle(for: NavigationViewController.self)
+
             guard let resourceBundleURL = frameworkBundle.url(
             forResource: "MapboxNavigationResources", withExtension: "bundle")
                 else { fatalError("MapboxNavigationResources.bundle not found!") }
@@ -22,6 +22,8 @@ extension Bundle {
                 else { fatalError("Cannot access MapboxNavigationResources.bundle!") }
             
             return resourceBundle
+            #else
+            return Bundle(for: NavigationViewController.self)
             #endif
         }
     }

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -132,6 +132,7 @@
 				352544D91E66623D004C8F1C /* Frameworks */,
 				352544DA1E66623D004C8F1C /* Resources */,
 				2C42AC3C47F2A0A83F753C88 /* [CP] Embed Pods Frameworks */,
+				2C3768632CC931CD00C04A8A /* Apply Mapbox token */,
 			);
 			buildRules = (
 			);
@@ -224,6 +225,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2C3768632CC931CD00C04A8A /* Apply Mapbox token */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Apply Mapbox token";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${SRCROOT}/../../../scripts/apply_mapbox_token.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		2C42AC3C47F2A0A83F753C88 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -438,7 +460,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -453,7 +476,10 @@
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = PodInstall/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.navigation.PodInstall;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -467,7 +493,10 @@
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = PodInstall/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.navigation.PodInstall;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -480,7 +509,11 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = PodInstallTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.navigation.PodInstallTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PodInstall.app/PodInstall";
@@ -494,7 +527,11 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = PodInstallTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.navigation.PodInstallTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PodInstall.app/PodInstall";

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall/Info.plist
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall/Info.plist
@@ -20,6 +20,17 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MBXAccessToken</key>
+	<string>YOUR_TOKEN</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Get user location</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location Usage Description</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>processing</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,7 +52,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Get user location</string>
 </dict>
 </plist>

--- a/Tests/CocoaPodsTest/PodInstall/PodInstall/ViewController.swift
+++ b/Tests/CocoaPodsTest/PodInstall/PodInstall/ViewController.swift
@@ -9,6 +9,7 @@ class ViewController: UIViewController {
 
         // Test that classes are accessible
         // and prevent comiler optimizations for unused imports.
+        _ = Bundle.mapboxCoreNavigation
         _ = PassiveLocationManager()
         _ = NavigationMapView(frame: .zero)
     }

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MapboxCommon: 0ff437e44988da6856e280d00ffb266564ed0487
   MapboxCoreMaps: f1bd9405f5b9d3e343f2fe4138775299699a22fb
-  MapboxCoreNavigation: 05b0fef0e17875b1077146db98e1d1f72ba35b3c
+  MapboxCoreNavigation: c26feb2d56acfdbde7ca237b8bb7a9c459d33b2a
   MapboxDirections: 3d468327d3e2ac52ae1be2176004976580cf6fd9
   MapboxMaps: e76b14f52c54c40b76ddecd04f40448e6f35a864
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
@@ -65,4 +65,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: bde8103af0e9b326531ee57cf1fa935cbd5f2e18
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.15.2

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - MapboxCommon (23.10.1)
-  - MapboxCoreMaps (10.18.0):
-    - MapboxCommon (~> 23.10)
+  - MapboxCommon (23.11.0)
+  - MapboxCoreMaps (10.19.1):
+    - MapboxCommon (~> 23.11)
   - MapboxCoreNavigation (2.19.0-beta.1):
     - MapboxDirections (~> 2.14)
     - MapboxNavigationNative (< 207.0.0, >= 206.0.1)
   - MapboxDirections (2.14.0):
     - Polyline (~> 5.0)
     - Turf (~> 2.8.0)
-  - MapboxMaps (10.18.2):
-    - MapboxCommon (= 23.10.1)
-    - MapboxCoreMaps (= 10.18.0)
-    - MapboxMobileEvents (= 1.0.10)
+  - MapboxMaps (10.19.0):
+    - MapboxCommon (= 23.11.0)
+    - MapboxCoreMaps (= 10.19.1)
+    - MapboxMobileEvents (= 2.0.0)
     - Turf (= 2.8.0)
-  - MapboxMobileEvents (1.0.10)
+  - MapboxMobileEvents (2.0.0)
   - MapboxNavigation (2.19.0-beta.1):
     - MapboxCoreNavigation (= 2.19.0-beta.1)
     - MapboxMaps (~> 10.18)
@@ -50,12 +50,12 @@ EXTERNAL SOURCES:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  MapboxCommon: 0ff437e44988da6856e280d00ffb266564ed0487
-  MapboxCoreMaps: f1bd9405f5b9d3e343f2fe4138775299699a22fb
+  MapboxCommon: 119f3759f7dc9457f0695848108ab323eb643cb4
+  MapboxCoreMaps: ca17f67baced23f8c952166ac6314c35bad3f66c
   MapboxCoreNavigation: c26feb2d56acfdbde7ca237b8bb7a9c459d33b2a
   MapboxDirections: 3d468327d3e2ac52ae1be2176004976580cf6fd9
-  MapboxMaps: e76b14f52c54c40b76ddecd04f40448e6f35a864
-  MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
+  MapboxMaps: b7f29ec7c33f7dc6d2947c1148edce6db81db9a7
+  MapboxMobileEvents: d044b9edbe0ec7df60f6c2c9634fe9a7f449266b
   MapboxNavigation: 08e931ce1894597f6b8e8241fb6794ffbbfd2a84
   MapboxNavigationNative: ef4ef55f669336b689a8941388a4b65796d1337b
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77


### PR DESCRIPTION
### Description
https://mapbox.atlassian.net/browse/NAVIOS-1842

### Implementation
Uses the same fix that was aded in #4668 for MapboxNavigation for MapboxCoreNavigation.
The Maps SDK [declares](https://github.com/mapbox/mapbox-maps-ios/blob/fb97a45e3b4c98b220dd89acf7b29a9876f9ab56/MapboxMaps.podspec#L22) `PrivacyInfo.xcprivacy` similarly in `resource_bundle`.