### PR TITLE
Update snapshot testing dependency by using `from` instead of `exact` versioning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/mapbox/mapbox-maps-ios.git", exact: mapsVersion),
         .package(url: "https://github.com/mapbox/turf-swift.git", exact: "4.0.0-beta.1"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.12.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.12.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
### Description

Related to that Issue #4737 I've changed the versioning of the dependency [Swift-Snapshot-Testing](https://github.com/pointfreeco/swift-snapshot-testing).
Please check that all your snapshot tests are running as expected.