### PR TITLE
Fix setting initial values for CarPlay navigation camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * `NavigationRouteOptions.init(waypoints:profileIdentifier:queryItems:)` and `NavigationMatchOptions.init(waypoints:profileIdentifier:queryItems:)` set the default values for `shapeFormat`, `locale`, `distanceMeasurementSystem`, `routeShapeResolution`, `includesSpokenInstructions`, and `includesVisualInstructions` only if the values were not passed in `queryItems`. ([#4794](https://github.com/mapbox/mapbox-navigation-ios/pull/4794))
 
+### Map
+
+* Fixed an issue where the initially set CarPlay navigation camera values were being overwritten when updates to this property were disabled.
+
 ## v2.20.2
 
 ### Routing


### PR DESCRIPTION
### Description
Fixes NAVIOS-2280

### Implementation

Steps:
1. disable some camera properties changes, e.g. `centerUpdatesAllowed = false`;
2. manually set the `followingCarPlayCamera.center` value;

Expected result:
The Nav SDK uses the initial value `followingCarPlayCamera.center` on CarPlay and doesn't change it.

Actual result:
The CarPlay `.center` value gets overridden.

The default navigation camera datasource previously checked only the mobile camera properties if they are nil, but set both the mobile and CarPlay camera properties.