### PR TITLE
Fixed ProfileIdentifier comparison for the custom profile identifiers, so that route refresh is enabled for custom automobileAvoidingTraffic profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.20.1
+
+### Packaging
+
+* MapboxCoreNavigation now requires [MapboxDirections v2.14.1](https://github.com/mapbox/mapbox-directions-swift/releases/tag/v2.14.1). ([#4776](https://github.com/mapbox/mapbox-navigation-ios/pull/4776))
+
+### Other changes
+
+* Fixed `ProfileIdentifier` comparison for the custom profile identifiers, so that route refresh is enabled for custom `automobileAvoidingTraffic` profiles.
+
 ## v2.20.0
 
 * MapboxNavigation now requires minimim [MapboxMaps v10.19.0](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.19.0). ([#4750](https://github.com/mapbox/mapbox-navigation-ios/pull/4750))

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mapbox-common/MapboxCommon.json" "23.11.4"
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-navigation-native/MapboxNavigationNative.xcframework.json" "206.1.0"
-github "mapbox/mapbox-directions-swift" "v2.14.0"
+github "mapbox/mapbox-directions-swift" "v2.14.1"
 github "mapbox/turf-swift" "v2.8.0"
 github "mattgallagher/CwlPreconditionTesting" "2.2.2"
 github "pointfreeco/swift-snapshot-testing" "1.9.0"

--- a/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MapboxNavigation-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "6512320ee7f0091a4c55abe2bc6414f078da88c8",
-          "version": "2.14.0"
+          "revision": "adbb51c83bf43143427bfa540cbbd658be7babdd",
+          "version": "2.14.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.14.0"),
+        .package(name: "MapboxDirections", url: "https://github.com/mapbox/mapbox-directions-swift.git", from: "2.14.1"),
         .package(name: "MapboxNavigationNative", url: "https://github.com/mapbox/mapbox-navigation-native-ios.git", from: "206.0.1"),
         .package(name: "MapboxMaps", url: "https://github.com/mapbox/mapbox-maps-ios.git", from: "10.19.0"),
         .package(name: "Solar", url: "https://github.com/ceeK/Solar.git", from: "3.0.0"),

--- a/Sources/MapboxCoreNavigation/LegacyRouteController.swift
+++ b/Sources/MapboxCoreNavigation/LegacyRouteController.swift
@@ -272,7 +272,7 @@ open class LegacyRouteController: NSObject, Router, InternalRouter, CLLocationMa
         let options = indexedRouteResponse.validatedRouteOptions
         self.routeProgress = RouteProgress(route: indexedRouteResponse.currentRoute!, options: options)
         self.dataSource = source
-        self.refreshesRoute = options.profileIdentifier == .automobileAvoidingTraffic && options.refreshingEnabled
+        self.refreshesRoute = options.profileIdentifier.isAutomobileAvoidingTraffic && options.refreshingEnabled
         UIDevice.current.isBatteryMonitoringEnabled = true
         
         super.init()

--- a/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
+++ b/Sources/MapboxCoreNavigation/MapboxRoutingProvider.swift
@@ -468,21 +468,29 @@ public class MapboxRoutingProvider: RoutingProvider {
 }
 
 extension ProfileIdentifier {
-    var nativeProfile: RoutingProfile {
-        var mode: RoutingMode
+    var isCycling: Bool {
+        rawValue.hasSuffix("cycling")
+    }
+
+    var mode: RoutingMode {
         switch self {
-        case .automobile:
-            mode = .driving
-        case .automobileAvoidingTraffic:
-            mode = .drivingTraffic
-        case .cycling:
-            mode = .cycling
-        case .walking:
-            mode = .walking
+        case _ where isAutomobile:
+            return .driving
+        case _ where isAutomobileAvoidingTraffic:
+            return .drivingTraffic
+        case _ where isCycling:
+            return .cycling
+        case _ where isWalking:
+            return .walking
         default:
-            mode = .driving
+            return .driving
         }
-        return RoutingProfile(mode: mode, account: "mapbox")
+    }
+
+    var nativeProfile: RoutingProfile {
+        let accountComponent = rawValue.split(separator: "/").first.map(String.init) ?? ""
+        let account = accountComponent.isEmpty ? "mapbox" : accountComponent
+        return RoutingProfile(mode: mode, account: account)
     }
 }
 

--- a/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/NavigationRouteOptions.swift
@@ -26,11 +26,9 @@ open class NavigationRouteOptions: RouteOptions, OptimizedForNavigation {
                    queryItems: queryItems)
         includesAlternativeRoutes = true
         attributeOptions = [.expectedTravelTime, .maximumSpeedLimit]
-        if profileIdentifier == .automobileAvoidingTraffic {
-            attributeOptions.update(with: .numericCongestionLevel)
-        }
         includesExitRoundaboutManeuver = true
-        if profileIdentifier == .automobileAvoidingTraffic {
+        if let profileIdentifier, profileIdentifier.isAutomobileAvoidingTraffic {
+            attributeOptions.update(with: .numericCongestionLevel)
             refreshingEnabled = true
         }
 
@@ -89,11 +87,13 @@ open class NavigationMatchOptions: MatchOptions, OptimizedForNavigation {
                    profileIdentifier: profileIdentifier,
                    queryItems: queryItems)
         attributeOptions = [.expectedTravelTime]
-        if profileIdentifier == .automobileAvoidingTraffic {
-            attributeOptions.update(with: .numericCongestionLevel)
-        }
-        if profileIdentifier == .automobile || profileIdentifier == .automobileAvoidingTraffic {
-            attributeOptions.insert(.maximumSpeedLimit)
+        if let profileIdentifier {
+            if profileIdentifier.isAutomobileAvoidingTraffic {
+                attributeOptions.update(with: .numericCongestionLevel)
+            }
+            if profileIdentifier.isAutomobile || profileIdentifier.isAutomobileAvoidingTraffic {
+                attributeOptions.insert(.maximumSpeedLimit)
+            }
         }
 
         optimizeForNavigation()

--- a/Sources/MapboxCoreNavigation/RouteController.swift
+++ b/Sources/MapboxCoreNavigation/RouteController.swift
@@ -676,7 +676,7 @@ open class RouteController: NSObject {
         let options = indexedRouteResponse.validatedRouteOptions
 
         self.routeProgress = RouteProgress(route: indexedRouteResponse.currentRoute!, options: options)
-        self.refreshesRoute = isRouteOptions && options.profileIdentifier == .automobileAvoidingTraffic && options.refreshingEnabled
+        self.refreshesRoute = isRouteOptions && options.profileIdentifier.isAutomobileAvoidingTraffic && options.refreshingEnabled
 
         super.init()
 

--- a/Sources/MapboxCoreNavigation/RouteOptions.swift
+++ b/Sources/MapboxCoreNavigation/RouteOptions.swift
@@ -3,12 +3,10 @@ import MapboxDirections
 
 extension RouteOptions {
     internal var activityType: CLActivityType {
-        switch self.profileIdentifier {
-        case .cycling, .walking:
+        if profileIdentifier.isCycling || profileIdentifier.isWalking {
             return .fitness
-        default:
-            return .otherNavigation
         }
+        return .otherNavigation
     }
     
     /**

--- a/Sources/MapboxCoreNavigation/Router.swift
+++ b/Sources/MapboxCoreNavigation/Router.swift
@@ -501,7 +501,8 @@ extension InternalRouter where Self: Router {
         let options = progress.reroutingOptions(from: origin)
         
         // https://github.com/mapbox/mapbox-navigation-ios/issues/3966
-        if isRerouting && (options.profileIdentifier == .automobile || options.profileIdentifier == .automobileAvoidingTraffic) {
+        let profile = options.profileIdentifier
+        if isRerouting && (profile.isAutomobile || profile.isAutomobileAvoidingTraffic) {
             options.initialManeuverAvoidanceRadius = initialManeuverAvoidanceRadius * origin.speed
         }
         

--- a/Tests/CocoaPodsTest/PodInstall/Podfile.lock
+++ b/Tests/CocoaPodsTest/PodInstall/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - MapboxCoreNavigation (2.20.0-beta.1):
     - MapboxDirections (~> 2.14)
     - MapboxNavigationNative (< 207.0.0, >= 206.0.1)
-  - MapboxDirections (2.14.0):
+  - MapboxDirections (2.14.1):
     - Polyline (~> 5.0)
     - Turf (~> 2.8.0)
   - MapboxMaps (10.19.4):
@@ -19,7 +19,7 @@ PODS:
     - MapboxMaps (~> 10.19)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (206.1.0):
+  - MapboxNavigationNative (206.1.1):
     - MapboxCommon (~> 23.10)
   - MapboxSpeech (2.1.1)
   - Polyline (5.1.0)
@@ -53,11 +53,11 @@ SPEC CHECKSUMS:
   MapboxCommon: cc47fafe3fe5408ca49240aa80fa64f27f275711
   MapboxCoreMaps: 35685edba03e44468aed57c3dfd7f8795edafda8
   MapboxCoreNavigation: 51fd9af7a3f64e5445e04cc54acf2f710fe78924
-  MapboxDirections: 3d468327d3e2ac52ae1be2176004976580cf6fd9
+  MapboxDirections: 34e4b3682f1efab7b6bdf6e89c8d2f8497b9fb49
   MapboxMaps: f87023cf0d72b180b40ea0b6fb4b2d7db6b73b71
   MapboxMobileEvents: d044b9edbe0ec7df60f6c2c9634fe9a7f449266b
   MapboxNavigation: 9b04fc0e20a687b4448c2a8db0391c69c4a61466
-  MapboxNavigationNative: ef4ef55f669336b689a8941388a4b65796d1337b
+  MapboxNavigationNative: d898e5882007b6caea5af158b0dffb7c75e7641d
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77
   Polyline: 2a1f29f87f8d9b7de868940f4f76deb8c678a5b1
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
@@ -65,4 +65,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: bde8103af0e9b326531ee57cf1fa935cbd5f2e18
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.15.2


### PR DESCRIPTION
### Description

Fixes [NAVIOS-2276](https://mapbox.atlassian.net/browse/NAVIOS-2276)

[NAVIOS-2276]: https://mapbox.atlassian.net/browse/NAVIOS-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ