### PR TITLE
SDK's audio sessions interrupt spoken audio from other apps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Fixed an issue where the initially set CarPlay navigation camera values were being overwritten when updates to this property were disabled.
 
+### Audio
+
+* Fixed an issue that audio sessions activated by the SDK (for playback of voice instructions and reroute sound) were not interrupting spoken audio content playback from other applications (e.g. Podcasts).
+
 ## v2.20.2
 
 ### Routing

--- a/Sources/MapboxNavigation/Audio/AVAudioSessionHelper.swift
+++ b/Sources/MapboxNavigation/Audio/AVAudioSessionHelper.swift
@@ -15,7 +15,7 @@ final class AVAudioSessionHelper {
     let settings: Settings = Settings(
         category: .playback,
         mode: .voicePrompt,
-        options: [.duckOthers, .mixWithOthers]
+        options: [.interruptSpokenAudioAndMixWithOthers, .duckOthers]
     )
     
     private init() {}


### PR DESCRIPTION
### Description
SDK's audio sessions now interrupt spoken audio content from other applications.
NAVIOS-2414

### Implementation
Default audio session category option `.mixWithOthers` replaced with  `.interruptSpokenAudioAndMixWithOthers`

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
6. Update Changelog.
7. Rebase onto main from the branch before merge.
-->