### PR TITLE
Fix typo in EventsManager.swift: 'vent' to 'event'

### DIFF
--- a/Sources/MapboxNavigationCore/Feedback/EventsManager.swift
+++ b/Sources/MapboxNavigationCore/Feedback/EventsManager.swift
@@ -44,7 +44,7 @@ public final class NavigationEventsManager: Sendable {
     ///  If you provide a custom feedback UI that lets users elaborate on an issue, you should call this before you show
     /// the custom UI so the location and timestamp are more accurate. Alternatively, you can use
     /// `FeedbackViewContoller` which handles feedback lifecycle internally.
-    /// - Parameter screenshotOption: The options to configure how the screenshot for the vent is provided.
+    /// - Parameter screenshotOption: The options to configure how the screenshot for the event is provided.
     /// - Returns: A ``FeedbackEvent``.
     /// - Postcondition: Call ``sendActiveNavigationFeedback(_:type:description:)`` and
     /// ``sendPassiveNavigationFeedback(_:type:description:)`` with the returned feedback to attach additional metadata


### PR DESCRIPTION
fixing a typo that is reflected in our public docs

### Description
<!--
Please describe the PR goals with a simple description of the issue.  Just the stuff needed to implement the fix / feature and a simple rationale strategy. It could contain many check points as following:

1. Include issue references (e.g., fixes [#issue](link))
2. Include check boxes to describe the tasks which were done/need to be done
-->

### Implementation
<!--
Include necessary implementation details, including clarifications, disclaimers etc, related to the approach used(e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->