### PR TITLE
Fix cached road shield and sprite image restore crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to the Mapbox Navigation SDK for iOS
 
+## v2.21.1
+
+### Other changes
+
+* Fixed a crash that could occur when restoring cached road shield and sprite images.
+
 ## v2.21.0
 
 ### Audio

--- a/Sources/MapboxNavigation/Cache.swift
+++ b/Sources/MapboxNavigation/Cache.swift
@@ -28,76 +28,268 @@ public protocol BimodalDataCache: BimodalCache {
 }
 
 protocol URLCaching {
-    func store(_ cachedResponse: CachedURLResponse, for url: URL)
-    func response(for url: URL) -> CachedURLResponse?
+    func store(_ data: Data, for url: URL)
+    func data(for url: URL) -> Data?
     func clearCache()
     func removeCache(for url: URL)
 }
 
 /**
- A general purpose URLCache used by `SpriteRepository` implementations.
+ A general purpose URL data cache used by `SpriteRepository` implementations.
  */
 internal class URLDataCache: URLCaching {
-    private static var defaultDiskCacheURL: URL {
+    private static var defaultCacheDirectory: URL {
         let fileManager = FileManager.default
         let basePath = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
         let identifier = Bundle.mapboxNavigation.bundleIdentifier!
-        return basePath.appendingPathComponent(identifier).appendingPathComponent("URLDataCache")
+        return basePath.appendingPathComponent(identifier)
+    }
+
+    private static var defaultDiskCacheURL: URL {
+        return defaultCacheDirectory.appendingPathComponent("URLDataCache-v2")
+    }
+
+    private static var legacyDiskCacheURL: URL {
+        return defaultCacheDirectory.appendingPathComponent("URLDataCache")
     }
     
-    private let urlCache: URLCache
+    private let memoryCache = NSCache<NSString, NSData>()
+    private let diskCacheURL: URL
     private static let defaultCapacity = 5 * 1024 * 1024
+    private let memoryCapacity: Int
+    private let diskCapacity: Int
+    private let fileManager: FileManager
+    private let diskAccessQueue: DispatchQueue
     private let cacheLock = NSLock()
+    private var memoryCosts = [String: Int]()
+    private var memoryUsage = 0
     
     var currentMemoryUsage: Int {
-        urlCache.currentMemoryUsage
+        cacheLock.lock()
+        defer {
+            cacheLock.unlock()
+        }
+        return memoryUsage
     }
     
     var currentDiskUsage: Int {
-        urlCache.currentDiskUsage
+        diskAccessQueue.sync {
+            return diskUsage()
+        }
     }
     
     init(memoryCapacity: Int? = nil, diskCapacity: Int? = nil, diskCacheURL: URL? = nil) {
-        let memoryCapacity = memoryCapacity ?? Self.defaultCapacity
-        let diskCapacity = diskCapacity ?? Self.defaultCapacity
-        let diskCacheURL = diskCacheURL ?? Self.defaultDiskCacheURL
-        if #available(iOS 13.0, *) {
-            urlCache = URLCache(memoryCapacity: memoryCapacity, diskCapacity: diskCapacity, directory: diskCacheURL)
-        } else {
-            urlCache = URLCache(memoryCapacity: memoryCapacity, diskCapacity: diskCapacity, diskPath: diskCacheURL.path)
+        // Only the default production cache has a known legacy URLCache directory to remove.
+        let shouldRemoveLegacyCache = diskCacheURL == nil
+        self.memoryCapacity = memoryCapacity ?? Self.defaultCapacity
+        self.diskCapacity = diskCapacity ?? Self.defaultCapacity
+        self.diskCacheURL = diskCacheURL ?? Self.defaultDiskCacheURL
+        self.fileManager = FileManager()
+        self.diskAccessQueue = DispatchQueue(label: Bundle.mapboxNavigation.bundleIdentifier! + ".URLDataCache.diskAccess")
+        memoryCache.name = "In-Memory URL Data Cache"
+        memoryCache.totalCostLimit = self.memoryCapacity
+        diskAccessQueue.sync {
+            if shouldRemoveLegacyCache {
+                // The old cache used URLCache and may contain CFNetwork metadata that can crash while being rehydrated.
+                // Remove it by file path only; do not open it through URLCache.
+                removeLegacyCacheIfNeeded()
+            }
+            createCacheDirIfNeeded()
         }
     }
-    
-    func store(_ cachedResponse: CachedURLResponse, for url: URL) {
-        cacheLock.lock()
-        defer {
-            cacheLock.unlock()
+
+    func store(_ data: Data, for url: URL) {
+        let key = cacheKey(for: url)
+        storeDataInMemoryCache(data, forKey: key)
+
+        guard diskCapacity > 0 else {
+            return
         }
-        urlCache.storeCachedResponse(cachedResponse, for: URLRequest(url))
-    }
-    
-    func response(for url: URL) -> CachedURLResponse? {
-        cacheLock.lock()
-        defer {
-            cacheLock.unlock()
+
+        diskAccessQueue.sync {
+            createCacheDirIfNeeded()
+            do {
+                try data.write(to: cacheURL(withKey: key))
+                pruneDiskCacheIfNeeded()
+            } catch {
+                Log.error("Failed to write data to URL cache.", category: .navigationUI)
+            }
         }
-        return urlCache.cachedResponse(for: URLRequest(url))
     }
-    
+
+    func data(for url: URL) -> Data? {
+        let key = cacheKey(for: url)
+
+        if let data = dataFromMemoryCache(forKey: key) {
+            return data
+        }
+
+        let diskData = diskAccessQueue.sync {
+            return dataFromDiskCache(forKey: key)
+        }
+
+        if let diskData {
+            storeDataInMemoryCache(diskData, forKey: key)
+        }
+
+        return diskData
+    }
+
     func clearCache() {
         cacheLock.lock()
-        defer {
-            cacheLock.unlock()
+        memoryCache.removeAllObjects()
+        memoryCosts.removeAll()
+        memoryUsage = 0
+        cacheLock.unlock()
+
+        diskAccessQueue.sync {
+            if fileManager.fileExists(atPath: diskCacheURL.path) {
+                do {
+                    try fileManager.removeItem(at: diskCacheURL)
+                } catch {
+                    Log.error("Failed to remove URL cache directory: \(diskCacheURL)", category: .navigationUI)
+                }
+            }
+            createCacheDirIfNeeded()
         }
-        urlCache.removeAllCachedResponses()
     }
-    
+
     func removeCache(for url: URL) {
+        let key = cacheKey(for: url)
+        removeDataFromMemoryCache(forKey: key)
+
+        diskAccessQueue.sync {
+            let cacheURL = cacheURL(withKey: key)
+            if fileManager.fileExists(atPath: cacheURL.path) {
+                do {
+                    try fileManager.removeItem(at: cacheURL)
+                } catch {
+                    Log.error("Failed to remove URL cache file: \(cacheURL)", category: .navigationUI)
+                }
+            }
+        }
+    }
+
+    private func storeDataInMemoryCache(_ data: Data, forKey key: String) {
+        guard data.count <= memoryCapacity else {
+            removeDataFromMemoryCache(forKey: key)
+            return
+        }
+
         cacheLock.lock()
         defer {
             cacheLock.unlock()
         }
-        urlCache.removeCachedResponse(for: URLRequest(url))
+
+        let previousCost = memoryCosts[key] ?? 0
+        memoryCache.setObject(data as NSData, forKey: key as NSString, cost: data.count)
+        memoryCosts[key] = data.count
+        memoryUsage += data.count - previousCost
+    }
+
+    private func dataFromMemoryCache(forKey key: String) -> Data? {
+        cacheLock.lock()
+        defer {
+            cacheLock.unlock()
+        }
+
+        guard let data = memoryCache.object(forKey: key as NSString) else {
+            return nil
+        }
+        return data as Data
+    }
+
+    private func removeDataFromMemoryCache(forKey key: String) {
+        cacheLock.lock()
+        defer {
+            cacheLock.unlock()
+        }
+
+        memoryCache.removeObject(forKey: key as NSString)
+        memoryUsage -= memoryCosts.removeValue(forKey: key) ?? 0
+    }
+
+    private func dataFromDiskCache(forKey key: String) -> Data? {
+        let url = cacheURL(withKey: key)
+
+        do {
+            let data = try Data(contentsOf: url)
+            // Treat disk reads as access for oldest-file pruning.
+            try? fileManager.setAttributes([.modificationDate: Date()], ofItemAtPath: url.path)
+            return data
+        } catch {
+            return nil
+        }
+    }
+
+    private func cacheKey(for url: URL) -> String {
+        return url.absoluteString.md5
+    }
+
+    private func cacheURL(withKey key: String) -> URL {
+        return diskCacheURL.appendingPathComponent(key)
+    }
+
+    private func createCacheDirIfNeeded() {
+        guard fileManager.fileExists(atPath: diskCacheURL.path) == false else {
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(at: diskCacheURL, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            Log.error("Failed to create URL cache directory: \(diskCacheURL)", category: .navigationUI)
+        }
+    }
+
+    private func removeLegacyCacheIfNeeded() {
+        let legacyDiskCacheURL = Self.legacyDiskCacheURL
+        guard fileManager.fileExists(atPath: legacyDiskCacheURL.path) else {
+            return
+        }
+
+        try? fileManager.removeItem(at: legacyDiskCacheURL)
+    }
+
+    private func pruneDiskCacheIfNeeded() {
+        var cacheFiles = diskCacheFiles()
+        var totalSize = cacheFiles.reduce(0) { $0 + $1.size }
+
+        guard totalSize > diskCapacity else {
+            return
+        }
+
+        cacheFiles.sort { $0.modificationDate < $1.modificationDate }
+        for cacheFile in cacheFiles where totalSize > diskCapacity {
+            do {
+                try fileManager.removeItem(at: cacheFile.url)
+                totalSize -= cacheFile.size
+            } catch {
+                Log.error("Failed to remove URL cache file: \(cacheFile.url)", category: .navigationUI)
+            }
+        }
+    }
+
+    private func diskUsage() -> Int {
+        return diskCacheFiles().reduce(0) { $0 + $1.size }
+    }
+
+    private func diskCacheFiles() -> [(url: URL, size: Int, modificationDate: Date)] {
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: diskCacheURL,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+            options: .skipsHiddenFiles
+        ) else {
+            return []
+        }
+
+        return urls.compactMap { url in
+            guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
+                  let size = values.fileSize else {
+                return nil
+            }
+            return (url, size, values.contentModificationDate ?? .distantPast)
+        }
     }
 }
 

--- a/Sources/MapboxNavigation/ImageDownloader/ImageDownloader.swift
+++ b/Sources/MapboxNavigation/ImageDownloader/ImageDownloader.swift
@@ -14,7 +14,9 @@ actor ImageDownloader: ImageDownloaderProtocol {
 
     init(configuration: URLSessionConfiguration? = nil) {
         let defaultConfiguration = URLSessionConfiguration.default
-        defaultConfiguration.urlCache = URLCache(memoryCapacity: 5 * 1024 * 1024, diskCapacity: 20 * 1024 * 1024)
+        // SpriteRepository owns sprite and shield persistence; avoid duplicate CFNetwork cache entries.
+        defaultConfiguration.urlCache = nil
+        defaultConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
         self.urlSession = URLSession(configuration: configuration ?? defaultConfiguration)
     }
 

--- a/Sources/MapboxNavigation/ImageDownloader/LegacyImageDownloader.swift
+++ b/Sources/MapboxNavigation/ImageDownloader/LegacyImageDownloader.swift
@@ -6,7 +6,9 @@ final class LegacyImageDownloader: ImageDownloaderProtocol {
 
     init(configuration: URLSessionConfiguration? = nil) {
         let defaultConfiguration = URLSessionConfiguration.default
-        defaultConfiguration.urlCache = URLCache(memoryCapacity: 5 * 1024 * 1024, diskCapacity: 20 * 1024 * 1024, diskPath: nil)
+        // SpriteRepository owns sprite and shield persistence; avoid duplicate CFNetwork cache entries.
+        defaultConfiguration.urlCache = nil
+        defaultConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
         self.urlSession = URLSession(configuration: configuration ?? defaultConfiguration)
     }
 

--- a/Sources/MapboxNavigation/SpriteRepository.swift
+++ b/Sources/MapboxNavigation/SpriteRepository.swift
@@ -133,7 +133,7 @@ class SpriteRepository {
                 return
             }
             
-            strongSelf.requestCache.store(cachedResponse, for: infoURL)
+            strongSelf.requestCache.store(cachedResponse.data, for: infoURL)
             completion(cachedResponse.data)
         })
     }
@@ -147,7 +147,7 @@ class SpriteRepository {
                 return
             }
 
-            strongSelf.requestCache.store(cachedResponse, for: imageURL)
+            strongSelf.requestCache.store(cachedResponse.data, for: imageURL)
             completion(image)
         })
     }
@@ -206,7 +206,7 @@ class SpriteRepository {
     }
     
     func getImage(with url: URL) -> UIImage? {
-        guard let data = requestCache.response(for: url)?.data else {
+        guard let data = requestCache.data(for: url) else {
             return nil
         }
         return UIImage(data: data, scale: VisualInstruction.Component.scale)
@@ -222,7 +222,7 @@ class SpriteRepository {
     func getSpriteInfo(styleURI: StyleURI) -> Data? {
         guard let styleID = styleID(for: styleURI),
               let infoURL = spriteURL(isImage: false, styleID: styleID) else { return  nil }
-        return requestCache.response(for: infoURL)?.data
+        return requestCache.data(for: infoURL)
     }
     
     func getSpriteInfo(styleURI: StyleURI, with key: String) -> SpriteInfo? {

--- a/Tests/MapboxNavigationTests/Helper/URLCacheSpy.swift
+++ b/Tests/MapboxNavigationTests/Helper/URLCacheSpy.swift
@@ -2,14 +2,14 @@ import Foundation
 @testable import MapboxNavigation
 
 final class URLCacheSpy: URLCaching {
-    var cache = [URL: CachedURLResponse]()
+    var cache = [URL: Data]()
     var clearCacheCalled = false
 
-    func store(_ cachedResponse: CachedURLResponse, for url: URL) {
-        cache[url] = cachedResponse
+    func store(_ data: Data, for url: URL) {
+        cache[url] = data
     }
 
-    func response(for url: URL) -> CachedURLResponse? {
+    func data(for url: URL) -> Data? {
         return cache[url]
     }
 

--- a/Tests/MapboxNavigationTests/InstructionsBannerViewSnapshotTests.swift
+++ b/Tests/MapboxNavigationTests/InstructionsBannerViewSnapshotTests.swift
@@ -535,12 +535,10 @@ class InstructionBannerTest: TestCase {
                   return
               }
         
-        let spriteResponse = URLResponse(url: spriteRequestURL, mimeType: nil, expectedContentLength: spriteData.count, textEncodingName: nil)
-        spriteRepository.requestCache.store( CachedURLResponse(response: spriteResponse, data: spriteData), for: spriteRequestURL)
+        spriteRepository.requestCache.store(spriteData, for: spriteRequestURL)
         
         let infoData = Fixture.JSONFromFileNamed(name: "sprite-info")
-        let infoResponse = URLResponse(url: infoRequestURL, mimeType: nil, expectedContentLength: infoData.count, textEncodingName: nil)
-        spriteRepository.requestCache.store( CachedURLResponse(response: infoResponse, data: infoData), for: infoRequestURL)
+        spriteRepository.requestCache.store(infoData, for: infoRequestURL)
     }
     
     func clearDiskCache() {
@@ -558,8 +556,7 @@ class InstructionBannerTest: TestCase {
             XCTFail("Failed to cache legacy images.")
             return
         }
-        let response = URLResponse(url: legacyURL, mimeType: nil, expectedContentLength: data.count, textEncodingName: nil)
-        spriteRepository.requestCache.store(CachedURLResponse(response: response, data: data), for: legacyURL)
+        spriteRepository.requestCache.store(data, for: legacyURL)
     }
 }
 

--- a/Tests/MapboxNavigationTests/URLDataCacheTests.swift
+++ b/Tests/MapboxNavigationTests/URLDataCacheTests.swift
@@ -4,6 +4,8 @@ import TestHelper
 
 class URLDataCacheTest: TestCase {
     let url = ShieldImage.i280.baseURL
+    let secondURL = URL(string: "https://www.mapbox.com/second-shield.png")!
+    let data = Fixture.JSONFromFileNamed(name: "sprite-info")
     var cache: URLDataCache!
     
     private static var cacheURL: URL {
@@ -26,23 +28,16 @@ class URLDataCacheTest: TestCase {
         super.tearDown()
     }
 
-    private func exampleData() -> Data {
-        return Fixture.JSONFromFileNamed(name: "sprite-info")
-    }
-
     func testStoreCache() {
-        let data = exampleData()
-        
         cache.store(data, for: url)
         
         let cachedData = cache.data(for: url)
         XCTAssertNotNil(cachedData)
         XCTAssertEqual(cachedData, data)
+        XCTAssertGreaterThan(cache.currentMemoryUsage, 0)
     }
     
     func testClearCache() {
-        let data = exampleData()
-
         cache.store(data, for: url)
         XCTAssertEqual(cache.data(for: url), data)
 
@@ -53,18 +48,17 @@ class URLDataCacheTest: TestCase {
     }
     
     func testRemoveRequestCache() {
-        let data = exampleData()
-        
         cache.store(data, for: url)
+        cache.store(data, for: secondURL)
         XCTAssertNotNil(cache.data(for: url))
+        XCTAssertNotNil(cache.data(for: secondURL))
         
         cache.removeCache(for: url)
         XCTAssertNil(cache.data(for: url))
+        XCTAssertEqual(cache.data(for: secondURL), data)
     }
 
     func testStoreCacheInMemoryOnly() {
-        let data = exampleData()
-        
         cache.store(data, for: url)
         
         let cachedData = cache.data(for: url)
@@ -73,8 +67,6 @@ class URLDataCacheTest: TestCase {
     }
     
     func testStoreCacheWithMemoryWarning() {
-        let data = exampleData()
-
         cache.store(data, for: url)
         XCTAssertEqual(cache.data(for: url), data)
 
@@ -83,8 +75,6 @@ class URLDataCacheTest: TestCase {
     }
     
     func testStoreCacheOutOfCapacity() {
-        let data = exampleData()
-        
         let limitCapacity = 1
         XCTAssertTrue(data.count > limitCapacity)
         
@@ -102,11 +92,10 @@ class URLDataCacheTest: TestCase {
     }
 
     func testStoreCacheOnDisk() {
-        let data = exampleData()
         let diskCache = URLDataCache(diskCapacity: data.count * 2, diskCacheURL: Self.cacheURL)
 
-        diskCache.clearCache()
         diskCache.store(data, for: url)
+        XCTAssertGreaterThan(diskCache.currentDiskUsage, 0)
         cache = URLDataCache(diskCapacity: 0, diskCacheURL: Self.cacheURL)
 
         XCTAssertEqual(cache.data(for: url), data)

--- a/Tests/MapboxNavigationTests/URLDataCacheTests.swift
+++ b/Tests/MapboxNavigationTests/URLDataCacheTests.swift
@@ -26,69 +26,67 @@ class URLDataCacheTest: TestCase {
         super.tearDown()
     }
 
-    private func exampleResponse(with storagePolicy: URLCache.StoragePolicy) -> CachedURLResponse {
-        let data = Fixture.JSONFromFileNamed(name: "sprite-info")
-        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: data.count, textEncodingName: nil)
-        let cachedResponse = CachedURLResponse(response: response, data: data, storagePolicy: storagePolicy)
-        return cachedResponse
+    private func exampleData() -> Data {
+        return Fixture.JSONFromFileNamed(name: "sprite-info")
     }
 
     func testStoreCache() {
-        let response = exampleResponse(with: .allowed)
+        let data = exampleData()
         
-        cache.store(response, for: url)
+        cache.store(data, for: url)
         
-        let cachedResponse = cache.response(for: url)
-        XCTAssertNotNil(cachedResponse)
-        XCTAssertEqual(cachedResponse, response)
+        let cachedData = cache.data(for: url)
+        XCTAssertNotNil(cachedData)
+        XCTAssertEqual(cachedData, data)
     }
     
     func testClearCache() {
-        let response = exampleResponse(with: .allowed)
+        let data = exampleData()
 
-        cache.store(response, for: url)
-        XCTAssertEqual(cache.response(for: url), response)
+        cache.store(data, for: url)
+        XCTAssertEqual(cache.data(for: url), data)
 
         cache.clearCache()
-        XCTAssertNil(cache.response(for: url)?.data)
+        XCTAssertNil(cache.data(for: url))
         XCTAssertEqual(cache.currentMemoryUsage, 0)
+        XCTAssertEqual(cache.currentDiskUsage, 0)
     }
     
     func testRemoveRequestCache() {
-        let response = exampleResponse(with: .allowed)
+        let data = exampleData()
         
-        cache.store(response, for: url)
-        XCTAssertNotNil(cache.response(for: url))
+        cache.store(data, for: url)
+        XCTAssertNotNil(cache.data(for: url))
         
         cache.removeCache(for: url)
-        XCTAssertNil(cache.response(for: url)?.data)
+        XCTAssertNil(cache.data(for: url))
     }
 
     func testStoreCacheInMemoryOnly() {
-        let response = exampleResponse(with: .allowedInMemoryOnly)
+        let data = exampleData()
         
-        cache.store(response, for: url)
+        cache.store(data, for: url)
         
-        let cachedResponse = cache.response(for: url)
-        XCTAssertEqual(cachedResponse, response)
-        XCTAssertEqual(cache.currentMemoryUsage, response.data.count)
+        let cachedData = cache.data(for: url)
+        XCTAssertEqual(cachedData, data)
+        XCTAssertEqual(cache.currentMemoryUsage, data.count)
     }
     
     func testStoreCacheWithMemoryWarning() {
-        let response = exampleResponse(with: .allowed)
+        let data = exampleData()
 
-        cache.store(response, for: url)
-        XCTAssertEqual(cache.response(for: url), response)
+        cache.store(data, for: url)
+        XCTAssertEqual(cache.data(for: url), data)
 
         NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
-        XCTAssertEqual(cache.response(for: url), response)
+        XCTAssertEqual(cache.data(for: url), data)
     }
     
     func testStoreCacheOutOfCapacity() {
-        let response = exampleResponse(with: .allowedInMemoryOnly)
+        let data = exampleData()
         
         let limitCapacity = 1
-        XCTAssertTrue(response.data.count > limitCapacity)
+        XCTAssertTrue(data.count > limitCapacity)
         
         let limitCache = URLDataCache(
             memoryCapacity: limitCapacity,
@@ -97,10 +95,21 @@ class URLDataCacheTest: TestCase {
         )
         limitCache.clearCache()
         
-        limitCache.store(response, for: url)
-        XCTAssertNil(cache.response(for: url))
+        limitCache.store(data, for: url)
+        XCTAssertNil(limitCache.data(for: url))
         XCTAssertEqual(limitCache.currentMemoryUsage, 0)
-        // not checking disk usage as it is always non-zero
+        XCTAssertEqual(limitCache.currentDiskUsage, 0)
+    }
+
+    func testStoreCacheOnDisk() {
+        let data = exampleData()
+        let diskCache = URLDataCache(diskCapacity: data.count * 2, diskCacheURL: Self.cacheURL)
+
+        diskCache.clearCache()
+        diskCache.store(data, for: url)
+        cache = URLDataCache(diskCapacity: 0, diskCacheURL: Self.cacheURL)
+
+        XCTAssertEqual(cache.data(for: url), data)
     }
 }
 


### PR DESCRIPTION
## Summary

This fixes a crash that could occur when restoring cached road shield and sprite images by replacing the `URLCache`-backed storage used by `SpriteRepository`.

- Keeps the existing 5 MB memory and disk cache limits.
- Cleans up the legacy cache directory so old corrupted entries are not reused.